### PR TITLE
Extend the far plane to show models with negative z coord

### DIFF
--- a/src/viewport/viewport.js
+++ b/src/viewport/viewport.js
@@ -428,7 +428,7 @@ export default class Viewport {
       2 * Math.atan((this.height / 2) / this.altitude),
       this.width / this.height,
       0.1,
-      this.farZ
+      this.farZ * 10.0
     );
 
     // Move camera to altitude


### PR DESCRIPTION
Extend the far plane for creating the perspective projection matrix so that models with negative height are also shown

@Pessimistress @ibgreen