### PR TITLE
Added accessors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -30,10 +30,7 @@
       }
     ],
     "constructor-super": 2,
-    "func-style": [
-      2,
-      "declaration"
-    ],
+    "func-style": 0,
     "generator-star-spacing": [
       2,
       {

--- a/example/main.js
+++ b/example/main.js
@@ -201,10 +201,8 @@ function pointsToArcs(points) {
     const target = points[i + 1];
 
     return {
-      position: {
-        x0: source.position.x, y0: source.position.y,
-        x1: target.position.x, y1: target.position.y
-      },
+      position0: [source.position.x, source.position.y],
+      position1: [target.position.x, target.position.y],
       color: [
         i % 255,
         255 - i % 255,
@@ -227,10 +225,8 @@ function pointsToLines(points) {
     const target = points[i + 1];
 
     return {
-      position: {
-        x0: source.position.x, y0: source.position.y,
-        x1: target.position.x, y1: target.position.y
-      },
+      position0: [source.position.x, source.position.y],
+      position1: [target.position.x, target.position.y],
       color: [0, 0, 255]
     };
   });

--- a/example/main.js
+++ b/example/main.js
@@ -114,13 +114,9 @@ function reducer(state = INITIAL_STATE, action) {
       const p1 = coordString.indexOf(')');
       const coords = coordString.slice(p0, p1).split(',');
       return {
-        position: {
-          x: Number(coords[1]),
-          y: Number(coords[0]),
-          z: 0
-        },
+        position: [Number(coords[1]), Number(coords[0]), 0],
         color: [88, 9, 124],
-        radius: (Math.random() * (15 - 5 + 1) + 5) / 10  // [0.5, 1.5]
+        radius: (Math.random() * (15 - 5 + 1) + 5) / 10
       };
     });
 
@@ -192,8 +188,8 @@ function pointsToArcs(points) {
   return points.map((point, i) => {
     if (i === points.length - 1) {
       return {
-        position0: [0, 0],
-        position1: [0, 0],
+        sourcePosition: [0, 0],
+        targetPosition: [0, 0],
         color: [35, 81, 128]
       };
     }
@@ -202,8 +198,8 @@ function pointsToArcs(points) {
     const target = points[i + 1];
 
     return {
-      position0: [source.position.x, source.position.y],
-      position1: [target.position.x, target.position.y],
+      sourcePosition: source.position,
+      targetPosition: target.position,
       color: [
         i % 255,
         255 - i % 255,
@@ -217,8 +213,8 @@ function pointsToLines(points) {
   return points.map((point, i) => {
     if (i === points.length - 1) {
       return {
-        position0: [0, 0],
-        position1: [0, 0],
+        sourcePosition: [0, 0],
+        targetPosition: [0, 0],
         color: [35, 81, 128]
       };
     }
@@ -227,8 +223,8 @@ function pointsToLines(points) {
     const target = points[i + 1];
 
     return {
-      position0: [source.position.x, source.position.y],
-      position1: [target.position.x, target.position.y],
+      sourcePosition: source.position,
+      targetPosition: target.position,
       color: [0, 0, 255]
     };
   });

--- a/example/main.js
+++ b/example/main.js
@@ -192,7 +192,8 @@ function pointsToArcs(points) {
   return points.map((point, i) => {
     if (i === points.length - 1) {
       return {
-        position: {x0: 0, y0: 0, x1: 0, y1: 0},
+        position0: [0, 0],
+        position1: [0, 0],
         color: [35, 81, 128]
       };
     }
@@ -216,7 +217,8 @@ function pointsToLines(points) {
   return points.map((point, i) => {
     if (i === points.length - 1) {
       return {
-        position: {x0: 0, y0: 0, x1: 0, y1: 0},
+        position0: [0, 0],
+        position1: [0, 0],
         color: [35, 81, 128]
       };
     }

--- a/src/layers/arc-layer/arc-layer.js
+++ b/src/layers/arc-layer/arc-layer.js
@@ -25,25 +25,35 @@ const glslify = require('glslify');
 const RED = [255, 0, 0];
 const BLUE = [0, 0, 255];
 
+const defaultGetPosition0 = x => x.position0;
+const defaultGetPosition1 = x => x.position1;
+const defaultGetColor = x => x.color;
+
 export default class ArcLayer extends BaseLayer {
   /**
    * @classdesc
    * ArcLayer
    *
    * @class
-   * @param {object} opts
+   * @param {object} props
    */
   constructor({
     strokeWidth = 1,
     color0 = RED,
     color1 = BLUE,
-    ...opts
+    getPosition0 = defaultGetPosition0,
+    getPosition1 = defaultGetPosition1,
+    getColor = defaultGetColor,
+    ...props
   } = {}) {
     super({
       strokeWidth,
       color0,
       color1,
-      ...opts
+      getPosition0,
+      getPosition1,
+      getColor,
+      ...props
     });
   }
 
@@ -105,26 +115,29 @@ export default class ArcLayer extends BaseLayer {
   }
 
   calculateInstancePositions(attribute) {
-    const {data} = this.props;
+    const {data, getPosition0, getPosition1} = this.props;
     const {value, size} = attribute;
     let i = 0;
-    for (const arc of data) {
-      value[i + 0] = arc.position.x0;
-      value[i + 1] = arc.position.y0;
-      value[i + 2] = arc.position.x1;
-      value[i + 3] = arc.position.y1;
+    for (const object of data) {
+      const position0 = getPosition0(object);
+      const position1 = getPosition1(object);
+      value[i + 0] = position0[0];
+      value[i + 1] = position0[1];
+      value[i + 2] = position1[0];
+      value[i + 3] = position1[1];
       i += size;
     }
   }
 
   calculateInstanceColors(attribute) {
-    const {data} = this.props;
+    const {data, getColor} = this.props;
     const {value, size} = attribute;
     let i = 0;
-    for (const point of data) {
-      value[i + 0] = point.color[0];
-      value[i + 1] = point.color[1];
-      value[i + 2] = point.color[2];
+    for (const object of data) {
+      const color = getColor(object);
+      value[i + 0] = color[0];
+      value[i + 1] = color[1];
+      value[i + 2] = color[2];
       i += size;
     }
   }

--- a/src/layers/choropleth-layer/choropleth-layer.js
+++ b/src/layers/choropleth-layer/choropleth-layer.js
@@ -51,11 +51,11 @@ export default class ChoroplethLayer extends BaseLayer {
     attributeManager.addDynamic({
       // Primtive attributes
       indices: {size: 1, update: this.calculateIndices, isIndexed: true},
-      positions: {size: 3, update: this.calculateInstancePositions},
-      colors: {size: 3, update: this.calculateInstanceColors},
+      positions: {size: 3, update: this.calculatePositions},
+      colors: {size: 3, update: this.calculateColors},
       // Instanced attributes
       pickingColors:
-		{size: 3, update: this.calculateInstancePickingColors, noAlloc: true}
+        {size: 3, update: this.calculatePickingColors, noAlloc: true}
     });
 
     this.setUniforms({opacity: this.props.opacity});
@@ -162,12 +162,12 @@ export default class ChoroplethLayer extends BaseLayer {
     this.state.model.setVertexCount(attribute.value.length / attribute.size);
   }
 
-  calculateInstancePositions(attribute) {
+  calculatePositions(attribute) {
     const vertices = flattenDeep(this.state.groupedVertices);
     attribute.value = new Float32Array(vertices);
   }
 
-  calculateInstanceColors(attribute) {
+  calculateColors(attribute) {
     const colors = this.state.groupedVerticesColors.map(
       colors => colors.map(
         color => this.props.drawContour ?
@@ -180,7 +180,7 @@ export default class ChoroplethLayer extends BaseLayer {
   }
 
   // Override the default picking colors calculation
-  calculateInstancePickingColors(attribute) {
+  calculatePickingColors(attribute) {
     const colors = this.state.groupedVertices.map(
       (vertices, choroplethIndex) => vertices.map(
         vertex => this.props.drawContour ? [-1, -1, -1] : [

--- a/src/layers/choropleth-layer/choropleth-layer.js
+++ b/src/layers/choropleth-layer/choropleth-layer.js
@@ -51,11 +51,11 @@ export default class ChoroplethLayer extends BaseLayer {
     attributeManager.addDynamic({
       // Primtive attributes
       indices: {size: 1, update: this.calculateIndices, isIndexed: true},
-      positions: {size: 3, update: this.calculatePositions},
-      colors: {size: 3, update: this.calculateColors},
+      positions: {size: 3, update: this.calculateInstancePositions},
+      colors: {size: 3, update: this.calculateInstanceColors},
       // Instanced attributes
-      pickingColors: {size: 3, update: this.calculatePickingColors,
-        noAlloc: true}
+      pickingColors:
+		{size: 3, update: this.calculateInstancePickingColors, noAlloc: true}
     });
 
     this.setUniforms({opacity: this.props.opacity});
@@ -98,61 +98,6 @@ export default class ChoroplethLayer extends BaseLayer {
     });
   }
 
-  calculatePositions(attribute) {
-    const vertices = flattenDeep(this.state.groupedVertices);
-    attribute.value = new Float32Array(vertices);
-  }
-
-  calculateIndices(attribute) {
-    // adjust index offset for multiple choropleths
-    const offsets = this.state.groupedVertices.reduce(
-      (acc, vertices) => [...acc, acc[acc.length - 1] + vertices.length],
-      [0]
-    );
-
-    const indices = this.state.groupedVertices.map(
-      (vertices, choroplethIndex) => this.props.drawContour ?
-        // 1. get sequentially ordered indices of each choropleth contour
-        // 2. offset them by the number of indices in previous choropleths
-        this.calculateContourIndices(vertices.length).map(
-          index => index + offsets[choroplethIndex]
-        ) :
-        // 1. get triangulated indices for the internal areas
-        // 2. offset them by the number of indices in previous choropleths
-        earcut(flattenDeep(vertices), null, 3).map(
-          index => index + offsets[choroplethIndex]
-        )
-    );
-
-    attribute.value = new Uint16Array(flattenDeep(indices));
-    attribute.target = this.state.gl.ELEMENT_ARRAY_BUFFER;
-    this.state.model.setVertexCount(attribute.value.length / attribute.size);
-  }
-
-  calculateColors(attribute) {
-    const colors = this.state.groupedVerticesColors.map(
-      colors => colors.map(
-        color => this.props.drawContour ? [0, 0, 0] : [color[0], color[1], color[2]]
-      )
-    );
-
-    attribute.value = new Float32Array(flattenDeep(colors));
-  }
-
-  // Override the default picking colors calculation
-  calculatePickingColors(attribute) {
-    const colors = this.state.groupedVertices.map(
-      (vertices, choroplethIndex) => vertices.map(
-        vertex => this.props.drawContour ? [-1, -1, -1] : [
-          (choroplethIndex + 1) % 256,
-          Math.floor((choroplethIndex + 1) / 256) % 256,
-          Math.floor((choroplethIndex + 1) / 256 / 256) % 256]
-      )
-    );
-
-    attribute.value = new Float32Array(flattenDeep(colors));
-  }
-
   extractChoropleths() {
     const {data} = this.props;
     const normalizedGeojson = normalize(data);
@@ -189,6 +134,63 @@ export default class ChoroplethLayer extends BaseLayer {
     }
     return [0, ...indices, 0];
 
+  }
+
+  calculateIndices(attribute) {
+    // adjust index offset for multiple choropleths
+    const offsets = this.state.groupedVertices.reduce(
+      (acc, vertices) => [...acc, acc[acc.length - 1] + vertices.length],
+      [0]
+    );
+
+    const indices = this.state.groupedVertices.map(
+      (vertices, choroplethIndex) => this.props.drawContour ?
+        // 1. get sequentially ordered indices of each choropleth contour
+        // 2. offset them by the number of indices in previous choropleths
+        this.calculateContourIndices(vertices.length).map(
+          index => index + offsets[choroplethIndex]
+        ) :
+        // 1. get triangulated indices for the internal areas
+        // 2. offset them by the number of indices in previous choropleths
+        earcut(flattenDeep(vertices), null, 3).map(
+          index => index + offsets[choroplethIndex]
+        )
+    );
+
+    attribute.value = new Uint16Array(flattenDeep(indices));
+    attribute.target = this.state.gl.ELEMENT_ARRAY_BUFFER;
+    this.state.model.setVertexCount(attribute.value.length / attribute.size);
+  }
+
+  calculateInstancePositions(attribute) {
+    const vertices = flattenDeep(this.state.groupedVertices);
+    attribute.value = new Float32Array(vertices);
+  }
+
+  calculateInstanceColors(attribute) {
+    const colors = this.state.groupedVerticesColors.map(
+      colors => colors.map(
+        color => this.props.drawContour ?
+          // TODO - why destructure and rebuild array?
+          [0, 0, 0] : [color[0], color[1], color[2]]
+      )
+    );
+
+    attribute.value = new Float32Array(flattenDeep(colors));
+  }
+
+  // Override the default picking colors calculation
+  calculateInstancePickingColors(attribute) {
+    const colors = this.state.groupedVertices.map(
+      (vertices, choroplethIndex) => vertices.map(
+        vertex => this.props.drawContour ? [-1, -1, -1] : [
+          (choroplethIndex + 1) % 256,
+          Math.floor((choroplethIndex + 1) / 256) % 256,
+          Math.floor((choroplethIndex + 1) / 256 / 256) % 256]
+      )
+    );
+
+    attribute.value = new Float32Array(flattenDeep(colors));
   }
 
   onHover(info) {

--- a/src/layers/hexagon-layer/hexagon-layer.js
+++ b/src/layers/hexagon-layer/hexagon-layer.js
@@ -21,9 +21,11 @@ import BaseLayer from '../base-layer';
 import {Model, Program, CylinderGeometry} from 'luma.gl';
 const glslify = require('glslify');
 
+const DEFAULT_COLOR = [255, 0, 0];
+
 const _getCentroid = x => x.centroid;
 const _getElevation = x => x.elevation || 0;
-const _getColor = x => x.color || [255, 0, 0];
+const _getColor = x => x.color || DEFAULT_COLOR;
 const _getVertices = x => x.vertices;
 
 export default class HexagonLayer extends BaseLayer {

--- a/src/layers/hexagon-layer/hexagon-layer.js
+++ b/src/layers/hexagon-layer/hexagon-layer.js
@@ -17,8 +17,6 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-/* eslint-disable func-style */
-
 import BaseLayer from '../base-layer';
 import {Model, Program, CylinderGeometry} from 'luma.gl';
 const glslify = require('glslify');

--- a/src/layers/line-layer/line-layer.js
+++ b/src/layers/line-layer/line-layer.js
@@ -22,12 +22,11 @@ import BaseLayer from '../base-layer';
 import {Model, Program, Geometry} from 'luma.gl';
 const glslify = require('glslify');
 
-const ATTRIBUTES = {
-};
+const DEFAULT_COLOR = [0, 255, 0];
 
-const defaultGetPosition0 = x => x.position0;
-const defaultGetPosition1 = x => x.position1;
-const defaultGetColor = x => x.color;
+const defaultGetSourcePosition = x => x.sourcePosition;
+const defaultGetTargetPosition = x => x.targetPosition;
+const defaultGetColor = x => x.color || DEFAULT_COLOR;
 
 export default class LineLayer extends BaseLayer {
   /**
@@ -39,15 +38,15 @@ export default class LineLayer extends BaseLayer {
    */
   constructor({
     strokeWidth = 9,
-    getPosition0 = defaultGetPosition0,
-    getPosition1 = defaultGetPosition1,
+    getSourcePosition = defaultGetSourcePosition,
+    getTargetPosition = defaultGetTargetPosition,
     getColor = defaultGetColor,
     ...opts
   } = {}) {
     super({
       strokeWidth,
-      getPosition0,
-      getPosition1,
+      getSourcePosition,
+      getTargetPosition,
       getColor,
       ...opts
     });
@@ -97,16 +96,16 @@ export default class LineLayer extends BaseLayer {
   }
 
   calculateInstancePositions(attribute) {
-    const {data, getPosition0, getPosition1} = this.props;
+    const {data, getSourcePosition, getTargetPosition} = this.props;
     const {value, size} = attribute;
     let i = 0;
     for (const object of data) {
-      const position0 = getPosition0(object);
-      const position1 = getPosition1(object);
-      value[i + 0] = position0[0];
-      value[i + 1] = position0[1];
-      value[i + 2] = position1[0];
-      value[i + 3] = position1[1];
+      const sourcePosition = getSourcePosition(object);
+      const targetPosition = getTargetPosition(object);
+      value[i + 0] = sourcePosition[0];
+      value[i + 1] = sourcePosition[1];
+      value[i + 2] = targetPosition[0];
+      value[i + 3] = targetPosition[1];
       i += size;
     }
   }

--- a/src/layers/line-layer/line-layer.js
+++ b/src/layers/line-layer/line-layer.js
@@ -25,6 +25,10 @@ const glslify = require('glslify');
 const ATTRIBUTES = {
 };
 
+const defaultGetPosition0 = x => x.position0;
+const defaultGetPosition1 = x => x.position1;
+const defaultGetColor = x => x.color;
+
 export default class LineLayer extends BaseLayer {
   /**
    * @classdesc
@@ -35,10 +39,16 @@ export default class LineLayer extends BaseLayer {
    */
   constructor({
     strokeWidth = 9,
+    getPosition0 = defaultGetPosition0,
+    getPosition1 = defaultGetPosition1,
+    getColor = defaultGetColor,
     ...opts
   } = {}) {
     super({
       strokeWidth,
+      getPosition0,
+      getPosition1,
+      getColor,
       ...opts
     });
   }
@@ -87,26 +97,29 @@ export default class LineLayer extends BaseLayer {
   }
 
   calculateInstancePositions(attribute) {
-    const {data} = this.props;
+    const {data, getPosition0, getPosition1} = this.props;
     const {value, size} = attribute;
     let i = 0;
-    for (const line of data) {
-      value[i + 0] = line.position.x0;
-      value[i + 1] = line.position.y0;
-      value[i + 2] = line.position.x1;
-      value[i + 3] = line.position.y1;
+    for (const object of data) {
+      const position0 = getPosition0(object);
+      const position1 = getPosition1(object);
+      value[i + 0] = position0[0];
+      value[i + 1] = position0[1];
+      value[i + 2] = position1[0];
+      value[i + 3] = position1[1];
       i += size;
     }
   }
 
   calculateInstanceColors(attribute) {
-    const {data} = this.props;
+    const {data, getColor} = this.props;
     const {value, size} = attribute;
     let i = 0;
-    for (const point of data) {
-      value[i + 0] = point.color[0];
-      value[i + 1] = point.color[1];
-      value[i + 2] = point.color[2];
+    for (const object of data) {
+      const color = getColor(object);
+      value[i + 0] = color[0];
+      value[i + 1] = color[1];
+      value[i + 2] = color[2];
       i += size;
     }
   }

--- a/src/layers/scatterplot-layer/scatterplot-layer.js
+++ b/src/layers/scatterplot-layer/scatterplot-layer.js
@@ -17,10 +17,13 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-
 import BaseLayer from '../base-layer';
 import {Model, Program, Geometry} from 'luma.gl';
 const glslify = require('glslify');
+
+const defaultGetPosition = x => x.position;
+const defaultGetRadius = x => x.radius;
+const defaultGetColor = x => x.color;
 
 export default class ScatterplotLayer extends BaseLayer {
   /*
@@ -31,8 +34,18 @@ export default class ScatterplotLayer extends BaseLayer {
    * @param {object} props
    * @param {number} props.radius - point radius
    */
-  constructor(props) {
-    super(props);
+  constructor({
+    getPosition = defaultGetPosition,
+    getRadius = defaultGetRadius,
+    getColor = defaultGetColor,
+    ...props
+  }) {
+    super({
+      getPosition,
+      getRadius,
+      getColor,
+      ...props
+    });
   }
 
   initializeState() {
@@ -94,31 +107,6 @@ export default class ScatterplotLayer extends BaseLayer {
     });
   }
 
-  calculateInstancePositions(attribute) {
-    const {data} = this.props;
-    const {value, size} = attribute;
-    let i = 0;
-    for (const point of data) {
-      value[i + 0] = point.position.x;
-      value[i + 1] = point.position.y;
-      value[i + 2] = point.position.z;
-      value[i + 3] = point.radius || 1;
-      i += size;
-    }
-  }
-
-  calculateInstanceColors(attribute) {
-    const {data} = this.props;
-    const {value, size} = attribute;
-    let i = 0;
-    for (const point of data) {
-      value[i + 0] = point.color[0];
-      value[i + 1] = point.color[1];
-      value[i + 2] = point.color[2];
-      i += size;
-    }
-  }
-
   calculateRadius() {
     // use radius if specified
     if (this.props.radius) {
@@ -135,4 +123,31 @@ export default class ScatterplotLayer extends BaseLayer {
     this.state.radius = Math.max(Math.sqrt(dx * dx + dy * dy), 2.0);
   }
 
+  calculateInstancePositions(attribute) {
+    const {data, getPosition, getRadius} = this.props;
+    const {value, size} = attribute;
+    let i = 0;
+    for (const point of data) {
+      const position = getPosition(point);
+      const radius = getRadius(point) || 1;
+      value[i + 0] = position[0];
+      value[i + 1] = position[1];
+      value[i + 2] = position[2];
+      value[i + 3] = radius;
+      i += size;
+    }
+  }
+
+  calculateInstanceColors(attribute) {
+    const {data, getColor} = this.props;
+    const {value, size} = attribute;
+    let i = 0;
+    for (const point of data) {
+      const color = getColor(point);
+      value[i + 0] = color[0];
+      value[i + 1] = color[1];
+      value[i + 2] = color[2];
+      i += size;
+    }
+  }
 }

--- a/src/layers/scatterplot-layer/scatterplot-layer.js
+++ b/src/layers/scatterplot-layer/scatterplot-layer.js
@@ -21,9 +21,11 @@ import BaseLayer from '../base-layer';
 import {Model, Program, Geometry} from 'luma.gl';
 const glslify = require('glslify');
 
+const DEFAULT_COLOR = [255, 0, 255];
+
 const defaultGetPosition = x => x.position;
 const defaultGetRadius = x => x.radius;
-const defaultGetColor = x => x.color;
+const defaultGetColor = x => x.color || DEFAULT_COLOR;
 
 export default class ScatterplotLayer extends BaseLayer {
   /*

--- a/test/layers-spec.js
+++ b/test/layers-spec.js
@@ -66,8 +66,8 @@ const FIXTURE = {
 
   choropleths: [], // CHOROPLETHS,
   hexagons: [],
-  points: [{position: [100, 100], color:[255, 0, 0]}],
-  arcs: [{startPosition: [0, 0], targetPosition: [1, 3], color:[255, 0, 0]}]
+  points: [{position: [100, 100]}],
+  arcs: [{sourcePosition: [0, 0], targetPosition: [1, 3]}]
 
 };
 


### PR DESCRIPTION
@gnavvy -  All positions now use array format and all layers use accessors that application can override. 

- Apps no longer have to transform data to a specific format to use deck.gl.
- Also apps can now pass any iterable objects (e.g. Immutable Lists) as deck.gl data props.

This is a breaking change that will be merged to dev branch and initially published in a 3.0.0 beta release.
