### PR TITLE
Additional fine tuning of fp64 functions and layers.

### DIFF
--- a/src/layers/fp64/scatterplot-layer/scatterplot-layer-fragment.glsl
+++ b/src/layers/fp64/scatterplot-layer/scatterplot-layer-fragment.glsl
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Uber Technologies, Inc.
+// Copyright (c) 2016 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/layers/fp64/scatterplot-layer/scatterplot-layer-vertex.glsl
+++ b/src/layers/fp64/scatterplot-layer/scatterplot-layer-vertex.glsl
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Uber Technologies, Inc.
+// Copyright (c) 2016 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/layers/fp64/scatterplot-layer/scatterplot-layer.js
+++ b/src/layers/fp64/scatterplot-layer/scatterplot-layer.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Uber Technologies, Inc.
+// Copyright (c) 2016 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/layers/shaderlib/fp64/cos-fp64.glsl
+++ b/src/layers/shaderlib/fp64/cos-fp64.glsl
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Uber Technologies, Inc.
+// Copyright (c) 2016 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -76,10 +76,8 @@ vec2 cos_fp64(vec2 a) {
         }
     }
 
-        int abs_k = int(abs(float(k)));
+    int abs_k = int(abs(float(k)));
 
-    // We just can't get PI/16 * 3.0 very accurately.
-    // so let's just store it
     if (abs_k > 4) {
         return vec2(0.0 / 0.0, 0.0 / 0.0);
     } else if (k == 3) {

--- a/src/layers/shaderlib/fp64/cos-taylor-fp64.glsl
+++ b/src/layers/shaderlib/fp64/cos-taylor-fp64.glsl
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Uber Technologies, Inc.
+// Copyright (c) 2016 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,10 +20,10 @@
 #pragma glslify: sum_fp64 = require(./sum-fp64, ONE=ONE)
 #pragma glslify: mul_fp64 = require(./mul-fp64, ONE=ONE)
 
-const vec2 inv_fact1 = vec2(4.16666679084301e-02, -1.2417634698280722e-09);
-const vec2 inv_fact3 = vec2(1.3888889225199819e-03, -3.3631094437103215e-11);
-const vec2 inv_fact5 = vec2(2.4801587642286904e-05, -3.406996025904184e-13);
-const vec2 inv_fact7 = vec2(2.755731998149713e-07, -7.575112367869873e-15);
+const vec2 INVERSE_FACTORIAL_4 = vec2(4.16666679084301e-02, -1.2417634698280722e-09); // 1/4!
+const vec2 INVERSE_FACTORIAL_6 = vec2(1.3888889225199819e-03, -3.3631094437103215e-11); // 1/6!
+const vec2 INVERSE_FACTORIAL_8 = vec2(2.4801587642286904e-05, -3.406996025904184e-13); // 1/8!
+const vec2 INVERSE_FACTORIAL_10 = vec2(2.755731998149713e-07, -7.575112367869873e-15); // 1/10!
 
 vec2 cos_taylor_fp64(vec2 a) {
   vec2 r, s, t, x;
@@ -37,19 +37,19 @@ vec2 cos_taylor_fp64(vec2 a) {
   s = sum_fp64(vec2(1.0, 0.0), r * 0.5);
 
   r = mul_fp64(r, x);
-  t = mul_fp64(r, inv_fact1);
+  t = mul_fp64(r, INVERSE_FACTORIAL_4);
   s = sum_fp64(s, t);
 
   r = mul_fp64(r, x);
-  t = mul_fp64(r, inv_fact3);
+  t = mul_fp64(r, INVERSE_FACTORIAL_6);
   s = sum_fp64(s, t);
 
   r = mul_fp64(r, x);
-  t = mul_fp64(r, inv_fact5);
+  t = mul_fp64(r, INVERSE_FACTORIAL_8);
   s = sum_fp64(s, t);
 
   r = mul_fp64(r, x);
-  t = mul_fp64(r, inv_fact7);
+  t = mul_fp64(r, INVERSE_FACTORIAL_10);
   s = sum_fp64(s, t);
 
   return s;

--- a/src/layers/shaderlib/fp64/div-fp64.glsl
+++ b/src/layers/shaderlib/fp64/div-fp64.glsl
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Uber Technologies, Inc.
+// Copyright (c) 2016 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/layers/shaderlib/fp64/exp-fp64.glsl
+++ b/src/layers/shaderlib/fp64/exp-fp64.glsl
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Uber Technologies, Inc.
+// Copyright (c) 2016 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -25,11 +25,11 @@
 const vec2 E = vec2(2.7182817459106445e+00, 8.254840366817007e-08);
 const vec2 LOG2 = vec2(0.6931471824645996e+00, -1.9046542121259336e-09);
 
-const vec2 inv_fact0 = vec2(1.666666716337204e-01, -4.967053879312289e-09);
-const vec2 inv_fact1 = vec2(4.16666679084301e-02, -1.2417634698280722e-09);
-const vec2 inv_fact2 = vec2(8.333333767950535e-03, -4.34617203337595e-10);
-const vec2 inv_fact3 = vec2(1.3888889225199819e-03, -3.3631094437103215e-11);
-const vec2 inv_fact4 = vec2(1.9841270113829523e-04,  -2.725596874933456e-12);
+const vec2 INVERSE_FACTORIAL_3 = vec2(1.666666716337204e-01, -4.967053879312289e-09); // 1/3!
+const vec2 INVERSE_FACTORIAL_4 = vec2(4.16666679084301e-02, -1.2417634698280722e-09); // 1/4!
+const vec2 INVERSE_FACTORIAL_5 = vec2(8.333333767950535e-03, -4.34617203337595e-10); // 1/5!
+const vec2 INVERSE_FACTORIAL_6 = vec2(1.3888889225199819e-03, -3.3631094437103215e-11); // 1/6!
+const vec2 INVERSE_FACTORIAL_7 = vec2(1.9841270113829523e-04,  -2.725596874933456e-12); // 1/7!
 
 vec2 exp_fp64(vec2 a) {
 
@@ -53,23 +53,23 @@ vec2 exp_fp64(vec2 a) {
   p = mul_fp64(r, r);
   s = sum_fp64(r, p * 0.5);
   p = mul_fp64(p, r);
-  t = mul_fp64(p, inv_fact0);
+  t = mul_fp64(p, INVERSE_FACTORIAL_3);
 
   s = sum_fp64(s, t);
   p = mul_fp64(p, r);
-  t = mul_fp64(p, inv_fact1);
+  t = mul_fp64(p, INVERSE_FACTORIAL_4);
 
   s = sum_fp64(s, t);
   p = mul_fp64(p, r);
-  t = mul_fp64(p, inv_fact2);
+  t = mul_fp64(p, INVERSE_FACTORIAL_5);
 
   s = sum_fp64(s, t);
   p = mul_fp64(p, r);
-  t = mul_fp64(p, inv_fact3);
+  t = mul_fp64(p, INVERSE_FACTORIAL_6);
 
   s = sum_fp64(s, t);
   p = mul_fp64(p, r);
-  t = mul_fp64(p, inv_fact4);
+  t = mul_fp64(p, INVERSE_FACTORIAL_7);
 
   s = sum_fp64(s, t);
 

--- a/src/layers/shaderlib/fp64/log-fp64.glsl
+++ b/src/layers/shaderlib/fp64/log-fp64.glsl
@@ -1,5 +1,4 @@
-
-// Copyright (c) 2015 Uber Technologies, Inc.
+// Copyright (c) 2016 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/layers/shaderlib/fp64/mat4-vec4-mul-fp64.glsl
+++ b/src/layers/shaderlib/fp64/mat4-vec4-mul-fp64.glsl
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Uber Technologies, Inc.
+// Copyright (c) 2016 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/layers/shaderlib/fp64/mul-fp64.glsl
+++ b/src/layers/shaderlib/fp64/mul-fp64.glsl
@@ -1,5 +1,4 @@
-
-// Copyright (c) 2015 Uber Technologies, Inc.
+// Copyright (c) 2016 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/layers/shaderlib/fp64/nint-fp64.glsl
+++ b/src/layers/shaderlib/fp64/nint-fp64.glsl
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Uber Technologies, Inc.
+// Copyright (c) 2016 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,8 +20,7 @@
 
 #pragma glslify: quickTwoSum = require(./quickTwoSum, ONE=ONE)
 
-float nint(float d)
-{
+float nint(float d) {
     if (d == floor(d)) return d;
     return floor(d + 0.5);
 }

--- a/src/layers/shaderlib/fp64/project-fp64.glsl
+++ b/src/layers/shaderlib/fp64/project-fp64.glsl
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Uber Technologies, Inc.
+// Copyright (c) 2016 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -17,13 +17,12 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+#pragma glslify: sub_fp64 = require(./sub-fp64, ONE=ONE)
 #pragma glslify: sum_fp64 = require(./sum-fp64, ONE=ONE)
 #pragma glslify: mul_fp64 = require(./mul-fp64, ONE=ONE)
 #pragma glslify: radians_fp64 = require(./radians-fp64, ONE=ONE)
-
-const float TILE_SIZE = 512.0;
-const float PI = 3.1415926536;
-const float WORLD_SCALE = TILE_SIZE / (PI * 2.0);
+#pragma glslify: log_fp64 = require(./log-fp64, ONE=ONE)
+#pragma glslify: tan_fp64 = require(./tan-fp64, ONE=ONE)
 
 const vec2 PI_FP64 = vec2(3.1415927410125732, -8.742278012618954e-8);
 const vec2 WORLD_SCALE_FP64 = vec2(81.4873275756836, 0.0000032873668232014097);
@@ -35,7 +34,7 @@ uniform vec2 mercatorScaleFP64;
 void mercatorProject_fp64(vec4 lnglat_fp64, out vec2 out_val[2]) { //longitude: lnglat_fp64.xy; latitude: lnglat_fp64.zw
 
   out_val[0] = sum_fp64(radians_fp64(lnglat_fp64.xy), PI_FP64);
-  out_val[1] = vec2(PI - log(tan(PI * 0.25 + radians(lnglat_fp64.z) * 0.5)), 0.0);
+  out_val[1] = sub_fp64(PI_FP64, log_fp64(tan_fp64(sum_fp64(PI_FP64 * 0.25, radians_fp64(lnglat_fp64.zw) * 0.5))));
   return;
 }
 void project_fp64(vec4 position_fp64, out vec2 out_val[2]) {

--- a/src/layers/shaderlib/fp64/quickTwoSum.glsl
+++ b/src/layers/shaderlib/fp64/quickTwoSum.glsl
@@ -1,5 +1,4 @@
-
-// Copyright (c) 2015 Uber Technologies, Inc.
+// Copyright (c) 2016 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/layers/shaderlib/fp64/radians-fp64.glsl
+++ b/src/layers/shaderlib/fp64/radians-fp64.glsl
@@ -1,5 +1,4 @@
-
-// Copyright (c) 2015 Uber Technologies, Inc.
+// Copyright (c) 2016 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -21,10 +20,10 @@
 #pragma glslify: mul_fp64 = require(./mul-fp64, ONE=ONE)
 #pragma glslify: div_fp64 = require(./div-fp64, ONE=ONE)
 
-const vec2 PI_fp64 = vec2(3.1415927410125732, -8.742278012618954e-8);
+const vec2 PI_FP64 = vec2(3.1415927410125732, -8.742278012618954e-8);
 
 vec2 radians_fp64(vec2 degree) {
-  return div_fp64(mul_fp64(degree, PI_fp64), vec2(180.0, 0.0));
+  return mul_fp64(div_fp64(degree, vec2(180.0, 0.0)), PI_FP64);
 }
 
 #pragma glslify: export(radians_fp64)

--- a/src/layers/shaderlib/fp64/sin-fp64.glsl
+++ b/src/layers/shaderlib/fp64/sin-fp64.glsl
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Uber Technologies, Inc.
+// Copyright (c) 2016 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -78,8 +78,6 @@ vec2 sin_fp64(vec2 a) {
 
     int abs_k = int(abs(float(k)));
 
-    // We just can't get PI/16 * 3.0 very accurately.
-    // so let's just store it
     if (abs_k > 4) {
         return vec2(0.0 / 0.0, 0.0 / 0.0);
     } else if (k == 3) {

--- a/src/layers/shaderlib/fp64/sin-taylor-fp64.glsl
+++ b/src/layers/shaderlib/fp64/sin-taylor-fp64.glsl
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Uber Technologies, Inc.
+// Copyright (c) 2016 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,11 +20,10 @@
 #pragma glslify: sum_fp64 = require(./sum-fp64, ONE=ONE)
 #pragma glslify: mul_fp64 = require(./mul-fp64, ONE=ONE)
 
-const vec2 inv_fact0 = vec2(1.666666716337204e-01, -4.967053879312289e-09);
-const vec2 inv_fact2 = vec2(8.333333767950535e-03, -4.34617203337595e-10);
-const vec2 inv_fact4 = vec2(1.9841270113829523e-04,  -2.725596874933456e-12);
-const vec2 inv_fact6 = vec2(2.75573188446287533e-06, 3.7935713937038186e-14);
-const vec2 inv_fact8 = vec2(2.5052107943679403e-08, 4.4176231769972645e-16);
+const vec2 INVERSE_FACTORIAL_3 = vec2(1.666666716337204e-01, -4.967053879312289e-09); // 1/3!
+const vec2 INVERSE_FACTORIAL_5 = vec2(8.333333767950535e-03, -4.34617203337595e-10); // 1/5!
+const vec2 INVERSE_FACTORIAL_7 = vec2(1.9841270113829523e-04,  -2.725596874933456e-12); // 1/7!
+const vec2 INVERSE_FACTORIAL_9 = vec2(2.75573188446287533e-06, 3.7935713937038186e-14); // 1/9!
 
 vec2 sin_taylor_fp64(vec2 a) {
   vec2 r, s, t, x;
@@ -38,19 +37,19 @@ vec2 sin_taylor_fp64(vec2 a) {
   r = a;
 
   r = mul_fp64(r, x);
-  t = mul_fp64(r, inv_fact0);
+  t = mul_fp64(r, INVERSE_FACTORIAL_3);
   s = sum_fp64(s, t);
 
   r = mul_fp64(r, x);
-  t = mul_fp64(r, inv_fact2);
+  t = mul_fp64(r, INVERSE_FACTORIAL_5);
   s = sum_fp64(s, t);
 
   r = mul_fp64(r, x);
-  t = mul_fp64(r, inv_fact4);
+  t = mul_fp64(r, INVERSE_FACTORIAL_7);
   s = sum_fp64(s, t);
 
   r = mul_fp64(r, x);
-  t = mul_fp64(r, inv_fact6);
+  t = mul_fp64(r, INVERSE_FACTORIAL_9);
   s = sum_fp64(s, t);
 
   return s;

--- a/src/layers/shaderlib/fp64/sincos-taylor-fp64.glsl
+++ b/src/layers/shaderlib/fp64/sincos-taylor-fp64.glsl
@@ -1,3 +1,22 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 #pragma glslify: sub_fp64 = require(./sub-fp64, ONE=ONE)
 #pragma glslify: mul_fp64 = require(./mul-fp64, ONE=ONE)
 #pragma glslify: sqrt_fp64 = require(./sqrt-fp64, ONE=ONE)

--- a/src/layers/shaderlib/fp64/split.glsl
+++ b/src/layers/shaderlib/fp64/split.glsl
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Uber Technologies, Inc.
+// Copyright (c) 2016 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/layers/shaderlib/fp64/sqrt-fp64.glsl
+++ b/src/layers/shaderlib/fp64/sqrt-fp64.glsl
@@ -1,5 +1,4 @@
-
-// Copyright (c) 2015 Uber Technologies, Inc.
+// Copyright (c) 2016 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/layers/shaderlib/fp64/sub-fp64.glsl
+++ b/src/layers/shaderlib/fp64/sub-fp64.glsl
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Uber Technologies, Inc.
+// Copyright (c) 2016 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/layers/shaderlib/fp64/sum-fp64.glsl
+++ b/src/layers/shaderlib/fp64/sum-fp64.glsl
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Uber Technologies, Inc.
+// Copyright (c) 2016 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/layers/shaderlib/fp64/tan-fp64.glsl
+++ b/src/layers/shaderlib/fp64/tan-fp64.glsl
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Uber Technologies, Inc.
+// Copyright (c) 2016 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/layers/shaderlib/fp64/twoProd.glsl
+++ b/src/layers/shaderlib/fp64/twoProd.glsl
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Uber Technologies, Inc.
+// Copyright (c) 2016 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -26,7 +26,7 @@ vec2 twoProd(float a, float b) {
   float prod = a * b;
   vec2 a_fp64 = split(a);
   vec2 b_fp64 = split(b);
-  float err =  a_fp64.y * b_fp64.y - (((prod - a_fp64.x * b_fp64.x) * ONE - a_fp64.x * b_fp64.y) * ONE -
+  float err =  a_fp64.y * b_fp64.y * ONE - (((prod - a_fp64.x * b_fp64.x) * ONE - a_fp64.x * b_fp64.y) * ONE -
     a_fp64.y * b_fp64.x) * ONE;
   return vec2(prod, err);
 }

--- a/src/layers/shaderlib/fp64/twoSqr.glsl
+++ b/src/layers/shaderlib/fp64/twoSqr.glsl
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Uber Technologies, Inc.
+// Copyright (c) 2016 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/layers/shaderlib/fp64/twoSub.glsl
+++ b/src/layers/shaderlib/fp64/twoSub.glsl
@@ -1,5 +1,4 @@
-
-// Copyright (c) 2015 Uber Technologies, Inc.
+// Copyright (c) 2016 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,7 +23,7 @@
 vec2 twoSub(float a, float b) {
   float s = (a - b) * ONE;
   float v = (s - a) * ONE;
-  float err = (a - (s - v)) - (b + v) * ONE;
+  float err = (a - (s - v)) * ONE - (b + v) * ONE;
   return vec2(s, err);
 }
 

--- a/src/layers/shaderlib/fp64/twoSum.glsl
+++ b/src/layers/shaderlib/fp64/twoSum.glsl
@@ -1,5 +1,4 @@
-
-// Copyright (c) 2015 Uber Technologies, Inc.
+// Copyright (c) 2016 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,7 +23,7 @@
 vec2 twoSum(float a, float b) {
   float s = (a + b) * ONE;
   float v = (s - a) * ONE;
-  float err = (a - (s - v)) + (b - v) * ONE;
+  float err = (a - (s - v))  * ONE + (b - v) * ONE;
   return vec2(s, err);
 }
 

--- a/src/layers/shaderlib/fp64/vec4-dot-fp64.glsl
+++ b/src/layers/shaderlib/fp64/vec4-dot-fp64.glsl
@@ -1,5 +1,4 @@
-
-// Copyright (c) 2015 Uber Technologies, Inc.
+// Copyright (c) 2016 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/layers/shaderlib/fp64/vec4-fp64.glsl
+++ b/src/layers/shaderlib/fp64/vec4-fp64.glsl
@@ -1,5 +1,4 @@
-
-// Copyright (c) 2015 Uber Technologies, Inc.
+// Copyright (c) 2016 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -18,8 +17,6 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-
-
 
 void vec4_fp64(vec4 a, out vec2 out_val[4]) {
   out_val[0].x = a[0];

--- a/src/layers/shaderlib/fp64/vec4-scalar-mul-fp64.glsl
+++ b/src/layers/shaderlib/fp64/vec4-scalar-mul-fp64.glsl
@@ -1,5 +1,4 @@
-
-// Copyright (c) 2015 Uber Technologies, Inc.
+// Copyright (c) 2016 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/layers/shaderlib/fp64/vec4-sum-fp64.glsl
+++ b/src/layers/shaderlib/fp64/vec4-sum-fp64.glsl
@@ -1,5 +1,4 @@
-
-// Copyright (c) 2015 Uber Technologies, Inc.
+// Copyright (c) 2016 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/test/shader.js
+++ b/src/test/shader.js
@@ -192,12 +192,6 @@ function checkError(result, reference)
   line = "GPU output: (" + result[0].toString() + ',' + result[1].toString() + ',' + result[2].toString() + ',' + result[3].toString() + ")<br>";
   addSpan(line, currentDiv);
 
-  console.log(reference[0]);
-  console.log(reference[1]);
-
-  console.log(result[0]);
-  console.log(result[1]);
-
   var referenceBits = new Int32Array(reference.buffer);
   var resultBits = new Int32Array(result.buffer);
 
@@ -620,8 +614,8 @@ function test_float_tan(gl, testName) {
   addSpan(line, currentDiv);
   return float_ref_vec2;
 }
-// Main entrance
 
+// Main entrance
 window.onload = () => {
   const canvas = document.createElement('canvas');
   document.body.appendChild(canvas);
@@ -638,129 +632,12 @@ window.onload = () => {
   var test_no = 0;
   const loop = 30;
 
-  // for (idx0 = 0; idx0 < loop; idx0++) {
-
-  //   var currentDiv = addDiv();
-  //   addSpan("------------------------", currentDiv);
-  //   addSpan("Loop No. " + test_no++, currentDiv);
-
-  //   var cpu_result = test_float_add(gl, "Float addition test");
-
-  //   render(gl);
-
-  //   var gpu_result = getGPUOutput(gl);
-
-  //   checkError(gpu_result, cpu_result);
-
-  //   addSpan("------------------------", currentDiv);
-
-  // }
-  // for (idx0 = 0; idx0 < loop; idx0++) {
-
-  //   var currentDiv = addDiv();
-  //   addSpan("------------------------", currentDiv);
-  //   addSpan("Loop No. " + test_no++, currentDiv);
-
-  //   var cpu_result = test_float_sub(gl, "Float subtraction test");
-
-  //   render(gl);
-
-  //   var gpu_result = getGPUOutput(gl);
-
-  //   checkError(gpu_result, cpu_result);
-
-  //   addSpan("------------------------", currentDiv);
-
-  // }
-  // for (idx0 = 0; idx0 < loop; idx0++) {
-  //   var currentDiv = addDiv();
-  //   addSpan("------------------------", currentDiv);
-  //   addSpan("Loop No. " + test_no++, currentDiv);
-
-  //   var cpu_result = test_float_mul(gl, "Float multiplication test");
-
-  //   render(gl);
-
-  //   var gpu_result = getGPUOutput(gl);
-
-  //   checkError(gpu_result, cpu_result);
-
-  //   addSpan("------------------------", currentDiv);
-
-  // }
-
-  // for (idx0 = 0; idx0 < loop; idx0++) {
-  //   var currentDiv = addDiv();
-  //   addSpan("------------------------", currentDiv);
-  //   addSpan("Loop No. " + test_no++, currentDiv);
-
-  //   var cpu_result = test_float_div(gl, "Float division test");
-
-  //   render(gl);
-
-  //   var gpu_result = getGPUOutput(gl);
-
-  //   checkError(gpu_result, cpu_result);
-
-  //   addSpan("------------------------", currentDiv);
-  // }
-
-  // for (idx0 = 0; idx0 < loop; idx0++) {
-  //   var currentDiv = addDiv();
-  //   addSpan("------------------------", currentDiv);
-  //   addSpan("Loop No. " + test_no++, currentDiv);
-
-  //   var cpu_result = test_float_sqrt(gl, "Float sqrt test");
-
-  //   render(gl);
-
-  //   var gpu_result = getGPUOutput(gl);
-
-  //   checkError(gpu_result, cpu_result);
-
-  //   addSpan("------------------------", currentDiv);
-
-  // }
-
-  // for (idx0 = 0; idx0 < loop; idx0++) {
-  //   var currentDiv = addDiv();
-  //   addSpan("------------------------", currentDiv);
-  //   addSpan("Loop No. " + test_no++, currentDiv);
-
-  //   var cpu_result = test_float_exp(gl, "Float exp test");
-
-  //   render(gl);
-
-  //   var gpu_result = getGPUOutput(gl);
-
-  //   checkError(gpu_result, cpu_result);
-
-  //   addSpan("------------------------", currentDiv);
-
-  // }
-
-  // for (idx0 = 0; idx0 < loop; idx0++) {
-  //   var currentDiv = addDiv();
-  //   addSpan("------------------------", currentDiv);
-  //   addSpan("Loop No. " + test_no++, currentDiv);
-
-  //   var cpu_result = test_float_log(gl, "Float log test");
-
-  //   render(gl);
-
-  //   var gpu_result = getGPUOutput(gl);
-
-  //   checkError(gpu_result, cpu_result);
-
-  //   addSpan("------------------------", currentDiv);
-
-  // }
   for (idx0 = 0; idx0 < loop; idx0++) {
     var currentDiv = addDiv();
     addSpan("------------------------", currentDiv);
     addSpan("Loop No. " + test_no++, currentDiv);
 
-    var cpu_result = test_float_sin(gl, "Float sin test");
+    var cpu_result = test_float_add(gl, "Float addition test");
 
     render(gl);
 
@@ -769,8 +646,154 @@ window.onload = () => {
     checkError(gpu_result, cpu_result);
 
     addSpan("------------------------", currentDiv);
+  }
+
+  for (idx0 = 0; idx0 < loop; idx0++) {
+    var currentDiv = addDiv();
+    addSpan("------------------------", currentDiv);
+    addSpan("Loop No. " + test_no++, currentDiv);
+
+    var cpu_result = test_float_sub(gl, "Float subtraction test");
+
+    render(gl);
+
+    var gpu_result = getGPUOutput(gl);
+
+    checkError(gpu_result, cpu_result);
+
+    addSpan("------------------------", currentDiv);
+  }
+
+  for (idx0 = 0; idx0 < loop; idx0++) {
+    var currentDiv = addDiv();
+    addSpan("------------------------", currentDiv);
+    addSpan("Loop No. " + test_no++, currentDiv);
+
+    var cpu_result = test_float_mul(gl, "Float multiplication test");
+
+    render(gl);
+
+    var gpu_result = getGPUOutput(gl);
+
+    checkError(gpu_result, cpu_result);
+
+    addSpan("------------------------", currentDiv);
+  }
+
+  for (idx0 = 0; idx0 < loop; idx0++) {
+    var currentDiv = addDiv();
+    addSpan("------------------------", currentDiv);
+    addSpan("Loop No. " + test_no++, currentDiv);
+
+    var cpu_result = test_float_div(gl, "Float division test");
+
+    render(gl);
+
+    var gpu_result = getGPUOutput(gl);
+
+    checkError(gpu_result, cpu_result);
+
+    addSpan("------------------------", currentDiv);
+  }
+
+  for (idx0 = 0; idx0 < loop; idx0++) {
+    var currentDiv = addDiv();
+    addSpan("------------------------", currentDiv);
+    addSpan("Loop No. " + test_no++, currentDiv);
+
+    var cpu_result = test_float_sqrt(gl, "Float sqrt test");
+
+    render(gl);
+
+    var gpu_result = getGPUOutput(gl);
+
+    checkError(gpu_result, cpu_result);
+
+    addSpan("------------------------", currentDiv);
+  }
+
+  for (idx0 = 0; idx0 < loop; idx0++) {
+    var currentDiv = addDiv();
+    addSpan("------------------------", currentDiv);
+    addSpan("Loop No. " + test_no++, currentDiv);
+
+    var cpu_result = test_float_exp(gl, "Float exp test");
+
+    render(gl);
+
+    var gpu_result = getGPUOutput(gl);
+
+    checkError(gpu_result, cpu_result);
+
+    addSpan("------------------------", currentDiv);
+  }
+
+  for (idx0 = 0; idx0 < loop; idx0++) {
+    var currentDiv = addDiv();
+    addSpan("------------------------", currentDiv);
+    addSpan("Loop No. " + test_no++, currentDiv);
+
+    var cpu_result = test_float_log(gl, "Float log test");
+
+    render(gl);
+
+    var gpu_result = getGPUOutput(gl);
+
+    checkError(gpu_result, cpu_result);
+
+    addSpan("------------------------", currentDiv);
+  }
+  for (idx0 = 0; idx0 < loop; idx0++) {
+    var currentDiv = addDiv();
+    addSpan("------------------------", currentDiv);
+    addSpan("Loop No. " + test_no++, currentDiv);
+
+    var cpu_result = test_float_sin(gl, "Float sin test");
+
+  //   render(gl);
+
+  //   var gpu_result = getGPUOutput(gl);
+
+  //   checkError(gpu_result, cpu_result);
+
+  //   addSpan("------------------------", currentDiv);
 
   }
+  for (idx0 = 0; idx0 < loop; idx0++) {
+    var currentDiv = addDiv();
+    addSpan("------------------------", currentDiv);
+    addSpan("Loop No. " + test_no++, currentDiv);
+
+    var cpu_result = test_float_cos(gl, "Float cos test");
+
+  //   render(gl);
+
+  //   var gpu_result = getGPUOutput(gl);
+
+  //   checkError(gpu_result, cpu_result);
+
+  //   addSpan("------------------------", currentDiv);
+
+
+  }
+
+  for (idx0 = 0; idx0 < loop; idx0++) {
+    var currentDiv = addDiv();
+    addSpan("------------------------", currentDiv);
+    addSpan("Loop No. " + test_no++, currentDiv);
+
+
+    var cpu_result = test_float_tan(gl, "Float tan test");
+
+    render(gl);
+
+    var gpu_result = getGPUOutput(gl);
+
+    checkError(gpu_result, cpu_result);
+
+    addSpan("------------------------", currentDiv);
+  }
+
   for (idx0 = 0; idx0 < loop; idx0++) {
     var currentDiv = addDiv();
     addSpan("------------------------", currentDiv);
@@ -785,8 +808,8 @@ window.onload = () => {
     checkError(gpu_result, cpu_result);
 
     addSpan("------------------------", currentDiv);
-
   }
+
   for (idx0 = 0; idx0 < loop; idx0++) {
     var currentDiv = addDiv();
     addSpan("------------------------", currentDiv);
@@ -801,7 +824,6 @@ window.onload = () => {
     checkError(gpu_result, cpu_result);
 
     addSpan("------------------------", currentDiv);
-
   }
 
 }


### PR DESCRIPTION
Fixed a bug in the Nvidia workaround path in twoSub, twoSum and twoProd functions. This bug shows itself through the sin/cos/tan function testings.

Made project-fp64() using the recently implemented log_fp64() and tan_fp64() so the mercator projection by GPU is truly high precision.

Other than that, mostly coding style and other miscellaneous changes addressing previous review comments.
1) Fixed a few lines of code left from debugging
2) Fixed the copy right notice in shader files
3) Constant name changes according to conventions

Please review @gnavvy @ibgreen