### PR TITLE
Hexagon layer api

### DIFF
--- a/docs/layers/hexagon-layer.md
+++ b/docs/layers/hexagon-layer.md
@@ -20,14 +20,14 @@ Inherits from all [Base Layer](/docs/layers/base-layer.md) properties.
 Primitive hexagon vertices as an array of six [lon, lat] pairs,
 in either clockwise or counter clouckwise direction.
 
-##### `dotRadius` (Number, optional)
+##### `radiusScale` (Number, optional)
 
 - Default: `1`
 
 Hexagon radius multiplier, between 0 - 1. It defines the gap between each hexagon.
 when set to 1, all hexagons will be closely placed to each other.
 
-##### `enable3d` (Boolean, optional)
+##### `extruded` (Boolean, optional)
 
 - Default: `true`
 

--- a/docs/layers/hexagon-layer.md
+++ b/docs/layers/hexagon-layer.md
@@ -24,20 +24,14 @@ in either clockwise or counter clouckwise direction.
 
 - Default: `1`
 
-Hexagon radius multiplier, between 0 - 1. It defines the gap between each hexagon.
-when set to 1, all hexagons will be closely placed to each other.
+Hexagon radius multiplier, between 0 - 1. The radius of hexagon is calculated by 
+radiusScale * getRadius(d)
 
 ##### `extruded` (Boolean, optional)
 
 - Default: `true`
 
 Whether to extrude hexagon. If se to false, all hexagons will be set to flat.
-
-#### `invisibleColor` (Number[3], optional)
-
-- Default: `[0, 0, 0]`
-
-To make one hexagon invisible, set its color to equal to invisibleColor
 
 #### `getCentroid` (Function, optional)
 
@@ -49,14 +43,8 @@ Method called to retrieve the centroid of each hexagon. Centoid should be set to
 
 - Default: `object => object.color`
 
-Method called to retrieve the color of each object. Color should be set to [r, g, b]
+Method called to retrieve the color of each object. Color should be set to [r, g, b, a]
 with each number between 0 -255
-
-#### `getAlpha` (Function, optional)
-
-- Default: `object => 255`
-
-Method called to retrieve the alpha of each object. Color should be set between 0 to 255
 
 #### `getElevation` (Function, optional)
 

--- a/examples/main/layer-controls.js
+++ b/examples/main/layer-controls.js
@@ -38,7 +38,8 @@ export default class LayerControls extends PureComponent {
 
   _renderSlider(settingName, value) {
     let max = 1;
-    if (/radius|width|height|pixel|size/i.test(settingName)) {
+    if (/radius|width|height|pixel|size/i.test(settingName) &&
+      !(/^((?!scale).)*$/).test(settingName)) {
       max = 100;
     }
 

--- a/examples/main/layer-examples.js
+++ b/examples/main/layer-examples.js
@@ -218,8 +218,9 @@ const HexagonLayerExample = {
     hexagonVertices: dataSamples.hexagons[0].vertices,
     getColor: h => [48, 128, h.value * 255],
     getElevation: h => h.value * 50,
-    enable3d: true,
+    extruded: true,
     pickable: true,
+    radiusScale: 1,
     opacity: 1
   }
 };

--- a/src/layers/core/hexagon-layer/hexagon-layer-vertex.glsl
+++ b/src/layers/core/hexagon-layer/hexagon-layer-vertex.glsl
@@ -19,7 +19,6 @@ uniform mat4 worldInverseTransposeMatrix;
 
 // Custom uniforms
 uniform float opacity;
-uniform vec3 invisibleColor;
 uniform float radius;
 uniform float angle;
 uniform float extruded;
@@ -81,11 +80,8 @@ void main(void) {
 
   vec3 lightWeightedColor = mix(vec3(1), lightWeighting, extruded) * (instanceColors.rgb / 255.0);
 
-  // Hide hexagon if set to invisibleColor
-  float alpha = instanceColors.rgb == invisibleColor ? 0. : opacity;
-
   // Color: Either opacity-multiplied instance color, or picking color
-  vec4 color = vec4(lightWeightedColor, alpha * instanceColors.a / 255.);
+  vec4 color = vec4(lightWeightedColor, opacity * instanceColors.a / 255.);
 
   vec4 pickingColor = vec4(instancePickingColors / 255., 1.);
 

--- a/src/layers/core/hexagon-layer/hexagon-layer-vertex.glsl
+++ b/src/layers/core/hexagon-layer/hexagon-layer-vertex.glsl
@@ -22,7 +22,8 @@ uniform float opacity;
 uniform vec3 invisibleColor;
 uniform float radius;
 uniform float angle;
-uniform float enable3d;
+uniform float extruded;
+uniform float radiusScale;
 
 // Lighting constants
 const vec3 ambientColor = vec3(1., 1., 1.);
@@ -51,12 +52,13 @@ void main(void) {
 
   // calculate elevation, if 3d not enabled set to 0
   // cylindar gemoetry height are between -0.5 to 0.5, transform it to between 0, 1
-  float elevation =  mix(0., project_scale(instancePositions.z  * (positions.y + 0.5) * ELEVATION_SCALE), enable3d);
+  float elevation =  mix(0., project_scale(instancePositions.z  * (positions.y + 0.5) * ELEVATION_SCALE), extruded);
 
+  float dotRadius = radius * clamp(radiusScale, 0.0, 1.0);
   // project center of hexagon
   vec4 centroidPosition = vec4(project_position(instancePositions.xy), elevation, 0.0);
 
-  gl_Position = project_to_clipspace(centroidPosition + vec4(vec2(rotatedPositions.xz * radius), 0., 1.));
+  gl_Position = project_to_clipspace(centroidPosition + vec4(vec2(rotatedPositions.xz * dotRadius), 0., 1.));
 
   // check whether hexagon is currently picked
   float selected = isPicked(instancePickingColors, selectedPickingColor);
@@ -77,7 +79,7 @@ void main(void) {
     shininess
   );
 
-  vec3 lightWeightedColor = mix(vec3(1), lightWeighting, enable3d) * (instanceColors.rgb / 255.0);
+  vec3 lightWeightedColor = mix(vec3(1), lightWeighting, extruded) * (instanceColors.rgb / 255.0);
 
   // Hide hexagon if set to invisibleColor
   float alpha = instanceColors.rgb == invisibleColor ? 0. : opacity;

--- a/src/layers/core/hexagon-layer/hexagon-layer.js
+++ b/src/layers/core/hexagon-layer/hexagon-layer.js
@@ -77,7 +77,7 @@ export default class HexagonLayer extends Layer {
    */
   constructor(props) {
     if (!props.hexagonVertices) {
-      log.once(0, 'hexagonVertices is missing, use default vertices of 1 km radius hexagon');
+      log.once(0, 'hexagonVertices is missing, use default vertices of a 1 km radius hexagon');
     }
 
     super(props);

--- a/src/layers/core/hexagon-layer/hexagon-layer.js
+++ b/src/layers/core/hexagon-layer/hexagon-layer.js
@@ -40,7 +40,7 @@ function positionsAreEqual(v1, v2) {
 const defaultProps = {
   id: 'hexagon-layer',
   data: [],
-  radiusScale: 0.2,
+  radiusScale: 1,
   extruded: true,
   hexagonVertices: null,
   invisibleColor: [0, 0, 0],


### PR DESCRIPTION
- use radiusScale instead of dotRadius
- use extruded instead of enable3d
- calculate default hexagonVertices if not provided