### PR TITLE
Fixed the wobbling in meters projection mode

### DIFF
--- a/shaderlib/project/project.glsl
+++ b/shaderlib/project/project.glsl
@@ -8,7 +8,7 @@ const float PROJECT_MERCATOR_OFFSETS = 2.;
 
 uniform float projectionMode;
 uniform float projectionScale;
-uniform vec2 projectionCenter;
+uniform vec4 projectionCenter;
 uniform vec3 projectionPixelsPerUnit;
 uniform mat4 projectionMatrix;
 uniform mat4 projectionMatrixUncentered;
@@ -209,7 +209,7 @@ vec2 project_position(vec2 position) {
     return (position + vec2(TILE_SIZE / 2.0)) * projectionScale;
   }
   if (projectionMode == PROJECT_MERCATOR_OFFSETS) {
-    return project_scale(position) + projectionCenter;
+    return project_scale(position);
   }
   // Covers projectionMode == PROJECT_MERCATOR
   return project_mercator_(position) * WORLD_SCALE * projectionScale;
@@ -226,6 +226,9 @@ vec4 project_position(vec4 position) {
 //
 
 vec4 project_to_clipspace(vec4 position) {
+  if (projectionMode == PROJECT_MERCATOR_OFFSETS) {
+    return projectionMatrix * vec4(position.xy, 0.0, 0.0) + projectionCenter;
+  }
   return projectionMatrix * position;
 }
 

--- a/src/layers/core/scatterplot-layer/scatterplot-layer-vertex.glsl
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer-vertex.glsl
@@ -34,9 +34,7 @@ varying vec4 vColor;
 void main(void) {
   vec3 center = project_position(instancePositions.xyz);
   vec3 vertex = positions * project_scale(radius * instancePositions.w);
-  gl_Position = project(vec4(center, 1.0)) +
-                project(vec4(vertex, 0.0));
-
+  gl_Position = project(vec4(center + vertex, 1.0));
   vec4 color = vec4(instanceColors.rgb, instanceColors.a * opacity) / 255.;
   vec4 pickingColor = vec4(instancePickingColors / 255., 1.);
 

--- a/src/viewport/viewport.js
+++ b/src/viewport/viewport.js
@@ -11,7 +11,7 @@ import Viewport, {COORDINATE_SYSTEM}
   // from 'viewport-mercator-project/perspective';
   from './old-viewport';
 import autobind from 'autobind-decorator';
-import {mat4, vec2} from 'gl-matrix';
+import {mat4} from 'gl-matrix';
 
 export {COORDINATE_SYSTEM}
   from 'viewport-mercator-project/perspective';
@@ -64,17 +64,36 @@ export default class WebGLViewport extends Viewport {
     // TODO: move the following line to initialization so that it's done only once
     const positionOriginPixels = this.projectFlat(positionOrigin);
 
-    const delta = vec2.subtract([],
-       positionOriginPixels,
-       this.center
-     );
-
-    const projectionCenter = vec2.add([],
-      this.center,
-      delta);
-
+    const projectedPositionOrigin = [positionOriginPixels[0], positionOriginPixels[1], 0.0, 1.0];
     const projections = this.getProjections();
-    const projectionMatrix = projections._viewProjectionMatrix;
+    const projectionMatrix = projections.viewProjectionMatrix;
+
+    const projectionCenter = [0.0, 0.0, 0.0, 0.0];
+
+    projectionCenter[0] =
+      projectionMatrix[0] * projectedPositionOrigin[0] +
+      projectionMatrix[4] * projectedPositionOrigin[1] +
+      projectionMatrix[8] * projectedPositionOrigin[2] +
+      projectionMatrix[12] * projectedPositionOrigin[3];
+
+    projectionCenter[1] =
+      projectionMatrix[1] * projectedPositionOrigin[0] +
+      projectionMatrix[5] * projectedPositionOrigin[1] +
+      projectionMatrix[9] * projectedPositionOrigin[2] +
+      projectionMatrix[13] * projectedPositionOrigin[3];
+
+    projectionCenter[2] =
+      projectionMatrix[2] * projectedPositionOrigin[0] +
+      projectionMatrix[6] * projectedPositionOrigin[1] +
+      projectionMatrix[10] * projectedPositionOrigin[2] +
+      projectionMatrix[14] * projectedPositionOrigin[3];
+
+    projectionCenter[3] =
+      projectionMatrix[3] * projectedPositionOrigin[0] +
+      projectionMatrix[7] * projectedPositionOrigin[1] +
+      projectionMatrix[11] * projectedPositionOrigin[2] +
+      projectionMatrix[15] * projectedPositionOrigin[3];
+
     // If necessary add modelMatrix to clipSpace projection
     if (modelMatrix) {
       mat4.multiply(projectionMatrix, projectionMatrix, modelMatrix);


### PR DESCRIPTION
Fixe the wobbling of meters projection mode by separating the transformation of origin and offset. 

 **mercatorProj(originPosition) * projectionMatrix** + offsetPosition * projectionMatrix

The **bold** part is done on CPU and the rest on GPU

Please verify before we merge @ibgreen 