### PR TITLE
Allocate frame buffer object only when the viewport size changed.

### DIFF
--- a/src/lib/layer-manager.js
+++ b/src/lib/layer-manager.js
@@ -32,6 +32,7 @@ import {Viewport} from '../viewport';
 import {log} from './utils';
 import assert from 'assert';
 import {pickLayers} from './pick-layers';
+import {FramebufferObject} from 'luma.gl';
 
 export default class LayerManager {
   constructor({gl}) {
@@ -45,7 +46,8 @@ export default class LayerManager {
       gl,
       uniforms: {},
       viewport: null,
-      viewportChanged: true
+      viewportChanged: true,
+      pickingFBO: null
     };
     this.redrawNeeded = true;
     Object.seal(this.context);
@@ -124,12 +126,23 @@ export default class LayerManager {
 
   pickLayer({x, y, mode}) {
     const {gl, uniforms} = this.context;
+
+    // Set up a frame buffer if needed
+    if (this.context.pickingFBO === null ||
+    gl.canvas.width !== this.context.pickingFBO.width ||
+    gl.canvas.height !== this.context.pickingFBO.height) {
+      this.context.pickingFBO = new FramebufferObject(gl, {
+        width: gl.canvas.width,
+        height: gl.canvas.height
+      });
+    }
     return pickLayers(gl, {
       x,
       y,
       uniforms,
       layers: this.layers,
-      mode
+      mode,
+      pickingFBO: this.context.pickingFBO
     });
   }
 

--- a/src/lib/pick-layers.js
+++ b/src/lib/pick-layers.js
@@ -1,21 +1,15 @@
 /* global window */
-import {GL, glContextWithState, FramebufferObject} from 'luma.gl';
+import {GL, glContextWithState} from 'luma.gl';
 
 /* eslint-disable max-depth, max-statements */
 export function pickLayers(gl, {
   layers,
+  pickingFBO,
   uniforms = {},
   x,
   y,
   mode
 }) {
-  // Set up a frame buffer if needed
-  // TODO - cache picking fbo (needs to be resized)?
-  const pickingFBO = new FramebufferObject(gl, {
-    width: gl.canvas.width,
-    height: gl.canvas.height
-  });
-
   // Convert from canvas top-left to WebGL bottom-left coordinates
   // And compensate for pixelRatio
   const pixelRatio = typeof window !== 'undefined' ?


### PR DESCRIPTION
As mentioned in the title. After the change, the profile data looks like:

<img width="598" alt="screen shot 2016-11-14 at 11 29 03 am" src="https://cloud.githubusercontent.com/assets/21322704/20279482/955dce80-aa5d-11e6-9b1c-3e4a02ecd61e.png">

comparing with what we saw in issue #216 

@gnavvy