### PR TITLE
GeoJSONLayer bug fixes

### DIFF
--- a/docs/layers/geojson-layer.md
+++ b/docs/layers/geojson-layer.md
@@ -37,12 +37,12 @@ Inherits from all [Base Layer properties](/docs/layers/base-layer.md):
       }
     }
 
-#### `onHovered` (Function, optional)
+#### `onHover` (Function, optional)
 
 Provides selected feature (and properties) along with mouse event when a
 GeoJson feature is hovered.
 
-#### `onClicked` (Function, optional)
+#### `onClick` (Function, optional)
 
 Provides selected feature (and properties) along with mouse event when a
 GeoJson feature is clicked.
@@ -54,19 +54,34 @@ GeoJson feature is clicked.
 ### `getStrokeWidth`
 
 ### `getFillColor`
+### `getHeight`
 
 ### `getPointColor`
-### `getPointRadius`
+### `getPointSize`
 
 ## Layer-specific Properties
 
-#### `strokeColor` (Boolean, optional)
 
-- Default: `false`
+#### `drawPoints` (Boolean, optional)
 
-Each object can have a `color`. strokeColor is the default.
+Draw Point features if true.
+
+
+#### `drawLines` (Boolean, optional)
+
+Draw LineString and MultiLineString features if true.
+
+
+#### `drawPolygons` (Boolean, optional)
+
+Draw outlines of Polygon and MultiPolygon features if true.
+
+
+#### `fillPolygons` (Boolean, optional)
+
+Fill areas of Polygon and MultiPolygon features if true.
 
 
 #### `extruded` (Boolean, optional)
 
-Draw choropleth contour if true, else fill choropleth area.
+Extrude Polygon and MultiPolygon features in 3D if true.

--- a/docs/layers/path-layer.md
+++ b/docs/layers/path-layer.md
@@ -10,16 +10,9 @@ Inherits from all [Base Layer](/docs/layers/base-layer.md) properties.
 ## Layer-specific Properties
 
 
-#### `getPathCount`
-
-default: `object => 1`
-
-Number of paths for an object
-
-
 #### `getPath` (Function, optional)
 
-- Default: `(object, index) => object.paths[index]`
+- Default: `(object, index) => object.paths`
 
 Returns the specified path for the object.
 
@@ -41,12 +34,11 @@ If the color alpha (the fourth component) is not provided,
 `alpha` will be set to `255`.
 
 
-#### `getCoordinate` (Function, optional)
+#### `getWidth` (Function, optional)
 
-- Default: `(path, index) => path[index]`
+- Default: `(object, index) => object.width || 1`
 
-Return a coordinate from a path. The coordinate is expected to be
-three components. The third component will be set to 0 if not provided.
+Return a width multiplier from each object.
 
 
 ##### `strokeWidth` (Number, optional)

--- a/examples/main/layer-examples.js
+++ b/examples/main/layer-examples.js
@@ -63,23 +63,10 @@ const GeoJsonLayerExample = {
   props: {
     id: 'geojsonLayer',
     data: dataSamples.choropleths,
-    getFillColor: f => [0, 0, ((Container.get(f, 'properties.ZIP_CODE') * 10) % 127) + 128],
-    getColor: f => [200, 0, 80],
-    opacity: 0.8,
-    drawContour: true
-  }
-};
-
-const GeoJsonLayerOutlineExample = {
-  layer: GeoJsonLayer,
-  props: {
-    id: 'geojsonLayer-outline',
-    data: dataSamples.choropleths,
-    fillPolygons: false,
-    getStrokeColor: f => [0, 0, ((Container.get(f, 'properties.ZIP_CODE') * 10) % 127) + 128],
-    getColor: f => [200, 0, 80],
-    opacity: 0.8,
-    drawContour: true
+    getFillColor: f => [0, 0, ((Container.get(f, 'properties.ZIP_CODE') * 10) % 127) + 128, 64],
+    getStrokeColor: f => [200, 0, 80],
+    strokeWidth: 4,
+    pickable: true
   }
 };
 
@@ -90,9 +77,9 @@ const GeoJsonLayerExtrudedExample = {
     data: dataSamples.choropleths,
     getHeight: f => ((f.properties.ZIP_CODE * 10) % 127) * 10,
     getFillColor: f => [0, 0, ((Container.get(f, 'properties.ZIP_CODE') * 23) % 100) + 155],
-    getColor: f => [0, 0, ((Container.get(f, 'properties.ZIP_CODE') * 10) % 256)],
-    opacity: 1,
-    extruded: true
+    drawPolygons: false,
+    extruded: true,
+    pickable: true
   }
 };
 
@@ -106,9 +93,7 @@ const GeoJsonLayerWireframeExample = {
     wireframe: true,
     lightSettings: {enabled: false},
     getHeight: f => ((f.properties.ZIP_CODE * 10) % 127) * 10,
-    getFillColor: f => [0, 0, ((Container.get(f, 'properties.ZIP_CODE') * 10) % 127) + 128],
-    getColor: f => [200, 0, 80],
-    opacity: 0.8
+    getStrokeColor: f => [200, 0, 80]
   }
 };
 
@@ -361,7 +346,6 @@ const ScatterplotLayer64PerfExample = (id, getData) => ({
 export default {
   'Core Layers': {
     'GeoJsonLayer': GeoJsonLayerExample,
-    'GeoJsonLayer (Outline)': GeoJsonLayerOutlineExample,
     'GeoJsonLayer (Extruded)': GeoJsonLayerExtrudedExample,
     'GeoJsonLayer (Wireframe)': GeoJsonLayerWireframeExample,
     // 'GeoJsonLayer (Immutable)': GeoJsonLayerImmutableExample,

--- a/examples/main/layer-info.js
+++ b/examples/main/layer-info.js
@@ -13,18 +13,24 @@ export default class LayerInfo extends PureComponent {
     this.onItemClicked = this._onMouseEvent.bind(this, 'clicked');
   }
 
-  _onMouseEvent(name, item) {
-    if (item.index < 0) {
-      item = null;
+  _onMouseEvent(name, info) {
+    if (info.index < 0) {
+      info = null;
     }
 
     const oldItem = this.state[name];
-    if (oldItem === item ||
-      (oldItem && item && oldItem.layer.id === item.layer.id && oldItem.index === item.index)) {
+    if (oldItem === info ||
+      (oldItem && info && oldItem.layer.id === info.layer.id && oldItem.index === info.index)) {
       // no change
       return;
     }
-    this.setState({[name]: item});
+    this.setState({[name]: info});
+  }
+
+  _infoToString(info) {
+    const object = info.feature || info.object;
+    const props = object.properties || object;
+    return JSON.stringify(props);
   }
 
   render() {
@@ -34,11 +40,11 @@ export default class LayerInfo extends PureComponent {
       <div id="layer-info">
         { hovered && (<div>
           <h4>Hover</h4>
-          <span>Layer: { hovered.layer.id } Index: { hovered.index }</span>
+          <span>Layer: { hovered.layer.id } Object: { this._infoToString(hovered) }</span>
         </div>) }
         { clicked && (<div>
           <h4>Click</h4>
-          <span>Layer: { clicked.layer.id } Index: { clicked.index }</span>
+          <span>Layer: { clicked.layer.id } Object: { this._infoToString(clicked) }</span>
         </div>) }
       </div>
     );

--- a/examples/main/layer-info.js
+++ b/examples/main/layer-info.js
@@ -29,6 +29,9 @@ export default class LayerInfo extends PureComponent {
 
   _infoToString(info) {
     const object = info.feature || info.object;
+    if (!object) {
+      return 'None';
+    }
     const props = object.properties || object;
     return JSON.stringify(props);
   }

--- a/src/layers/core/geojson-layer/geojson-layer.js
+++ b/src/layers/core/geojson-layer/geojson-layer.js
@@ -19,11 +19,9 @@
 // THE SOFTWARE.
 
 import {Layer} from '../../../lib';
-import {autobind} from '../../../react';
 import ScatterplotLayer from '../scatterplot-layer';
 import PathLayer from '../path-layer/path-layer';
 import PolygonLayer from '../polygon-layer/polygon-layer';
-import flatten from 'lodash.flatten';
 
 import {get} from '../../../lib/utils';
 import {getGeojsonFeatures, separateGeojsonFeatures} from './geojson';

--- a/src/layers/core/geojson-layer/geojson-layer.js
+++ b/src/layers/core/geojson-layer/geojson-layer.js
@@ -124,7 +124,7 @@ export default class GeoJsonLayer extends Layer {
     const polygonFillLayer = fillPolygons && new PolygonLayer(Object.assign({}, this.props, {
       id: `${id}-polygon-fill`,
       data: polygonFeatures,
-      getPolygon: f => get(f, 'geometry.coordinates'),
+      getPolygon: getCoordinates,
       getHeight,
       getColor: getFillColor,
       extruded,

--- a/src/layers/core/geojson-layer/geojson.js
+++ b/src/layers/core/geojson-layer/geojson.js
@@ -47,6 +47,8 @@ export function separateGeojsonFeatures(features) {
   const pointFeatures = [];
   const lineFeatures = [];
   const polygonFeatures = [];
+  const polygonOutlineFeatures = [];
+
   Container.forEach(features, feature => {
     const type = Container.get(feature, 'geometry.type');
     const coordinates = Container.get(feature, 'geometry.coordinates');
@@ -65,19 +67,26 @@ export function separateGeojsonFeatures(features) {
       lineFeatures.push(feature);
       break;
     case 'MultiLineString':
-      // Break multipolygons into multiple polygons with same properties
+      // Break multilinestrings into multiple lines with same properties
       Container.forEach(coordinates, path => {
         lineFeatures.push({geometry: {coordinates: path}, properties, feature});
       });
       break;
     case 'Polygon':
       polygonFeatures.push(feature);
+      // Break polygon into multiple lines with same properties
+      Container.forEach(coordinates, path => {
+        polygonOutlineFeatures.push({geometry: {coordinates: path}, properties, feature});
+      });
       break;
     case 'MultiPolygon':
       // Break multipolygons into multiple polygons with same properties
       Container.forEach(coordinates, polygon => {
-        const subFeature = {geometry: {coordinates: polygon}, properties, feature};
-        polygonFeatures.push(subFeature);
+        polygonFeatures.push({geometry: {coordinates: polygon}, properties, feature});
+        // Break polygon into multiple lines with same properties
+        Container.forEach(polygon, path => {
+          polygonOutlineFeatures.push({geometry: {coordinates: path}, properties, feature});
+        });
       });
       break;
       // Not yet supported
@@ -90,6 +99,7 @@ export function separateGeojsonFeatures(features) {
   return {
     pointFeatures,
     lineFeatures,
-    polygonFeatures
+    polygonFeatures,
+    polygonOutlineFeatures
   };
 }

--- a/src/layers/core/path-layer/path-layer.js
+++ b/src/layers/core/path-layer/path-layer.js
@@ -7,9 +7,9 @@ import {join} from 'path';
 const defaultProps = {
   opacity: 1,
   strokeWidth: 1,
-  getPath: feature => feature.geometry.coordinates,
-  getColor: feature => feature.properties.color,
-  getWidth: feature => feature.properties.width || 1
+  getPath: object => object.path,
+  getColor: object => object.color,
+  getWidth: object => object.width || 1
 };
 
 export default class PathLayer extends Layer {
@@ -199,13 +199,13 @@ export default class PathLayer extends Layer {
   }
 
   calculateDirections(attribute) {
-    const {data, strokeWidth, getWidth} = this.props;
+    const {data, getWidth} = this.props;
     const {paths, pointCount} = this.state;
     const directions = new Float32Array(pointCount * attribute.size * 2);
 
     let i = 0;
-    paths.forEach(path => {
-      const w = getWidth(data[path._index]) || strokeWidth;
+    paths.forEach((path, index) => {
+      const w = getWidth(data[index], index);
       path.forEach(() => {
         directions[i++] = w;
         directions[i++] = -w;
@@ -221,8 +221,8 @@ export default class PathLayer extends Layer {
     const colors = new Uint8Array(pointCount * attribute.size * 2);
 
     let i = 0;
-    paths.forEach(path => {
-      const pointColor = getColor(data[path._index]);
+    paths.forEach((path, index) => {
+      const pointColor = getColor(data[index], index);
       if (isNaN(pointColor[3])) {
         pointColor[3] = 255;
       }

--- a/src/layers/core/path-layer/path-layer.js
+++ b/src/layers/core/path-layer/path-layer.js
@@ -53,12 +53,7 @@ export default class PathLayer extends Layer {
       // this.state.paths only stores point positions in each path
       this.state.paths = [];
 
-      props.data.map(f => getPaths(f)).forEach((paths, index) => {
-        paths.forEach(path => {
-          path._index = index;
-        });
-        this.state.paths.push(...paths);
-      });
+      this.state.paths =props.data.map(getPaths);
 
       this.state.pointCount = 0;
       this.state.indexCount = 0;
@@ -84,18 +79,6 @@ export default class PathLayer extends Layer {
       thickness: this.props.strokeWidth || 1,
       miterLimit: 1
     }));
-  }
-
-  pick(opts) {
-    super.pick(opts);
-    const {info} = opts;
-    if (!info) {
-      return;
-    }
-    const index = info.index;
-    const feature = index >= 0 ? this.props.data[index] : null;
-    info.feature = feature;
-    info.object = feature;
   }
 
   getModel(gl) {

--- a/src/layers/core/path-layer/path-layer.js
+++ b/src/layers/core/path-layer/path-layer.js
@@ -6,13 +6,10 @@ import {join} from 'path';
 
 const defaultProps = {
   opacity: 1,
-  color: [64, 64, 64, 255],
   strokeWidth: 1,
-  strokeOpacity: 1,
   getPaths: feature => feature.geometry.coordinates,
   getColor: feature => feature.properties.color,
-  getWidth: feature => feature.properties.width || 1,
-  getOpacity: feature => feature.properties.opacity
+  getWidth: feature => feature.properties.width || 1
 };
 
 export default class PathLayer extends Layer {

--- a/src/layers/core/path-layer/path-layer.js
+++ b/src/layers/core/path-layer/path-layer.js
@@ -7,7 +7,7 @@ import {join} from 'path';
 const defaultProps = {
   opacity: 1,
   strokeWidth: 1,
-  getPaths: feature => feature.geometry.coordinates,
+  getPath: feature => feature.geometry.coordinates,
   getColor: feature => feature.properties.color,
   getWidth: feature => feature.properties.width || 1
 };
@@ -46,14 +46,12 @@ export default class PathLayer extends Layer {
   }
 
   updateState({oldProps, props, changeFlags}) {
-    const {getPaths} = this.props;
+    const {getPath} = this.props;
     const {attributeManager} = this.state;
 
     if (changeFlags.dataChanged) {
       // this.state.paths only stores point positions in each path
-      this.state.paths = [];
-
-      this.state.paths =props.data.map(getPaths);
+      this.state.paths = props.data.map(getPath);
 
       this.state.pointCount = 0;
       this.state.indexCount = 0;

--- a/src/layers/core/polygon-layer/polygon-layer.js
+++ b/src/layers/core/polygon-layer/polygon-layer.js
@@ -122,18 +122,6 @@ export default class PolygonLayer extends Layer {
     }
   }
 
-  pick(opts) {
-    super.pick(opts);
-    const {info} = opts;
-    if (!info) {
-      return;
-    }
-    const index = info.index;
-    const feature = index >= 0 ? this.props.data[index] : null;
-    info.feature = feature;
-    info.object = feature;
-  }
-
   getModel(gl) {
     const shaders = assembleShaders(gl, this.getShaders());
     return new Model({

--- a/src/layers/core/polygon-layer/polygon-layer.js
+++ b/src/layers/core/polygon-layer/polygon-layer.js
@@ -107,8 +107,7 @@ export default class PolygonLayer extends Layer {
       const {getPolygon, extruded, wireframe, getHeight} = props;
 
       // TODO - avoid creating a temporary array here: let the tesselator iterate
-      const polygons = [];
-      Container.forEach(props.data, feature => polygons.push(getPolygon(feature) || []));
+      const polygons = props.data.map(getPolygon);
 
       this.setState({
         polygonTesselator: !extruded ?


### PR DESCRIPTION
- Fix PathLayer rendering
  * PathLayer cannot accept both line and polygon features
- Fix picking on GeoJSONLayer
  * aggregates results from every `onHover`, `onClick` fired by sublayers
- Correct prop names in examples
- Remove dead code

@ibgreen @gnavvy