### PR TITLE
Add per-layer settings to example app

### DIFF
--- a/examples/main/app.css
+++ b/examples/main/app.css
@@ -38,30 +38,47 @@ h4 {
 	padding: 0 20px 40px 20px;
 }
 
-#layer-selector {
+.layer-selector {
 	flex: 1 1 auto;
   padding: 0;
   overflow-x: hidden;
   overflow-y: scroll;
 }
 
-#layer-controls {
-	border-top: groove 2px #fff;
+.layer-controls {
+	border: groove 2px #fff;
+  border-left: none;
+  border-right: none;
+  padding: 8px 0;
 	flex: 0 1 auto;
 }
 
-input[type=range] {
-	width: 100%;
-	margin-bottom: 12px;
-}
-
 /* Checkbox style adapted from http://cssdeck.com/labs/css-checkbox-styles */
-input[type=checkbox] {
-	visibility: hidden;
+.input-group {
+  color: #333;
+  line-height: 28px;
+  display: table;
+  width: 100%;
+}
+.input-group > * {
+  display: table-cell;
+  width: 50%;
+  vertical-align: middle;
+}
+.input-group input[type=range] {
+  width: 100%;
+  vertical-align: middle;
+}
+.color-picker {
+  width: 18px;
+  height: 18px;
+  vertical-align: middle;
+  border: solid 1px #ccc;
+  display: block;
+  margin: 5px 2px;
 }
 
 .checkbox {
-	color: #333;
 	text-align: center;
 	width: 20px;
 	height: 20px;
@@ -72,7 +89,12 @@ input[type=checkbox] {
 	position: relative;
 }
 
+.checkbox input {
+  visibility: hidden;
+}
+
 .checkbox label {
+  color: #333;
 	cursor: pointer;
 	position: absolute;
 	width: 14px;
@@ -105,7 +127,7 @@ input[type=checkbox] {
 	opacity: 0.3;
 }
 
-.checkbox input[type=checkbox]:checked + label:after {
+.checkbox input:checked + label:after {
 	background: #40bf00;
 	opacity: 1;
 }

--- a/examples/main/app.css
+++ b/examples/main/app.css
@@ -26,23 +26,17 @@ h4 {
 	position: fixed;
 	z-index: 9;
 	top: 0;
+  bottom: 0;
 	right: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
   height: 100%;
   width: 280px;
   background: rgba(255, 255, 255, 0.5);
-  display: flex;
-  flex-flow: column;
 }
 
 #control-panel > div{
-	padding: 0 20px 40px 20px;
-}
-
-.layer-selector {
-	flex: 1 1 auto;
-  padding: 0;
-  overflow-x: hidden;
-  overflow-y: scroll;
+	padding: 0 20px 20px 20px;
 }
 
 .layer-controls {
@@ -50,7 +44,6 @@ h4 {
   border-left: none;
   border-right: none;
   padding: 8px 0;
-	flex: 0 1 auto;
 }
 
 /* Checkbox style adapted from http://cssdeck.com/labs/css-checkbox-styles */

--- a/examples/main/app.js
+++ b/examples/main/app.js
@@ -171,7 +171,7 @@ class App extends PureComponent {
           {...mapViewState}
           onWebGLInitialized={ this._onWebGLInitialized }
           layers={this._renderExamples()}
-          effects={effects ? this._effects : undefined}
+          effects={effects ? this._effects : []}
         />
 
         <FPSStats isActive/>

--- a/examples/main/app.js
+++ b/examples/main/app.js
@@ -38,6 +38,7 @@ class App extends PureComponent {
       },
       activeExamples: DEFAULT_ACTIVE_LAYERS,
       settings: {
+        effects: false,
         separation: 0,
         rotationZ: 0,
         rotationX: 0
@@ -134,7 +135,7 @@ class App extends PureComponent {
   }
 
   _renderMap() {
-    const {width, height, mapViewState} = this.state;
+    const {width, height, mapViewState, settings: {effects}} = this.state;
     return (
       <MapboxGLMap
         mapboxApiAccessToken={MAPBOX_ACCESS_TOKEN}
@@ -150,7 +151,7 @@ class App extends PureComponent {
           {...mapViewState}
           onWebGLInitialized={ this._onWebGLInitialized }
           layers={this._renderExamples()}
-          effects={this._effects}
+          effects={effects ? this._effects : undefined}
         />
 
         <FPSStats isActive/>

--- a/examples/main/app.js
+++ b/examples/main/app.js
@@ -104,10 +104,10 @@ class App extends PureComponent {
   _renderExampleLayer(example, settings, index) {
     const {layer: Layer, props, getData} = example;
     const {infoPanel} = this.refs;
-    const layerProps = {};
+    const layerProps = Object.assign({}, props, settings);
 
     if (props.pickable) {
-      Object.assign(layerProps, props, settings, {
+      Object.assign(layerProps, {
         onHover: infoPanel ? infoPanel.onItemHovered : noop,
         onClick: infoPanel ? infoPanel.onItemClicked : noop
       });
@@ -186,15 +186,15 @@ class App extends PureComponent {
       <div>
         { this._renderMap() }
         <div id="control-panel">
+          <LayerControls
+            title="Composite Settings"
+            settings={settings}
+            onChange={this._onUpdateContainerSettings}/>
           <LayerSelector
             activeExamples={activeExamples}
             examples={LAYER_CATEGORIES}
             onToggleLayer={this._onToggleLayer}
             onUpdateLayer={this._onUpdateLayerSettings} />
-          <LayerControls
-            title="Composite Settings"
-            settings={settings}
-            onChange={this._onUpdateContainerSettings}/>
         </div>
         <LayerInfo ref="infoPanel"/>
       </div>

--- a/examples/main/layer-controls.js
+++ b/examples/main/layer-controls.js
@@ -1,4 +1,5 @@
 import React, {PureComponent} from 'react';
+import ColorPicker from './utils/color-picker';
 
 export default class LayerControls extends PureComponent {
 
@@ -7,60 +8,87 @@ export default class LayerControls extends PureComponent {
     // Only update if we have a confirmed change
     if (settings[settingName] !== newValue) {
       // Create a new object so that shallow-equal detects a change
-      this.props.onSettingsChange({
+      this.props.onChange({
         ...settings,
         [settingName]: newValue
       });
     }
   }
 
-  _renderSlider(settingName, setting, value, title) {
+  _renderColorPicker(settingName, value) {
     return (
-      <div key={settingName} >
+      <div key={settingName}>
         <div className="input-group" >
-          <label className="label" htmlFor={settingName}>
-            {title}
-          </label>
-          <input
-            type="range"
-            id={settingName}
-            min={setting.min || 0}
-            max={setting.max || 1}
-            step={setting.step || 0.01}
-            value={value}
-            onChange={ e => this._onValueChange(settingName, Number(e.target.value)) }/>
+          <label>{settingName}</label>
+          <ColorPicker value={value}
+            onChange={this._onValueChange.bind(this, settingName)} />
         </div>
       </div>
     );
   }
 
-  _renderCheckbox(settingName, setting, value, title) {
+  _renderSlider(settingName, value) {
+    let max = 1;
+    if (/radius|width|height|pixel|size/i.test(settingName)) {
+      max = 100;
+    }
+
     return (
       <div key={settingName} >
-        <div className="checkbox" >
+        <div className="input-group" >
+          <label className="label" htmlFor={settingName}>
+            {settingName}
+          </label>
+          <div>
+            <input
+              type="range"
+              id={settingName}
+              min={0} max={max} step={max / 100}
+              value={value}
+              onChange={ e => this._onValueChange(settingName, Number(e.target.value)) }/>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  _renderCheckbox(settingName, value) {
+    return (
+      <div key={settingName} >
+        <div className="input-group" >
+          <label htmlFor={settingName}>
+            <span>{settingName}</span>
+          </label>
           <input
             type="checkbox"
             id={settingName}
             checked={value}
             onChange={ e => this._onValueChange(settingName, e.target.checked) }/>
-
-          <label htmlFor={settingName}>
-            <span>{title}</span>
-          </label>
         </div>
       </div>
     );
   }
 
+  _renderSetting(settingName, value) {
+    switch (typeof value) {
+    case 'boolean':
+      return this._renderCheckbox(settingName, value);
+    case 'number':
+      return this._renderSlider(settingName, value);
+    default:
+      if (/color/i.test(settingName)) {
+        return this._renderColorPicker(settingName, value);
+      }
+    }
+    return null;
+  }
+
   render() {
-    const {settings} = this.props;
+    const {title, settings} = this.props;
     return (
-      <div id="layer-controls" >
-        <h4>Layer Controls</h4>
-        {this._renderCheckbox('effects', {}, settings.effects, 'Enable Effects')}
-        {this._renderSlider('separation', {}, settings.separation, 'Separation')}
-        {this._renderSlider('rotationZ', {}, settings.rotationZ, 'Rotation (in plane)')}
-        {this._renderSlider('rotationX', {}, settings.rotationX, 'Rotation (3D)')}
+      <div className="layer-controls" >
+        { title && <h4>{title}</h4>}
+        { Object.keys(settings).map(key => this._renderSetting(key, settings[key])) }
       </div>
     );
   }

--- a/examples/main/layer-controls.js
+++ b/examples/main/layer-controls.js
@@ -8,10 +8,19 @@ export default class LayerControls extends PureComponent {
     // Only update if we have a confirmed change
     if (settings[settingName] !== newValue) {
       // Create a new object so that shallow-equal detects a change
-      this.props.onChange({
-        ...settings,
-        [settingName]: newValue
-      });
+      const newSettings = {...this.props.settings};
+
+      if (settingName.indexOf('get') === 0) {
+        newSettings[settingName] = d => newValue;
+        newSettings.updateTriggers = {
+          ...newSettings.updateTriggers,
+          [settingName]: {value: newValue.toString()}
+        };
+      } else {
+        newSettings[settingName] = newValue;
+      }
+
+      this.props.onChange(newSettings);
     }
   }
 

--- a/examples/main/layer-controls.js
+++ b/examples/main/layer-controls.js
@@ -2,8 +2,7 @@ import React, {PureComponent} from 'react';
 
 export default class LayerControls extends PureComponent {
 
-  _onSliderChange(settingName, e) {
-    const newValue = Number(e.target.value);
+  _onValueChange(settingName, newValue) {
     const {settings} = this.props;
     // Only update if we have a confirmed change
     if (settings[settingName] !== newValue) {
@@ -29,7 +28,25 @@ export default class LayerControls extends PureComponent {
             max={setting.max || 1}
             step={setting.step || 0.01}
             value={value}
-            onChange={this._onSliderChange.bind(this, settingName)}/>
+            onChange={ e => this._onValueChange(settingName, Number(e.target.value)) }/>
+        </div>
+      </div>
+    );
+  }
+
+  _renderCheckbox(settingName, setting, value, title) {
+    return (
+      <div key={settingName} >
+        <div className="checkbox" >
+          <input
+            type="checkbox"
+            id={settingName}
+            checked={value}
+            onChange={ e => this._onValueChange(settingName, e.target.checked) }/>
+
+          <label htmlFor={settingName}>
+            <span>{title}</span>
+          </label>
         </div>
       </div>
     );
@@ -40,6 +57,7 @@ export default class LayerControls extends PureComponent {
     return (
       <div id="layer-controls" >
         <h4>Layer Controls</h4>
+        {this._renderCheckbox('effects', {}, settings.effects, 'Enable Effects')}
         {this._renderSlider('separation', {}, settings.separation, 'Separation')}
         {this._renderSlider('rotationZ', {}, settings.rotationZ, 'Rotation (in plane)')}
         {this._renderSlider('rotationX', {}, settings.rotationX, 'Rotation (3D)')}

--- a/examples/main/layer-examples.js
+++ b/examples/main/layer-examples.js
@@ -19,7 +19,6 @@ import {
   ChoroplethLayer64,
   ExtrudedChoroplethLayer64
 
-  // Container
 } from 'deck.gl';
 
 import * as dataSamples from './data-samples';

--- a/examples/main/layer-examples.js
+++ b/examples/main/layer-examples.js
@@ -419,5 +419,3 @@ export default {
     'ScatterplotLayer64 10M': ScatterplotLayer64PerfExample('10M', dataSamples.getPoints10M)
   }
 };
-
-export const DEFAULT_ACTIVE_LAYERS = {};

--- a/examples/main/layer-examples.js
+++ b/examples/main/layer-examples.js
@@ -17,9 +17,9 @@ import {
 
   ChoroplethLayer,
   ChoroplethLayer64,
-  ExtrudedChoroplethLayer64,
+  ExtrudedChoroplethLayer64
 
-  Container
+  // Container
 } from 'deck.gl';
 
 import * as dataSamples from './data-samples';
@@ -96,8 +96,8 @@ const GeoJsonLayerExtrudedExample = {
     id: 'geojsonLayer-example',
     data: dataSamples.choropleths,
     getHeight: f => ((f.properties.ZIP_CODE * 10) % 127) * 10,
-    getFillColor: f => [0, 0, ((Container.get(f, 'properties.ZIP_CODE') * 23) % 100) + 155],
-    drawPolygons: false,
+    getFillColor: f => [0, 0, ((f.properties.ZIP_CODE * 23) % 100) + 155],
+    drawPolygons: true,
     extruded: true,
     pickable: true
   }
@@ -296,7 +296,7 @@ const ChoroplethLayerExample = {
   props: {
     id: 'choroplethLayerSolid',
     data: dataSamples.choropleths,
-    getColor: f => [((Container.get(f, 'properties.ZIP_CODE') * 10) % 127) + 128, 0, 0],
+    getColor: f => [((f.properties.ZIP_CODE * 10) % 127) + 128, 0, 0],
     opacity: 0.8,
     pickable: true
   }

--- a/examples/main/layer-selector.js
+++ b/examples/main/layer-selector.js
@@ -1,21 +1,28 @@
 import React, {PureComponent} from 'react';
+import LayerControls from './layer-controls';
 
 export default class LayerSelector extends PureComponent {
 
-  _renderExampleButton(exampleName) {
-    const {activeExamples, onChange} = this.props;
+  _renderExampleButton(exampleName, example) {
+    const {activeExamples} = this.props;
+    const settings = activeExamples[exampleName];
 
     return (
-      <div key={ exampleName } className="checkbox" >
-        <input
-          type="checkbox"
-          id={exampleName}
-          checked={activeExamples[exampleName] || ''}
-          onChange={e => onChange(exampleName)}
-        />
-        <label htmlFor={ exampleName } >
-          <span>{ exampleName }</span>
-        </label>
+      <div key={ exampleName } >
+        <div className="checkbox" >
+          <input
+            type="checkbox"
+            id={exampleName}
+            checked={Boolean(settings)}
+            onChange={() => this.props.onToggleLayer(exampleName, example)}
+          />
+          <label htmlFor={ exampleName } >
+            <span>{ exampleName }</span>
+          </label>
+        </div>
+
+        { settings && <LayerControls settings={settings}
+          onChange={this.props.onUpdateLayer.bind(this, exampleName)} /> }
       </div>
     );
   }
@@ -37,7 +44,7 @@ export default class LayerSelector extends PureComponent {
 
   render() {
     return (
-      <div id="layer-selector" >
+      <div className="layer-selector" >
         {
           this._renderExampleCategories(this.props.examples)
         }

--- a/examples/main/layer-selector.js
+++ b/examples/main/layer-selector.js
@@ -2,7 +2,7 @@ import React, {PureComponent} from 'react';
 
 export default class LayerSelector extends PureComponent {
 
-  _renderExampleButton(exampleName, example) {
+  _renderExampleButton(exampleName) {
     const {activeExamples, onChange} = this.props;
 
     return (
@@ -10,7 +10,6 @@ export default class LayerSelector extends PureComponent {
         <input
           type="checkbox"
           id={exampleName}
-          name="layerStatus"
           checked={activeExamples[exampleName] || ''}
           onChange={e => onChange(exampleName)}
         />

--- a/examples/main/utils/color-picker.js
+++ b/examples/main/utils/color-picker.js
@@ -1,14 +1,26 @@
 /* global document */
 import React, {PureComponent} from 'react';
 
-function pad2(str) {
-  while (str.length < 2) {
+/*
+ * convert a number to a hex string.
+ * @param {number} x - number to convert
+ * @param {number} len - minimum length of the string
+ * @returns {string} formatted hex string
+ */
+function numberToHex(x, len = 0) {
+  let str = x.toString(16);
+  while (str.length < len) {
     str = `0${str}`;
   }
   return str;
 }
 
-function toHexString(value) {
+/*
+ * convert a color from [r, g, b] array or accessor to a hex string.
+ * @param {string | array | function} value - color value or accessor
+ * @returns {string} hex color string
+ */
+function getColorHex(value) {
   if (typeof value === 'function') {
     try {
       value = value();
@@ -20,12 +32,17 @@ function toHexString(value) {
     return value;
   }
   if (Array.isArray(value) && value.length >= 3) {
-    return `#${value.slice(0, 3).map(v => pad2(v.toString(16))).join('')}`;
+    return `#${value.slice(0, 3).map(v => numberToHex(v, 2)).join('')}`;
   }
   return '#888';
 }
 
-function hexStringToArray(str) {
+/*
+ * convert a color from a hex string to [r, g, b] array.
+ * @param {string} str - color hex string
+ * @returns {array} color value in [r, g, b]
+ */
+function getColorArray(str) {
   return [
     parseInt(str.slice(1, 3), 16),
     parseInt(str.slice(3, 5), 16),
@@ -40,7 +57,7 @@ export default class ColorPicker extends PureComponent {
     const input = document.createElement('input');
     input.type = 'color';
     input.value = color;
-    input.onchange = () => onChange(hexStringToArray(input.value));
+    input.onchange = () => onChange(getColorArray(input.value));
     input.onblur = () => document.body.removeChild(input);
 
     document.body.appendChild(input);
@@ -48,7 +65,7 @@ export default class ColorPicker extends PureComponent {
   }
 
   render() {
-    const color = toHexString(this.props.value);
+    const color = getColorHex(this.props.value);
     return (
       <div className="color-picker" style={{background: color}}
         onClick={ this._onClick.bind(this, color) } />

--- a/examples/main/utils/color-picker.js
+++ b/examples/main/utils/color-picker.js
@@ -1,0 +1,57 @@
+/* global document */
+import React, {PureComponent} from 'react';
+
+function pad2(str) {
+  while (str.length < 2) {
+    str = `0${str}`;
+  }
+  return str;
+}
+
+function toHexString(value) {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'function') {
+    const funcText = value.toString();
+    const colorArray = (funcText.match(/\[\d+(,\s*\d+){2,3}\]/) || [])[0];
+    if (colorArray) {
+      value = JSON.parse(colorArray);
+    }
+  }
+  if (Array.isArray(value) && value.length >= 3) {
+    return `#${value.slice(0, 3).map(v => pad2(v.toString(16))).join('')}`;
+  }
+  return '#888';
+}
+
+function hexStringToArray(str) {
+  return [
+    parseInt(str.slice(1, 3), 16),
+    parseInt(str.slice(3, 5), 16),
+    parseInt(str.slice(5, 7), 16)
+  ];
+}
+
+export default class ColorPicker extends PureComponent {
+
+  _onClick(color) {
+    const {onChange} = this.props;
+    const input = document.createElement('input');
+    input.type = 'color';
+    input.value = color;
+    input.onchange = () => onChange(hexStringToArray(input.value));
+    input.onblur = () => document.body.removeChild(input);
+
+    document.body.appendChild(input);
+    input.click();
+  }
+
+  render() {
+    const color = toHexString(this.props.value);
+    return (
+      <div className="color-picker" style={{background: color}}
+        onClick={ this._onClick.bind(this, color) } />
+    );
+  }
+}

--- a/examples/main/utils/color-picker.js
+++ b/examples/main/utils/color-picker.js
@@ -9,15 +9,15 @@ function pad2(str) {
 }
 
 function toHexString(value) {
+  if (typeof value === 'function') {
+    try {
+      value = value();
+    } catch (err) {
+      // is data dependent
+    }
+  }
   if (typeof value === 'string') {
     return value;
-  }
-  if (typeof value === 'function') {
-    const funcText = value.toString();
-    const colorArray = (funcText.match(/\[\d+(,\s*\d+){2,3}\]/) || [])[0];
-    if (colorArray) {
-      value = JSON.parse(colorArray);
-    }
   }
   if (Array.isArray(value) && value.length >= 3) {
     return `#${value.slice(0, 3).map(v => pad2(v.toString(16))).join('')}`;


### PR DESCRIPTION
Prop types are inferred from names and values in `layer.defaultProps` and `example.props`.
Only accessors supported are color accessors. Update triggers are keyed to the prop name.
Updating the `effects` prop on `DeckGL` does not seem to work.

@ibgreen