### PR TITLE
change bool uniform to float uniform

### DIFF
--- a/shaderlib/project.glsl
+++ b/shaderlib/project.glsl
@@ -2,7 +2,7 @@ const float TILE_SIZE = 512.0;
 const float PI = 3.1415926536;
 const float WORLD_SCALE = TILE_SIZE / (PI * 2.0);
 
-uniform bool disableMercatorProjector;
+uniform float disableMercatorProjector;
 uniform float mercatorScale;
 
 // non-linear projection: lnglats => unit tile [0-1, 0-1]
@@ -14,7 +14,7 @@ vec2 mercatorProject(vec2 lnglat) {
 }
 
 vec2 project(vec2 position) {
-  if (disableMercatorProjector) {
+  if (disableMercatorProjector == 1.0) {
     return (position + vec2(TILE_SIZE / 2.0)) * mercatorScale;
   } else {
     return mercatorProject(position) * WORLD_SCALE * mercatorScale;

--- a/src/layers/base-layer.js
+++ b/src/layers/base-layer.js
@@ -494,7 +494,7 @@ export default class BaseLayer {
       viewport: [0, 0, width, height],
       mercatorScale: Math.pow(2, zoom),
       mercatorCenter: [longitude, latitude],
-      disableMercatorProjector
+      disableMercatorProjector: disableMercatorProjector ? 1 : 0
     });
 
     log(3, this.state.viewport, latitude, longitude, zoom);


### PR DESCRIPTION
A trial fix for https://github.com/uber/deck.gl/issues/63, certain implementation of webgl has a regression in GLSL such that boolean uniforms cannot be used.