### PR TITLE
add cache support for reusing shader programs

### DIFF
--- a/src/layers/core/arc-layer/arc-layer.js
+++ b/src/layers/core/arc-layer/arc-layer.js
@@ -98,12 +98,17 @@ export default class ArcLayer extends Layer {
       positions = [...positions, i, i, i];
     }
 
+    const program = this.state.program ? {
+      program: this.state.program
+    } : assembleShaders(gl, {
+      vs: glslify('./arc-layer-vertex.glsl'),
+      fs: glslify('./arc-layer-fragment.glsl')
+    });
+
     return new Model({
       gl,
-      ...assembleShaders(gl, {
-        vs: glslify('./arc-layer-vertex.glsl'),
-        fs: glslify('./arc-layer-fragment.glsl')
-      }),
+      id: this.props.id,
+      ...program,
       geometry: new Geometry({
         drawMode: GL.LINE_STRIP,
         positions: new Float32Array(positions)

--- a/src/layers/core/choropleth-layer/choropleth-layer.js
+++ b/src/layers/core/choropleth-layer/choropleth-layer.js
@@ -115,13 +115,17 @@ export default class ChoroplethLayer extends Layer {
   }
 
   getModel(gl) {
+    const program = this.state.program ? {
+      program: this.state.program
+    } : assembleShaders(gl, {
+      vs: glslify('./choropleth-layer-vertex.glsl'),
+      fs: glslify('./choropleth-layer-fragment.glsl')
+    });
+
     return new Model({
       gl,
       id: this.props.id,
-      ...assembleShaders(gl, {
-        vs: glslify('./choropleth-layer-vertex.glsl'),
-        fs: glslify('./choropleth-layer-fragment.glsl')
-      }),
+      ...program,
       geometry: new Geometry({
         drawMode: this.props.drawContour ? GL.LINES : GL.TRIANGLES
       }),

--- a/src/layers/core/line-layer/line-layer.js
+++ b/src/layers/core/line-layer/line-layer.js
@@ -86,13 +86,17 @@ export default class LineLayer extends Layer {
   createModel(gl) {
     const positions = [0, 0, 0, 1, 1, 1];
 
+    const program = this.state.program ? {
+      program: this.state.program
+    } : assembleShaders(gl, {
+      vs: glslify('./line-layer-vertex.glsl'),
+      fs: glslify('./line-layer-fragment.glsl')
+    });
+
     return new Model({
       gl,
       id: this.props.id,
-      ...assembleShaders(gl, {
-        vs: glslify('./line-layer-vertex.glsl'),
-        fs: glslify('./line-layer-fragment.glsl')
-      }),
+      ...program,
       geometry: new Geometry({
         drawMode: GL.LINE_STRIP,
         positions: new Float32Array(positions)

--- a/src/layers/core/scatterplot-layer/scatterplot-layer.js
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer.js
@@ -123,13 +123,17 @@ export default class ScatterplotLayer extends Layer {
       ];
     }
 
+    const program = this.state.program ? {
+      program: this.state.program
+    } : assembleShaders(gl, {
+      vs: glslify('./scatterplot-layer-vertex.glsl'),
+      fs: glslify('./scatterplot-layer-fragment.glsl')
+    });
+
     return new Model({
       gl,
-      id: 'scatterplot',
-      ...assembleShaders(gl, {
-        vs: glslify('./scatterplot-layer-vertex.glsl'),
-        fs: glslify('./scatterplot-layer-fragment.glsl')
-      }),
+      id: this.props.id,
+      ...program,
       geometry: new Geometry({
         drawMode: GL.TRIANGLE_FAN,
         positions: new Float32Array(positions)

--- a/src/layers/core/screen-grid-layer/screen-grid-layer.js
+++ b/src/layers/core/screen-grid-layer/screen-grid-layer.js
@@ -79,13 +79,17 @@ export default class ScreenGridLayer extends Layer {
   }
 
   getModel(gl) {
+    const program = this.state.program ? {
+      program: this.state.program
+    } : assembleShaders(gl, {
+      vs: glslify('./screen-grid-layer-vertex.glsl'),
+      fs: glslify('./screen-grid-layer-fragment.glsl')
+    });
+
     return new Model({
       gl,
       id: this.props.id,
-      ...assembleShaders(gl, {
-        vs: glslify('./screen-grid-layer-vertex.glsl'),
-        fs: glslify('./screen-grid-layer-fragment.glsl')
-      }),
+      ...program,
       geometry: new Geometry({
         drawMode: GL.TRIANGLE_FAN,
         vertices: new Float32Array([0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0])

--- a/src/layers/fp64/arc-layer/arc-layer.js
+++ b/src/layers/fp64/arc-layer/arc-layer.js
@@ -100,15 +100,20 @@ export default class ArcLayer64 extends Layer {
     for (let i = 0; i < NUM_SEGMENTS; i++) {
       positions = [...positions, i, i, i];
     }
+
+    const program = this.state.program ? {
+      program: this.state.program
+    } : assembleShaders(gl, {
+      vs: glslify('./arc-layer-vertex.glsl'),
+      fs: glslify('./arc-layer-fragment.glsl'),
+      fp64: true,
+      project64: true
+    });
+
     return new Model({
       gl,
       id: this.props.id,
-      ...assembleShaders(gl, {
-        vs: glslify('./arc-layer-vertex.glsl'),
-        fs: glslify('./arc-layer-fragment.glsl'),
-        fp64: true,
-        project64: true
-      }),
+      ...program,
       geometry: new Geometry({
         drawMode: GL.LINE_STRIP,
         positions: new Float32Array(positions)

--- a/src/layers/fp64/choropleth-layer/choropleth-layer.js
+++ b/src/layers/fp64/choropleth-layer/choropleth-layer.js
@@ -113,15 +113,19 @@ export default class ChoroplethLayer64 extends Layer {
   }
 
   getModel(gl) {
+    const program = this.state.program ? {
+      program: this.state.program
+    } : assembleShaders(gl, {
+      vs: glslify('./choropleth-layer-vertex.glsl'),
+      fs: glslify('./choropleth-layer-fragment.glsl'),
+      fp64: true,
+      project64: true
+    });
+
     return new Model({
       gl,
       id: this.props.id,
-      ...assembleShaders(gl, {
-        vs: glslify('./choropleth-layer-vertex.glsl'),
-        fs: glslify('./choropleth-layer-fragment.glsl'),
-        fp64: true,
-        project64: true
-      }),
+      ...program,
       geometry: new Geometry({
         drawMode: this.props.drawContour ? GL.LINES : GL.TRIANGLES
       }),

--- a/src/layers/fp64/extruded-choropleth-layer/extruded-choropleth-layer.js
+++ b/src/layers/fp64/extruded-choropleth-layer/extruded-choropleth-layer.js
@@ -137,15 +137,19 @@ export default class ExtrudedChoroplethLayer64 extends Layer {
     gl.enable(GL.DEPTH_TEST);
     gl.depthFunc(GL.LEQUAL);
 
+    const program = this.state.program ? {
+      program: this.state.program
+    } : assembleShaders(gl, {
+      vs: glslify('./extruded-choropleth-layer-vertex.glsl'),
+      fs: glslify('./extruded-choropleth-layer-fragment.glsl'),
+      fp64: true,
+      project64: true
+    });
+
     return new Model({
       gl,
       id: this.props.id,
-      ...assembleShaders(gl, {
-        vs: glslify('./extruded-choropleth-layer-vertex.glsl'),
-        fs: glslify('./extruded-choropleth-layer-fragment.glsl'),
-        fp64: true,
-        project64: true
-      }),
+      ...program,
       geometry: new Geometry({
         drawMode: this.props.drawWireframe ? GL.LINES : GL.TRIANGLES
       }),

--- a/src/layers/fp64/line-layer/line-layer.js
+++ b/src/layers/fp64/line-layer/line-layer.js
@@ -85,15 +85,19 @@ export default class LineLayer64 extends Layer {
   createModel(gl) {
     const positions = [0, 0, 0, 1, 1, 1];
 
+    const program = this.state.program ? {
+      program: this.state.program
+    } : assembleShaders(gl, {
+      vs: glslify('./line-layer-vertex.glsl'),
+      fs: glslify('./line-layer-fragment.glsl'),
+      fp64: true,
+      project64: true
+    });
+
     return new Model({
       gl,
       id: this.props.id,
-      ...assembleShaders(gl, {
-        vs: glslify('./line-layer-vertex.glsl'),
-        fs: glslify('./line-layer-fragment.glsl'),
-        fp64: true,
-        project64: true
-      }),
+      ...program,
       geometry: new Geometry({
         drawMode: GL.LINE_STRIP,
         positions: new Float32Array(positions)

--- a/src/layers/fp64/scatterplot-layer/scatterplot-layer.js
+++ b/src/layers/fp64/scatterplot-layer/scatterplot-layer.js
@@ -111,15 +111,19 @@ export default class ScatterplotLayer64 extends Layer {
       ];
     }
 
+    const program = this.state.program ? {
+      program: this.state.program
+    } : assembleShaders(gl, {
+      vs: glslify('./scatterplot-layer-vertex.glsl'),
+      fs: glslify('./scatterplot-layer-fragment.glsl'),
+      fp64: true,
+      project64: true
+    });
+
     return new Model({
       gl,
       id: this.props.id,
-      ...assembleShaders(gl, {
-        vs: glslify('./scatterplot-layer-vertex.glsl'),
-        fs: glslify('./scatterplot-layer-fragment.glsl'),
-        fp64: true,
-        project64: true
-      }),
+      ...program,
       geometry: new Geometry({
         drawMode: GL.TRIANGLE_FAN,
         positions: new Float32Array(positions)

--- a/src/layers/samples/enhanced-choropleth-layer/enhanced-choropleth-layer.js
+++ b/src/layers/samples/enhanced-choropleth-layer/enhanced-choropleth-layer.js
@@ -89,13 +89,17 @@ export default class EnhancedChoroplethLayer extends Layer {
   }
 
   getModel(gl) {
+    const program = this.state.program ? {
+      program: this.state.program
+    } : assembleShaders(gl, {
+      vs: VERTEX_SHADER,
+      fs: FRAGMENT_SHADER
+    });
+
     return new Model({
       gl,
       id: this.props.id,
-      ...assembleShaders(gl, {
-        vs: VERTEX_SHADER,
-        fs: FRAGMENT_SHADER
-      }),
+      ...program,
       geometry: new Geometry({drawMode: GL.TRIANGLES}),
       vertexCount: 0,
       isIndexed: true

--- a/src/lib/layer.js
+++ b/src/lib/layer.js
@@ -332,6 +332,8 @@ export default class Layer {
     // Initialize state only once
     this.setState({
       attributeManager: new AttributeManager({id: this.props.id}),
+      // reuse existing program (prevent from re-initializing shaders)
+      program: updateParams.program,
       model: null,
       needsRedraw: true,
       dataChanged: true

--- a/src/react/deckgl.js
+++ b/src/react/deckgl.js
@@ -58,13 +58,17 @@ export default class DeckGL extends React.Component {
 
   constructor(props) {
     super(props);
-    this.state = {};
     this.needsRedraw = true;
     this.layerManager = null;
   }
 
   componentWillReceiveProps(nextProps) {
     this._updateLayers(nextProps);
+  }
+
+  componentWillUnmount() {
+    // LayerManager is an ordinary JS class, set to null for GC
+    this.layerManager = null;
   }
 
   _updateLayers(nextProps) {


### PR DESCRIPTION
partially solves the extra overheads introduced due to recursive layer initialization when matching composited layers. (https://github.com/uber/deck.gl/blob/master/src/lib/layer-manager.js#L237)

potentially helpful for on-the-fly adding and removing layers (e.g. highlighting selection).
