### PR TITLE
Build on Node 6 & 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ addons:
     - libgl1-mesa-dri
     - libglapi-mesa
     - libosmesa6
+    - libxi-dev
 node_js:
-  - '5'
+  - 6
+  - 7
 before_script:
   - export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start


### PR DESCRIPTION
Travis now test the project using the Node 6 LTS version and the latest 7, so we can have better vision of our current support and future possible issues coming in a next update.