### PR TITLE
Package lighting code as shader module. Add sphere geometry and lighting

### DIFF
--- a/examples/main/layer-examples.js
+++ b/examples/main/layer-examples.js
@@ -12,6 +12,13 @@ import {
   LineLayer64
 } from 'deck.gl';
 
+// TODO - should point light location really be in lng/lat?
+const POINT_LIGHT_LOCATION = [
+  37.751537058389985,
+  -122.42694203247012,
+  1e4
+];
+
 import * as dataSamples from './data-samples';
 
 const ArcLayerExample = {
@@ -89,7 +96,8 @@ const ScatterplotLayerExample = {
     strokeWidth: 2,
     pickable: true,
     radiusMinPixels: 1,
-    radiusMaxPixels: 30
+    radiusMaxPixels: 30,
+    pointLightLocation: POINT_LIGHT_LOCATION
   }
 };
 
@@ -104,7 +112,8 @@ const ScatterplotLayerMetersExample = {
     getPosition: d => d,
     getColor: d => [0, 0, 255],
     opacity: 0.5,
-    pickable: true
+    pickable: true,
+    pointLightLocation: POINT_LIGHT_LOCATION
   }
 };
 
@@ -152,13 +161,7 @@ const ExtrudedChoroplethLayer64Example = {
     id: 'extrudedChoroplethLayer64',
     data: dataSamples.choropleths,
     getColor: f => [((f.properties.ZIP_CODE * 10) % 127) + 128, 0, 0],
-    pointLightLocation: [
-      // props.mapViewState.longitude,
-      // props.mapViewState.latitude,
-      37.751537058389985,
-      -122.42694203247012,
-      1e4
-    ],
+    pointLightLocation: POINT_LIGHT_LOCATION,
     opacity: 1.0,
     pickable: true
   }

--- a/src/layers/core/scatterplot-layer/circle.js
+++ b/src/layers/core/scatterplot-layer/circle.js
@@ -1,0 +1,38 @@
+import {Geometry} from 'luma.gl';
+
+// These match the numeric values of the corresponding GL constants
+// Redefining them here avoids a hard dependency between the
+// abstract geometries and the WebGL library.
+export const DRAW_MODE = {
+  TRIANGLE_FAN: 6
+};
+
+// Creates a circle in the XY plane with the specified radius
+export default class CircleGeometry extends Geometry {
+  constructor({
+    sides = 16,
+    radius = 1,
+    id = 'circle-geometry'
+    // id = uid('circle-geometry'),
+  } = {}) {
+    const positions = [];
+    const normals = [];
+    const texCoords = [];
+    for (let i = 0; i < sides; i++) {
+      const cosi = Math.cos(Math.PI * 2 * i / sides);
+      const sini = Math.sin(Math.PI * 2 * i / sides);
+      positions.push(cosi * radius, sini * radius, 0);
+      normals.push(0, 0, 1);
+      texCoords.push(cosi, sini);
+    }
+
+    super({
+      drawMode: DRAW_MODE.TRIANGLE_FAN,
+      attributes: {
+        positions: new Float32Array(positions),
+        normals: new Float32Array(normals),
+        texCoords: new Float32Array(texCoords)
+      }
+    });
+  }
+}

--- a/src/layers/core/scatterplot-layer/scatterplot-layer-vertex.glsl
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer-vertex.glsl
@@ -21,6 +21,7 @@
 #define SHADER_NAME scatterplot-layer-vertex-shader
 
 attribute vec3 positions;
+attribute vec3 normals;
 
 attribute vec3 instancePositions;
 attribute float instanceRadius;
@@ -48,7 +49,8 @@ void main(void) {
   gl_Position = project_to_clipspace(vec4(center + vertex, 1.0));
 
   // Apply opacity to instance color, or return instance picking color
-  vec4 color = vec4(instanceColors.rgb, instanceColors.a * opacity) / 255.;
+  vec3 rgb = applyLighting(vertex, normals, instanceColors.rgb);
+  vec4 color = vec4(rgb, instanceColors.a * opacity) / 255.;
   vec4 pickingColor = vec4(instancePickingColors / 255., 1.);
   vColor = mix(color, pickingColor, renderPickingBuffer);
 }

--- a/src/layers/fp64/extruded-choropleth-layer/extruded-choropleth-layer-vertex.glsl
+++ b/src/layers/fp64/extruded-choropleth-layer/extruded-choropleth-layer-vertex.glsl
@@ -24,33 +24,11 @@ uniform float opacity;
 uniform vec3 colors;
 uniform float elevation;
 
-uniform vec3 uAmbientColor;
-uniform float uPointLightAmbientCoefficient;
-uniform vec3 uPointLightLocation;
-uniform vec3 uPointLightColor;
-uniform float uPointLightAttenuation;
-
-uniform vec3 uMaterialSpecularColor;
-uniform float uMaterialShininess;
-
 attribute vec4 positions;
 attribute vec2 heights;
 attribute vec3 normals;
 
 varying vec4 vColor;
-
-vec3 applyLighting(vec3 position_modelspace, vec3 normal_modelspace, vec3 color) {
-
-  vec3 pointLightLocation_modelspace = vec3(project_position(uPointLightLocation));
-  vec3 lightDirection = normalize(pointLightLocation_modelspace - position_modelspace);
-
-  vec3 ambient = uPointLightAmbientCoefficient * color / 255.0 * uAmbientColor / 255.0;
-
-  float diffuseCoefficient = max(dot(normal_modelspace, lightDirection), 0.0);
-  vec3 diffuse = diffuseCoefficient * uPointLightColor / 255. * color / 255.;
-
-  return ambient + uPointLightAttenuation * diffuse;
-}
 
 void main(void) {
   vec2 projected_xy[2];
@@ -65,14 +43,14 @@ void main(void) {
 
   gl_Position = project_to_clipspace_fp64(vertex_pos_modelspace);
 
-  vec3 color = applyLighting(
-  	vec3(
-  	  vertex_pos_modelspace[0].x,
-  	  vertex_pos_modelspace[1].x,
-  	  vertex_pos_modelspace[2].x),
-  	normals,
-  	colors
+  vec3 vertex =  vec3(
+    vertex_pos_modelspace[0].x,
+    vertex_pos_modelspace[1].x,
+    vertex_pos_modelspace[2].x
   );
+
+  vec3 color = applyLighting(vertex, normals, colors);
+
+  // TODO - Picking colors???
   vColor = vec4(color, opacity);
 }
-// `;

--- a/src/layers/fp64/scatterplot-layer/scatterplot-layer-64.js
+++ b/src/layers/fp64/scatterplot-layer/scatterplot-layer-64.js
@@ -25,14 +25,13 @@ import {join} from 'path';
 
 export default class ScatterplotLayer64 extends ScatterplotLayer {
 
-  // Override the super class vertex shader
+  // Override the base layer's vertex shader and request 64 bit modules
   getShaders(id) {
-    return {
+    return Object.assign({}, super.getShaders(), {
       vs: readFileSync(join(__dirname, './scatterplot-layer-64-vertex.glsl'), 'utf8'),
-      fs: super.getShaders().fs,
       fp64: true,
       project64: true
-    };
+    });
   }
 
   initializeState() {
@@ -44,10 +43,11 @@ export default class ScatterplotLayer64 extends ScatterplotLayer {
     attributeManager.addInstanced({
       instancePositions64xy: {size: 4, update: this.calculateInstancePositions64xy},
       instancePositions64z: {size: 2, update: this.calculateInstancePositions64z}
-      // Reusing from base class
-      // instanceRadius: {size: 1, update: this.calculateInstanceRadius},
-      // instanceColors: {size: 4, type: GL.UNSIGNED_BYTE, update: this.calculateInstanceColors}
+      // Reusing from base class: instanceRadius, instanceColors
     });
+
+    // TODO - Delete (or disable) the 32 bit instancePositions attribute.
+    // For now it gets allocated/calculated even though it is not used by 64 bit layer.
   }
 
   calculateInstancePositions64xy(attribute) {

--- a/src/shader-utils/index.js
+++ b/src/shader-utils/index.js
@@ -1,1 +1,2 @@
 export * from './assemble-shaders';
+export * from './shader-chunks';

--- a/src/shader-utils/shader-chunks.js
+++ b/src/shader-utils/shader-chunks.js
@@ -2,3 +2,4 @@
 export * from '../shaderlib/fp64';
 export * from '../shaderlib/project';
 export * from '../shaderlib/project64';
+export * from '../shaderlib/lighting';

--- a/src/shaderlib/lighting/index.js
+++ b/src/shaderlib/lighting/index.js
@@ -1,0 +1,33 @@
+import fs from 'fs';
+import path from 'path';
+export const lighting = {
+  interface: 'lighting',
+  source: fs.readFileSync(path.join(__dirname, 'apply-lighting.glsl'), 'utf8')
+};
+
+const DEFAULT_AMBIENT_COLOR = [255, 255, 255];
+const DEFAULT_POINTLIGHT_AMBIENT_COEFFICIENT = 0.1;
+const DEFAULT_POINTLIGHT_LOCATION = [40.4406, -79.9959, 100];
+const DEFAULT_POINTLIGHT_COLOR = [255, 255, 255];
+const DEFAULT_POINTLIGHT_ATTENUATION = 1.0;
+const DEFAULT_MATERIAL_SPECULAR_COLOR = [255, 255, 255];
+const DEFAULT_MATERIAL_SHININESS = 1;
+
+export function lightingSetUniforms(modelOrLayer, props) {
+  const {
+    ambientColor, pointLightColor,
+    pointLightLocation, pointLightAmbientCoefficient,
+    pointLightAttenuation, materialSpecularColor, materialShininess
+  } = props;
+
+  modelOrLayer.setUniforms({
+    uAmbientColor: ambientColor || DEFAULT_AMBIENT_COLOR,
+    uPointLightAmbientCoefficient:
+      pointLightAmbientCoefficient || DEFAULT_POINTLIGHT_AMBIENT_COEFFICIENT,
+    uPointLightLocation: pointLightLocation || DEFAULT_POINTLIGHT_LOCATION,
+    uPointLightColor: pointLightColor || DEFAULT_POINTLIGHT_COLOR,
+    uPointLightAttenuation: pointLightAttenuation || DEFAULT_POINTLIGHT_ATTENUATION,
+    uMaterialSpecularColor: materialSpecularColor || DEFAULT_MATERIAL_SPECULAR_COLOR,
+    uMaterialShininess: materialShininess || DEFAULT_MATERIAL_SHININESS
+  });
+}


### PR DESCRIPTION
@shaojingli @Pessimistress @gnavvy This is an experimental PR, for discussion. 

<img width="492" alt="screen shot 2017-01-12 at 12 04 06 pm" src="https://cloud.githubusercontent.com/assets/7025232/21910069/59271a0c-d8cf-11e6-84a1-c6f07a9d0691.png">

The idea here is to generalize all layers to 3D, and strarting with ScatterplotLayer:
* Make sure it takes a Z coordinate (already done)
* Enable it to use a 3D primitive (sphere)
* Adding lighting.

Some downsides to making these changes to scatterplot layer
* Doesn't allow for custom fragment shader to render circles.
* At the moment, including lighting in the scatterplot will slow down the rendering quite a bit. This will be less of a concern later when we build shaders dynamically.

For now maybe a separate `Scatterplot3DLayer`?

PS - This PR also refactored our basic lighting code into a reusable shader module. This part should probably be broken out and landed right away.