### PR TITLE
Improve Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
-# deck.gl
+<p align="right">
+  <a href="https://npmjs.org/package/deck.gl">
+    <img src="https://img.shields.io/npm/v/deck.gl.svg?style=flat-square" alt="version" />
+  </a>
+  <a href="https://travis-ci.org/uber/deck.gl">
+    <img src="https://img.shields.io/travis/uber/deck.gl/master.svg?style=flat-square" alt="build" />
+  </a>
+  <a href="https://npmjs.org/package/deck.gl">
+    <img src="https://img.shields.io/npm/dm/deck.gl.svg?style=flat-square" alt="downloads" />
+  </a>
+  <a href="http://starveller.sigsev.io/uber/deck.gl">
+    <img src="http://starveller.sigsev.io/api/repos/uber/deck.gl/badge" alt="stars" />
+  </a>
+</p>
 
-> A WebGL overlay suite for React providing a set of highly performant data visualization overlays.
+<h1 align="center">deck.gl</h1>
+<p align="center">A WebGL overlay suite for React providing a set of highly performant data visualization overlays.</p>
 
 ![screenshot](screenshot.png)
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # deck.gl
 
-A WebGL overlay suite for React providing a set of highly performant
-data visualization overlays.
+> A WebGL overlay suite for React providing a set of highly performant data visualization overlays.
 
 ![screenshot](screenshot.png)
 
-Design goals:
+    npm install --save deck.gl
+
+#### Design goals
+
 - Provide overlays that plug directly into react-map-gl's overlay model,
   enabling overlays to work on maps.
 - Provide highly performant data visualization overlays in 2 and 3 dimensions.
@@ -17,61 +19,49 @@ Design goals:
 - Special focus on buffer management, allowing both automatic buffer updates
   but also full application control of buffer allocation and management
 
+#### Features
 
-Features:
 - Web Mercator projections are handled in shader on GPU. No projections are
   done in JavaScript (unless needed for a uniform calculation or reverse
   projection of e.g. picked coordinate etc). Specify your lat,lon once and
   never touch it again.
-- Can accept data stored in any ES6 container
-  (supporting \[Symbol.iterator\] iteration).
+- Can accept data stored in any ES6 container (supporting `Symbol.iterator`).
 - Automatic and manual WebGL buffer management to support.
-
-
-## Installation
-
-```
-npm install --save deck.gl
 
 ## Usage
 
-```
-import {
-  DeckGLOverlay,
-  /* import layers here */
-} from 'deck.gl';
+    import {
+      DeckGLOverlay,
+      /* import layers here */
+    } from 'deck.gl';
 
-const mapState = {
-  latitude: 37.55,
-  longitude: -122.2,
-  zoom: 9,
-  ...
-}
+    const mapState = {
+      latitude: 37.55,
+      longitude: -122.2,
+      zoom: 9,
+      ...
+    }
 
-<DeckGLOverlay
-  width={1920}
-  height={1080}
-  mapState={mapState},  // optional
-  layers={[/* put layer instances here */]}
-/>
-```
+    <DeckGLOverlay
+      width={1920}
+      height={1080}
+      mapState={mapState},  // optional
+      layers={[/* put layer instances here */]}
+    />
 
----
+Take a look at the docs website or browse the [docs folder](./docs).
 
 ## Example
-```
-npm run start
-```
 
-```
+    npm run start
+
 Note: **Building** deck.gl (not importing) has a dependency on node
 version 0.12 or higher. If you use an older version, you can install
 a node version manager like nvm and use a separate shell to install
-and build deck.gl
-```
-npm install -g nvm && nvm install 0.12 && nvm use 0.12
-```
+and build deck.gl.
 
-## Data source
+    npm install -g nvm && nvm install 0.12 && nvm use 0.12
 
-https://data.sfgov.org/
+#### Data source
+
+[SF OpenData](https://data.sfgov.org)


### PR DESCRIPTION
People expect to see the package install command/name quickly, without having to scroll nor look into the `package.json`.