### PR TITLE
Enable fill coloring for choropleths

### DIFF
--- a/src/layers/choropleth-layer/choropleth-layer.js
+++ b/src/layers/choropleth-layer/choropleth-layer.js
@@ -138,8 +138,8 @@ export default class ChoroplethLayer extends Layer {
 
   calculateColors(attribute) {
     const colors = this.state.groupedVerticesColors.map(
-      vertices => vertices.map(
-        vertex => this.props.drawContour ? [0, 0, 0] : [vertex[0], vertex[1], vertex[2]]
+      colors => colors.map(
+        color => this.props.drawContour ? [0, 0, 0] : [color[0], color[1], color[2]]
       )
     );
 

--- a/src/layers/choropleth-layer/choropleth-layer.js
+++ b/src/layers/choropleth-layer/choropleth-layer.js
@@ -137,9 +137,9 @@ export default class ChoroplethLayer extends Layer {
   }
 
   calculateColors(attribute) {
-    const colors = this.state.groupedVertices.map(
+    const colors = this.state.groupedVerticesColors.map(
       vertices => vertices.map(
-        vertex => this.props.drawContour ? [0, 0, 0] : [128, 128, 128]
+        vertex => this.props.drawContour ? [0, 0, 0] : [vertex[0], vertex[1], vertex[2]]
       )
     );
 
@@ -179,6 +179,11 @@ export default class ChoroplethLayer extends Layer {
     this.state.groupedVertices = this.state.choropleths.map(
       choropleth => choropleth.coordinates.map(
         coordinate => [coordinate[0], coordinate[1], 0]
+      )
+    );
+    this.state.groupedVerticesColors = this.state.choropleths.map(
+      choropleth => choropleth.coordinates.map(
+        coordinate => choropleth.properties.color || [128, 128, 128]
       )
     );
   }


### PR DESCRIPTION
Responds to https://github.com/uber/deck.gl/pull/46, allows users to specify a rgb vector a property of each geojson layer being passed in. Example

![screen shot 2016-08-08 at 11 56 13 am](https://cloud.githubusercontent.com/assets/6854312/17492089/20fcbb82-5d5f-11e6-9485-96a254d35e0d.png)
