### PR TITLE
PathLayer: support color-per-point

### DIFF
--- a/docs/layers/path-layer.md
+++ b/docs/layers/path-layer.md
@@ -9,10 +9,9 @@ Inherits from all [Base Layer](/docs/layers/base-layer.md) properties.
 
 ## Layer-specific Properties
 
-
 #### `getPath` (Function, optional)
 
-- Default: `(object, index) => object.paths`
+- Default: `(object, index) => object.path`
 
 Returns the specified path for the object.
 
@@ -21,11 +20,15 @@ A path is an array of coordinates.
 
 #### `getColor` (Function, optional)
 
-Returns an array of color
+Returns an color (array of numbers, RGBA) or array of colors (array of arrays).
 
 - Default `(object, index) => object.color`
 
-Method called to determine the rgba color of the source.
+Method called to determine either the stroke color for the whole path, or the
+color at each point.
+
+If the method returns an array of colors, the length of the array must match
+the length of the path returned by `getPath`.
 
 If the method does not return a value for the given object,
 fallback to `strokeColor`.

--- a/src/layers/core/path-layer/path-layer.js
+++ b/src/layers/core/path-layer/path-layer.js
@@ -240,20 +240,40 @@ export default class PathLayer extends Layer {
 
     let i = 0;
     paths.forEach((path, index) => {
-      const pointColor = getColor(data[index], index) || DEFAULT_COLOR;
-      if (isNaN(pointColor[3])) {
-        pointColor[3] = 255;
-      }
-      for (let ptIndex = 0; ptIndex < path.length; ptIndex++) {
-        // two copies for outside edge and inside edge each
-        colors[i++] = pointColor[0];
-        colors[i++] = pointColor[1];
-        colors[i++] = pointColor[2];
-        colors[i++] = pointColor[3];
-        colors[i++] = pointColor[0];
-        colors[i++] = pointColor[1];
-        colors[i++] = pointColor[2];
-        colors[i++] = pointColor[3];
+      const color = getColor(data[index], index) || DEFAULT_COLOR;
+      if (Array.isArray(color[0])) {
+        if (color.length !== path.length) {
+          throw new Error('PathLayer getColor() returned a color array, but the number of ' +
+           `colors returned doesn't match the number of points in the path. Index ${index}`);
+        }
+        color.forEach((pointColor) => {
+          const alpha = isNaN(pointColor[3]) ? 255 : pointColor[3];
+          // two copies for outside edge and inside edge each
+          colors[i++] = pointColor[0];
+          colors[i++] = pointColor[1];
+          colors[i++] = pointColor[2];
+          colors[i++] = alpha;
+          colors[i++] = pointColor[0];
+          colors[i++] = pointColor[1];
+          colors[i++] = pointColor[2];
+          colors[i++] = alpha;
+        });
+      } else {
+        const pointColor = color;
+        if (isNaN(pointColor[3])) {
+          pointColor[3] = 255;
+        }
+        for (let ptIndex = 0; ptIndex < path.length; ptIndex++) {
+          // two copies for outside edge and inside edge each
+          colors[i++] = pointColor[0];
+          colors[i++] = pointColor[1];
+          colors[i++] = pointColor[2];
+          colors[i++] = pointColor[3];
+          colors[i++] = pointColor[0];
+          colors[i++] = pointColor[1];
+          colors[i++] = pointColor[2];
+          colors[i++] = pointColor[3];
+        }
       }
     });
 

--- a/src/layers/core/scatterplot-layer/scatterplot-layer.js
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer.js
@@ -58,10 +58,12 @@ export default class ScatterplotLayer extends Layer {
     /* eslint-enable max-len */
   }
 
-  updateState({props, oldProps}) {
+  updateState(info) {
+    const {props, oldProps} = info;
     if (props.drawOutline !== oldProps.drawOutline) {
       this.state.model.geometry.drawMode = props.drawOutline ? GL.LINE_LOOP : GL.TRIANGLE_FAN;
     }
+    super.updateState(info);
   }
 
   draw({uniforms}) {


### PR DESCRIPTION
Small change. Allow `PathLayer#getColor` to optionally return an array of colors instead of a single color. If it returns an array, the length must match the number of points returned by `getPath`.

This lets you draw paths that change color along their length, or paths where the alpha channel fades out along the length of the path.

