### PR TITLE
Update layer docs

### DIFF
--- a/docs/layer.md
+++ b/docs/layer.md
@@ -9,11 +9,9 @@ The layer class also defines the lifecycle methods of the layers, as well as
 a a couple of support methods which the lifecycle methods can use. These are
 important only when subclassing layers and are therefore described separetely.
 
-
 ## Layer Properties
 
-
-### `id` (string, optional): layer id
+##### `id` (String, optional)
 
 The id must be unique among all your layers. The layer's id defaults to the
 `Layer` class name. If you have more than one instance of the same
@@ -25,53 +23,56 @@ which helps avoid id collisions in this case.
 
 E.g. assuming a composite GeoJsonLayer layer that renders two sublayers,
 choropleths and lines, with those ids:
-```
-   new GeoJsonLayer({id: 'street-grid'});
-```
+
+    new GeoJsonLayer({id: 'street-grid'});
+
 Will generate the following layers and ids:
-```
-   GeoJsonLayer:'street-grid'
-   ChoroplethLayer:'street-grid-choropleth'
-   LineLayer:'street-grid-choropleth'
-```
+
+    GeoJsonLayer: 'street-grid'
+    ChoroplethLayer: 'street-grid-choropleth'
+    LineLayer: 'street-grid-choropleth'
 
 React Note: `id` is similar to the `key` property used in React to match
 components between rendering calls.
 
+##### `viewport` (Viewport, optional)
 
-### `viewport` (Viewport, optional, default=injected from context)
+- Default: Injected from context
 
 Viewport can be supplied to override the context supplied viewport.
 
+##### `pickable` (Boolean, optional)
 
-### `pickable` [bool, optional, default=false]
+- Default: `false`
 
 Whether layer responds to mouse events.
 
+##### `visible` (Boolean, optional)
 
-### `visible` [bool, optional, default=true] whether layer is drawn
+- Default: `true`
+
+Whether layer is drawn.
 
 For performance reasons it is often better to control layer visibility
 with the `visible` prop rather than through conditional rendering.
 
 Compare:
-```
-   const layers = [
-   	 new MyLayer({visible: showMyLayer});
-   ];
-```
+
+    const layers = [
+      new MyLayer({visible: showMyLayer});
+    ];
+
 with
-```
-   const layers = [];
-   if (showMyLayer) {
-   	 new MyLayer({visible: showMyLayer});
-   }
-```
+
+    const layers = [];
+    if (showMyLayer) {
+      new MyLayer({visible: showMyLayer});
+    }
+
 In the second example (conditional rendering) the layer state will
 be destroyed and regenerated every time the showMyLayer flag changes.
 
-
-### `opacity` (number, required)
+##### `opacity` (Number, required)
 
 The opacity of the layer. deck.gl automatically applies gamma to the opacity
 in an attempt to make opacity changes appear linear (i.e. the opacity is
@@ -81,8 +82,7 @@ Note: While it is a recommended convention that all deck.gl layers should
 support the opacity prop, it is up to each layer's fragment shader
 to implement support for opacity.
 
-
-### `projectionMode` (number, optional)
+##### `projectionMode` (Number, optional)
 
 Specifies how layer positions and offsets should be interpreted.
 
@@ -92,8 +92,7 @@ is also possible to interpret positions as meter offsets from the
 
 See the article on Coordinate Systems for details.
 
-
-### `projectionCenter` ([Number, Number], optional)
+##### `projectionCenter` ([Number, Number], optional)
 
 Required when the `projectionMode` is in meter offsets.
 
@@ -101,8 +100,7 @@ Specifies a longitude and a latitude from which meter offsets are calculated.
 
 See the article on Coordinate Systems for details
 
-
-### `viewMatrix` (Number[16], optional)
+##### `viewMatrix` (Number[16], optional)
 
 An optional 4x4 matrix that is premultiplied into the affine projection
 matrices used by shader `project` GLSL function and the Viewport's `project`
@@ -116,8 +114,7 @@ Note that the matrix projection is applied after the non-linear mercator
 projection calculations are resolved, so be careful when using view matrices
 with lng/lat encoded coordinates.
 
-
-### data (Iterable Object or Array, optional)
+##### `data` (Iterable Object or Array, optional)
 
 The data prop should contain an iterable JavaScript container,
 please see JavaScript `[Symbol.iterator]`.
@@ -127,8 +124,7 @@ while e.g. initializing asynchronous data, deck.gl allows data to be
 omitted or supplied as null (or undefined). These cases are treated
 as if an empty array had been supplied.
 
-
-### dataIterator (ES6 Iterator, optional)
+##### `dataIterator` (ES6 Iterator, optional)
 
 Normally the iterator for data is extracted by looking at the
 `[Symbol.iterator]` field of the supplied container. Sometimes
@@ -139,16 +135,14 @@ Note: deck.gl even supplies an object iterator (`makeObjectValueIterator`)
 making it possible to use objects directly as `data` props in deck.gl
 without first converting them to arrays.
 
-```
-   import {ScatterplotLayer, objectValueIterator} from `deck.gl`;
-   new ScatterplotLayer({
-     data: {element1: [0, 0], element2: [1, 1]},
-     dataIterator: makeObjectValueIterator(data)
-   });
-```
 
+    import {ScatterplotLayer, objectValueIterator} from `deck.gl`;
+    new ScatterplotLayer({
+      data: {element1: [0, 0], element2: [1, 1]},
+      dataIterator: makeObjectValueIterator(data)
+    });
 
-### dataComparator (Function, optional, null)
+##### `dataComparator` (Function, optional)
 
 This prop causes the `data` prop to be compared using a custom comparison
 function. The comparison function is called with the old data and the new
@@ -162,14 +156,12 @@ would obviously have considerable performance impact and should only
 be used as a temporary solution for small data sets until the application
 can be refactored to avoid the need.
 
-
-### numInstances (Number, optional)
+##### `numInstances` (Number, optional)
 
 deck.gl is often able to autodetect the number of objects in your `data` prop,
 however in special situations it can be useful to control this directly.
 
-
-### onHover (Function, optional)
+##### `onHover` (Function, optional)
 
 This callback will be called when the mouse hovers over a feature drawn
 by the layer (assuming it is not occluded by any succeeding layers).
@@ -178,10 +170,9 @@ The function will be called with a single parameter `info`, which is an
 object that contains a variety of fields describing the hover event and
 what was hovered.
 
-Requires 'pickable' to be true.
+**Requires `pickable` to be true.**
 
-
-### onClick (Function, optional)
+##### `onClick` (Function, optional)
 
 This callback will be called when the mouse hovers over a feature drawn
 by the layer (assuming it is not occluded by any succeeding layers).
@@ -190,10 +181,9 @@ The function will be called with a single parameter `info`, which is an
 object that contains a variety of fields describing the click event and
 what was hovered.
 
-Requires 'pickable' to be true.
+**Requires `pickable` to be true.**
 
-
-### updateTriggers
+##### `updateTriggers`
 
 This prop expects an object with keys matching attribute names.
 Each attributeName will contain an object with keys representing property names.
@@ -211,10 +201,9 @@ shallowly, and if a change is detected, the attribute is invalidated
 (all attributes are invalidated if the `all` key is used.)
 
 Note: updateTriggers are ignored by the normal shallow comparison, so it is
-OK for the app to mint a new object on every render.
+ok for the app to mint a new object on every render.
 
-
-### "attributes" properties
+##### "attributes" properties
 
 The layer will look for properties with names matching its attributes,
 and if present, assume their contents is a typed array or WebGLBuffer,
@@ -233,7 +222,6 @@ This allows an application to supply its own buffers properties.
 If attributes are shared between layers, a useful technique is to create
 a separate AttributeManager and calculate the attributes once, and then
 pass them in as "overrides" to the layers.
-
 
 ## Layer Methods
 

--- a/docs/layers/arc-layer.md
+++ b/docs/layers/arc-layer.md
@@ -1,9 +1,42 @@
-## Arc Layer
+# Arc Layer
 
 The Arc Layer takes in paired latitude and longitude coordinated points and
 render them as arcs that links the starting and ending points.
 
-**Layer-specific Parameters**
+Inherits from all [Base Layer properties](/docs/layer.md).
 
-* `data` (array, required) array of objects: [{ position: {x0, y0, x1, y1},
-color }, ...]
+## Layer-specific Properties
+
+##### `strokeWidth` (Number, optional)
+
+- Default: `1`
+
+The stroke width used to draw each arc.
+
+##### `getSourcePosition` (Function, optional)
+
+- Default: `object => object.sourcePosition`
+
+Method called to retrieve the source position of each object.
+
+##### `getTargetPosition` (Function, optional)
+
+- Default: `object => object.targetPosition`
+
+Method called to retrieve the target position of each object.
+
+##### `getSourceColor` (Function, optional)
+
+- Default: `object => object.color`
+
+Method called to determine the color of the source.
+
+If the method does not return a value for the given object, fallback to `[0, 0, 255]`.
+
+##### `getTargetColor` (Function, optional)
+
+- Default `object => object.color`
+
+Method called to determine the color of the source.
+
+If the method does not return a value for the given object, fallback to `[0, 0, 255]`.

--- a/docs/layers/choropleth-layer.md
+++ b/docs/layers/choropleth-layer.md
@@ -1,72 +1,67 @@
-## Choropleth Layer
+# Choropleth Layer
 
 The Choropleth Layer takes in [GeoJson](http://geojson.org/) formatted data and
 renders it as interactive choropleths.
+
+Inherits from all [Base Layer properties](/docs/layer.md).
+
+## Layer-specific Properties
+
+##### `drawContour` (Boolean, optional)
+
+- Default: `false`
+
+Draw choropleth contour if true, else fill choropleth area.
+
+##### `onChoroplethHovered` (Function, optional)
+
+Provides selected choropleth properties along with mouse event when the choropleth is hovered.
+
+##### `onChoroplethClicked` (Function, optional)
+
+Provides selected choropleth properties along with mouse event when the choropleth is clicked.
+  
+#### Additional notes
 
 By supplying a GeoJson `FeatureCollection` you can add multiple polygons.
 Each Feature has an optional "properties" object. The layer will look for an
 optional property "color", which is expected to be a 3 element array of values
 between 0 and 255, representing the RGB values for the color of that `Feature`
 
-```
-  { "type": "FeatureCollection",
-    "features": [
-      { "type": "Feature",
-        "geometry": {"type": "Point", "coordinates": [102.0, 0.5]},
-        "properties": {"prop0": "value0"}
+
+    {
+      "type": "FeatureCollection",
+        "features": [
+        {
+          "type": "Feature",
+          "geometry": {"type": "Point", "coordinates": [102.0, 0.5]},
+          "properties": {"prop0": "value0"}
         },
-      { "type": "Feature",
-        "geometry": {
-          "type": "LineString",
-          "coordinates": [
-            [102.0, 0.0], [103.0, 1.0], [104.0, 0.0], [105.0, 1.0]
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "LineString",
+            "coordinates": [
+              [102.0, 0.0], [103.0, 1.0], [104.0, 0.0], [105.0, 1.0]
             ]
           },
-        "properties": {
-          "color": [255, 0, 0],
-          "prop1": 0.0
+          "properties": {
+            "color": [255, 0, 0],
+            "prop1": 0.0
           }
         },
-      { "type": "Feature",
-         "geometry": {
-           "type": "Polygon",
-           "coordinates": [
-             [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0],
-               [100.0, 1.0], [100.0, 0.0] ]
-             ]
-         },
-         "properties": {
-           "color": [255, 255, 0],
-           "prop1": {"application": "defined"}
-           }
-         }
-       ]
-     }
-``
-
-
-  **Common Parameters**
-
-  * `id` (string, required): layer ID
-  * `width` (number, required) width of the layer
-  * `height` (number, required) height of the layer
-  * `longitude` (number, required) longitude of the map center
-  * `latitude` (number, required) latitude of the map center
-  * `zoom` (number, required) zoom level of the map
-  * `opacity` (number, required) opacity of the layer
-  * `isPickable` [bool, optional, default=false] whether layer responses to
-  mouse events
-
-  **Layer-specific Parameters**
-
-  * `data` (object, required) input data in GeoJson format
-  * `drawContour` [bool, optional, default=false] draw choropleth contour if
-  true, else fill choropleth area
-
-  **Callbacks**
-
-  * `onChoroplethHovered` [function, optional] bubbles choropleth properties
-  when mouse hovering
-  * `onChoroplethClicked` [function, optional] bubbles choropleth properties
-  when mouse clicking
-
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Polygon",
+            "coordinates": [
+              [[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]]
+            ]
+          },
+          "properties": {
+            "color": [255, 255, 0],
+            "prop1": {"application": "defined"}
+          }
+        }
+      ]
+    }

--- a/docs/layers/line-layer.md
+++ b/docs/layers/line-layer.md
@@ -1,9 +1,34 @@
-## Line Layer
+# Line Layer
 
 The Line Layer takes in paired latitude and longitude coordinated points and
 render them as arcs that links the starting and ending points.
 
-**Layer-specific Parameters**
+Inherits from all [Base Layer properties](/docs/layer.md).
 
-* `data` (array, required) array of objects: [{ position: {x0, y0, x1, y1},
-color }, ...]
+## Layer-specific Properties
+
+##### `strokeWidth` (Number, optional)
+
+- Default: `9`
+
+The stroke width used to draw each line.
+
+##### `getSourcePosition` (Function, optional)
+
+- Default: `object => object.sourcePosition`
+
+Method called to retrieve the source position of each object.
+
+##### `getTargetPosition` (Function, optional)
+
+- Default: `object => object.targetPosition`
+
+Method called to retrieve the target position of each object.
+
+##### `getColor` (Function, optional)
+
+- Default: `object => object.color`
+
+Method called to determine the color of the source.
+
+If the method does not return a value for the given object, fallback to `[0, 0, 255]`.

--- a/docs/layers/sample-layers.md
+++ b/docs/layers/sample-layers.md
@@ -11,6 +11,7 @@ If a production application wants to use one of these layers, we recommend
 copying these layers rather than importing them into to your application to
 avoid being affected by changes when updating to new versions of deck.gl.
 
+Inherits from all [Base Layer properties](/docs/layer.md).
 
 ### ExtrudedChoroplethLayer
 
@@ -19,18 +20,47 @@ long, thin triangles. This provides control over line thickness
 while ensuring good line mitering, overcoming WebGL's limitations in this
 regard.
 
-**Note:** very sharp angles can generate very long miters and handling of this
+**Note:** Very sharp angles can generate very long miters and handling of this
 case needs more work, but for "modest" angles (e.g. 60 degrees in hexagons)
 the results will be good.
 
-**Properties**
+##### `drawContour` (Boolean, optional)
 
-* `drawContour` [boolean, default=true] whether to draw a contour
-* `strokeColor`: [array, [0, 0, 0]] contour will be draw in this color
-* `strokeWidth`: [number, 3] width of line segments
-* `fillColor`: [array [128, 128, 128]] fill will be drawn in this color
-* `elevation`: [number, 0] choropleth will be drawn at this elevation
-* `getColor`: [function, optional] data accessor: get Color for segment
+- Default: `true`
 
-See common deck.gl layer properties below for more information on inherited
-props.
+Whether to draw a contour.
+
+##### `opacity` (Number, optional)
+
+- Default: `1`
+
+Change the opacity, from `0` to `1`.
+
+##### `strokeColor`: (Number[3], optional)
+
+- Default: `[0, 0, 0]`
+
+The contour will be draw in this color.
+
+##### `strokeWidth`: (Number, optional)
+
+- Default: `3`
+
+Width of line segments.
+
+##### `fillColor`: (Number[3], optional)
+
+- Default: `[128, 128, 128]`
+
+Fill will be drawn in this color.
+
+##### `elevation`: (Number, optional)
+
+- Default: `0`
+
+Choropleth will be drawn at this elevation.
+
+##### `getColor`: (Function, optional)
+
+Provide a custom method which gets the segment and that needs to return a color.
+If it is not defined, simply use the `strokeColor`.

--- a/docs/layers/scatterplot-layer.md
+++ b/docs/layers/scatterplot-layer.md
@@ -1,8 +1,45 @@
-## Scatterplot Layer
+# Scatterplot Layer
 
-In addition to default layer properties:
+The Scatterplot Layer takes in paride latitude and longitude coordinated points and render them as circles with a certain radius.
 
-* `data` (array, required) array of objects: [{ position, color, radius }, ...]
-* `drawOutline` [boolean, optional, false] only draw outline of dot
-* `radius` [number, optional, default=10] global radius across all markers
-* `strokeWidth` [number, optional, default=1] width of stroke if only drawing outline
+Inherits from all [Base Layer properties](/docs/layer.md).
+
+## Layer-specific Properties
+
+##### `strokeWidth` (Number, optional)
+
+- Default: `1`
+
+Width of stroke if drawing outline.
+
+##### `drawOutline` (Boolean, optional)
+
+- Default: `false`
+
+Only draw outline of dot.
+
+##### `radius` (Number, optional)
+
+- Default: `30`
+
+Global radius across all markers.
+
+##### `getPosition` (Function, optional)
+
+- Default: `object => object.position`
+
+Method called to retrieve the position of each object.
+
+##### `getRadius` (Function, optional)
+
+- Default: `object => object.radius`
+
+Method called to retrieve the radius of each object.
+
+##### `getColor` (Function, optional)
+
+- Default: `object => object.color`
+
+Method called to retrieve the color of each object.
+
+Fallback to `[255, 0, 255]` if the object doesn't have a color property

--- a/docs/layers/screen-grid-layer.md
+++ b/docs/layers/screen-grid-layer.md
@@ -1,4 +1,4 @@
-## ScreenGridLayer
+# ScreenGridLayer
 
 The ScreenGridLayer takes in an array of latitude and longitude
 coordinated points, aggregates them into histogram bins and
@@ -9,9 +9,42 @@ needs to be reaggregated by the layer whenever the map is zoomed or panned.
 This means that this layer is best used with small data set, however the
 visuals when used with the right data set can be quite effective.
 
+Inherits from all [Base Layer properties](/docs/layer.md).
 
-**Layer-specific Parameters**
+## Layer-specific Properties
 
-* `data` (array, required) array of objects: [{ position, color }, ...]
-* `unitWidth` [number, optional, default=100] unit width of the bins
-* `unitHeight` [number, optional, default=100] unit height of the bins
+##### `unitWidth` (Number, optional)
+
+- Default: `100`
+
+Unit width of the bins.
+
+##### `unitHeight` (Number, optional)
+
+- Default: `100`
+
+Unit height of the bins.
+
+#### `minColor` (Number[4], optional)
+
+- Default: `[0, 0, 0, 255]`
+
+Expressed as an rgba array, minimal color that could be rendered by a tile.
+
+#### `maxColor` (Number[4], optional)
+
+- Default: `[0, 255, 0, 255]`
+
+Expressed as an rgba array, maximal color that could be rendered by a tile.
+
+#### `getPosition` (Function, optional)
+
+- Default: `object => object.position`
+
+Method called to retrieve the position of each object.
+
+#### `getWeight` (Function, optional)
+
+- Default: `object => 1`
+
+Method called to retrieve the weight of each object.

--- a/src/layers/core/choropleth-layer/choropleth-layer.js
+++ b/src/layers/core/choropleth-layer/choropleth-layer.js
@@ -43,9 +43,9 @@ export default class ChoroplethLayer extends Layer {
    * @class
    * @param {object} props
    * @param {bool} props.drawContour - ? drawContour : drawArea
-   * @param {function} props.onChoroplethHovered - provide proerties of the
+   * @param {function} props.onChoroplethHovered - provide properties of the
    * selected choropleth, together with the mouse event when mouse hovered
-   * @param {function} props.onChoroplethClicked - provide proerties of the
+   * @param {function} props.onChoroplethClicked - provide properties of the
    * selected choropleth, together with the mouse event when mouse clicked
    */
   constructor(props) {


### PR DESCRIPTION
Standardized parameters types case among layer docs, and moved the default values (if any) down the heading, to provide more control over the markup with its value and possible description.

Had a little doubt about keeping the additional notes in the *Choropleth* one, since it's in the `data` object so I kept it for now.