### PR TITLE
Fix Layer#checkProp to only error on undefined/null

### DIFF
--- a/src/layer.js
+++ b/src/layer.js
@@ -456,7 +456,7 @@ export default class Layer {
   }
 
   checkProp(property, propertyName) {
-    if (typeof property === 'undefined' || property === null) {
+    if (property === undefined || property === null) {
       throw new Error(`Property ${propertyName} undefined in layer ${this.props.id}`);
     }
   }

--- a/src/layer.js
+++ b/src/layer.js
@@ -92,6 +92,8 @@ export default class Layer {
       assert(props.data[Symbol.iterator], 'data prop must have an iterator');
     }
 
+    this.props = props;
+
     this.checkProp(props.data, 'data');
     this.checkProp(props.id, 'id');
     this.checkProp(props.width, 'width');
@@ -103,7 +105,6 @@ export default class Layer {
     this.checkProp(props.longitude, 'longitude');
     this.checkProp(props.zoom, 'zoom');
 
-    this.props = props;
     this.count = counter++;
   }
   /* eslint-enable max-statements */
@@ -455,8 +456,8 @@ export default class Layer {
   }
 
   checkProp(property, propertyName) {
-    if (!property) {
-      throw new Error(`Property ${propertyName} undefined in layer ${this.id}`);
+    if (typeof property === 'undefined' || property === null) {
+      throw new Error(`Property ${propertyName} undefined in layer ${this.props.id}`);
     }
   }
 

--- a/test/layer-spec.js
+++ b/test/layer-spec.js
@@ -16,10 +16,42 @@ const LAYER_PROPS = {
   zoom: 1,
   data: []
 };
+const LAYER_PROPS_ZEROES = {
+  id: 'testLayer',
+  width: 0,
+  height: 0,
+  latitude: 0,
+  longitude: 0,
+  zoom: 0,
+  data: []
+};
+const LAYER_PROPS_MISSING = {
+  id: 'testLayer',
+  width: 1,
+  // height: 1,
+  longitude: 1,
+  zoom: 1,
+  data: []
+}
 
 test('Layer#constructor', t => {
   const layer = new Layer(LAYER_PROPS);
   t.ok(layer, 'Layer created');
+  t.end();
+});
+
+test('Layer#constructor with zeroes', t => {
+  const layer = new Layer(LAYER_PROPS_ZEROES);
+  t.ok(layer, 'Layer created');
+  t.end();
+});
+
+test('Layer#constructor with missing prps', t => {
+  t.throws(
+    () => new Layer(LAYER_PROPS_MISSING),
+    /Property height undefined in layer testLayer/,
+    'Expected missing props to throw an error'
+  );
   t.end();
 });
 

--- a/test/layer-spec.js
+++ b/test/layer-spec.js
@@ -46,7 +46,7 @@ test('Layer#constructor with zeroes', t => {
   t.end();
 });
 
-test('Layer#constructor with missing prps', t => {
+test('Layer#constructor with missing props', t => {
   t.throws(
     () => new Layer(LAYER_PROPS_MISSING),
     /Property height undefined in layer testLayer/,


### PR DESCRIPTION
Fixes #31 

I added unit tests confirming this behavior, but there's still a test failure on

```
⨯ Viewport projection matrix
  not ok 7 TypeError: viewport.getZoomedViewProjectionMatrix is not a function
    ---
      operator: error
      expected: 
      actual:   {}
      at: Test.exports.Test.run (/Users/Hyde/src/deck.gl/node_modules/tape-catch/index.js:29:10)
      stack:
        TypeError: viewport.getZoomedViewProjectionMatrix is not a function
          at Test._cb (viewport-spec.js:55:39)
```

I'm not sure the best solution to this, so I just left it as-is.