### PR TITLE
Enable multipolygon display in choropleth

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "babel-core": "^6.7.7",
     "babel-polyfill": "^6.1.19",
     "earcut": "^2.0.6",
+    "geojson-coords": "0.0.0",
     "geojson-normalize": "0.0.1",
     "get-pixels": "^3.3.0",
     "gl-matrix": "^2.3.2",

--- a/src/layers/choropleth-layer/choropleth-layer.js
+++ b/src/layers/choropleth-layer/choropleth-layer.js
@@ -21,6 +21,7 @@
 import Layer from '../../layer';
 import earcut from 'earcut';
 import flattenDeep from 'lodash.flattendeep';
+import geojsonCoords from 'geojson-coords';
 import normalize from 'geojson-normalize';
 import {Model, Program, Geometry} from 'luma.gl';
 const glslify = require('glslify');
@@ -165,14 +166,9 @@ export default class ChoroplethLayer extends Layer {
     const normalizedGeojson = normalize(data);
 
     this.state.choropleths = normalizedGeojson.features.map(choropleth => {
-      let coordinates = choropleth.geometry.coordinates[0];
-      // flatten nested polygons
-      if (coordinates.length === 1 && coordinates[0].length > 2) {
-        coordinates = coordinates[0];
-      }
       return {
         properties: choropleth.properties,
-        coordinates
+        coordinates: geojsonCoords(choropleth.geometry)
       };
     });
 


### PR DESCRIPTION
The current coordinatization of of polygons works well for polygons, but not for deeply nested multi-polygons. For instance, here's a picture of the current solution 
![screen shot 2016-08-08 at 11 29 58 am](https://cloud.githubusercontent.com/assets/6854312/17491865/413402d0-5d5e-11e6-8886-140f068bb82d.png)

I believe that this is being caused by t solution being unable to deeply "un-nest", which causes the renderer to think these deeply nested polygons are the same and to try to connect them.
