### PR TITLE
Fix an issue in scatterplot64 that height is nan when the data source has no z data

### DIFF
--- a/src/layers/fp64/scatterplot-layer/scatterplot-layer-64.js
+++ b/src/layers/fp64/scatterplot-layer/scatterplot-layer-64.js
@@ -148,7 +148,7 @@ export default class ScatterplotLayer64 extends Layer {
     let i = 0;
     for (const point of data) {
       const position = getPosition(point);
-      [value[i + 0], value[i + 1]] = fp64ify(position[2]);
+      [value[i + 0], value[i + 1]] = fp64ify(position[2] || 0);
       i += size;
     }
   }


### PR DESCRIPTION
NOTE: this is a PR against the master branch.

One line fix to get around nan when z data is 0.
This is a fix that has already been landed in dev branch. Porting it to master to unbreak users