### PR TITLE
ScatterplotLayer bugfix: update when data changes

### DIFF
--- a/src/layers/core/scatterplot-layer/scatterplot-layer.js
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer.js
@@ -58,10 +58,12 @@ export default class ScatterplotLayer extends Layer {
     /* eslint-enable max-len */
   }
 
-  updateState({props, oldProps}) {
+  updateState(info) {
+    const {props, oldProps} = info;
     if (props.drawOutline !== oldProps.drawOutline) {
       this.state.model.geometry.drawMode = props.drawOutline ? GL.LINE_LOOP : GL.TRIANGLE_FAN;
     }
+    super.updateState(info);
   }
 
   draw({uniforms}) {


### PR DESCRIPTION
Currently on the dev branch, when you change the `data` prop on a `ScatterplotLayer`, it doesn't invalidate attributes.

@ibgreen @Pessimistress 