### PR TITLE
Use Uint8Array for Scatterplot colors and instancePickingColors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,15 +16,20 @@ All notable changes to deck.gl will be documented in this file.
 
 ### Beta-3.0.0 Releases
 
+#### [dev] -
+- PERF: Enable Uint8Array attributes
+  - Layer.instancePickingColors and Scatterplot.instanceColors now Uint8Arrays
+
 #### [v3.0.0-beta31] - Stabilization/Performance round
-- FIX to lineWidth warning
+- FIX: Scatterplot lineWidth warning
 - FIX: context.viewport = null in draw
 - FIX: opacity prop.
 - FEATURE: Enables prop diff tracing (deck.log.priority = 1)
-- FIX: Defeat spurious redraws
+- PERF: Defeat spurious redraws
 
 #### [v3.0.0-beta30] - Perf fixes - significantly reduce GPU load.
 - FIX: compareProps and updateTriggers fixes
+- PERF: reduce unnecessary updates
 - Doc updates
 
 #### [v3.0.0-beta29] -

--- a/example/layer-examples.js
+++ b/example/layer-examples.js
@@ -21,6 +21,7 @@ import {
 
 const ArcLayerExample = props =>
   new ArcLayer({
+    ...props,
     data: props.arcs,
     strokeWidth: props.arcStrokeWidth || 1,
     pickable: true,
@@ -30,6 +31,7 @@ const ArcLayerExample = props =>
 
 const ChoroplethLayerContourExample = props =>
   new ChoroplethLayer({
+    ...props,
     id: props.id || 'choroplethContourLayer',
     data: props.choropleths,
     opacity: 0.8,
@@ -38,6 +40,7 @@ const ChoroplethLayerContourExample = props =>
 
 const ChoroplethLayerExample = props =>
   new ChoroplethLayer({
+    ...props,
     data: props.choropleths,
     opacity: 0.01,
     pickable: true,
@@ -47,6 +50,7 @@ const ChoroplethLayerExample = props =>
 
 const ScreenGridLayerExample = props =>
   new ScreenGridLayer({
+    ...props,
     data: props.points,
     pickable: false,
     opacity: 0.06
@@ -54,6 +58,7 @@ const ScreenGridLayerExample = props =>
 
 const LineLayerExample = props =>
   new LineLayer({
+    ...props,
     data: props.lines,
     strokeWidth: props.lineStrokeWidth || 1,
     pickable: true,
@@ -63,8 +68,8 @@ const LineLayerExample = props =>
 
 const ScatterplotLayerExample = props =>
   new ScatterplotLayer({
+    ...props,
     data: props.points,
-    drawOutline: true,
     opacity: 0.5,
     strokeWidth: 2,
     pickable: true,
@@ -74,7 +79,8 @@ const ScatterplotLayerExample = props =>
 
 const ScatterplotLayerMeterExample = props =>
   new ScatterplotLayer({
-    id: props.id || 'scatterplotLayer-meters',
+    ...props,
+    drawOutline: true,
     projectionMode: 2,
     projectionCenter: [
       props.mapViewState.longitude,
@@ -95,7 +101,7 @@ const ScatterplotLayerMeterExample = props =>
 
 const GeoJsonLayerExample = props =>
   new GeoJsonLayer({
-    id: props.id || 'geoJsonLayer',
+    ...props,
     data: props.choropleths,
     getColor: x => [
       Math.random() * 255,
@@ -112,7 +118,7 @@ const GeoJsonLayerExample = props =>
 
 const ScatterplotLayer64Example = props =>
   new ScatterplotLayer64({
-    id: props.id || 'scatterplotLayer64',
+    ...props,
     data: props.points,
     pickable: true,
     onHover: props.onScatterplotHovered,
@@ -121,7 +127,7 @@ const ScatterplotLayer64Example = props =>
 
 const ArcLayer64Example = props =>
   new ArcLayer64({
-    id: props.id || 'arcLayer64',
+    ...props,
     data: props.arcs,
     strokeWidth: props.arcStrokeWidth || 1,
     pickable: true,
@@ -131,7 +137,7 @@ const ArcLayer64Example = props =>
 
 const ChoroplethLayer64ContourExample = props =>
   new ChoroplethLayer64({
-
+    ...props,
     data: props.choropleths,
     opacity: 0.8,
     drawContour: true
@@ -139,7 +145,7 @@ const ChoroplethLayer64ContourExample = props =>
 
 const ChoroplethLayer64SolidExample = props =>
   new ChoroplethLayer64({
-    id: props.id || 'choroplethLayer64',
+    ...props,
     data: props.choropleths,
     opacity: 0.01,
     pickable: true,
@@ -149,7 +155,7 @@ const ChoroplethLayer64SolidExample = props =>
 
 const ExtrudedChoroplethLayer64Example = props =>
 new ExtrudedChoroplethLayer64({
-  id: props.id || 'extrudedChoroplethLayer64',
+  ...props,
   data: props.extrudedChoropleths,
   pointLightLocation: [
     props.mapViewState.longitude,
@@ -162,7 +168,7 @@ new ExtrudedChoroplethLayer64({
 
 const LineLayer64Example = props =>
   new LineLayer64({
-    id: props.id || 'lineLayer64',
+    ...props,
     data: props.arcs,
     strokeWidth: props.arcStrokeWidth || 1,
     pickable: true,
@@ -174,6 +180,7 @@ const LineLayer64Example = props =>
 
 const EnhancedChoroplethLayerExample = props =>
   new EnhancedChoroplethLayer({
+    ...props,
     data: props.choropleths,
     opacity: 0.01,
     pickable: true,

--- a/package.json
+++ b/package.json
@@ -99,11 +99,15 @@
   },
   "scripts": {
     "build": "npm run build-dist && npm run build-script",
-    "build-dist": "npm run build-clean && npm run build-src && npm run build-shaderlib",
     "build-clean": "rm -fr dist/*",
+    "build-dist": "npm run build-clean && npm run build-src && npm run build-shaderlib",
     "build-src": "babel src -d dist --source-maps inline --copy-files",
     "build-shaderlib": "babel shaderlib -d dist/shaderlib --source-maps inline --copy-files",
     "build-script": "browserify src/bundle.js -t babelify -t glslify | uglifyjs > dist/deckgl.min.js",
+
+    "build-watch": "npm run build-clean && npm run build-src-watch && npm run build-shaderlib-watch",
+    "build-src-watch": "babel src -d dist --source-maps inline --copy-files --watch &",
+    "build-shaderlib-watch": "babel shaderlib -d dist/shaderlib --source-maps inline --copy-files --watch &",
 
     "demo-start": "budo demo/src/javascripts/main.js:main.min.js --dir demo/src/static/ --open --  -t sassify -t babelify -t glslify",
     "demo-build": "npm run demo-build-clean && npm run demo-build-copy && npm run demo-build-script",
@@ -122,6 +126,7 @@
     "test-electron": "browserify dist/test/electron.js | testron | faucet",
     "test-shader": "budo src/test/shader.js:build/test-bundle.js --dir test --live --open --port 3001 --watch-glob '**/*.{html,css,scss,js,glsl}' -- -t babelify -t glslify",
     "profile-disc": "browserify src/bundle.js --full-paths -t babelify -t glslify | uglifyjs | discify --open",
-    "start": "npm run build-dist && budo example/main.js:example/bundle.js --live --open --port 3000 --css example/main.css --title 'deck.gl' --watch-glob '**/*.{html,css,js,glsl}' -- -t babelify -t envify"
+
+    "start": "npm run build-watch && budo example/main.js:example/bundle.js --live --open --port 3000 --css example/main.css --title 'deck.gl' --watch-glob '**/*.{html,css,js,glsl}' -- -t babelify -t envify"
   }
 }

--- a/src/layers/core/choropleth-layer/choropleth-layer.js
+++ b/src/layers/core/choropleth-layer/choropleth-layer.js
@@ -57,10 +57,18 @@ export default class ChoroplethLayer extends Layer {
       // Primtive attributes
       indices: {size: 1, update: this.calculateIndices, isIndexed: true},
       positions: {size: 3, update: this.calculatePositions},
-      colors: {size: 3, update: this.calculateColors},
+      colors: {
+        type: GL.UNSIGNED_BYTE,
+        size: 3,
+        update: this.calculateColors
+      },
       // Instanced attributes
-      pickingColors:
-        {size: 3, update: this.calculatePickingColors, noAlloc: true}
+      pickingColors: {
+        type: GL.UNSIGNED_BYTE,
+        size: 3,
+        update: this.calculatePickingColors,
+        noAlloc: true
+      }
     });
 
     const IndexType = gl.getExtension('OES_element_index_uint') ?
@@ -185,7 +193,7 @@ export default class ChoroplethLayer extends Layer {
       }
     );
 
-    attribute.value = new Float32Array(flattenDeep(colors));
+    attribute.value = new Uint8Array(flattenDeep(colors));
   }
 }
 

--- a/src/layers/core/scatterplot-layer/scatterplot-layer.js
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer.js
@@ -63,23 +63,24 @@ export default class ScatterplotLayer extends Layer {
 
   initializeState() {
     const {gl} = this.context;
-    const drawMode = this.props.drawOutline ? GL.LINE_LOOP : GL.TRIANGLE_FAN;
-    const model = this._getModel(gl, drawMode);
+    const model = this._getModel(gl);
     this.setState({model});
 
     const {attributeManager} = this.state;
     attributeManager.addInstanced({
       instancePositions: {size: 4, update: this.calculateInstancePositions},
-      instanceColors: {size: 3, update: this.calculateInstanceColors}
+      instanceColors: {
+        type: GL.UNSIGNED_BYTE,
+        size: 3,
+        update: this.calculateInstanceColors
+      }
     });
   }
 
-  updateState({oldProps, props}) {
-    if (oldProps.drawOutline !== props.drawOutline) {
-      const {gl} = this.context;
-      const drawMode = props.drawOutline ? GL.LINE_LOOP : GL.TRIANGLE_FAN;
-      const model = this._getModel(gl, drawMode);
-      this.state.model = model;
+  updateState({props, oldProps}) {
+    if (props.drawOutline !== oldProps.drawOutline) {
+      this.state.model.geometry.drawMode =
+        props.drawOutline ? GL.LINE_LOOP : GL.TRIANGLE_FAN;
     }
   }
 
@@ -95,7 +96,7 @@ export default class ScatterplotLayer extends Layer {
     gl.lineWidth(oldLineWidth);
   }
 
-  _getModel(gl, drawMode) {
+  _getModel(gl) {
     const NUM_SEGMENTS = 16;
     const PI2 = Math.PI * 2;
 
@@ -117,7 +118,7 @@ export default class ScatterplotLayer extends Layer {
         fs: glslify('./scatterplot-layer-fragment.glsl')
       }),
       geometry: new Geometry({
-        drawMode: drawMode || GL.TRIANGLE_FAN,
+        drawMode: GL.TRIANGLE_FAN,
         positions: new Float32Array(positions)
       }),
       isInstanced: true

--- a/src/lib/attribute-manager.js
+++ b/src/lib/attribute-manager.js
@@ -1,4 +1,5 @@
 /* eslint-disable guard-for-in */
+import {GL, glArrayFromType} from 'luma.gl';
 import {log} from './utils';
 import assert from 'assert';
 function noop() {}
@@ -406,7 +407,7 @@ export default class AttributeManager {
 
       // Allocate a new typed array if needed
       if (attribute.needsAlloc) {
-        const ArrayType = attribute.type || Float32Array;
+        const ArrayType = glArrayFromType(attribute.type || GL.FLOAT);
         attribute.value = new ArrayType(attribute.size * allocCount);
         this.onLog(2, `${this.id}:${attributeName} allocated ${allocCount}`);
         attribute.needsAlloc = false;

--- a/src/lib/layer.js
+++ b/src/lib/layer.js
@@ -360,9 +360,13 @@ export default class Layer {
     const {attributeManager} = this.state;
     // All instanced layers get instancePickingColors attribute by default
     // Their shaders can use it to render a picking scene
+    // TODO - this slows down non instanced layers
     attributeManager.addInstanced({
-      instancePickingColors:
-        {size: 3, update: this.calculateInstancePickingColors}
+      instancePickingColors: {
+        type: GL.UNSIGNED_BYTE,
+        size: 3,
+        update: this.calculateInstancePickingColors
+      }
     });
 
     // Call subclass lifecycle methods


### PR DESCRIPTION
@shaojingli @Pessimistress @gnavvy 
This long overdue fix saves 21 bytes per instance for most layers (4 x colors + 3 x pickingColors = 7 colors).
- Float32Array - 7 x 4 = 28 bytes per instance
- Uint8Array - 7 x 1 = 7 bytes per instance

This should more than make up for memory expansion from 64 bits, which is usually 4-8 bytes
per instance.

@apercu - If you are updating color attributes for all layers, you could also update type to `GL.UNSIGNED_BYTE`.
