### PR TITLE
onLayerHover and onLayerClick return first match

### DIFF
--- a/docs/using-with-react.md
+++ b/docs/using-with-react.md
@@ -108,9 +108,10 @@ Callback arguments:
 Callback - called when the mouse moves over the layers.
 
 Arguments:
-- `info` - the `info` object of the topmost
-- `pickedInfos` - an array of info objects for all visible layers that
-matched the picked coordinate, in top to bottom order.
+- `info` - the [info](#remarks) object for the topmost matched layer
+at the coordinate
+- `pickedInfos` - an array of info objects for all visible and pickable 
+layers, in top to bottom order.
 - `event` - the original MouseEvent object
 
 ##### `onLayerClick` (Function, optional)
@@ -118,9 +119,10 @@ matched the picked coordinate, in top to bottom order.
 Callback - called when clicking on the layer.
 
 Arguments:
-- `info` - the `info` object of the topmost
-- `pickedInfos` - an array of info objects for all visible layers that
-matched the picked coordinate, in top to bottom order.
+- `info` - the [info](#remarks) object for the topmost matched layer
+at the coordinate
+- `pickedInfos` - an array of info objects for all visible and pickable 
+layers, in top to bottom order.
 - `event` - the original MouseEvent object
 
 ## Remarks

--- a/docs/using-with-react.md
+++ b/docs/using-with-react.md
@@ -110,8 +110,8 @@ Callback - called when the mouse moves over the layers.
 Arguments:
 - `info` - the [info](#remarks) object for the topmost matched layer
 at the coordinate
-- `pickedInfos` - an array of info objects for all visible and pickable 
-layers, in top to bottom order.
+- `pickedInfos` - an array of info objects for all pickable layers that
+are visible, in top to bottom order.
 - `event` - the original MouseEvent object
 
 ##### `onLayerClick` (Function, optional)
@@ -121,8 +121,8 @@ Callback - called when clicking on the layer.
 Arguments:
 - `info` - the [info](#remarks) object for the topmost matched layer
 at the coordinate
-- `pickedInfos` - an array of info objects for all visible and pickable 
-layers, in top to bottom order.
+- `pickedInfos` - an array of info objects for all pickable layers that
+are visible, in top to bottom order.
 - `event` - the original MouseEvent object
 
 ## Remarks

--- a/src/react/deckgl.js
+++ b/src/react/deckgl.js
@@ -115,7 +115,8 @@ export default class DeckGL extends React.Component {
   @autobind _onClick(event) {
     const {x, y} = event;
     const selectedInfos = this.layerManager.pickLayer({x, y, mode: 'click'});
-    const firstInfo = selectedInfos.length > 0 ? selectedInfos[0] : null;
+    const firstInfo = selectedInfos.length > 0 ?
+      selectedInfos.find(info => info.index >= 0) : null;
     // Event.event holds the original MouseEvent object
     this.props.onLayerClick(firstInfo, selectedInfos, event.event);
   }
@@ -124,7 +125,8 @@ export default class DeckGL extends React.Component {
   @autobind _onMouseMove(event) {
     const {x, y} = event;
     const selectedInfos = this.layerManager.pickLayer({x, y, mode: 'hover'});
-    const firstInfo = selectedInfos.length > 0 ? selectedInfos[0] : null;
+    const firstInfo = selectedInfos.length > 0 ?
+      selectedInfos.find(info => info.index >= 0) : null;
     // Event.event holds the original MouseEvent object
     this.props.onLayerHover(firstInfo, selectedInfos, event.event);
   }

--- a/src/react/deckgl.js
+++ b/src/react/deckgl.js
@@ -115,8 +115,7 @@ export default class DeckGL extends React.Component {
   @autobind _onClick(event) {
     const {x, y} = event;
     const selectedInfos = this.layerManager.pickLayer({x, y, mode: 'click'});
-    const firstInfo = selectedInfos.length > 0 ?
-      selectedInfos.find(info => info.index >= 0) : null;
+    const firstInfo = selectedInfos.find(info => info.index >= 0);
     // Event.event holds the original MouseEvent object
     this.props.onLayerClick(firstInfo, selectedInfos, event.event);
   }
@@ -125,8 +124,7 @@ export default class DeckGL extends React.Component {
   @autobind _onMouseMove(event) {
     const {x, y} = event;
     const selectedInfos = this.layerManager.pickLayer({x, y, mode: 'hover'});
-    const firstInfo = selectedInfos.length > 0 ?
-      selectedInfos.find(info => info.index >= 0) : null;
+    const firstInfo = selectedInfos.find(info => info.index >= 0);
     // Event.event holds the original MouseEvent object
     this.props.onLayerHover(firstInfo, selectedInfos, event.event);
   }


### PR DESCRIPTION
`onLayerHover(info, pickedInfos, event)`
`onLayerHover(info, pickedInfos, event)`
The first argument is more useful if it is the first non-empty layer under the pointer instead of the topmost layer.