### PR TITLE
Remove GeoJSON prop override

### DIFF
--- a/examples/main/layer-info.js
+++ b/examples/main/layer-info.js
@@ -17,13 +17,6 @@ export default class LayerInfo extends PureComponent {
     if (info.index < 0) {
       info = null;
     }
-
-    const oldItem = this.state[name];
-    if (oldItem === info ||
-      (oldItem && info && oldItem.layer.id === info.layer.id && oldItem.index === info.index)) {
-      // no change
-      return;
-    }
     this.setState({[name]: info});
   }
 


### PR DESCRIPTION
Hack picking differently (for now) to avoid rewriting props.
Eventually we need to re-architect picking to fix composite layers.
Known issues:
- hover events are one frame behind
- picking info's `index` and `object` are not correct

@ibgreen