### PR TITLE
Fix arc layer flickering

### DIFF
--- a/src/layers/core/arc-layer/arc-layer-vertex.glsl
+++ b/src/layers/core/arc-layer/arc-layer-vertex.glsl
@@ -52,11 +52,14 @@ void main(void) {
   vec2 target = preproject(instancePositions.zw);
 
   float segmentIndex = positions.x;
+
+  float vertex_height = paraboloid(source, target, segmentIndex);
+  if (vertex_height < 0.0) vertex_height = 0.0;
   vec3 p = vec3(
     // xy: linear interpolation of source & target
     mix(source, target, segmentIndex / N),
     // z: paraboloid interpolate of source & target
-    sqrt(paraboloid(source, target, segmentIndex))
+    sqrt(vertex_height)
   );
 
   gl_Position = project(vec4(p, 1.0));

--- a/src/layers/fp64/arc-layer/arc-layer-vertex.glsl
+++ b/src/layers/fp64/arc-layer/arc-layer-vertex.glsl
@@ -63,7 +63,11 @@ void main(void) {
 
   vertex_pos_modelspace[0] = mixed_temp[0];
   vertex_pos_modelspace[1] = mixed_temp[1];
-  vertex_pos_modelspace[2] = sqrt_fp64(paraboloid_fp64(projectedSourceCoord, projectedTargetCoord, segmentIndex));
+
+  vec2 vertex_height = paraboloid_fp64(projectedSourceCoord, projectedTargetCoord, segmentIndex);
+  if (vertex_height.x < 0.0 || (vertex_height.x == 0.0 && vertex_height.y <= 0.0)) vertex_height = vec2(0.0, 0.0);
+
+  vertex_pos_modelspace[2] = sqrt_fp64(vertex_height);
   vertex_pos_modelspace[3] = vec2(1.0, 0.0);
 
   gl_Position = project_to_clipspace_fp64(vertex_pos_modelspace);


### PR DESCRIPTION
Attempt to fix the arc layer flickering.

The flickering of the segment 0 of arc layer seems due to negative results returned by the paraboloid() and paraboloid_fp64() function. 