### PR TITLE
Split the viewport into GL and non-GL related classes.

### DIFF
--- a/example/layer-examples.js
+++ b/example/layer-examples.js
@@ -16,10 +16,7 @@ import {
 
 import {
   GeoJsonLayer,
-  HexagonLayer,
-  EnhancedChoroplethLayer,
-  PointCloudLayer,
-  VoronoiLayer
+  EnhancedChoroplethLayer
 } from '../src/layers/samples';
 
 const ArcLayerExample = props =>

--- a/src/lib/layer.js
+++ b/src/lib/layer.js
@@ -489,13 +489,16 @@ export default class Layer {
       return false;
     }
 
-    const {attributeManager, model} = this.state;
     let redraw = false;
     redraw = redraw || this.state.needsRedraw;
     this.state.needsRedraw = this.state.needsRedraw && !clearRedrawFlags;
 
-    redraw = redraw || attributeManager.getNeedsRedraw({clearRedrawFlags});
-    redraw = redraw || (model && model.getNeedsRedraw({clearRedrawFlags}));
+    const {attributeManager, model} = this.state;
+    redraw = redraw ||
+      (attributeManager && attributeManager.getNeedsRedraw({clearRedrawFlags}));
+    redraw = redraw ||
+      (model && model.getNeedsRedraw({clearRedrawFlags}));
+
     return redraw;
   }
 
@@ -526,8 +529,13 @@ export default class Layer {
   // Check if any update triggers have changed, and invalidate
   // attributes accordingly.
   _diffUpdateTriggers(oldProps, newProps) {
-    let change = false;
     const {attributeManager} = this.state;
+    if (!attributeManager) {
+      return false;
+    }
+
+    let change = false;
+
     for (const propName in newProps.updateTriggers) {
       const oldTriggers = oldProps.updateTriggers[propName];
       const newTriggers = newProps.updateTriggers[propName];
@@ -542,6 +550,7 @@ export default class Layer {
         }
       }
     }
+
     return change;
   }
 
@@ -558,6 +567,10 @@ export default class Layer {
   // Calls attribute manager to update any WebGL attributes
   _updateAttributes(props) {
     const {attributeManager, model} = this.state;
+    if (!attributeManager) {
+      return;
+    }
+
     const numInstances = this.getNumInstances(props);
     // Figure out data length
     attributeManager.update({

--- a/src/viewport/index.js
+++ b/src/viewport/index.js
@@ -1,6 +1,10 @@
+// Note: The base viewport class will be moved to a separate module
+// viewport-mercator-project
 export * from './viewport';
 export {default as BaseViewport} from './viewport';
+
+// The WebGL Viewport is a subclass of the BaseViewport that generates
+// WebGL Matrices and Uniforms for deck.gl
 export * from './webgl-viewport';
-export {default as WebGLViewport} from './webgl-viewport';
 export {default as Viewport} from './webgl-viewport';
 export {default as default} from './webgl-viewport';

--- a/src/viewport/index.js
+++ b/src/viewport/index.js
@@ -1,2 +1,6 @@
-export {default as default} from './viewport';
-export {default as Viewport} from './viewport';
+export * from './viewport';
+export {default as BaseViewport} from './viewport';
+export * from './webgl-viewport';
+export {default as WebGLViewport} from './webgl-viewport';
+export {default as Viewport} from './webgl-viewport';
+export {default as default} from './webgl-viewport';

--- a/src/viewport/webgl-viewport.js
+++ b/src/viewport/webgl-viewport.js
@@ -1,0 +1,107 @@
+// View and Projection Matrix calculations for mapbox-js style
+// map view properties
+//
+// ATTRIBUTION:
+// Projection matrix creation are intentionally kept compatible with
+// mapbox-gl's implementation to ensure that seamless interoperation
+// with mapbox and react-map-gl.
+// See: transform.js in https://github.com/mapbox/mapbox-gl-js
+
+import Viewport, {COORDINATE_SYSTEM} from './viewport';
+import autobind from 'autobind-decorator';
+import {mat4, vec2} from 'gl-matrix';
+
+function fp64ify(a) {
+  const hiPart = Math.fround(a);
+  const loPart = a - Math.fround(a);
+  return [hiPart, loPart];
+}
+
+export default class WebGLViewport extends Viewport {
+
+  constructor(options) {
+    super(options);
+    this._calculateWebGLMatrices();
+  }
+
+  /**
+   * Returns a projection matrix suitable for shaders
+   * @return {Float32Array} - 4x4 projection matrix that can be used in shaders
+   */
+  @autobind
+  getProjectionMatrix() {
+    return this.glProjectionMatrix;
+  }
+
+  @autobind
+  getProjectionMatrixFP64() {
+    return this.glProjectionMatrixFP64;
+  }
+
+  @autobind
+  getProjectionMatrixUncentered() {
+    return this.glProjectionMatrixUncentered;
+  }
+
+  getWebGLMatrices() {
+    return {
+      projectionMatrix: this.glProjectionMatrix,
+      projectionFP64: this.glProjectionMatrixFP64
+    };
+  }
+
+  @autobind
+  getUniforms({
+    projectionMode = COORDINATE_SYSTEM.LNGLAT,
+    projectionCenter = [0, 0],
+    modelMatrix = null
+  } = {}) {
+    projectionCenter = vec2.subtract([],
+      this.projectFlat(projectionCenter),
+      this.center
+    );
+
+    const projections = this.getProjections();
+
+    const projectionMatrix = projections._viewProjectionMatrix;
+    // If necessary add modelMatrix to clipSpace projection
+    if (modelMatrix) {
+      mat4.multiply(projectionMatrix, projectionMatrix, modelMatrix);
+    }
+
+    // this._dy64ifyProjectionMatrix();
+
+    // TODO - clean up, not all of these are used
+    // _ONE uniform is a hack to make tan_fp64() callable in existing 32-bit layers
+    return {
+      projectionMode,
+      projectionMatrix: this.glProjectionMatrix,
+      projectionFP64: this.glProjectionMatrixFP64,
+      projectionScale: this.scale,
+      projectionScaleFP64: fp64ify(this.scale),
+      projectionCenter,
+      projectionPixelsPerUnit: this.pixelsPerMeter
+      // projectionMatrixCentered: this.glProjectionMatrix,
+      // projectionMatrixUncentered: this.glProjectionMatrixUncentered
+    };
+  }
+
+  _calculateWebGLMatrices() {
+    this.glProjectionMatrix =
+      new Float32Array(this.viewProjectionMatrix);
+    this.glProjectionMatrixFP64 = new Float32Array(32);
+    this._dy64ifyProjectionMatrix();
+  }
+
+  _dy64ifyProjectionMatrix() {
+    // Transpose the projection matrix to column major for GLSL.
+    for (let i = 0; i < 4; ++i) {
+      for (let j = 0; j < 4; ++j) {
+        [
+          this.glProjectionMatrixFP64[(i * 4 + j) * 2],
+          this.glProjectionMatrixFP64[(i * 4 + j) * 2 + 1]
+        ] = fp64ify(this.glProjectionMatrix[j * 4 + i]);
+      }
+    }
+  }
+}


### PR DESCRIPTION
@shaojingli @gnavvy - Step 1 towards moving core viewport to viewport-mercator-project.