### PR TITLE
Set Viewport project/unproject default to screen coordinates

### DIFF
--- a/src/lib/viewports/viewport.js
+++ b/src/lib/viewports/viewport.js
@@ -119,7 +119,7 @@ export default class Viewport {
    * @param {Object} opts.topLeft=true - Whether projected coords are top left
    * @return {Array} - [x, y] or [x, y, z] in top left coords
    */
-  project(xyz, {topLeft = false} = {}) {
+  project(xyz, {topLeft = true} = {}) {
     const Z = xyz[2] || 0;
     // console.error('projecting non-linear', xyz);
     const [X, Y] = this.projectFlat(xyz);
@@ -144,7 +144,7 @@ export default class Viewport {
    * @param {Array} xyz -
    * @return {Array} - [lng, lat, Z] or [X, Y, Z]
    */
-  unproject(xyz, {topLeft = false} = {}) {
+  unproject(xyz, {topLeft = true} = {}) {
     // console.error('unprojecting linear', xyz);
     const [x = 0, y = 0, z = 0] = xyz;
     // const y2 = topLeft ? this.height - 1 - y : y;

--- a/test/lib/index.js
+++ b/test/lib/index.js
@@ -1,4 +1,5 @@
 import './utils/compare-objects.spec';
+import './viewports';
 import './attribute-manager.spec';
 import './viewport-uniforms.spec';
 import './layer.spec';

--- a/test/lib/viewports/index.js
+++ b/test/lib/viewports/index.js
@@ -1,0 +1,1 @@
+import './web-mercator-viewport.spec';

--- a/test/lib/viewports/web-mercator-viewport.spec.js
+++ b/test/lib/viewports/web-mercator-viewport.spec.js
@@ -1,0 +1,67 @@
+import {WebMercatorViewport} from 'deck.gl/lib/viewports';
+import test from 'tape-catch';
+import {toLowPrecision} from '../../test-utils';
+
+const viewportProps = {
+  latitude: 37.75,
+  longitude: -122.43,
+  zoom: 11.5,
+  pitch: 30,
+  bearing: 0,
+  width: 800,
+  height: 600
+};
+
+test('Viewport constructor', t => {
+  const viewport = new WebMercatorViewport(viewportProps);
+
+  t.ok(viewport, 'Viewport construction successful');
+
+  const viewportState = {};
+  Object.keys(viewportProps).forEach(key => {
+    viewportState[key] = viewport[key];
+  });
+
+  t.deepEquals(viewportState, viewportProps, 'Viewport props assigned');
+  t.end();
+});
+
+test('Viewport projection', t => {
+  const viewport = new WebMercatorViewport(viewportProps);
+  const TEST_CASES = [
+    {
+      title: 'project (center)',
+      func: 'project',
+      input: [-122.43, 37.75],
+      expected: [400, 300]
+    },
+    {
+      title: 'project (corner)',
+      func: 'project',
+      input: [-122.55, 37.83],
+      expected: [-1.329741801625046, 6.796120915775314]
+    }
+    // {
+    //   title: 'unproject (center)',
+    //   func: 'unproject',
+    //   input: [400, 300],
+    //   expected: [-122.43, 37.75]
+    // },
+    // {
+    //   title: 'unproject (corner)',
+    //   func: 'unproject',
+    //   input: [0, 0],
+    //   expected: [-122.55024809579456, 37.832294933238586]
+    // }
+  ];
+
+  TEST_CASES.forEach(({title, func, input, expected}) => {
+    const output = viewport[func](input);
+    t.deepEquals(
+      output.map(x => toLowPrecision(x)),
+      expected.map(x => toLowPrecision(x)),
+      title
+    );
+  });
+  t.end();
+});


### PR DESCRIPTION
- Match default value of option `topLeft` with JSDoc
- Fix bug where y is flipped in `ScreenGridLayer`
- Fix bug where picking info produce wrong `latLng` values
- Add tests

@ibgreen @heshan0131