### PR TITLE
IconLayer API Audit

### DIFF
--- a/docs/layers/icon-layer.md
+++ b/docs/layers/icon-layer.md
@@ -33,11 +33,11 @@ Icon names mapped to icon definitions. Each icon is defined with the following v
   If `false`, pixel color from the image is applied.
   Default: `false`
 
-##### `size` (Number, optional)
+##### `sizeScale` (Number, optional)
 
-- Default: `30`
+- Default: `1`
 
-Icon size in pixels
+Icon size multiplier.
 
 ##### `getPosition` (Function, optional)
 
@@ -51,14 +51,15 @@ Method called to retrieve the position of each object, returns `[lng, lat, z]`.
 
 Method called to retrieve the icon name of each object, returns string.
 
-##### `getScale` (Function, optional)
+##### `getSize` (Function, optional)
 
-- Default: `d => d.size`
+- Default: `d => d.size || 1`
 
-Method called to retrieve the size multiplier of each object, returns a number.
+Method called to retrieve the size of each object, returns a number. Unit is pixels.
 
 ##### `getColor` (Function, optional)
 
-- Default: `d => d.color`
+- Default: `d => d.color || [0, 0, 0, 255]`
 
 Method called to retrieve the color of each object, returns `[r, g, b, a]`.
+If the alpha component is not supplied, it is set to `255`.

--- a/examples/main/layer-examples.js
+++ b/examples/main/layer-examples.js
@@ -54,11 +54,11 @@ const IconLayerExample = {
     iconAtlas: 'data/icon-atlas.png',
     iconMapping: dataSamples.iconAtlas,
     data: dataSamples.points,
-    size: 24,
+    sizeScale: 24,
     getPosition: d => d.COORDINATES,
     getColor: d => [64, 64, 72],
     getIcon: d => d.PLACEMENT === 'SW' ? 'marker' : 'marker-warning',
-    getScale: d => d.RACKS > 2 ? 2 : 1,
+    getSize: d => d.RACKS > 2 ? 2 : 1,
     opacity: 0.8,
     pickable: true
   }

--- a/src/layers/core/icon-layer/icon-layer-vertex.glsl
+++ b/src/layers/core/icon-layer/icon-layer-vertex.glsl
@@ -29,7 +29,7 @@ attribute vec4 instanceIconFrames;
 attribute float instanceColorModes;
 attribute vec2 instanceOffsets;
 
-uniform vec2 size;
+uniform vec2 sizeScale;
 
 uniform float renderPickingBuffer;
 uniform vec2 iconsTextureDim;
@@ -40,7 +40,7 @@ varying vec2 vTextureCoords;
 
 void main(void) {
   vec3 center = project_position(instancePositions);
-  vec2 vertex = (positions + instanceOffsets * 2.0) * size * instanceSizes;
+  vec2 vertex = (positions + instanceOffsets * 2.0) * sizeScale * instanceSizes;
   gl_Position = project_to_clipspace(vec4(center, 1.0)) + vec4(vertex, 0.0, 0.0);
 
   vTextureCoords = mix(


### PR DESCRIPTION
- renamed `getScale` to `getSize`
- renamed `size` to `sizeScale`
- moved color fallback to the default accessor

@shaojingli @gnavvy @ibgreen @heshan0131 @apercu @abmai