### PR TITLE
add line width support for the choropleth layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ renders it as interactive choropleths.
   * `opacity` (number, required) opacity of the layer
   * `isPickable` [bool, optional, default=false] whether layer responses to
   mouse events
+  * `lineWidth` [number, optional, default=1] the line width of the contour
 
   **Layer-specific Parameters**
 

--- a/example/main.js
+++ b/example/main.js
@@ -396,7 +396,8 @@ class ExampleApp extends React.Component {
       zoom: mapViewState.zoom,
       data: choropleths,
       opacity: 0.8,
-      drawContour: true
+      drawContour: true,
+      strokeWidth: 2
     });
   }
 


### PR DESCRIPTION
currently, the choropleth layer uses a global line width for this contour.
that is, if other layers set the line width, the choropleth layer will pick that value, which is not desired.
this fix allows the user to specify the line width via the lineWidth prop.

@ibgreen