### PR TITLE
PathLayer Miter Fix -- POC

### DIFF
--- a/docs/layers/path-layer.md
+++ b/docs/layers/path-layer.md
@@ -23,29 +23,27 @@ A path is an array of coordinates.
 
 Returns an array of color
 
-- Default `(object, index) => object.color`
+- Default `(object, index) => object.color || [0, 0, 0, 255]`
 
 Method called to determine the rgba color of the source.
-
-If the method does not return a value for the given object,
-fallback to `strokeColor`.
 
 If the color alpha (the fourth component) is not provided,
 `alpha` will be set to `255`.
 
 
-#### `getWidth` (Function, optional)
+#### `getStrokeWidth` (Function, optional)
 
-- Default: `(object, index) => object.width`
+- Default: `(object, index) => object.width || 1`
 
-Return a width multiplier from each object.
+Method called to determine the width to draw each path with.
+Unit is meters.
 
 
-##### `strokeWidth` (Number, optional)
+##### `strokeWidthScale` (Number, optional)
 
 - Default: `1`
 
-The stroke width used to draw each line. Unit is meters.
+The global stroke width multiplier.
 
 ##### `strokeMinPixels` (Number, optional)
 
@@ -60,15 +58,16 @@ The minimum stroke size in pixels.
 
 The maximum stroke size in pixels.
 
+##### `rounded` (Boolean, optional)
+
+- Default: `false`
+
+Type of joint. If `true`, draw round joints. Otherwise draw miter joints.
+
 
 ##### `miterLimit` (Number, optional)
 
 - Default: `4`
 
-The maximum extent of the join as a ratio to the stroke-width.
-
-
-##### `strokeColor` (Number, optional)
-
-- Default: `[0, 0, 0, 255]`
-
+The maximum extent of a joint in ratio to the stroke width.
+Only works if `rounded` is `false`.

--- a/examples/main/data-samples.js
+++ b/examples/main/data-samples.js
@@ -16,6 +16,15 @@ export const meterPoints = pointGrid(1e3, [-5000, -5000, 5000, 5000]);
 
 export const worldGrid = pointsToWorldGrid(points, 0.5);
 
+export const zigzag = [
+  {path: (new Array(12)).fill(0).map(
+    (d, i) => [
+      positionOrigin[0] + i * i * 0.001,
+      positionOrigin[1] + Math.cos(i * Math.PI) * 0.2 / (i + 4)
+    ])
+  }
+];
+
 // time consuming - only generate on demand
 let _points100K = null;
 export function getPoints100K() {

--- a/examples/main/layer-controls.js
+++ b/examples/main/layer-controls.js
@@ -38,8 +38,8 @@ export default class LayerControls extends PureComponent {
 
   _renderSlider(settingName, value) {
     let max = 1;
-    if (/radius|width|height|pixel|size/i.test(settingName) &&
-      !(/^((?!scale).)*$/).test(settingName)) {
+    if (/radius|width|height|pixel|size|miter/i.test(settingName) &&
+      (/^((?!scale).)*$/).test(settingName)) {
       max = 100;
     }
 

--- a/examples/main/layer-examples.js
+++ b/examples/main/layer-examples.js
@@ -131,11 +131,11 @@ const PathLayerExample = {
   props: {
     id: 'pathLayer',
     data: dataSamples.zigzag,
-    strokeWidth: 500,
     opacity: 0.6,
     getPath: f => f.path,
     getColor: f => [128, 0, 0],
-    pickable: false
+    getStrokeWidth: f => 10,
+    pickable: true
   }
 };
 

--- a/examples/main/layer-examples.js
+++ b/examples/main/layer-examples.js
@@ -9,7 +9,7 @@ import {
   GridLayer,
   GeoJsonLayer,
   // PolygonLayer,
-  // PathLayer,
+  PathLayer,
 
   ScatterplotLayer64,
   ArcLayer64,
@@ -126,16 +126,18 @@ const GeoJsonLayerExtrudedExample = {
 //   }
 // };
 
-// const PathLayerExample = {
-//   layer: ChoroplethLayer,
-//   props: {
-//     id: 'choroplethLayerSolid',
-//     data: dataSamples.polygons,
-//     getColor: f => [((f.properties.ZIP_CODE * 10) % 127) + 128, 0, 0],
-//     opacity: 0.8,
-//     pickable: true
-//   }
-// };
+const PathLayerExample = {
+  layer: PathLayer,
+  props: {
+    id: 'pathLayer',
+    data: dataSamples.zigzag,
+    strokeWidth: 500,
+    opacity: 0.6,
+    getPath: f => f.path,
+    getColor: f => [128, 0, 0],
+    pickable: false
+  }
+};
 
 const ScreenGridLayerExample = {
   layer: ScreenGridLayer,
@@ -372,7 +374,7 @@ export default {
     'GeoJsonLayer (Extruded)': GeoJsonLayerExtrudedExample,
     // 'GeoJsonLayer (Immutable)': GeoJsonLayerImmutableExample,
     // PolygonLayer: PolygonLayerExample,
-    // PathLayer: PathLayerExample,
+    PathLayer: PathLayerExample,
     'ScatterplotLayer': ScatterplotLayerExample,
     'ScatterplotLayer (meters)': ScatterplotLayerMetersExample,
     ArcLayer: ArcLayerExample,

--- a/src/layers/core/path-layer/path-layer-fragment.glsl
+++ b/src/layers/core/path-layer/path-layer-fragment.glsl
@@ -24,8 +24,19 @@
 precision highp float;
 #endif
 
+uniform float jointType;
+
 varying vec4 vColor;
+varying vec3 vCornerUV;
+varying float shouldDiscard;
 
 void main(void) {
+  if (shouldDiscard > 1.0) {
+    discard;
+  }
+  // if joint is rounded, test distance from the corner
+  if (jointType > 0.0 && vCornerUV.z > 0.0 && length(vCornerUV.xy) > 1.0) {
+    discard;
+  }
   gl_FragColor = vColor;
 }

--- a/src/layers/core/path-layer/path-layer-fragment.glsl
+++ b/src/layers/core/path-layer/path-layer-fragment.glsl
@@ -25,17 +25,18 @@ precision highp float;
 #endif
 
 uniform float jointType;
+uniform float miterLimit;
 
 varying vec4 vColor;
-varying vec3 vCornerUV;
-varying float shouldDiscard;
+varying vec2 vCornerOffset;
+varying float vMiterLength;
 
 void main(void) {
-  if (shouldDiscard > 1.0) {
+  // if joint is rounded, test distance from the corner
+  if (jointType > 0.0 && vMiterLength > 0.0 && length(vCornerOffset) > 1.0) {
     discard;
   }
-  // if joint is rounded, test distance from the corner
-  if (jointType > 0.0 && vCornerUV.z > 0.0 && length(vCornerUV.xy) > 1.0) {
+  if (jointType == 0.0 && vMiterLength > miterLimit) {
     discard;
   }
   gl_FragColor = vColor;

--- a/src/layers/core/path-layer/path-layer-vertex.glsl
+++ b/src/layers/core/path-layer/path-layer-vertex.glsl
@@ -1,71 +1,197 @@
 #define SHADER_NAME path-layer-vertex-shader
 
-attribute float directions;
 attribute vec3 positions;
-attribute vec3 leftDeltas;
-attribute vec3 rightDeltas;
 
-attribute vec4 colors;
-attribute vec3 pickingColors;
+attribute vec3 instanceStartPositions;
+attribute vec3 instanceEndPositions;
+attribute vec3 instanceLeftDeltas;
+attribute vec3 instanceRightDeltas;
+attribute vec4 instanceColors;
+attribute vec3 instancePickingColors;
 
 uniform float thickness;
 uniform float strokeMinPixels;
 uniform float strokeMaxPixels;
+uniform float jointType;
 uniform float miterLimit;
 uniform float opacity;
 uniform float renderPickingBuffer;
 
 varying vec4 vColor;
+varying vec3 vCornerUV;
+varying float shouldDiscard;
 
 // calculate line join positions
-vec2 lineJoin(vec3 prevProjected, vec3 currProjected, vec3 nextProjected) {
-  // get 2D screen coordinates
-  vec2 prevScreen = prevProjected.xy;
-  vec2 currScreen = currProjected.xy;
-  vec2 nextScreen = nextProjected.xy;
+vec3 miterJoin(vec3 prevPoint, vec3 currPoint, vec3 nextPoint) {
 
-  float len = clamp(project_scale(thickness),
-    strokeMinPixels, strokeMaxPixels);
+  float offset = clamp(project_scale(thickness),
+    strokeMinPixels, strokeMaxPixels) / 2.0;
+  float offsetScale = 1.0;
+
+  vec2 deltaA = currPoint.xy - prevPoint.xy;
+  vec2 deltaB = nextPoint.xy - currPoint.xy;
 
   vec2 dir = vec2(0.0);
-  if (currScreen == prevScreen) {
+  float offsetDirection = positions.y;
+  shouldDiscard = positions.z;
+
+  if (deltaA == vec2(0.0)) {
     // starting point uses (next - current)
-    dir = normalize(nextScreen - currScreen);
-  } else if (currScreen == nextScreen) {
+    dir = normalize(deltaB);
+  } else if (deltaB == vec2(0.0)) {
     // ending point uses (current - previous)
-    dir = normalize(currScreen - prevScreen);
+    dir = normalize(deltaA);
   } else {
-    // somewhere in middle, needs a join
-    // get directions from (C - B) and (B - A)
-    vec2 dirA = normalize(currScreen - prevScreen);
-    vec2 dirB = normalize(nextScreen - currScreen);
-    // now compute the miter join normal and length
+    vec2 dirA = normalize(deltaA);
+    vec2 dirB = normalize(deltaB);
+    // direction of the corner
     vec2 tangent = normalize(dirA + dirB);
-    vec2 perp = vec2(-dirA.y, dirA.x);
+    // width offset from current position
+    dir = mix(dirB, dirA, positions.x);
+    vec2 perp = vec2(-dir.y, dir.x);
+
     vec2 miterVec = vec2(-tangent.y, tangent.x);
     dir = tangent;
-    len *= min(miterLimit, 1.0 / dot(miterVec, perp));
-  }
-  vec2 normal = vec2(-dir.y, dir.x);
-  normal *= len / 2.0;
+    offsetScale = 1.0 / dot(miterVec, perp);
 
-  return currProjected.xy + normal * directions;
+    bool isOutsideCorner = (dirB.y > dirA.y) == (positions.y < 0.0);
+
+    if (!isOutsideCorner && positions.z == 0.0) {
+      // is inside corner
+      float maxLen = min(length(deltaA), length(deltaB));
+      maxLen *= abs(dot(miterVec, dirA));
+      if (offsetScale * offset > maxLen) {
+        isOutsideCorner = true;
+      }
+    }
+
+    // needs cropping?
+    if (offsetScale > miterLimit) {
+      if (positions.z == 1.0) {
+        // is bevel center point
+        offsetDirection = dirB.y > dirA.y ? -1.0 : 1.0;
+        offsetScale = miterLimit;
+        shouldDiscard = 0.0;
+      } else if (isOutsideCorner) {
+        // is outside corner
+        // move to bevel center
+        currPoint += vec3(miterVec * (offset * miterLimit) * offsetDirection, 0.0);
+
+        // offset from bevel center
+        offsetScale = (offsetScale - miterLimit) / offsetScale;
+        offsetScale /= abs(dot(miterVec, dirA));
+        offsetDirection *= float((dirB.y > dirA.y) == (positions.x == 0.)) * 2. - 1.;
+        dir = miterVec;
+      }
+    }
+  }
+  vec2 normal = vec2(-dir.y, dir.x) * offsetDirection;
+
+  return currPoint + vec3(normal * offset * offsetScale, 0.0);
 }
 
+vec3 roundJoin(vec3 prevPoint, vec3 currPoint, vec3 nextPoint) {
+
+  float offset = clamp(project_scale(thickness),
+    strokeMinPixels, strokeMaxPixels) / 2.0;
+  float offsetScale = 1.0;
+
+  vec2 deltaA = currPoint.xy - prevPoint.xy;
+  vec2 deltaB = nextPoint.xy - currPoint.xy;
+
+  vec2 dir = vec2(0.0);
+  float offsetDirection = positions.y;
+  float isOutsideCorner = 0.0;
+
+  if (deltaA == vec2(0.0)) {
+    // starting point uses (next - current)
+    dir = normalize(deltaB);
+    // end cap
+    if (positions.z == 1.0) {
+      dir = vec2(-dir.y, dir.x);
+      offsetDirection = 1.0;
+      offsetScale = 4.0;
+      isOutsideCorner = 1.0;
+    }
+
+  } else if (deltaB == vec2(0.0)) {
+    // ending point uses (current - previous)
+    dir = normalize(deltaA);
+    // end cap
+    if (positions.z == 1.0) {
+      dir = vec2(-dir.y, dir.x);
+      offsetDirection = -1.0;
+      offsetScale = 4.0;
+      isOutsideCorner = 1.0;
+    }
+
+  } else {
+
+    vec2 dirA = normalize(deltaA);
+    vec2 dirB = normalize(deltaB);
+
+    if ((dirB.y > dirA.y) == (positions.y < 0.0) && positions.z == 0.0) {
+      // is outside corner
+      dir = mix(dirB, dirA, positions.x);
+    } else {
+      // direction of the corner
+      vec2 tangent = normalize(dirA + dirB);
+      // width offset from current position
+      dir = mix(dirB, dirA, positions.x);
+      vec2 perp = vec2(-dir.y, dir.x);
+
+      vec2 miterVec = vec2(-tangent.y, tangent.x);
+      dir = tangent;
+      offsetScale = 1.0 / dot(miterVec, perp);
+
+      if (positions.z == 1.0) {
+        // is bevel center point
+        offsetDirection = dirB.y > dirA.y ? -1.0 : 1.0;
+        isOutsideCorner = offsetScale;
+      } else {
+        // is inside
+        float maxLen = min(length(deltaA), length(deltaB));
+        maxLen *= abs(dot(miterVec, dirA));
+        if (offsetScale * offset > maxLen) {
+          dir = mix(dirB, dirA, positions.x);
+          offsetScale = 1.0;
+        } else {
+          isOutsideCorner = -offsetScale;
+        }
+      }
+    }
+  }
+
+  vec2 normal = vec2(-dir.y, dir.x) * offsetDirection;
+  vCornerUV = vec3(normal * offsetScale, isOutsideCorner);
+
+  return currPoint + vec3(normal * offset * offsetScale, 0.0);
+}
+
+
 void main() {
-  vec4 color = vec4(colors.rgb, colors.a * opacity) / 255.;
-  vec4 pickingColor = vec4(pickingColors.rgb, 255.) / 255.;
+  vec4 color = vec4(instanceColors.rgb, instanceColors.a * opacity) / 255.;
+  vec4 pickingColor = vec4(instancePickingColors, 255.) / 255.;
   vColor = mix(color, pickingColor, renderPickingBuffer);
 
-  vec3 prevProjected = project_position(positions - leftDeltas);
-  vec3 currProjected = project_position(positions);
-  vec3 nextProjected = project_position(positions + rightDeltas);
+  float isEnd = positions.x;
 
-  gl_Position = project_to_clipspace(
-    vec4(
-      lineJoin(prevProjected, currProjected, nextProjected),
-      currProjected.z + 0.1,
-      1.0
-    )
-  );
+  vec3 prevPosition = mix(-instanceLeftDeltas, vec3(0.0), isEnd) + instanceStartPositions;
+  prevPosition = project_position(prevPosition);
+
+  vec3 currPosition = mix(instanceStartPositions, instanceEndPositions, isEnd);
+  currPosition = project_position(currPosition);
+
+  vec3 nextPosition = mix(vec3(0.0), instanceRightDeltas, isEnd) + instanceEndPositions;
+  nextPosition = project_position(nextPosition);
+
+  vec3 pos;
+
+  if (jointType == 0.0) {
+    pos = miterJoin(prevPosition, currPosition, nextPosition);
+  } else {
+    pos = roundJoin(prevPosition, currPosition, nextPosition);
+  }
+
+  gl_Position = project_to_clipspace(vec4(pos, 1.0));
 }

--- a/src/layers/core/path-layer/path-layer-vertex.glsl
+++ b/src/layers/core/path-layer/path-layer-vertex.glsl
@@ -6,10 +6,11 @@ attribute vec3 instanceStartPositions;
 attribute vec3 instanceEndPositions;
 attribute vec3 instanceLeftDeltas;
 attribute vec3 instanceRightDeltas;
+attribute float instanceWidths;
 attribute vec4 instanceColors;
 attribute vec3 instancePickingColors;
 
-uniform float thickness;
+uniform float widthScale;
 uniform float strokeMinPixels;
 uniform float strokeMaxPixels;
 uniform float jointType;
@@ -30,7 +31,7 @@ float flipIfTrue(bool flag) {
 // calculate line join positions
 vec3 lineJoin(vec3 prevPoint, vec3 currPoint, vec3 nextPoint) {
 
-  float width = clamp(project_scale(thickness),
+  float width = clamp(project_scale(instanceWidths * widthScale),
     strokeMinPixels, strokeMaxPixels) / 2.0;
 
   vec2 deltaA = currPoint.xy - prevPoint.xy;

--- a/src/layers/core/path-layer/path-layer.js
+++ b/src/layers/core/path-layer/path-layer.js
@@ -219,7 +219,7 @@ export default class PathLayer extends Layer {
     paths.forEach((path, index) => {
       const width = getStrokeWidth(data[index], index);
       for (let ptIndex = 1; ptIndex < path.length; ptIndex++) {
-        value[i++] = width
+        value[i++] = width;
       }
     });
   }

--- a/src/layers/core/path-layer/path-layer.js
+++ b/src/layers/core/path-layer/path-layer.js
@@ -82,16 +82,18 @@ export default class PathLayer extends Layer {
     const shaders = assembleShaders(gl, this.getShaders());
 
     /*
-     *       \
-     *    \   \ 1                               3
-     * \   .   o-------------------------------o-_  5
-     *  \   \ / ""--..__                      /   ;o
-     *   \   @- - - - - ""--..__- - - - - - -/ -@`  '.
-     *    \ /                   ""--..__    /,-`:    |
-     *     o----------------------------""-o`   :    |
-     *   0,2                             4 |    :    |
-     *                                     |    :    |
-     *
+     *       _  
+     *        "-_ 1                   3                       5
+     *     _     "o---------------------o-------------------_-o
+     *       -   / ""--..__              '.             _.-' /
+     *   _     "@- - - - - ""--..__- - - - x - - - -_.@'    /
+     *    "-_  /                   ""--..__ '.  _,-` :     /
+     *       "o----------------------------""-o'    :     /
+     *      0,2                            4 / '.  :     /
+     *                                      /   '.:     /
+     *                                     /     :'.   /
+     *                                    /     :  ', /
+     *                                   /     :     o
      */
 
     const SEGMENT_INDICES = [
@@ -108,7 +110,9 @@ export default class PathLayer extends Layer {
     //   0, 1, 1, 2, 0, 2, 1, 3, 2, 4, 3, 4, 3, 5, 4, 5
     // ];
 
-    // [isEnd, offsetDirection, isCenter]
+    // [0] position on segment - 0: start, 1: end
+    // [1] side of path - -1: left, 0: center, 1: right
+    // [2] role - 0: offset point 1: joint point
     const SEGMENT_POSITIONS = [
       // bevel start corner
       0, 0, 1,


### PR DESCRIPTION
Re: [Mitering bug: PathLayer produces uneven strokes if the path has acute angles #337](https://github.com/uber/deck.gl/issues/337)

Current PathLayer:
![path-old](https://cloud.githubusercontent.com/assets/2059298/22760151/15208e4c-ee0a-11e6-9232-87bd48ab7121.png)

Fixed miter (still some z-fighting issues):
![path-miter](https://cloud.githubusercontent.com/assets/2059298/22760125/04aa5fca-ee0a-11e6-8345-e5fca1cc0f7c.png)

Basically one extra point is added to each corner to control the joint.
This also allows us to do other line joints:
![path-rounded](https://cloud.githubusercontent.com/assets/2059298/22760157/1769b37c-ee0a-11e6-81ef-dc72122e40c3.png)

In this POC I'm switching to an instancing model. Comparing instanced against indexed draws:
- removed the requirement of the `OES_element_index_uint` extension
- reduce attribute length to 1/3
- the number of vertex shader calls per path increased from `numPoints * 3` to `(numPoints - 1) * 6`

Setting the perf concerns aside, it does open some pretty nice opportunities for us such as dashed lines. 
@ibgreen @contra @dcposch
