### PR TITLE
make compute[Picking]Colors fast

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,5 +120,6 @@
     "test-shader": "npm run build-dist && budo src/test/shader.js:build/test-bundle.js --dir test --live --open --port 3001 --watch-glob '**/*.{html,css,scss,js,glsl}' -- -t babelify -t brfs-babel",
     "profile-disc": "browserify src/bundle.js --full-paths -t babelify -t brfs-babel | uglifyjs | discify --open",
     "start": "npm run build-watch && budo example/main.js:example/bundle.js --live --open --port 3000 --css example/main.css --title 'deck.gl' --watch-glob '**/*.{html,css,js,glsl}' -- -t brfs-babel -t babelify -t envify"
-  }
+  },
+  "browserify": { "transform": [ "babelify" ] }
 }


### PR DESCRIPTION
reduce code duplication, reduce memory allocations, update a Uint8Array directly rather than creating tons of JS arrays and calling flatten() each time. since these functions must run every single frame when picking is enabled and the user is moving their mouse quickly, this makes a big difference.

fixes #301 

see that bug for details on how i measured the following frame rates:

### before: 3 FPS in debug mode

![image](https://cloud.githubusercontent.com/assets/169280/22186119/6b10b362-e0a5-11e6-99cb-fd027575eea2.png)

CPU bound, with most of the time spent in `isFlattenable` and `baseFlatten`, which are both called from `flatten`.

### after: 20 FPS in debug mode

![image](https://cloud.githubusercontent.com/assets/169280/22189208/10f330f0-e0d0-11e6-8911-4854cf363c8c.png)

flatten is gone, and most of the time is now spent in `getError`, which goes away once we disable debug mode. (i left it on to get an apples to apples comparison.)

**tldr; mousing over my choropleth map with 1600 regions and 200k total vertices is smooth now**