### PR TITLE
Fix ScatterplotLayer radius when accessor is not defined

### DIFF
--- a/src/layers/core/scatterplot-layer/scatterplot-layer.js
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer.js
@@ -164,7 +164,7 @@ export default class ScatterplotLayer extends Layer {
     let i = 0;
     for (const point of data) {
       const radius = getRadius(point);
-      value[i + 0] = isNaN(radius) ? 0 : radius;
+      value[i + 0] = isNaN(radius) ? 1 : radius;
       i += size;
     }
   }


### PR DESCRIPTION
Fallback to instanceRadius=1 since radius is calculated as radius * instanceRadius