### PR TITLE
Fix picking

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "gl": "^4.0.1",
     "immutable": "^3.7.5",
     "jsdom": "^9.2.1",
-    "luma.gl": "^2.5.1",
+    "luma.gl": "^2.5.3",
     "react": "^15.0.2",
     "react-addons-test-utils": "^15.0.2",
     "react-dom": "^15.0.2",
@@ -85,7 +85,7 @@
   "peerDependencies": {
     "react": "0.14.x - 15.x",
     "react-dom": "0.14.x - 15.x",
-    "luma.gl": "^2.5.1"
+    "luma.gl": "^2.5.3"
   },
   "scripts": {
     "build": "npm run build-clean && npm run build-compile && npm run build-script && npm run build-script-min",

--- a/src/layers/base-layer.js
+++ b/src/layers/base-layer.js
@@ -396,7 +396,7 @@ export default class BaseLayer {
     this.willUnmount();
   }
 
-  calculateInstancePickingColors(attribute, numInstances) {
+  calculateInstancePickingColors(attribute, {numInstances}) {
     const {value, size} = attribute;
     // add 1 to index to seperate from no selection
     for (let i = 0; i < numInstances; i++) {


### PR DESCRIPTION
Fixes #73

@gnavvy @abmai @contra

Using the new luma logging it was easy to spot that the picking colors attribute was all zeroes. Fixed by a one line change to second parameter in `Layer.calculateInstancePickingColors`.

