### PR TITLE
PathLayer perf improvements

### DIFF
--- a/docs/layers/path-layer.md
+++ b/docs/layers/path-layer.md
@@ -36,7 +36,7 @@ If the color alpha (the fourth component) is not provided,
 
 #### `getWidth` (Function, optional)
 
-- Default: `(object, index) => object.width || 1`
+- Default: `(object, index) => object.width`
 
 Return a width multiplier from each object.
 
@@ -45,7 +45,27 @@ Return a width multiplier from each object.
 
 - Default: `1`
 
-The stroke width used to draw each line.
+The stroke width used to draw each line. Unit is meters.
+
+##### `strokeMinPixels` (Number, optional)
+
+- Default: `0`
+
+The minimum stroke size in pixels.
+
+
+##### `strokeMaxPixels` (Number, optional)
+
+- Default: `None`
+
+The maximum stroke size in pixels.
+
+
+##### `miterLimit` (Number, optional)
+
+- Default: `4`
+
+The maximum extent of the join as a ratio to the stroke-width.
 
 
 ##### `strokeColor` (Number, optional)

--- a/examples/main/layer-examples.js
+++ b/examples/main/layer-examples.js
@@ -85,6 +85,7 @@ const GeoJsonLayerExample = {
       return setOpacity(color, opacity);
     },
     strokeWidth: 10,
+    strokeMinPixels: 1,
     pickable: true
   }
 };

--- a/src/layers/core/path-layer/path-layer-vertex.glsl
+++ b/src/layers/core/path-layer/path-layer-vertex.glsl
@@ -9,6 +9,8 @@ attribute vec4 colors;
 attribute vec3 pickingColors;
 
 uniform float thickness;
+uniform float strokeMinPixels;
+uniform float strokeMaxPixels;
 uniform float miterLimit;
 uniform float opacity;
 uniform float renderPickingBuffer;
@@ -22,7 +24,8 @@ vec2 lineJoin(vec3 prevProjected, vec3 currProjected, vec3 nextProjected) {
   vec2 currScreen = currProjected.xy;
   vec2 nextScreen = nextProjected.xy;
 
-  float len = project_scale(thickness);
+  float len = clamp(project_scale(thickness),
+    strokeMinPixels, strokeMaxPixels);
 
   vec2 dir = vec2(0.0);
   if (currScreen == prevScreen) {

--- a/src/layers/core/path-layer/path-layer-vertex.glsl
+++ b/src/layers/core/path-layer/path-layer-vertex.glsl
@@ -1,9 +1,9 @@
 #define SHADER_NAME path-layer-vertex-shader
 
 attribute float directions;
-attribute vec3 prevPositions;
 attribute vec3 positions;
-attribute vec3 nextPositions;
+attribute vec3 leftDeltas;
+attribute vec3 rightDeltas;
 
 attribute vec4 colors;
 attribute vec3 pickingColors;
@@ -54,9 +54,9 @@ void main() {
   vec4 pickingColor = vec4(pickingColors.rgb, 255.) / 255.;
   vColor = mix(color, pickingColor, renderPickingBuffer);
 
-  vec3 prevProjected = project_position(prevPositions);
+  vec3 prevProjected = project_position(positions - leftDeltas);
   vec3 currProjected = project_position(positions);
-  vec3 nextProjected = project_position(nextPositions);
+  vec3 nextProjected = project_position(positions + rightDeltas);
 
   gl_Position = project_to_clipspace(
     vec4(

--- a/src/layers/core/path-layer/path-layer.js
+++ b/src/layers/core/path-layer/path-layer.js
@@ -107,10 +107,10 @@ export default class PathLayer extends Layer {
       const ptCount = path.length;
 
       // counter-clockwise triangulation
-      //
-      //             0 |---| 2
+      //                ___
+      //             0 |  /| 2
       //  o---o  =>    o / o
-      //             1 |---| 3
+      //             1 |/__| 3
       //
       for (let ptIndex = 0; ptIndex < ptCount - 1; ptIndex++) {
         // triangle A with indices: 0, 1, 2
@@ -171,7 +171,7 @@ export default class PathLayer extends Layer {
 
   calculateRightDeltas(attribute) {
     const {paths, pointCount} = this.state;
-    
+
     const rightDeltas = new Float32Array(pointCount * attribute.size * 2);
 
     let i = 0;
@@ -185,7 +185,7 @@ export default class PathLayer extends Layer {
         i += 3;
       });
     });
-    
+
     attribute.value = rightDeltas;
   }
 

--- a/src/layers/core/path-layer/path-layer.js
+++ b/src/layers/core/path-layer/path-layer.js
@@ -51,19 +51,9 @@ export default class PathLayer extends Layer {
     if (changeFlags.dataChanged) {
       // this.state.paths only stores point positions in each path
       const paths = props.data.map(getPath);
+      const pointCount = paths.reduce((count, path) => count + path.length, 0);
 
-      let pointCount = 0;
-      let indexCount = 0;
-
-      paths.forEach(path => {
-        const ptCount = path.length;
-        pointCount += ptCount;
-        // path.length - 1: n points => n-1 line segments
-        // * 2 * 3: each segment is rendered as 2 triangles with 3 vertices
-        indexCount += (ptCount - 1) * 2 * 3;
-      });
-
-      this.setState({paths, pointCount, indexCount});
+      this.setState({paths, pointCount});
       attributeManager.invalidateAll();
     }
   }
@@ -92,7 +82,11 @@ export default class PathLayer extends Layer {
   }
 
   calculateIndices(attribute) {
-    const {paths, IndexType, model, indexCount, pointCount} = this.state;
+    const {paths, IndexType, model, pointCount} = this.state;
+
+    // each path with length n has n-1 line segments
+    // * 2 * 3: each segment is rendered as 2 triangles with 3 vertices
+    const indexCount = (pointCount - paths.length) * 2 * 3;
 
     if (IndexType === Uint16Array && indexCount > 65535) {
       throw new Error('Vertex count exceeds browser\'s limit');

--- a/src/layers/core/path-layer/path-layer.js
+++ b/src/layers/core/path-layer/path-layer.js
@@ -8,7 +8,10 @@ const DEFAULT_COLOR = [0, 0, 0, 255];
 
 const defaultProps = {
   opacity: 1,
-  strokeWidth: 1,
+  strokeWidth: 1, // stroke width in meters
+  miterLimit: 4,
+  strokeMinPixels: 0, //  min stroke width in pixels
+  strokeMaxPixels: Number.MAX_SAFE_INTEGER, // max stroke width in pixels
   getPath: object => object.path,
   getColor: object => object.color,
   getWidth: object => object.width
@@ -63,10 +66,14 @@ export default class PathLayer extends Layer {
   }
 
   draw({uniforms}) {
+    const {opacity, strokeWidth, miterLimit, strokeMinPixels, strokeMaxPixels} = this.props;
+
     this.state.model.render(Object.assign({}, uniforms, {
-      opacity: this.props.opacity,
-      thickness: this.props.strokeWidth,
-      miterLimit: 1
+      opacity,
+      thickness: strokeWidth,
+      miterLimit,
+      strokeMinPixels,
+      strokeMaxPixels
     }));
   }
 

--- a/test/bench/index.js
+++ b/test/bench/index.js
@@ -42,12 +42,12 @@ suite
   const layer = new ChoroplethLayer({data: data.points});
   testInitializeLayer({layer});
 })
-.add('ChoroplethLayer#initialize', () => {
-  const layer = new ChoroplethLayer({data: data.choropleths});
-  testInitializeLayer({layer});
-})
 .add('PathLayer#initialize', () => {
   const layer = new PathLayer({data: lines});
+  testInitializeLayer({layer});
+})
+.add('ChoroplethLayer#initialize', () => {
+  const layer = new ChoroplethLayer({data: data.choropleths});
   testInitializeLayer({layer});
 })
 .add('PolygonLayer#initialize (flat)', () => {

--- a/test/bench/index.js
+++ b/test/bench/index.js
@@ -6,6 +6,7 @@ import * as data from '../data';
 import {
   ScatterplotLayer,
   PolygonLayer,
+  PathLayer,
   ChoroplethLayer,
   ExtrudedChoroplethLayer64
 } from 'deck.gl';
@@ -15,6 +16,7 @@ import {parseColor} from 'deck.gl/lib/utils/color';
 import {testInitializeLayer} from '../test-utils';
 
 const suite = new Suite();
+const lines = data.choropleths.features.map(f => ({path: f.geometry.coordinates[0]}));
 
 const COLOR_STRING = '#FFEEBB';
 const COLOR_ARRAY = [222, 222, 222];
@@ -42,6 +44,10 @@ suite
 })
 .add('ChoroplethLayer#initialize', () => {
   const layer = new ChoroplethLayer({data: data.choropleths});
+  testInitializeLayer({layer});
+})
+.add('PathLayer#initialize', () => {
+  const layer = new PathLayer({data: lines});
   testInitializeLayer({layer});
 })
 .add('PolygonLayer#initialize (flat)', () => {


### PR DESCRIPTION
- do not construct intermediate arrays
- replace `prevPositions` and `nextPositions` with delta (prep for 64bit version)
- add benchmark
