### PR TITLE
Fix fallback size on IconLayer

### DIFF
--- a/src/layers/core/icon-layer/icon-layer.js
+++ b/src/layers/core/icon-layer/icon-layer.js
@@ -49,8 +49,8 @@ const DEFAULT_COLOR = [0, 0, 0, 255];
 const defaultProps = {
   getPosition: x => x.position,
   getIcon: x => x.icon,
-  getColor: x => x.color || DEFAULT_COLOR,
-  getScale: x => x.size || 1,
+  getColor: x => x.color,
+  getScale: x => x.size,
   iconAtlas: null,
   iconMapping: {},
   size: 30
@@ -156,7 +156,8 @@ export default class IconLayer extends Layer {
     const {value} = attribute;
     let i = 0;
     for (const object of data) {
-      value[i++] = getScale(object);
+      const size = getScale(object);
+      value[i++] = isNaN(size) ? 1 : size;
     }
   }
 

--- a/src/layers/core/icon-layer/icon-layer.js
+++ b/src/layers/core/icon-layer/icon-layer.js
@@ -50,7 +50,7 @@ const defaultProps = {
   getPosition: x => x.position,
   getIcon: x => x.icon,
   getColor: x => x.color || DEFAULT_COLOR,
-  getScale: x => x.size,
+  getScale: x => x.size || 1,
   iconAtlas: null,
   iconMapping: {},
   size: 30
@@ -156,7 +156,7 @@ export default class IconLayer extends Layer {
     const {value} = attribute;
     let i = 0;
     for (const object of data) {
-      value[i++] = getScale(object) || 1;
+      value[i++] = getScale(object);
     }
   }
 

--- a/src/layers/core/path-layer/path-layer.js
+++ b/src/layers/core/path-layer/path-layer.js
@@ -4,12 +4,14 @@ import {GL, Model, Geometry} from 'luma.gl';
 import {readFileSync} from 'fs';
 import {join} from 'path';
 
+const DEFAULT_COLOR = [0, 0, 0, 255];
+
 const defaultProps = {
   opacity: 1,
   strokeWidth: 1,
   getPath: object => object.path,
   getColor: object => object.color,
-  getWidth: object => object.width || 1
+  getWidth: object => object.width
 };
 
 export default class PathLayer extends Layer {
@@ -74,7 +76,7 @@ export default class PathLayer extends Layer {
   draw({uniforms}) {
     this.state.model.render(Object.assign({}, uniforms, {
       opacity: this.props.opacity,
-      thickness: this.props.strokeWidth || 1,
+      thickness: this.props.strokeWidth,
       miterLimit: 1
     }));
   }
@@ -205,7 +207,11 @@ export default class PathLayer extends Layer {
 
     let i = 0;
     paths.forEach((path, index) => {
-      const w = getWidth(data[index], index);
+      let w = getWidth(data[index], index);
+      if (isNaN(w)) {
+        w = 1;
+      }
+
       path.forEach(() => {
         directions[i++] = w;
         directions[i++] = -w;
@@ -222,7 +228,7 @@ export default class PathLayer extends Layer {
 
     let i = 0;
     paths.forEach((path, index) => {
-      const pointColor = getColor(data[index], index);
+      const pointColor = getColor(data[index], index) || DEFAULT_COLOR;
       if (isNaN(pointColor[3])) {
         pointColor[3] = 255;
       }

--- a/src/layers/core/scatterplot-layer/scatterplot-layer.js
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer.js
@@ -24,12 +24,11 @@ import {GL, Model, Geometry} from 'luma.gl';
 import {readFileSync} from 'fs';
 import {join} from 'path';
 
-const DEFAULT_RADIUS = 30;
 const DEFAULT_COLOR = [255, 0, 255, 255];
 
 const defaultGetPosition = x => x.position;
-const defaultGetRadius = x => x.radius || DEFAULT_RADIUS;
-const defaultGetColor = x => x.color || DEFAULT_COLOR;
+const defaultGetRadius = x => x.radius;
+const defaultGetColor = x => x.color;
 
 const defaultProps = {
   getPosition: defaultGetPosition,
@@ -120,39 +119,36 @@ export default class ScatterplotLayer extends Layer {
 
   calculateInstancePositions(attribute) {
     const {data, getPosition} = this.props;
-    const {value, size} = attribute;
+    const {value} = attribute;
     let i = 0;
     for (const point of data) {
       const position = getPosition(point);
-      value[i + 0] = position[0] || 0;
-      value[i + 1] = position[1] || 0;
-      value[i + 2] = position[2] || 0;
-      i += size;
+      value[i++] = position[0];
+      value[i++] = position[1];
+      value[i++] = position[2] || 0;
     }
   }
 
   calculateInstanceRadius(attribute) {
     const {data, getRadius} = this.props;
-    const {value, size} = attribute;
+    const {value} = attribute;
     let i = 0;
     for (const point of data) {
       const radius = getRadius(point);
-      value[i + 0] = isNaN(radius) ? 1 : radius;
-      i += size;
+      value[i++] = isNaN(radius) ? 1 : radius;
     }
   }
 
   calculateInstanceColors(attribute) {
     const {data, getColor} = this.props;
-    const {value, size} = attribute;
+    const {value} = attribute;
     let i = 0;
     for (const point of data) {
-      const color = getColor(point);
-      value[i + 0] = color[0] || 0;
-      value[i + 1] = color[1] || 0;
-      value[i + 2] = color[2] || 0;
-      value[i + 3] = isNaN(color[3]) ? DEFAULT_COLOR[3] : color[3];
-      i += size;
+      const color = getColor(point) || DEFAULT_COLOR;
+      value[i++] = color[0];
+      value[i++] = color[1];
+      value[i++] = color[2];
+      value[i++] = isNaN(color[3]) ? DEFAULT_COLOR[3] : color[3];
     }
   }
 }


### PR DESCRIPTION
- Fix bug where size === 0 gets overwritten
- Consistent fallback strategy in IconLayer, ScatterplotLayer and PathLayer:
  * fallback check in update functions instead of default accessors
  * always check before using value returned by accessor
  * do not use `||` on numeric values unless fallback is 0