### PR TITLE
Expose a `pick` lifecycle method that layers can override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to deck.gl will be documented in this file.
 ### Beta-3.0.0 Releases
 
 #### [dev] -
+ - FEATURE: `Layer.pick` lifecycle method - Let's layers take control of picking
  - FEATURE: Support for Composite Layers
  - FEATURE: new GeoJsonLayer - Initial composite layer, only Polygons for now.
  - BREAKING: Introducing `context` that is shared between layers.

--- a/README.md
+++ b/README.md
@@ -27,15 +27,11 @@ Features:
   (supporting \[Symbol.iterator\] iteration).
 - Automatic and manual WebGL buffer management to support.
 
+
 ## Installation
 
 ```
 npm install --save deck.gl
-```
-Note: deck.gl has a dependency on node version 0.12 or higher. If you use an older version, you can install a node version manager like nvm and use a separate shell to install and build deck.gl
-```
-npm install -g nvm && nvm install 0.12 && nvm use 0.12
-```
 
 ## Usage
 
@@ -59,254 +55,21 @@ const mapState = {
   layers={[/* put layer instances here */]}
 />
 ```
+
 ---
-
-### DeckGLOverlay:
-
-* **deckgl-overlay**
-A react component that takes in viewport parameters, layer instances and
-generates an overlay consists of single/multiple layers sharing the same
-rendering context. Internally, the deckgl-overlay initializes a WebGL context
-attached to a canvas element, sets up the animation loop and calls provided
-callbacks on initial load and for each rendering frames. The deckgl-overlay
-also handles events propagation across layers, and prevents unnecessary
-calculation taking advantage of the react lifecycle functions.
-
-  **Parameters**
-  * `id` (string, optional) canvas ID for customizing styling
-  * `width` (number, required) width of the canvas
-  * `height` (number, required) height of the canvas
-  * `layers` (array, required) the list of layers to be rendered
-  * `blending` (object, optional) blending settings
-  * `gl` (object, optional) gl context
-  * `debug` (bool, optional) boolean flag for enabling debug mode
-  * `camera` (Camera, optional) a luma.gl camera instance
-  * `style` (object, optional) css styles for the deckgl-canvas
-  * `pixelRatio` (number, optional) pixelRatio, will use device ratio by default
-
-  **Callbacks**
-  * `onWebGLInitialized` [function, optional] callback on initiating gl-context
-
-### Supported Layers:
-
-* #### Choropleth Layer
-The Choropleth Layer takes in [GeoJson](http://geojson.org/) formatted data and
-renders it as interactive choropleths.
-
-  **Common Parameters**
-
-  * `id` (string, required): layer ID
-  * `width` (number, required) width of the layer
-  * `height` (number, required) height of the layer
-  * `longitude` (number, required) longitude of the map center
-  * `latitude` (number, required) latitude of the map center
-  * `zoom` (number, required) zoom level of the map
-  * `opacity` (number, required) opacity of the layer
-  * `isPickable` [bool, optional, default=false] whether layer responses to
-  mouse events
-
-  **Layer-specific Parameters**
-
-  * `data` (object, required) input data in GeoJson format
-  * `drawContour` [bool, optional, default=false] draw choropleth contour if
-  true, else fill choropleth area
-
-  **Callbacks**
-
-  * `onChoroplethHovered` [function, optional] bubbles choropleth properties
-  when mouse hovering
-  * `onChoroplethClicked` [function, optional] bubbles choropleth properties
-  when mouse clicking
-
-* #### Hexagon Layer
-  The Hexagon Layer takes in a list of hexagon objects and renders them as
-  interactive hexagons.
-
-    **Common Parameters**
-
-    * `id` (string, required): layer ID
-    * `width` (number, required) width of the layer
-    * `height` (number, required) height of the layer
-    * `longitude` (number, required) longitude of the map center
-    * `latitude` (number, required) latitude of the map center
-    * `zoom` (number, required) zoom level of the map
-    * `opacity` (number, required) opacity of the layer
-    * `isPickable` [bool, optional, default=false] whether layer responses to
-    mouse events
-
-    **Layer-specific Parameters**
-
-    * `data` (array, required) array of hexagon objects: [{ centroid, vertices,
-    color }, ...]
-    * `dotRadius` [number, optional, default=10] radius of each hexagon
-    * `elevation` [number, optional, default=0.02] height scale of hexagons
-    * `lightingEnabled` [bool, optional, default=false] whether lighting is
-    enabled
-
-    **Callbacks**
-
-    * `onHexagonHovered` [function, optional] bubbles selection index when mouse
-    hovering
-    * `onHexagonClicked` [function, optional] bubbles selection index when mouse
-    clicking
-
-* #### Scatterplot Layer
-  The Scatterplot Layer takes in and renders an array of latitude and longitude
-  coordinated points.
-
-    **Common Parameters**
-
-    * `id` (string, required): layer ID
-    * `width` (number, required) width of the layer
-    * `height` (number, required) height of the layer
-    * `longitude` (number, required) longitude of the map center
-    * `latitude` (number, required) latitude of the map center
-    * `zoom` (number, required) zoom level of the map
-    * `opacity` (number, required) opacity of the layer
-    * `isPickable` [bool, optional, default=false] whether layer responses to
-    mouse events
-
-    **Layer-specific Parameters**
-
-    * `data` (array, required) array of objects: [{ position, color, radius }, ...]
-    * `radius` [number, optional, default=10] global radius across all markers
-
-* #### Arc Layer
-  The Arc Layer takes in paired latitude and longitude coordinated points and
-  render them as arcs that links the starting and ending points.
-
-    **Common Parameters**
-
-    * `id` (string, required): layer ID
-    * `width` (number, required) width of the layer
-    * `height` (number, required) height of the layer
-    * `longitude` (number, required) longitude of the map center
-    * `latitude` (number, required) latitude of the map center
-    * `zoom` (number, required) zoom level of the map
-    * `opacity` (number, required) opacity of the layer
-    * `isPickable` [bool, optional, default=false] whether layer responses to
-    mouse events
-
-    **Layer-specific Parameters**
-
-    * `data` (array, required) array of objects: [{ position: {x0, y0, x1, y1},
-    color }, ...]
-
-* #### Grid Layer
-  The Grid Layer takes in an array of latitude and longitude coordinated points,
-  aggregates them into histogram bins and renders as a grid.
-
-    **Common Parameters**
-
-    * `id` (string, required): layer ID
-    * `width` (number, required) width of the layer
-    * `height` (number, required) height of the layer
-    * `longitude` (number, required) longitude of the map center
-    * `latitude` (number, required) latitude of the map center
-    * `zoom` (number, required) zoom level of the map
-    * `opacity` (number, required) opacity of the layer
-    * `isPickable` [bool, optional, default=false] whether layer responses to
-    mouse events
-
-    **Layer-specific Parameters**
-
-    * `data` (array, required) array of objects: [{ position, color }, ...]
-    * `unitWidth` [number, optional, default=100] unit width of the bins
-    * `unitHeight` [number, optional, default=100] unit height of the bins
-
-
-## Notes on data property
-
-The `data` property will accept any containers that can be iterated over using
-ES6 for-of iteration, this includes e.g. native Arrays, ES6 Sets and Maps,
-all Immutable.js containers etc. The notable exception are native JavaScript
-object maps. It is recommended to use ES6 Maps instead.
-
-It is recommended, but not required, to use immutable data (containers AND
-objects) as it ensures that changes to `data` property trigger a rerender.
-(See the notes on `rerenderCount` and `updateCount` properties.)
-
-
-## Notes on picking
-
-**Note**: Because DeckGL layers are designed to take any type of iterable
-collection as data (which may not support "random access" array style
-references of its elements), the picking calculates and index but the
-actual object.
-
-FEATURE IDEA: The base layer could take an optional getObject(index) accessor
-and call it if supplied.
-
-
-## Notes on WebGL buffer management
-
-deck.gl Layers were designed with data flow architectures like React in mind.
-The challenge is of course that in the react model, every change to application
-state causes a full rerender. The rendering callbacks are then supposed to
-detect what changes were made a limit rerendering as appropriate. When you
-have a couple of 100K element WebGL buffers to update, this can become quite
-expensive unless change detection is well managed.
-
-
-### Data Management using automatic Buffer updates
-
-The layer will expect each object to provide a number of "attributes" that it
-can use to set the GL buffers. By default, the layer will look for these
-attributes to be available as fields directly on the objects during iteration
-over the supplied data set. To gain more control of attribute access and/or
-to do on-the-fly calculation of attributes.
-
-
-### Manual Buffer Management
-
-For ultimate performance and control of updates, the application can do its
-own management of the glbuffers. Each Layer can accept buffers directly as
-props.
-
-**Note:** The application can provide some buffers and let others be managed
-by the layer. As an example management of the `instancePickingColors` buffer is
-normally left to the layer.
-
-**Note**: A layer only renders when a property change is detected. For
-performance reasons, property change detection uses shallow compare,
-which means that mutating an element inside a buffer or a mutable data array
-does not register as a property change, and thus does not trigger a rerender.
-To force trigger a render after mutating buffers, simply increment the
-`renderCount` property. To force trigger a buffer update after mutating data,
-increment the `updateCount` property.
-
-
-## Notes on Blending Modes
-
-To get a handle on blending modes, it helps to consider that deck.gl
-renders in a separate transparent div on top of the map div,
-so it is actually the browser that blends the deck.gl output into the map,
-not WebGL, and the default blending in the browser typically does not give
-ideal effects.
-
-There is a CSS property `mix-blend-mode` in modern browsers
-that allows control over blending:
-```
-.overlays canvas {
-  mix-blend-mode: multiply;
-}
-```
-`multiply` blend mode is usually the right choice, as it only darkens.
-This will keep your overlay colors, but let map legends underneath
-remain black and legible.
-
-**Note:** that there is a caveat with setting `mix-blend-mode`:
-it can affect other peer HTML elements, especially other map children (perhaps
-controls or legends that are being rendered on top of the map).
-If this is an issue, set isolation CSS prop on the map (DeckGLOverlay parent)
-element.
-```
-     isolation: 'isolate'
-```
 
 ## Example
 ```
 npm run start
+```
+
+```
+Note: **Building** deck.gl (not importing) has a dependency on node
+version 0.12 or higher. If you use an older version, you can install
+a node version manager like nvm and use a separate shell to install
+and build deck.gl
+```
+npm install -g nvm && nvm install 0.12 && nvm use 0.12
 ```
 
 ## Data source

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,16 @@
+# Getting Started
+
+
+## Learning deck.gl
+
+How you approach learning deck.gl will probably depend on your previous
+knowledge and how you want to use it.
+
+
+### Understanding WebGL
+
+
+### Understanding Reactive / Dataflow Architecture
+
+The key to writing good, performant deck.gl layers lies in understanding
+how to minimize updates of any calculated data, such as WebGL.

--- a/src/lib/layer-manager.js
+++ b/src/lib/layer-manager.js
@@ -28,6 +28,7 @@ import {Viewport} from '../viewport';
 import {fp64ify} from '../lib/utils/fp64';
 import {log} from './utils';
 import assert from 'assert';
+import {pickModels} from './pick-models';
 
 export default class LayerManager {
   constructor({gl}) {
@@ -97,15 +98,16 @@ export default class LayerManager {
     return this;
   }
 
-  getLayerPickingModels() {
-    const models = [];
-    for (const layer of this.layers) {
-      const {visible, pickable, isPickable} = layer.props;
-      if (visible && (pickable || isPickable) && layer.state.model) {
-        models.push(layer.state.model);
-      }
-    }
-    return models;
+  pickLayer({x, y, pixelRatio, type}) {
+    const {gl, uniforms} = this.context;
+    return pickModels(gl, {
+      x,
+      y,
+      pixelRatio,
+      uniforms,
+      layers: this.layers,
+      type
+    });
   }
 
   needsRedraw({clearRedrawFlags = false} = {}) {

--- a/src/react/deckgl.js
+++ b/src/react/deckgl.js
@@ -23,13 +23,9 @@ import React, {PropTypes} from 'react';
 import autobind from 'autobind-decorator';
 
 import WebGLRenderer from './webgl-renderer';
-import {GL, Group} from 'luma.gl';
-// import {pickModels} from 'luma.gl';
+import {GL} from 'luma.gl';
 import {DEFAULT_BLENDING} from './config';
 import {LayerManager} from '../lib';
-// TODO - picking needs to be better integrated
-import {pickModels} from '../lib/pick-models';
-import {log} from '../lib/utils';
 
 // TODO - move default to WebGL renderer
 const DEFAULT_PIXEL_RATIO =
@@ -107,24 +103,16 @@ export default class DeckGL extends React.Component {
 
   // Route events to layers
   @autobind _onClick(event) {
-    const picked = this._pick(event.x, event.y);
-    const info = {picked, ...event};
-    for (const item of picked) {
-      if (item.model.userData.layer.onClick({color: item.color, ...info})) {
-        return;
-      }
-    }
+    const {x, y} = event;
+    const {pixelRatio} = this.props;
+    this.state.layerManager.pickLayer({x, y, pixelRatio, type: 'click'});
   }
 
   // Route events to layers
   @autobind _onMouseMove(event) {
-    const picked = this._pick(event.x, event.y);
-    const info = {picked, ...event};
-    for (const item of picked) {
-      if (item.model.userData.layer.onHover({color: item.color, ...info})) {
-        return;
-      }
-    }
+    const {x, y} = event;
+    const {pixelRatio} = this.props;
+    this.state.layerManager.pickLayer({x, y, pixelRatio, type: 'hover'});
   }
 
   @autobind _onRenderFrame({gl}) {
@@ -135,23 +123,10 @@ export default class DeckGL extends React.Component {
       return;
     }
 
-    log(1, 'rendering frame');
-
     // clear depth and color buffers
     gl.clear(GL.COLOR_BUFFER_BIT | GL.DEPTH_BUFFER_BIT);
 
     layerManager.drawLayers();
-  }
-
-  _pick(x, y) {
-    const {pixelRatio} = this.props;
-    const {gl, layerManager} = this.state;
-    const pickedModels = pickModels(gl, {
-      x: x * pixelRatio,
-      y: y * pixelRatio,
-      group: new Group({children: layerManager.getLayerPickingModels()})
-    });
-    return pickedModels;
   }
 
   render() {

--- a/src/test/layers/core-layers.spec.js
+++ b/src/test/layers/core-layers.spec.js
@@ -68,7 +68,7 @@ test('ScreenGridLayer#constructor', t => {
 
   const layer = new ScreenGridLayer({
     data: points,
-    isPickable: false,
+    pickable: false,
     opacity: 0.06
   });
 
@@ -82,7 +82,7 @@ test('ChoroplethLayer#constructor', t => {
   const layer = new ChoroplethLayer({
     data: choropleths,
     opacity: 0.8,
-    isPickable: false,
+    pickable: false,
     drawContour: true
   });
 
@@ -95,14 +95,14 @@ test('ScatterplotLayer#constructor', t => {
 
   const layer = new ScatterplotLayer({
     data: points,
-    isPickable: true
+    pickable: true
   });
   t.ok(layer instanceof ScatterplotLayer, 'ScatterplotLayer created');
 
   const emptyLayer = new ScatterplotLayer({
     id: 'emptyScatterplotLayer',
     data: [],
-    isPickable: true
+    pickable: true
   });
   t.ok(emptyLayer instanceof ScatterplotLayer, 'Empty ScatterplotLayer created');
 
@@ -110,7 +110,7 @@ test('ScatterplotLayer#constructor', t => {
     () => new ScatterplotLayer({
       id: 'nullScatterplotLayer',
       data: null,
-      isPickable: true
+      pickable: true
     }),
     'Null ScatterplotLayer did not throw exception'
   );
@@ -131,14 +131,14 @@ test('ArcLayer#constructor', t => {
   const layer = new ArcLayer({
     id: 'arcLayer',
     data: arcs,
-    isPickable: true
+    pickable: true
   });
   t.ok(layer instanceof ArcLayer, 'ArcLayer created');
 
   const emptyLayer = new ArcLayer({
     id: 'emptyArcLayer',
     data: [],
-    isPickable: true
+    pickable: true
   });
   t.ok(emptyLayer instanceof ArcLayer, 'Empty ArcLayer created');
 
@@ -146,7 +146,7 @@ test('ArcLayer#constructor', t => {
     () => new ArcLayer({
       id: 'nullArcLayer',
       data: null,
-      isPickable: true
+      pickable: true
     }),
     'Null ArcLayer did not throw exception'
   );

--- a/src/test/lib/layer.spec.js
+++ b/src/test/lib/layer.spec.js
@@ -10,20 +10,10 @@ const dataVariants = [
 
 const LAYER_PROPS = {
   id: 'testLayer',
-  width: 1,
-  height: 1,
-  latitude: 1,
-  longitude: 1,
-  zoom: 1,
   data: []
 };
 const LAYER_PROPS_ZEROES = {
   id: 'testLayer',
-  width: 0,
-  height: 0,
-  latitude: 0,
-  longitude: 0,
-  zoom: 0,
   data: []
 };
 


### PR DESCRIPTION
@Pessimistress This PR routes picking through `layer.pick` lifecycle method, enabling layers to override default picking behavior.

Also substantially cleans up the picking code.