### PR TITLE
Fixed the unnecessary layer draw calls when there is no layer #300

### DIFF
--- a/src/lib/layer-manager.js
+++ b/src/lib/layer-manager.js
@@ -42,7 +42,7 @@ export default class LayerManager {
     this.layers = [];
     // Tracks if any layers were drawn last update
     // Needed to ensure that screen is cleared when no layers are shown
-    this.layerCleared = false;
+    this.screenCleared = false;
     this.oldContext = {};
     this.context = {
       gl,
@@ -142,14 +142,14 @@ export default class LayerManager {
 
     // Make sure that buffer is cleared once when layer list becomes empty
     if (this.layers.length === 0) {
-      if (this.layerCleared === false) {
+      if (this.screenCleared === false) {
         redraw = true;
-        this.layerCleared = true;
+        this.screenCleared = true;
         return true;
       }
     } else {
-      if (this.layerCleared === true) {
-        this.layerCleared = false;
+      if (this.screenCleared === true) {
+        this.screenCleared = false;
       }
     }
 

--- a/src/lib/layer-manager.js
+++ b/src/lib/layer-manager.js
@@ -42,7 +42,7 @@ export default class LayerManager {
     this.layers = [];
     // Tracks if any layers were drawn last update
     // Needed to ensure that screen is cleared when no layers are shown
-    this.drewLayers = false;
+    this.layerCleared = false;
     this.oldContext = {};
     this.context = {
       gl,
@@ -51,7 +51,6 @@ export default class LayerManager {
       viewportChanged: true,
       pickingFBO: null
     };
-    this.redrawNeeded = true;
     Object.seal(this.context);
   }
 
@@ -142,19 +141,20 @@ export default class LayerManager {
     let redraw = false;
 
     // Make sure that buffer is cleared once when layer list becomes empty
-    if (this.layers.length === 0 && this.drewLayers) {
-      redraw = true;
-      return true;
-    }
-
-    if (this.redrawNeeded) {
-      this.redrawNeeded = false;
-      redraw = true;
+    if (this.layers.length === 0) {
+      if (this.layerCleared === false) {
+        redraw = true;
+        this.layerCleared = true;
+        return true;
+      }
+    } else {
+      if (this.layerCleared === true) {
+        this.layerCleared = false;
+      }
     }
 
     for (const layer of this.layers) {
       redraw = redraw || layer.getNeedsRedraw({clearRedrawFlags});
-      this.drewLayers = true;
     }
     return redraw;
   }

--- a/src/react/deckgl.js
+++ b/src/react/deckgl.js
@@ -135,16 +135,16 @@ export default class DeckGL extends React.Component {
   }
 
   _onRenderFrame({gl}) {
-    if (!this.layerManager.needsRedraw({clearRedrawFlags: true})) {
+    const redraw = this.layerManager.needsRedraw({clearRedrawFlags: true});
+    if (!redraw) {
       return;
     }
+
     // clear depth and color buffers
     gl.clear(GL.COLOR_BUFFER_BIT | GL.DEPTH_BUFFER_BIT);
 
     this.effectManager.preDraw();
-
     this.layerManager.drawLayers({pass: 'primary'});
-
     this.effectManager.draw();
   }
 


### PR DESCRIPTION
Fixed an issue in the layer manager that even when no layer is selected, deck.gl still issues draw calls. #300  