### PR TITLE
ScatterplotLayer perf improvement + lineWidth fix

### DIFF
--- a/src/layers/core/scatterplot-layer/scatterplot-layer-fragment.glsl
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer-fragment.glsl
@@ -25,7 +25,11 @@ precision highp float;
 #endif
 
 varying vec4 vColor;
+varying vec2 uv;
 
 void main(void) {
+  if (length(uv) > 1.0) {
+    discard;
+  }
   gl_FragColor = vColor;
 }

--- a/src/layers/core/scatterplot-layer/scatterplot-layer-fragment.glsl
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer-fragment.glsl
@@ -24,17 +24,15 @@
 precision highp float;
 #endif
 
-uniform float drawOutline;
-
 varying vec4 vColor;
-varying vec2 uv;
-varying float strokeWidthRatio;
+varying vec2 unitPosition;
+varying float innerUnitRadius;
 
 void main(void) {
 
-  float distToCenter = length(uv);
+  float distToCenter = length(unitPosition);
 
-  if (distToCenter <= 1.0 && (drawOutline == 0.0 || distToCenter >= 1.0 - strokeWidthRatio)) {
+  if (distToCenter <= 1.0 && distToCenter >= innerUnitRadius) {
     gl_FragColor = vColor;
   } else {
     discard;

--- a/src/layers/core/scatterplot-layer/scatterplot-layer-fragment.glsl
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer-fragment.glsl
@@ -24,12 +24,19 @@
 precision highp float;
 #endif
 
+uniform float drawOutline;
+
 varying vec4 vColor;
 varying vec2 uv;
+varying float strokeWidthRatio;
 
 void main(void) {
-  if (length(uv) > 1.0) {
+
+  float distToCenter = length(uv);
+
+  if (distToCenter <= 1.0 && (drawOutline == 0.0 || distToCenter >= 1.0 - strokeWidthRatio)) {
+    gl_FragColor = vColor;
+  } else {
     discard;
   }
-  gl_FragColor = vColor;
 }

--- a/src/layers/core/scatterplot-layer/scatterplot-layer-vertex.glsl
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer-vertex.glsl
@@ -36,21 +36,27 @@ uniform float drawOutline;
 uniform float strokeWidth;
 
 varying vec4 vColor;
-varying vec2 uv;
-varying float strokeWidthRatio;
+varying vec2 unitPosition;
+varying float innerUnitRadius;
 
 void main(void) {
   // Multiply out radius and clamp to limits
-  float radiusPixels = clamp(
+  float outerRadiusPixels = clamp(
     project_scale(radius * instanceRadius),
     radiusMinPixels, radiusMaxPixels
-  ) + drawOutline * strokeWidth / 2.0;
-  strokeWidthRatio = strokeWidth / radiusPixels;
+  );
+  // outline is centered at the radius
+  // outer radius needs to offset by half stroke width
+  outerRadiusPixels += drawOutline * strokeWidth / 2.0;
 
-  uv = positions.xy;
+  // position on the containing square in [-1, 1] space
+  unitPosition = positions.xy;
+  // 0 - solid circle, 1 - stroke with lineWidth=0
+  innerUnitRadius = drawOutline * (1.0 - strokeWidth / outerRadiusPixels);
+
   // Find the center of the point and add the current vertex
   vec3 center = project_position(instancePositions);
-  vec3 vertex = positions * radiusPixels;
+  vec3 vertex = positions * outerRadiusPixels;
   gl_Position = project_to_clipspace(vec4(center + vertex, 1.0));
 
   // Apply opacity to instance color, or return instance picking color

--- a/src/layers/core/scatterplot-layer/scatterplot-layer-vertex.glsl
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer-vertex.glsl
@@ -32,16 +32,20 @@ uniform float radius;
 uniform float radiusMinPixels;
 uniform float radiusMaxPixels;
 uniform float renderPickingBuffer;
+uniform float drawOutline;
+uniform float strokeWidth;
 
 varying vec4 vColor;
 varying vec2 uv;
+varying float strokeWidthRatio;
 
 void main(void) {
   // Multiply out radius and clamp to limits
   float radiusPixels = clamp(
     project_scale(radius * instanceRadius),
     radiusMinPixels, radiusMaxPixels
-  );
+  ) + drawOutline * strokeWidth / 2.0;
+  strokeWidthRatio = strokeWidth / radiusPixels;
 
   uv = positions.xy;
   // Find the center of the point and add the current vertex

--- a/src/layers/core/scatterplot-layer/scatterplot-layer-vertex.glsl
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer-vertex.glsl
@@ -34,6 +34,7 @@ uniform float radiusMaxPixels;
 uniform float renderPickingBuffer;
 
 varying vec4 vColor;
+varying vec2 uv;
 
 void main(void) {
   // Multiply out radius and clamp to limits
@@ -42,6 +43,7 @@ void main(void) {
     radiusMinPixels, radiusMaxPixels
   );
 
+  uv = positions.xy;
   // Find the center of the point and add the current vertex
   vec3 center = project_position(instancePositions);
   vec3 vertex = positions * radiusPixels;

--- a/src/layers/core/scatterplot-layer/scatterplot-layer.js
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer.js
@@ -102,6 +102,7 @@ export default class ScatterplotLayer extends Layer {
       id: this.props.id,
       vs: shaders.vs,
       fs: shaders.fs,
+      timerQueryEnabled: true,
       geometry: new Geometry({
         drawMode: GL.TRIANGLE_FAN,
         positions: new Float32Array(positions)

--- a/src/layers/core/scatterplot-layer/scatterplot-layer.js
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer.js
@@ -85,7 +85,7 @@ export default class ScatterplotLayer extends Layer {
       id: this.props.id,
       vs: shaders.vs,
       fs: shaders.fs,
-      timerQueryEnabled: true,
+      // timerQueryEnabled: true,
       geometry: new Geometry({
         drawMode: GL.TRIANGLE_FAN,
         positions: new Float32Array(positions)

--- a/src/layers/core/scatterplot-layer/scatterplot-layer.js
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer.js
@@ -58,17 +58,10 @@ export default class ScatterplotLayer extends Layer {
     /* eslint-enable max-len */
   }
 
-  updateState(info) {
-    const {props, oldProps} = info;
-    if (props.drawOutline !== oldProps.drawOutline) {
-      this.setUniforms({drawOutline: props.drawOutline ? 1 : 0});
-    }
-    super.updateState(info);
-  }
-
   draw({uniforms}) {
-    const {radius, radiusMinPixels, radiusMaxPixels, strokeWidth} = this.props;
+    const {radius, radiusMinPixels, radiusMaxPixels, drawOutline, strokeWidth} = this.props;
     this.state.model.render(Object.assign({}, uniforms, {
+      drawOutline: drawOutline ? 1 : 0,
       strokeWidth,
       radius,
       radiusMinPixels,
@@ -77,6 +70,7 @@ export default class ScatterplotLayer extends Layer {
   }
 
   _getModel(gl) {
+    // a square that minimally cover the unit circle
     const positions = [-1, -1, 0, -1, 1, 0, 1, 1, 0, 1, -1, 0];
     const shaders = assembleShaders(gl, this.getShaders());
 
@@ -85,7 +79,6 @@ export default class ScatterplotLayer extends Layer {
       id: this.props.id,
       vs: shaders.vs,
       fs: shaders.fs,
-      // timerQueryEnabled: true,
       geometry: new Geometry({
         drawMode: GL.TRIANGLE_FAN,
         positions: new Float32Array(positions)

--- a/src/layers/core/scatterplot-layer/scatterplot-layer.js
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer.js
@@ -83,18 +83,7 @@ export default class ScatterplotLayer extends Layer {
   }
 
   _getModel(gl) {
-    const NUM_SEGMENTS = 16;
-    const positions = [];
-    for (let i = 0; i < NUM_SEGMENTS; i++) {
-      positions.push(
-        Math.cos(Math.PI * 2 * i / NUM_SEGMENTS),
-        Math.sin(Math.PI * 2 * i / NUM_SEGMENTS),
-        0
-      );
-    }
-    /* eslint-disable */
-
-
+    const positions = [-1, -1, 0, -1, 1, 0, 1, 1, 0, 1, -1, 0];
     const shaders = assembleShaders(gl, this.getShaders());
 
     return new Model({
@@ -109,7 +98,6 @@ export default class ScatterplotLayer extends Layer {
       }),
       isInstanced: true
     });
-    return model;
   }
 
   calculateInstancePositions(attribute) {

--- a/src/layers/core/scatterplot-layer/scatterplot-layer.js
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer.js
@@ -61,25 +61,19 @@ export default class ScatterplotLayer extends Layer {
   updateState(info) {
     const {props, oldProps} = info;
     if (props.drawOutline !== oldProps.drawOutline) {
-      this.state.model.geometry.drawMode = props.drawOutline ? GL.LINE_LOOP : GL.TRIANGLE_FAN;
+      this.setUniforms({drawOutline: props.drawOutline ? 1 : 0});
     }
     super.updateState(info);
   }
 
   draw({uniforms}) {
-    const {gl} = this.context;
-    const lineWidth = this.screenToDevicePixels(this.props.strokeWidth);
-    gl.lineWidth(lineWidth);
+    const {radius, radiusMinPixels, radiusMaxPixels, strokeWidth} = this.props;
     this.state.model.render(Object.assign({}, uniforms, {
-      radius: this.props.radius,
-      radiusMinPixels: this.props.radiusMinPixels,
-      radiusMaxPixels: this.props.radiusMaxPixels
+      strokeWidth,
+      radius,
+      radiusMinPixels,
+      radiusMaxPixels
     }));
-    // Setting line width back to 1 is here to workaround a Google Chrome bug
-    // gl.clear() and gl.isEnabled() will return GL_INVALID_VALUE even with
-    // correct parameter
-    // This is not happening on Safari and Firefox
-    gl.lineWidth(1.0);
   }
 
   _getModel(gl) {


### PR DESCRIPTION
- Switch from drawing 16-sided polygon to square + fragment shader, about 3x faster
- Fix lineWidth

@ibgreen @shaojingli The `strokeWidth` here is also in pixels, which is consistent with v3 but not the new PathLayer. We probably need another pass of API audit.