### PR TITLE
Remove getParameter() calls

### DIFF
--- a/src/layers/core/arc-layer/arc-layer.js
+++ b/src/layers/core/arc-layer/arc-layer.js
@@ -82,10 +82,8 @@ export default class ArcLayer extends Layer {
   draw({uniforms}) {
     const {gl} = this.context;
     const lineWidth = this.screenToDevicePixels(this.props.strokeWidth);
-    const oldLineWidth = gl.getParameter(GL.LINE_WIDTH);
     gl.lineWidth(lineWidth);
     this.state.model.render(uniforms);
-    gl.lineWidth(oldLineWidth);
   }
 
   _createModel(gl) {

--- a/src/layers/core/arc-layer/arc-layer.js
+++ b/src/layers/core/arc-layer/arc-layer.js
@@ -84,6 +84,11 @@ export default class ArcLayer extends Layer {
     const lineWidth = this.screenToDevicePixels(this.props.strokeWidth);
     gl.lineWidth(lineWidth);
     this.state.model.render(uniforms);
+    // Setting line width back to 1 is here to workaround a Google Chrome bug
+    // gl.clear() and gl.isEnabled() will return GL_INVALID_VALUE even with
+    // correct parameter
+    // This is not happening on Safari and Firefox
+    gl.lineWidth(1.0);
   }
 
   _createModel(gl) {

--- a/src/layers/core/choropleth-layer/choropleth-layer.js
+++ b/src/layers/core/choropleth-layer/choropleth-layer.js
@@ -96,10 +96,8 @@ export default class ChoroplethLayer extends Layer {
   draw({uniforms}) {
     const {gl} = this.context;
     const lineWidth = this.screenToDevicePixels(this.props.strokeWidth);
-    const oldLineWidth = gl.getParameter(GL.LINE_WIDTH);
     gl.lineWidth(lineWidth);
     this.state.model.render(uniforms);
-    gl.lineWidth(oldLineWidth);
   }
 
   pick(opts) {

--- a/src/layers/core/choropleth-layer/choropleth-layer.js
+++ b/src/layers/core/choropleth-layer/choropleth-layer.js
@@ -98,6 +98,11 @@ export default class ChoroplethLayer extends Layer {
     const lineWidth = this.screenToDevicePixels(this.props.strokeWidth);
     gl.lineWidth(lineWidth);
     this.state.model.render(uniforms);
+    // Setting line width back to 1 is here to workaround a Google Chrome bug
+    // gl.clear() and gl.isEnabled() will return GL_INVALID_VALUE even with
+    // correct parameter
+    // This is not happening on Safari and Firefox
+    gl.lineWidth(1.0);
   }
 
   pick(opts) {

--- a/src/layers/core/line-layer/line-layer.js
+++ b/src/layers/core/line-layer/line-layer.js
@@ -74,10 +74,8 @@ export default class LineLayer extends Layer {
   draw({uniforms}) {
     const {gl} = this.context;
     const lineWidth = this.screenToDevicePixels(this.props.strokeWidth);
-    const oldLineWidth = gl.getParameter(GL.LINE_WIDTH);
     gl.lineWidth(lineWidth);
     this.state.model.render(uniforms);
-    gl.lineWidth(oldLineWidth);
   }
 
   createModel(gl) {

--- a/src/layers/core/line-layer/line-layer.js
+++ b/src/layers/core/line-layer/line-layer.js
@@ -76,6 +76,11 @@ export default class LineLayer extends Layer {
     const lineWidth = this.screenToDevicePixels(this.props.strokeWidth);
     gl.lineWidth(lineWidth);
     this.state.model.render(uniforms);
+    // Setting line width back to 1 is here to workaround a Google Chrome bug
+    // gl.clear() and gl.isEnabled() will return GL_INVALID_VALUE even with
+    // correct parameter
+    // This is not happening on Safari and Firefox
+    gl.lineWidth(1.0);
   }
 
   createModel(gl) {

--- a/src/layers/core/scatterplot-layer/scatterplot-layer.js
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer.js
@@ -94,6 +94,11 @@ export default class ScatterplotLayer extends Layer {
       ...uniforms,
       radius: this.props.radius
     });
+    // Setting line width back to 1 is here to workaround a Google Chrome bug
+    // gl.clear() and gl.isEnabled() will return GL_INVALID_VALUE even with
+    // correct parameter
+    // This is not happening on Safari and Firefox
+    gl.lineWidth(1.0);
   }
 
   _getModel(gl) {

--- a/src/layers/core/scatterplot-layer/scatterplot-layer.js
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer.js
@@ -89,13 +89,11 @@ export default class ScatterplotLayer extends Layer {
   draw({uniforms}) {
     const {gl} = this.context;
     const lineWidth = this.screenToDevicePixels(this.props.strokeWidth);
-    const oldLineWidth = gl.getParameter(GL.LINE_WIDTH);
     gl.lineWidth(lineWidth);
     this.state.model.render({
       ...uniforms,
       radius: this.props.radius
     });
-    gl.lineWidth(oldLineWidth);
   }
 
   _getModel(gl) {

--- a/src/layers/core/screen-grid-layer/screen-grid-layer.js
+++ b/src/layers/core/screen-grid-layer/screen-grid-layer.js
@@ -74,10 +74,8 @@ export default class ScreenGridLayer extends Layer {
     const {minColor, maxColor} = this.props;
     const {model, cellScale, maxCount} = this.state;
     const {gl} = this.context;
-    const depthWriteMask = gl.getParameter(GL.DEPTH_WRITEMASK);
     gl.depthMask(true);
     model.render({...uniforms, minColor, maxColor, cellScale, maxCount});
-    gl.depthMask(depthWriteMask);
   }
 
   getModel(gl) {

--- a/src/layers/fp64/arc-layer/arc-layer.js
+++ b/src/layers/fp64/arc-layer/arc-layer.js
@@ -85,10 +85,8 @@ export default class ArcLayer64 extends Layer {
   draw({uniforms}) {
     const {gl} = this.context;
     const lineWidth = this.screenToDevicePixels(this.props.strokeWidth);
-    const oldLineWidth = gl.getParameter(GL.LINE_WIDTH);
     gl.lineWidth(lineWidth);
     this.state.model.render(uniforms);
-    gl.lineWidth(oldLineWidth);
   }
 
   createModel(gl) {

--- a/src/layers/fp64/arc-layer/arc-layer.js
+++ b/src/layers/fp64/arc-layer/arc-layer.js
@@ -87,6 +87,11 @@ export default class ArcLayer64 extends Layer {
     const lineWidth = this.screenToDevicePixels(this.props.strokeWidth);
     gl.lineWidth(lineWidth);
     this.state.model.render(uniforms);
+    // Setting line width back to 1 is here to workaround a Google Chrome bug
+    // gl.clear() and gl.isEnabled() will return GL_INVALID_VALUE even with
+    // correct parameter
+    // This is not happening on Safari and Firefox
+    gl.lineWidth(1.0);
   }
 
   createModel(gl) {

--- a/src/layers/fp64/choropleth-layer/choropleth-layer.js
+++ b/src/layers/fp64/choropleth-layer/choropleth-layer.js
@@ -96,6 +96,11 @@ export default class ChoroplethLayer64 extends Layer {
     const lineWidth = this.screenToDevicePixels(this.props.strokeWidth);
     gl.lineWidth(lineWidth);
     this.state.model.render(uniforms);
+    // Setting line width back to 1 is here to workaround a Google Chrome bug
+    // gl.clear() and gl.isEnabled() will return GL_INVALID_VALUE even with
+    // correct parameter
+    // This is not happening on Safari and Firefox
+    gl.lineWidth(1.0);
   }
 
   pick(opts) {

--- a/src/layers/fp64/choropleth-layer/choropleth-layer.js
+++ b/src/layers/fp64/choropleth-layer/choropleth-layer.js
@@ -94,10 +94,8 @@ export default class ChoroplethLayer64 extends Layer {
   draw({uniforms}) {
     const {gl} = this.context;
     const lineWidth = this.screenToDevicePixels(this.props.strokeWidth);
-    const oldLineWidth = gl.getParameter(GL.LINE_WIDTH);
     gl.lineWidth(lineWidth);
     this.state.model.render(uniforms);
-    gl.lineWidth(oldLineWidth);
   }
 
   pick(opts) {

--- a/src/layers/fp64/line-layer/line-layer.js
+++ b/src/layers/fp64/line-layer/line-layer.js
@@ -75,6 +75,11 @@ export default class LineLayer64 extends Layer {
     const lineWidth = this.screenToDevicePixels(this.props.strokeWidth);
     gl.lineWidth(lineWidth);
     this.state.model.render(uniforms);
+    // Setting line width back to 1 is here to workaround a Google Chrome bug
+    // gl.clear() and gl.isEnabled() will return GL_INVALID_VALUE even with
+    // correct parameter
+    // This is not happening on Safari and Firefox
+    gl.lineWidth(1.0);
   }
 
   createModel(gl) {

--- a/src/layers/fp64/line-layer/line-layer.js
+++ b/src/layers/fp64/line-layer/line-layer.js
@@ -73,10 +73,8 @@ export default class LineLayer64 extends Layer {
   draw({uniforms}) {
     const {gl} = this.context;
     const lineWidth = this.screenToDevicePixels(this.props.strokeWidth);
-    const oldLineWidth = gl.getParameter(GL.LINE_WIDTH);
     gl.lineWidth(lineWidth);
     this.state.model.render(uniforms);
-    gl.lineWidth(oldLineWidth);
   }
 
   createModel(gl) {


### PR DESCRIPTION
gl.getParameter() calls bring significant performance hit to the library. We should remove it and find a better way to preserve line width settings later. 