### PR TITLE
Adding npm commands for pushing demos and documentation to gh-pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,8 @@
     "demo-build-clean": "rm -fr dist-demo && mkdir -p dist-demo",
     "demo-build-copy": " mkdir -p dist-demo/docs && cp -R demo/src/static/* dist-demo/ && cp -R docs dist-demo",
     "demo-build-script": "NODE_ENV=production browserify demo/src/javascripts/main.js -o -t babelify -t sassify -t glslify | uglifyjs > dist-demo/main.min.js",
+    "demo-gh-pages": "git subtree push --prefix dist-demo origin gh-pages",
+    "demo-publish": "npm run build && npm run demo-build && git add dist-demo -f && git commit -m 'UPDATE DOCS' --no-verify && npm run demo-gh-pages",
     "lint": "eslint src",
     "precommit": "npm test",
     "mypublish": "npm run build && npm run test-fast && npm publish",


### PR DESCRIPTION
- `demo-gh-pages`: pushes the demo dist folder to be the root of github pages
- `demo-publish`: compiles deck.gl and the demos, then pushes the changes to `gh-pages` using `demo-gh-pages`