### PR TITLE
Support drawCount uniform to control polygon offsets (defeat z-fighting)

### DIFF
--- a/docs/writing-shaders.md
+++ b/docs/writing-shaders.md
@@ -37,14 +37,21 @@ void main(void) {
 
 ```
 
+## Uniforms
 
-### Opacity (Fragment Shader)
+### `layerIndex` uniform
+
+The layerIndex is a small integer that starts at zero and is incremented
+for each layer that is rendered. It can be used to add small offsets to
+the z coordinate of layers to resolve z-fighting between overlapping
+layers.
+
+### `opacity` uniform
 
 In the fragment shader, multiply the fragment color with the opacity
-uniform or call the `layerColor` method.
+uniform.
 
-
-### Picking (Fragment Shader)
+### `picking` uniforms
 
 If you choose to implement picking through picking colors, make sure
 the `pickingColors` or `instancePickingColors` attribute is correctly set up,

--- a/src/lib/layer-manager.js
+++ b/src/lib/layer-manager.js
@@ -115,9 +115,11 @@ export default class LayerManager {
     assert(this.context.viewport, 'LayerManager.drawLayers: viewport not set');
 
     const {uniforms} = this.context;
+    let drawCount = 0;
     for (const layer of this.layers) {
       if (layer.props.visible) {
-        layer.drawLayer({uniforms});
+        layer.drawLayer({uniforms, drawCount});
+        drawCount++;
       }
     }
 

--- a/src/lib/layer-manager.js
+++ b/src/lib/layer-manager.js
@@ -115,11 +115,11 @@ export default class LayerManager {
     assert(this.context.viewport, 'LayerManager.drawLayers: viewport not set');
 
     const {uniforms} = this.context;
-    let drawCount = 0;
+    let layerIndex = 0;
     for (const layer of this.layers) {
       if (layer.props.visible) {
-        layer.drawLayer({uniforms, drawCount});
-        drawCount++;
+        layer.drawLayer({uniforms, layerIndex});
+        layerIndex++;
       }
     }
 

--- a/src/lib/layer.js
+++ b/src/lib/layer.js
@@ -425,10 +425,10 @@ export default class Layer {
   }
 
   // Calculates uniforms
-  drawLayer({uniforms = {}, drawCount = 0}) {
+  drawLayer({uniforms = {}, layerIndex = 0}) {
     assert(this.context.viewport, 'Layer missing context.viewport');
     const viewportUniforms = this.context.viewport.getUniforms(this.props);
-    uniforms = {...uniforms, ...viewportUniforms, drawCount};
+    uniforms = {...uniforms, ...viewportUniforms, layerIndex};
     // Call subclass lifecycle method
     this.draw({uniforms});
     // End lifecycle method

--- a/src/lib/layer.js
+++ b/src/lib/layer.js
@@ -425,10 +425,10 @@ export default class Layer {
   }
 
   // Calculates uniforms
-  drawLayer({uniforms = {}}) {
+  drawLayer({uniforms = {}, drawCount = 0}) {
     assert(this.context.viewport, 'Layer missing context.viewport');
     const viewportUniforms = this.context.viewport.getUniforms(this.props);
-    uniforms = {...uniforms, ...viewportUniforms};
+    uniforms = {...uniforms, ...viewportUniforms, drawCount};
     // Call subclass lifecycle method
     this.draw({uniforms});
     // End lifecycle method
@@ -499,7 +499,8 @@ export default class Layer {
 
   // PRIVATE METHODS
 
-  // The comparison of the data prop has some special handling
+  // The comparison of the data prop requires special handling
+  // the dataComparator should be used if supplied
   _diffDataProps(oldProps, newProps) {
     // Support optional app defined comparison of data
     const {dataComparator} = newProps;
@@ -515,7 +516,7 @@ export default class Layer {
     return null;
   }
 
-  // Check if any update triggers have changed, and invalidate
+  // Checks if any update triggers have changed, and invalidate
   // attributes accordingly.
   /* eslint-disable max-statements */
   _diffUpdateTriggers(oldProps, newProps) {


### PR DESCRIPTION
@shaojingli @gnavvy 

By adding a `drawCount` uniform we can add small offsets in the vertex shader while rendering to avoid z-fighting.

`drawCount` is simply an integer starting at 0 and incremented for each rendered layer.