### PR TITLE
Fixes sample-layers example

### DIFF
--- a/examples/sample-layers/app.css
+++ b/examples/sample-layers/app.css
@@ -1,0 +1,126 @@
+body {
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 13px;
+	-webkit-font-smoothing: antialiased;
+  margin:0;
+  padding:0;
+  overflow:hidden;
+}
+
+h4 {
+	margin-top: 24px;
+	margin-bottom: 8px;
+}
+
+#layer-info {
+  position: fixed;
+  z-index: 9;
+  margin: 20px;
+  left: 0;
+  bottom: 0;
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+#control-panel {
+	position: fixed;
+	z-index: 9;
+	top: 0;
+  bottom: 0;
+	right: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  height: 100%;
+  width: 280px;
+  background: rgba(255, 255, 255, 0.5);
+}
+
+#control-panel > div{
+	padding: 0 20px 20px 20px;
+}
+
+.layer-controls {
+	border: groove 2px #fff;
+  border-left: none;
+  border-right: none;
+  padding: 8px 0;
+}
+
+/* Checkbox style adapted from http://cssdeck.com/labs/css-checkbox-styles */
+.input-group {
+  color: #333;
+  line-height: 28px;
+  display: table;
+  width: 100%;
+}
+.input-group > * {
+  display: table-cell;
+  width: 50%;
+  vertical-align: middle;
+}
+.input-group input[type=range] {
+  width: 100%;
+  vertical-align: middle;
+}
+.color-picker {
+  width: 18px;
+  height: 18px;
+  vertical-align: middle;
+  border: solid 1px #ccc;
+  display: block;
+  margin: 5px 2px;
+}
+
+.checkbox {
+	text-align: center;
+	width: 20px;
+	height: 20px;
+	margin: 12px 20px 12px 0;
+	background: #fcfcfc;
+	border-radius: 50px;
+	box-shadow: inset 0px 1px 1px white, 0px 1px 3px rgba(0,0,0,0.5);
+	position: relative;
+}
+
+.checkbox input {
+  visibility: hidden;
+}
+
+.checkbox label {
+  color: #333;
+	cursor: pointer;
+	position: absolute;
+	width: 14px;
+	height: 14px;
+	border-radius: 50px;
+	left: 3px;
+	top: 3px;
+	white-space: nowrap;
+	box-shadow: inset 0px 1px 1px rgba(0,0,0,0.5), 0px 1px 0px rgba(255,255,255,1);
+}
+
+.checkbox label > span {
+	padding-left: 30px;
+}
+
+.checkbox label:after {
+	opacity: 0.1;
+	content: '';
+	position: absolute;
+	width: 100%;
+	height: 100%;
+	left: 0;
+	top: 0;
+	background: #000000;
+	border-radius: 50px;
+	box-shadow: 0px 1px 3px rgba(0,0,0,0.5);
+}
+
+.checkbox label:hover::after {
+	opacity: 0.3;
+}
+
+.checkbox input:checked + label:after {
+	background: #40bf00;
+	opacity: 1;
+}

--- a/examples/sample-layers/index.html
+++ b/examples/sample-layers/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset='UTF-8' />
+    <title>deck.gl example</title>
+	<link href="app.css" rel="stylesheet">
+  </head>
+  <body>
+    <script src='bundle.js'></script>
+  </body>
+</html>

--- a/examples/sample-layers/layers/enhanced-choropleth-layer/README.md
+++ b/examples/sample-layers/layers/enhanced-choropleth-layer/README.md
@@ -1,0 +1,60 @@
+# Enhanced Choropleth Layer (64 bit) **REMOVED**
+
+Note: The `EnhancedChoroplethLayer` sample layer has been removed in deck.gl v4
+in favor of the new `PathLayer`. It is still available as a stand-alone
+example in the examples folder and can be copied from there, but is no longer
+included in the deck.gl package.
+
+A layer that extrudes lines in Choropleth polygons by tesselating them into
+long, thin triangles. This provides control over line thickness
+while ensuring good line mitering, overcoming WebGL's limitations in this
+regard.
+
+**Note:** Very sharp angles can generate very long miters and handling of this
+case needs more work, but for "modest" angles (e.g. 60 degrees in hexagons)
+the results will be good.
+
+    import {ExtrudedChoroplethLayer64} from 'deck.gl';
+
+Inherits from all [Base Layer](/docs/layers/base-layer.md) properties.
+
+##### `drawContour` (Boolean, optional)
+
+- Default: `true`
+
+Whether to draw a contour.
+
+##### `opacity` (Number, optional)
+
+- Default: `1`
+
+Change the opacity, from `0` to `1`.
+
+##### `strokeColor`: (Number[3], optional)
+
+- Default: `[0, 0, 0]`
+
+The contour will be draw in this color.
+
+##### `strokeWidth`: (Number, optional)
+
+- Default: `3`
+
+Width of line segments.
+
+##### `fillColor`: (Number[3], optional)
+
+- Default: `[128, 128, 128]`
+
+Fill will be drawn in this color.
+
+##### `elevation`: (Number, optional)
+
+- Default: `0`
+
+Choropleth will be drawn at this elevation.
+
+##### `getColor`: (Function, optional)
+
+Provide a custom method which gets the segment and that needs to return a color.
+If it is not defined, simply use the `strokeColor`.

--- a/examples/sample-layers/layers/enhanced-choropleth-layer/enhanced-choropleth-layer-fragment.glsl.js
+++ b/examples/sample-layers/layers/enhanced-choropleth-layer/enhanced-choropleth-layer-fragment.glsl.js
@@ -18,31 +18,16 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#define SHADER_NAME enhanced-choropleth-layer-vertex-shader
+module.exports = `\
+#define SHADER_NAME enhanced-choropleth-layer-fragment-shader
 
-attribute vec3 positions;
-attribute vec3 colors;
-attribute vec3 pickingColors;
-
-uniform float opacity;
-uniform float renderPickingBuffer;
-uniform vec3 selectedPickingColor;
+#ifdef GL_ES
+precision highp float;
+#endif
 
 varying vec4 vColor;
 
-vec4 getColor(
-  vec4 color, float opacity, vec3 pickingColor, float renderPickingBuffer
-) {
-  vec4 color4 = vec4(color.rgb / 255., color.a / 255. * opacity);
-  vec4 pickingColor4 = vec4(pickingColor / 255., 1.);
-  return mix(color4, pickingColor4, renderPickingBuffer);
-}
-
 void main(void) {
-  vec2 pos = preproject(positions.xy);
-  gl_Position = project(vec4(pos, 0., 1.));
-
-  vec4 color = vec4(colors / 255., opacity);
-  vec4 pickingColor = vec4(pickingColors / 255., 1.);
-  vColor = mix(color, pickingColor, renderPickingBuffer);
+  gl_FragColor = vColor;
 }
+`;

--- a/examples/sample-layers/layers/enhanced-choropleth-layer/enhanced-choropleth-layer-vertex.glsl.js
+++ b/examples/sample-layers/layers/enhanced-choropleth-layer/enhanced-choropleth-layer-vertex.glsl.js
@@ -18,14 +18,33 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#define SHADER_NAME enhanced-choropleth-layer-fragment-shader
+module.exports = `\
+#define SHADER_NAME enhanced-choropleth-layer-vertex-shader
 
-#ifdef GL_ES
-precision highp float;
-#endif
+attribute vec3 positions;
+attribute vec3 colors;
+attribute vec3 pickingColors;
+
+uniform float opacity;
+uniform float renderPickingBuffer;
+uniform vec3 selectedPickingColor;
 
 varying vec4 vColor;
 
-void main(void) {
-  gl_FragColor = vColor;
+vec4 getColor(
+  vec4 color, float opacity, vec3 pickingColor, float renderPickingBuffer
+) {
+  vec4 color4 = vec4(color.rgb / 255., color.a / 255. * opacity);
+  vec4 pickingColor4 = vec4(pickingColor / 255., 1.);
+  return mix(color4, pickingColor4, renderPickingBuffer);
 }
+
+void main(void) {
+  vec2 pos = preproject(positions.xy);
+  gl_Position = project(vec4(pos, 0., 1.));
+
+  vec4 color = vec4(colors / 255., opacity);
+  vec4 pickingColor = vec4(pickingColors / 255., 1.);
+  vColor = mix(color, pickingColor, renderPickingBuffer);
+}
+`;

--- a/examples/sample-layers/layers/enhanced-choropleth-layer/enhanced-choropleth-layer.js
+++ b/examples/sample-layers/layers/enhanced-choropleth-layer/enhanced-choropleth-layer.js
@@ -18,14 +18,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {Layer} from '../../../lib';
-import {assembleShaders} from '../../../shader-utils';
-import {flatten, normalizeGeojson} from '../../../lib/utils';
+import {Layer} from 'deck.gl';
+import {assembleShaders} from 'deck.gl';
+import {normalizeGeojson} from './geojson';
+import flatten from 'lodash.flattendeep';
 import {GL, Model, Geometry} from 'luma.gl';
 import earcut from 'earcut';
 import extrudePolyline from 'extrude-polyline';
-import {readFileSync} from 'fs';
-import {join} from 'path';
 
 const defaultProps = {
   getColor: null,
@@ -85,8 +84,8 @@ export default class EnhancedChoroplethLayer extends Layer {
 
   getShaders() {
     return {
-      vs: readFileSync(join(__dirname, './enhanced-choropleth-layer-vertex.glsl'), 'utf8'),
-      fs: readFileSync(join(__dirname, './enhanced-choropleth-layer-fragment.glsl'), 'utf8')
+      vs: require('./enhanced-choropleth-layer-vertex.glsl'),
+      fs: require('./enhanced-choropleth-layer-fragment.glsl')
     };
   }
 

--- a/examples/sample-layers/layers/enhanced-choropleth-layer/geojson.js
+++ b/examples/sample-layers/layers/enhanced-choropleth-layer/geojson.js
@@ -1,0 +1,154 @@
+/**
+ * "Normalizes" complete or partial GeoJSON data into iterable list of features
+ * Can accept GeoJSON geometry or "Feature", "FeatureCollection" in addition
+ * to plain arrays and iterables.
+ * Works by extracting the feature array or wrapping single objects in an array,
+ * so that subsequent code can simply iterate over features.
+ *
+ * @param {object} geojson - geojson data
+ * @param {Object|Array} data - geojson object (FeatureCollection, Feature or
+ *  Geometry) or array of features
+ * @return {Array|"iteratable"} - iterable list of features
+ */
+export function getGeojsonFeatures(geojson) {
+  // If array, assume this is a list of features
+  if (Array.isArray(geojson)) {
+    return geojson;
+  }
+
+  const type = geojson.type;
+  switch (type) {
+  case 'Point':
+  case 'MultiPoint':
+  case 'LineString':
+  case 'MultiLineString':
+  case 'Polygon':
+  case 'MultiPolygon':
+  case 'GeometryCollection':
+    // Wrap the geometry object in a 'Feature' object and wrap in an array
+    return [
+      {type: 'Feature', properties: {}, geometry: geojson}
+    ];
+  case 'Feature':
+    // Wrap the feature in a 'Features' array
+    return [geojson];
+  case 'FeatureCollection':
+    // Just return the 'Features' array from the collection
+    return geojson.features;
+  default:
+    throw new Error('Unknown geojson type');
+  }
+}
+
+/*
+ * converts a GeoJSON "Feature" object to a list of GeoJSON polygon-style coordinates
+ * @param {Object | Array} data - geojson object or array of feature
+ * @returns {[Number,Number,Number][][][]} array of choropleths
+ */
+export function featureToPolygons(feature) {
+  const geometry = feature.geometry;
+  // If no geometry field, assume that "feature" is the polygon list
+  if (geometry === undefined) {
+    return feature;
+  }
+
+  const type = geometry.type;
+  const coordinates = geometry.coordinates;
+
+  let polygons;
+  switch (type) {
+  case 'MultiPolygon':
+    polygons = coordinates;
+    break;
+  case 'Polygon':
+    polygons = [coordinates];
+    break;
+  case 'LineString':
+    // TODO - should lines really be handled in this switch?
+    polygons = [[coordinates]];
+    break;
+  case 'MultiLineString':
+    // TODO - should lines really be handled in this switch?
+    polygons = coordinates.map(coords => [coords]);
+    break;
+  default:
+    polygons = [];
+  }
+  return polygons;
+}
+
+// DEPRECATED - USED BY OLD CHOROPLETH LAYERS
+
+/*
+ * converts list of features from a GeoJSON object to a list of GeoJSON
+ * polygon-style coordinates
+ * @param {Object} data - geojson object
+ * @returns {[Number,Number,Number][][][]} array of choropleths
+ */
+export function extractPolygons(data) {
+  const normalizedGeojson = normalizeGeojson(data);
+  const features = normalizedGeojson.features;
+
+  const result = [];
+  features.forEach((feature, featureIndex) => {
+    let choropleths = featureToPolygons(feature);
+
+    /* eslint-disable max-nested-callbacks */
+    choropleths = choropleths.map(
+      choropleth => choropleth.map(
+        polygon => polygon.map(
+          coord => [
+            coord[0],
+            coord[1],
+            coord[2] || 0
+          ]
+        )
+      )
+    );
+    /* eslint-enable max-nested-callbacks */
+
+    for (const choropleth of choropleths) {
+      choropleth.featureIndex = featureIndex;
+    }
+    result.push(...choropleths);
+  });
+  return result;
+}
+
+/**
+ * "Normalizes" a GeoJSON geometry or "Feature" into a "FeatureCollection",
+ * by wrapping it in an extra object/array.
+ *
+ * @param {object} geojson - geojson data
+ * @return {object} - normalized geojson data
+ */
+export function normalizeGeojson(geojson) {
+  const type = geojson.type;
+  switch (type) {
+  case 'Point':
+  case 'MultiPoint':
+  case 'LineString':
+  case 'MultiLineString':
+  case 'Polygon':
+  case 'MultiPolygon':
+  case 'GeometryCollection':
+    // Wrap the geometry object in a "Feature" and add the feature to a "FeatureCollection"
+    return {
+      type: 'FeatureCollection',
+      features: [
+        {type: 'Feature', properties: {}, geometry: geojson}
+      ]
+    };
+  case 'Feature':
+    // Add the feature to a "FeatureCollection"
+    return {
+      type: 'FeatureCollection',
+      features: [geojson]
+    };
+  case 'FeatureCollection':
+    // Just return the feature collection
+    return geojson;
+  default:
+    throw new Error('Unknown geojson type');
+  }
+}

--- a/examples/sample-layers/layers/index.js
+++ b/examples/sample-layers/layers/index.js
@@ -1,1 +1,0 @@
-export {default as EnhancedChoroplethLayer} from './enhanced-choropleth-layer';

--- a/examples/sample-layers/layers/multi-color-path-layer/multi-color-path-layer.js
+++ b/examples/sample-layers/layers/multi-color-path-layer/multi-color-path-layer.js
@@ -49,3 +49,5 @@ colors returned doesn't match the number of points in the path. Index ${index}`)
     attribute.value = colors;
   }
 }
+
+MultiColorPathLayer.layerName = 'MultiColorPathLayer';

--- a/examples/sample-layers/layers/multi-color-path-layer/multi-color-path-layer.js
+++ b/examples/sample-layers/layers/multi-color-path-layer/multi-color-path-layer.js
@@ -1,5 +1,6 @@
 import {PathLayer} from 'deck.gl';
 
+// PathLayer subclass by @dcposch
 export default class MultiColorPathLayer extends PathLayer {
   calculateColors(attribute) {
     const {data, getColor} = this.props;

--- a/examples/sample-layers/layers/multi-color-path-layer/multi-color-path-layer.js
+++ b/examples/sample-layers/layers/multi-color-path-layer/multi-color-path-layer.js
@@ -1,0 +1,50 @@
+import {PathLayer} from 'deck.gl';
+
+export default class MultiColorPathLayer extends PathLayer {
+  calculateColors(attribute) {
+    const {data, getColor} = this.props;
+    const {paths, pointCount} = this.state;
+    const {size} = attribute;
+    const colors = new Uint8ClampedArray(pointCount * size * 2);
+
+    let i = 0;
+    paths.forEach((path, index) => {
+      const color = getColor(data[index], index);
+      if (Array.isArray(color[0])) {
+        if (color.length !== path.length) {
+          throw new Error(`PathLayer getColor() returned a color array, but the number of \
+colors returned doesn't match the number of points in the path. Index ${index}`);
+        }
+        color.forEach((pointColor) => {
+          const alpha = isNaN(pointColor[3]) ? 255 : pointColor[3];
+          // two copies for outside edge and inside edge each
+          colors[i++] = pointColor[0];
+          colors[i++] = pointColor[1];
+          colors[i++] = pointColor[2];
+          colors[i++] = alpha;
+          colors[i++] = pointColor[0];
+          colors[i++] = pointColor[1];
+          colors[i++] = pointColor[2];
+          colors[i++] = alpha;
+        });
+      } else {
+        const pointColor = color;
+        if (isNaN(pointColor[3])) {
+          pointColor[3] = 255;
+        }
+        for (let ptIndex = 0; ptIndex < path.length; ptIndex++) {
+          // two copies for outside edge and inside edge each
+          colors[i++] = pointColor[0];
+          colors[i++] = pointColor[1];
+          colors[i++] = pointColor[2];
+          colors[i++] = pointColor[3];
+          colors[i++] = pointColor[0];
+          colors[i++] = pointColor[1];
+          colors[i++] = pointColor[2];
+          colors[i++] = pointColor[3];
+        }
+      }
+    });
+    attribute.value = colors;
+  }
+}

--- a/examples/sample-layers/package.json
+++ b/examples/sample-layers/package.json
@@ -4,10 +4,13 @@
   },
   "dependencies": {
     "babel-polyfill": "^6.16.0",
-    "deck.gl": "3.1.0-beta.16",
+    "deck.gl": "^4.0.0-beta.2",
+    "extrude-polyline": "^1.0.6",
     "immutable": "^3.8.1",
-    "luma.gl": "3.0.0-alpha.4",
+    "lodash.flattendeep": "^4.4.0",
+    "luma.gl": "3.0.0-beta.9",
     "react": "^15.4.1",
+    "react-autobind": "^1.0.6",
     "react-dom": "^15.4.1",
     "react-map-gl": "^1.7.2",
     "react-stats": "^0.0.5"

--- a/examples/sample-layers/src/app.js
+++ b/examples/sample-layers/src/app.js
@@ -1,0 +1,211 @@
+/* global window, document */
+import DeckGL from 'deck.gl';
+import {experimental} from 'deck.gl';
+const {ReflectionEffect} = experimental;
+
+import React, {PureComponent} from 'react';
+import ReactDOM from 'react-dom';
+import MapboxGLMap from 'react-map-gl';
+import {FPSStats} from 'react-stats';
+import autobind from 'react-autobind';
+
+import {Matrix4} from 'luma.gl';
+
+import LayerInfo from './layer-info';
+import LayerSelector from './layer-selector';
+import LayerControls from './layer-controls';
+import LAYER_CATEGORIES from './layer-examples';
+
+/* eslint-disable no-process-env */
+const MAPBOX_ACCESS_TOKEN = process.env.MAPBOX_ACCESS_TOKEN || // eslint-disable-line
+  'Set MAPBOX_ACCESS_TOKEN environment variable or put your token here.';
+
+const noop = () => {};
+
+// ---- View ---- //
+class App extends PureComponent {
+  constructor(props) {
+    super(props);
+    autobind(this);
+
+    this.state = {
+      mapViewState: {
+        latitude: 37.751537058389985,
+        longitude: -122.42694203247012,
+        zoom: 11.5,
+        pitch: 30,
+        bearing: 0
+      },
+      activeExamples: {},
+      settings: {
+        effects: false,
+        separation: 0,
+        rotationZ: 0,
+        rotationX: 0
+      }
+    };
+
+    this._effects = [new ReflectionEffect()];
+  }
+
+  componentWillMount() {
+    this._onResize();
+    window.addEventListener('resize', this._onResize);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this._onResize);
+  }
+
+  _onResize() {
+    this.setState({width: window.innerWidth, height: window.innerHeight});
+  }
+
+  _onViewportChanged(mapViewState) {
+    if (mapViewState.pitch > 60) {
+      mapViewState.pitch = 60;
+    }
+    this.setState({mapViewState});
+  }
+
+  _onToggleLayer(exampleName, example) {
+    const activeExamples = {...this.state.activeExamples};
+    activeExamples[exampleName] = !activeExamples[exampleName];
+    this.setState({activeExamples});
+  }
+
+  _onUpdateLayerSettings(exampleName, settings) {
+    const activeExamples = {...this.state.activeExamples};
+    activeExamples[exampleName] = {
+      ...activeExamples[exampleName],
+      ...settings
+    };
+    this.setState({activeExamples});
+  }
+
+  _onWebGLInitialized(gl) {
+    gl.enable(gl.DEPTH_TEST);
+    gl.depthFunc(gl.LEQUAL);
+  }
+
+  _onUpdateContainerSettings(settings) {
+    this.setState({settings});
+  }
+
+  _renderExampleLayer(example, settings, index) {
+    const {layer: Layer, props, getData} = example;
+    const {infoPanel} = this.refs;
+    const layerProps = Object.assign({}, props, settings);
+
+    if (props.pickable) {
+      Object.assign(layerProps, {
+        onHover: infoPanel ? infoPanel.onItemHovered : noop,
+        onClick: infoPanel ? infoPanel.onItemClicked : noop
+      });
+    }
+
+    if (getData) {
+      Object.assign(layerProps, {data: getData()});
+    }
+
+    Object.assign(layerProps, {
+      modelMatrix: this._getModelMatrix(index, layerProps.projectionMode === 2)
+    });
+
+    return new Layer(layerProps);
+  }
+
+  /* eslint-disable max-depth */
+  _renderExamples() {
+    let index = 1;
+    const layers = [];
+    const {activeExamples} = this.state;
+
+    for (const categoryName of Object.keys(LAYER_CATEGORIES)) {
+      for (const exampleName of Object.keys(LAYER_CATEGORIES[categoryName])) {
+
+        const settings = activeExamples[exampleName];
+        // An example is a function that returns a DeckGL layer instance
+        if (settings) {
+          const example = LAYER_CATEGORIES[categoryName][exampleName];
+          const layer = this._renderExampleLayer(example, settings, index++);
+
+          if (typeof settings !== 'object') {
+            activeExamples[exampleName] = layer.props;
+          }
+
+          layers.push(layer);
+        }
+      }
+    }
+    return layers;
+  }
+  /* eslint-enable max-depth */
+
+  _getModelMatrix(index, offsetMode) {
+    const {settings: {separation, rotationZ, rotationX}} = this.state;
+    // const {mapViewState: {longitude, latitude}} = this.props;
+    // const modelMatrix = new Matrix4().fromTranslation([0, 0, 1000 * index * separation]);
+    const modelMatrix = new Matrix4()
+      .fromTranslation([0, 0, 1000 * index * separation]);
+    if (offsetMode) {
+      modelMatrix.rotateZ(index * rotationZ * Math.PI);
+      modelMatrix.rotateX(index * rotationX * Math.PI);
+    }
+    return modelMatrix;
+  }
+
+  _renderMap() {
+    const {width, height, mapViewState, settings: {effects}} = this.state;
+    return (
+      <MapboxGLMap
+        mapboxApiAccessToken={MAPBOX_ACCESS_TOKEN}
+        width={width} height={height}
+        perspectiveEnabled
+        { ...mapViewState }
+        onChangeViewport={this._onViewportChanged}>
+
+        <DeckGL
+          debug
+          id="default-deckgl-overlay"
+          width={width} height={height}
+          {...mapViewState}
+          onWebGLInitialized={ this._onWebGLInitialized }
+          layers={this._renderExamples()}
+          effects={effects ? this._effects : []}
+        />
+
+        <FPSStats isActive/>
+      </MapboxGLMap>
+    );
+  }
+
+  render() {
+    const {settings, activeExamples} = this.state;
+
+    return (
+      <div>
+        { this._renderMap() }
+        <div id="control-panel">
+          <LayerControls
+            title="Composite Settings"
+            settings={settings}
+            onChange={this._onUpdateContainerSettings}/>
+          <LayerSelector
+            activeExamples={activeExamples}
+            examples={LAYER_CATEGORIES}
+            onToggleLayer={this._onToggleLayer}
+            onUpdateLayer={this._onUpdateLayerSettings} />
+        </div>
+        <LayerInfo ref="infoPanel"/>
+      </div>
+    );
+  }
+}
+
+// ---- Main ---- //
+
+const container = document.createElement('div');
+document.body.appendChild(container);
+
+ReactDOM.render(<App />, container);

--- a/examples/sample-layers/src/data-samples.js
+++ b/examples/sample-layers/src/data-samples.js
@@ -1,0 +1,45 @@
+/* load data samples for display */
+import allPoints from '../../main/data/sf.bike.parking.json';
+import {pointGrid} from './utils';
+import {pointsToWorldGrid} from './utils/grid-aggregator';
+
+export {default as choropleths} from '../../main/data/sf.zip.geo.json';
+export {default as geojson} from '../../main/data/sample.geo.json';
+export {default as hexagons} from '../../main/data/hexagons.json';
+export {default as routes} from '../../main/data/sfmta.routes.json';
+export {default as iconAtlas} from '../../main/data/icon-atlas.json';
+
+export const points = allPoints;
+export const positionOrigin = [-122.45, 37.75, 0];
+
+export const meterPoints = pointGrid(1e3, [-5000, -5000, 5000, 5000]);
+
+export const worldGrid = pointsToWorldGrid(points, 0.5);
+
+export const zigzag = [
+  {path: (new Array(12)).fill(0).map(
+    (d, i) => [
+      positionOrigin[0] + i * i * 0.001,
+      positionOrigin[1] + Math.cos(i * Math.PI) * 0.2 / (i + 4)
+    ])
+  }
+];
+
+// time consuming - only generate on demand
+let _points100K = null;
+export function getPoints100K() {
+  _points100K = _points100K || pointGrid(1e5, [-122.6, 37.6, -122.2, 37.9]);
+  return _points100K;
+}
+
+let _points1M = null;
+export function getPoints1M() {
+  _points1M = _points1M || pointGrid(1e6, [-122.6, 37.6, -122.2, 37.9]);
+  return _points1M;
+}
+
+let _points10M = null;
+export function getPoints10M() {
+  _points10M = _points10M || pointGrid(1e7, [-122.6, 37.6, -122.2, 37.9]);
+  return _points10M;
+}

--- a/examples/sample-layers/src/layer-controls.js
+++ b/examples/sample-layers/src/layer-controls.js
@@ -1,0 +1,105 @@
+import React, {PureComponent} from 'react';
+import ColorPicker from './utils/color-picker';
+
+export default class LayerControls extends PureComponent {
+
+  _onValueChange(settingName, newValue) {
+    const {settings} = this.props;
+    // Only update if we have a confirmed change
+    if (settings[settingName] !== newValue) {
+      // Create a new object so that shallow-equal detects a change
+      const newSettings = {...this.props.settings};
+
+      if (settingName.indexOf('get') === 0) {
+        newSettings[settingName] = d => newValue;
+        newSettings.updateTriggers = {
+          ...newSettings.updateTriggers,
+          [settingName]: {value: newValue.toString()}
+        };
+      } else {
+        newSettings[settingName] = newValue;
+      }
+
+      this.props.onChange(newSettings);
+    }
+  }
+
+  _renderColorPicker(settingName, value) {
+    return (
+      <div key={settingName}>
+        <div className="input-group" >
+          <label>{settingName}</label>
+          <ColorPicker value={value}
+            onChange={this._onValueChange.bind(this, settingName)} />
+        </div>
+      </div>
+    );
+  }
+
+  _renderSlider(settingName, value) {
+    let max = 1;
+    if (/radius|width|height|pixel|size|miter/i.test(settingName) &&
+      (/^((?!scale).)*$/).test(settingName)) {
+      max = 100;
+    }
+
+    return (
+      <div key={settingName} >
+        <div className="input-group" >
+          <label className="label" htmlFor={settingName}>
+            {settingName}
+          </label>
+          <div>
+            <input
+              type="range"
+              id={settingName}
+              min={0} max={max} step={max / 100}
+              value={value}
+              onChange={ e => this._onValueChange(settingName, Number(e.target.value)) }/>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  _renderCheckbox(settingName, value) {
+    return (
+      <div key={settingName} >
+        <div className="input-group" >
+          <label htmlFor={settingName}>
+            <span>{settingName}</span>
+          </label>
+          <input
+            type="checkbox"
+            id={settingName}
+            checked={value}
+            onChange={ e => this._onValueChange(settingName, e.target.checked) }/>
+        </div>
+      </div>
+    );
+  }
+
+  _renderSetting(settingName, value) {
+    switch (typeof value) {
+    case 'boolean':
+      return this._renderCheckbox(settingName, value);
+    case 'number':
+      return this._renderSlider(settingName, value);
+    default:
+      if (/color/i.test(settingName)) {
+        return this._renderColorPicker(settingName, value);
+      }
+    }
+    return null;
+  }
+
+  render() {
+    const {title, settings} = this.props;
+    return (
+      <div className="layer-controls" >
+        { title && <h4>{title}</h4>}
+        { Object.keys(settings).map(key => this._renderSetting(key, settings[key])) }
+      </div>
+    );
+  }
+}

--- a/examples/sample-layers/src/layer-examples.js
+++ b/examples/sample-layers/src/layer-examples.js
@@ -38,6 +38,8 @@ const EnhancedChoroplethLayerExample = {
   }
 };
 
+const COLORS = new Array(1000).fill(0).map(x => Math.random() * 256);
+
 const MultiColorPathLayerExample = {
   layer: MultiColorPathLayer,
   props: {
@@ -45,7 +47,7 @@ const MultiColorPathLayerExample = {
     data: dataSamples.zigzag,
     opacity: 0.6,
     getPath: f => f.path,
-    getColor: f => [128, 0, 0],
+    getColor: f => COLORS,
     getStrokeWidth: f => 10,
     pickable: true
   }

--- a/examples/sample-layers/src/layer-examples.js
+++ b/examples/sample-layers/src/layer-examples.js
@@ -1,0 +1,63 @@
+/* eslint-disable quote-props */
+import {ScatterplotLayer} from 'deck.gl';
+
+import EnhancedChoroplethLayer from '../layers/enhanced-choropleth-layer/enhanced-choropleth-layer';
+import MultiColorPathLayer from '../layers/multi-color-path-layer/multi-color-path-layer';
+
+import * as dataSamples from './data-samples';
+// import {parseColor, setOpacity} from './utils/color';
+
+// Demonstrate immutable support
+// import Immutable from 'immutable';
+// const immutableChoropleths = Immutable.fromJS(dataSamples.choropleths);
+
+const ScatterplotLayerExample = {
+  layer: ScatterplotLayer,
+  props: {
+    id: 'scatterplotLayer',
+    data: dataSamples.points,
+    getPosition: d => d.COORDINATES,
+    getColor: d => [255, 128, 0],
+    getRadius: d => d.SPACES,
+    opacity: 0.5,
+    strokeWidth: 2,
+    pickable: true,
+    radiusMinPixels: 1,
+    radiusMaxPixels: 30
+  }
+};
+
+const EnhancedChoroplethLayerExample = {
+  layer: EnhancedChoroplethLayer,
+  props: {
+    id: 'choroplethLayerSolid',
+    data: dataSamples.choropleths,
+    getColor: f => [((f.properties.ZIP_CODE * 10) % 127) + 128, 0, 0],
+    opacity: 0.8,
+    pickable: true
+  }
+};
+
+const MultiColorPathLayerExample = {
+  layer: MultiColorPathLayer,
+  props: {
+    id: 'pathLayer',
+    data: dataSamples.zigzag,
+    opacity: 0.6,
+    getPath: f => f.path,
+    getColor: f => [128, 0, 0],
+    getStrokeWidth: f => 10,
+    pickable: true
+  }
+};
+
+export default {
+  'Sample Layers': {
+    'EnhancedChoroplethLayer': EnhancedChoroplethLayerExample,
+    'MultiColorPathLayer': MultiColorPathLayerExample
+  },
+
+  'Core Layers': {
+    'ScatterplotLayer': ScatterplotLayerExample
+  }
+};

--- a/examples/sample-layers/src/layer-info.js
+++ b/examples/sample-layers/src/layer-info.js
@@ -1,0 +1,48 @@
+import React, {PureComponent} from 'react';
+
+export default class LayerInfo extends PureComponent {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      hovered: null,
+      clicked: null
+    };
+
+    this.onItemHovered = this._onMouseEvent.bind(this, 'hovered');
+    this.onItemClicked = this._onMouseEvent.bind(this, 'clicked');
+  }
+
+  _onMouseEvent(name, info) {
+    if (info.index < 0) {
+      info = null;
+    }
+    this.setState({[name]: info});
+  }
+
+  _infoToString(info) {
+    const object = info.feature || info.object;
+    if (!object) {
+      return 'None';
+    }
+    const props = object.properties || object;
+    return JSON.stringify(props);
+  }
+
+  render() {
+    const {hovered, clicked} = this.state;
+
+    return (
+      <div id="layer-info">
+        { hovered && (<div>
+          <h4>Hover</h4>
+          <span>Layer: { hovered.layer.id } Object: { this._infoToString(hovered) }</span>
+        </div>) }
+        { clicked && (<div>
+          <h4>Click</h4>
+          <span>Layer: { clicked.layer.id } Object: { this._infoToString(clicked) }</span>
+        </div>) }
+      </div>
+    );
+  }
+}

--- a/examples/sample-layers/src/layer-selector.js
+++ b/examples/sample-layers/src/layer-selector.js
@@ -1,0 +1,54 @@
+import React, {PureComponent} from 'react';
+import LayerControls from './layer-controls';
+
+export default class LayerSelector extends PureComponent {
+
+  _renderExampleButton(exampleName, example) {
+    const {activeExamples} = this.props;
+    const settings = activeExamples[exampleName];
+
+    return (
+      <div key={ exampleName } >
+        <div className="checkbox" >
+          <input
+            type="checkbox"
+            id={exampleName}
+            checked={Boolean(settings)}
+            onChange={() => this.props.onToggleLayer(exampleName, example)}
+          />
+          <label htmlFor={ exampleName } >
+            <span>{ exampleName }</span>
+          </label>
+        </div>
+
+        { settings && <LayerControls settings={settings}
+          onChange={this.props.onUpdateLayer.bind(this, exampleName)} /> }
+      </div>
+    );
+  }
+
+  _renderExampleCategories(examples) {
+    return Object.keys(examples).map(categoryName => {
+      const category = examples[categoryName];
+      return (
+        <div key={categoryName}>
+          <h4>{ categoryName }</h4>
+          {
+            Object.keys(category)
+              .map(exampleName => this._renderExampleButton(exampleName, category[exampleName]))
+          }
+        </div>
+      );
+    });
+  }
+
+  render() {
+    return (
+      <div className="layer-selector" >
+        {
+          this._renderExampleCategories(this.props.examples)
+        }
+      </div>
+    );
+  }
+}

--- a/examples/sample-layers/src/utils/color-picker.js
+++ b/examples/sample-layers/src/utils/color-picker.js
@@ -1,0 +1,74 @@
+/* global document */
+import React, {PureComponent} from 'react';
+
+/*
+ * convert a number to a hex string.
+ * @param {number} x - number to convert
+ * @param {number} len - minimum length of the string
+ * @returns {string} formatted hex string
+ */
+function numberToHex(x, len = 0) {
+  let str = x.toString(16);
+  while (str.length < len) {
+    str = `0${str}`;
+  }
+  return str;
+}
+
+/*
+ * convert a color from [r, g, b] array or accessor to a hex string.
+ * @param {string | array | function} value - color value or accessor
+ * @returns {string} hex color string
+ */
+function getColorHex(value) {
+  if (typeof value === 'function') {
+    try {
+      value = value();
+    } catch (err) {
+      // is data dependent
+    }
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (Array.isArray(value) && value.length >= 3) {
+    return `#${value.slice(0, 3).map(v => numberToHex(v, 2)).join('')}`;
+  }
+  return '#888';
+}
+
+/*
+ * convert a color from a hex string to [r, g, b] array.
+ * @param {string} str - color hex string
+ * @returns {array} color value in [r, g, b]
+ */
+function getColorArray(str) {
+  return [
+    parseInt(str.slice(1, 3), 16),
+    parseInt(str.slice(3, 5), 16),
+    parseInt(str.slice(5, 7), 16)
+  ];
+}
+
+export default class ColorPicker extends PureComponent {
+
+  _onClick(color) {
+    const {onChange} = this.props;
+    const input = document.createElement('input');
+    input.type = 'color';
+    input.value = color;
+    input.onchange = () => onChange(getColorArray(input.value));
+    input.onblur = () => document.body.removeChild(input);
+
+    document.body.appendChild(input);
+    input.click();
+  }
+
+  render() {
+    const color = getColorHex(this.props.value);
+    return (
+      <div className="color-picker" style={{background: color}}
+        onClick={ this._onClick.bind(this, color) } />
+    );
+  }
+}

--- a/examples/sample-layers/src/utils/color.js
+++ b/examples/sample-layers/src/utils/color.js
@@ -1,0 +1,42 @@
+
+// Parse array or string color
+export function parseColor(color) {
+  if (Array.isArray(color)) {
+    if (color.length === 3) {
+      return [color[0], color[1], color[2], 255];
+    }
+    return color;
+  }
+  if (typeof color === 'string') {
+    return parseHexColor(color);
+  }
+  return null;
+}
+
+// Parse a hex color
+export function parseHexColor(color) {
+  const array = new Uint8ClampedArray(4);
+  if (color.length === 7) {
+    const value = parseInt(color.substring(1), 16);
+    array[0] = value / 65536;
+    array[1] = (value / 256) % 256;
+    array[2] = value % 256;
+    array[3] = 255;
+  } else if (color.length === 9) {
+    const value = parseInt(color.substring(1), 16);
+    array[0] = value / 16777216;
+    array[1] = (value / 65536) % 256;
+    array[2] = (value / 256) % 256;
+    array[3] = value % 256;
+  }
+  return array;
+}
+
+export function setOpacity(color, opacity = 127) {
+  return [color[0], color[1], color[2], opacity];
+}
+
+export function applyOpacity(color, opacity = 127) {
+  return [color[0], color[1], color[2], opacity];
+}
+

--- a/examples/sample-layers/src/utils/grid-aggregator.js
+++ b/examples/sample-layers/src/utils/grid-aggregator.js
@@ -1,0 +1,84 @@
+const R_EARTH = 6378;
+
+/**
+ * Aggregate points for the grid layer
+ * @param {array} points
+ * @param {number} worldUnitSize - unit size in kilometer
+ * @returns {object} - grid data and cell dimension
+ */
+export function pointsToWorldGrid(points, worldUnitSize) {
+
+  // find the geometric center of sample points
+  const allLat = points.map(p => p.COORDINATES[1]);
+  const latMin = Math.min.apply(null, allLat);
+  const latMax = Math.max.apply(null, allLat);
+
+  const centerLat = (latMin + latMax) / 2;
+
+  const gridOffset = _calculateGridLatLonOffset(worldUnitSize, centerLat);
+
+  // calculate count per cell
+  const gridHash = points.reduce((accu, pt) => {
+    const latIdx = Math.floor((pt.COORDINATES[1] + 90) / gridOffset.latOffset);
+    const lonIdx = Math.floor((pt.COORDINATES[0] + 180) / gridOffset.lonOffset);
+    const key = `${latIdx}-${lonIdx}`;
+
+    accu[key] = accu[key] + 1 || 1;
+    return accu;
+  }, {});
+
+  const maxHeight = Math.max.apply(null, Object.values(gridHash));
+
+  const data = Object.keys(gridHash).reduce((accu, key) => {
+    const idxs = key.split('-');
+    const latIdx = parseInt(idxs[0], 10);
+    const lonIdx = parseInt(idxs[1], 10);
+
+    accu.push({
+      position: [
+        -180 + gridOffset.lonOffset * lonIdx,
+        -90 + gridOffset.latOffset * latIdx
+      ],
+      value: gridHash[key] / maxHeight
+    });
+
+    return accu;
+  }, []);
+
+  return Object.assign({data}, gridOffset);
+}
+
+/**
+ * calculate grid layer cell size in lat lon based on world unit size
+ * and current latitude
+ * @param {number} worldUnitSize
+ * @param {number} latitude
+ * @returns {object} - lat delta and lon delta
+ */
+export function _calculateGridLatLonOffset(worldUnitSize, latitude) {
+  const latOffset = calculateLatOffset(worldUnitSize);
+  const lonOffset = calculateLonOffset(latitude, worldUnitSize);
+  return {latOffset, lonOffset};
+}
+
+/**
+ * with a given x-km change, calculate the increment of latitude
+ * based on stackoverflow http://stackoverflow.com/questions/7477003
+ * @param {number} dy - change in km
+ * @return {number} - increment in latitude
+ */
+export function calculateLatOffset(dy) {
+  return (dy / R_EARTH) * (180 / Math.PI);
+}
+
+/**
+ * with a given x-km change, and current latitude
+ * calculate the increment of longitude
+ * based on stackoverflow http://stackoverflow.com/questions/7477003
+ * @param {number} lat - latitude of current location (based on city)
+ * @param {number} dx - change in km
+ * @return {number} - increment in longitude
+ */
+export function calculateLonOffset(lat, dx) {
+  return (dx / R_EARTH) * (180 / Math.PI) / Math.cos(lat * Math.PI / 180);
+}

--- a/examples/sample-layers/src/utils/index.js
+++ b/examples/sample-layers/src/utils/index.js
@@ -1,0 +1,27 @@
+
+// generate points in a grid
+export function pointGrid(N, bbox) {
+  const dLon = bbox[2] - bbox[0];
+  const dLat = bbox[3] - bbox[1];
+  const aspectRatio = dLon / dLat;
+  const sizeX = Math.round(Math.sqrt(N * aspectRatio));
+  const sizeY = Math.round(Math.sqrt(N / aspectRatio));
+
+  const stepX = dLon / sizeX;
+  const stepY = dLat / sizeY;
+
+  const points = Array(sizeX * sizeY);
+  let index = 0;
+
+  for (let x = 0; x < sizeX; x++) {
+    for (let y = 0; y < sizeY; y++) {
+      points[index] = [
+        bbox[0] + stepX * x,
+        bbox[1] + stepY * y
+      ];
+      index++;
+    }
+  }
+
+  return points;
+}

--- a/examples/sample-layers/webpack.config.js
+++ b/examples/sample-layers/webpack.config.js
@@ -3,27 +3,15 @@ const webpack = require('webpack');
 
 module.exports = {
   entry: {
-    app: resolve('./app.js')
+    app: resolve('./src/app.js')
   },
 
   devtool: 'source-maps',
 
   resolve: {
     alias: {
-      // mapbox-gl config
-      // webworkify: 'webworkify-webpack-dropin'
-      // 'gl-matrix': resolve('./node_modules/gl-matrix/dist/gl-matrix.js'),
-      // // Work against base library
-      // 'deck.gl': resolve('../../dist/lib-bundle.js'),
-      // // Using our dependencies
-      // 'luma.gl': resolve('./node_modules/luma.gl'),
-      // 'viewport-mercator-project': resolve('./node_modules/viewport-mercator-project'),
-      // react: resolve('./node_modules/react'),
-      // 'autobind-decorator': resolve('./node_modules/autobind-decorator'),
-      // brfs: resolve('./node_modules/brfs'),
-      // earcut: resolve('./node_modules/earcut'),
-      // 'geojson-normalize': resolve('./node_modules/geojson-normalize'),
-      // 'lodash.flattendeep': resolve('./node_modules/lodash.flattendeep')
+      // From mapbox-gl-js README. Required for non-browserify bundlers (e.g. webpack):
+      'mapbox-gl$': resolve('./node_modules/mapbox-gl/dist/mapbox-gl.js')
     }
   },
 

--- a/examples/sample-layers/yarn.lock
+++ b/examples/sample-layers/yarn.lock
@@ -126,6 +126,10 @@ arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
+as-number@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/as-number/-/as-number-1.0.0.tgz#acb27e34f8f9d8ab0da9e376f3b8959860f80a66"
+
 asap@~2.0.3:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.5.tgz#522765b50c3510490e52d7dcfe085ef9ba96958f"
@@ -190,7 +194,7 @@ aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
-babel-polyfill@^6.16.0, babel-polyfill@^6.5.0:
+babel-polyfill@^6.16.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.22.0.tgz#1ac99ebdcc6ba4db1e2618c387b2084a82154a3b"
   dependencies:
@@ -701,13 +705,7 @@ date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
 
-debug@^2.2.0:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
-  dependencies:
-    ms "0.7.2"
-
-debug@~2.2.0:
+debug@^2.2.0, debug@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
   dependencies:
@@ -717,9 +715,9 @@ decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
-deck.gl@3.1.0-beta.16:
-  version "3.1.0-beta.16"
-  resolved "https://registry.yarnpkg.com/deck.gl/-/deck.gl-3.1.0-beta.16.tgz#b77d3cd7d905d494aaf16530e07641ce6bccc0b8"
+deck.gl@^4.0.0-beta.2:
+  version "4.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/deck.gl/-/deck.gl-4.0.0-beta.2.tgz#9884588982600eeab2d1377b5d17a4a885933a1d"
   dependencies:
     earcut "^2.0.6"
     file-loader "^0.9.0"
@@ -1000,6 +998,14 @@ extglob@^0.3.1:
   dependencies:
     is-extglob "^1.0.0"
 
+extrude-polyline@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/extrude-polyline/-/extrude-polyline-1.0.6.tgz#7e6afe1f349a4182fa3f61a00d93979b95f18b20"
+  dependencies:
+    as-number "^1.0.0"
+    gl-vec2 "^1.0.0"
+    polyline-miter-util "^1.0.1"
+
 extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
@@ -1206,6 +1212,10 @@ gl-constants@^1.0.0:
 gl-matrix@^2.3.1, gl-matrix@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/gl-matrix/-/gl-matrix-2.3.2.tgz#aac808c74af7d5db05fe04cb60ca1a0fcb174d74"
+
+gl-vec2@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gl-vec2/-/gl-vec2-1.0.0.tgz#77fce6ae9612856d6c8b621cd261cd8281b9c637"
 
 glob-base@^0.3.0:
   version "0.3.0"
@@ -1712,11 +1722,10 @@ loose-envify@^1.0.0, loose-envify@^1.1.0:
   dependencies:
     js-tokens "^3.0.0"
 
-luma.gl@3.0.0-alpha.4:
-  version "3.0.0-alpha.4"
-  resolved "https://registry.yarnpkg.com/luma.gl/-/luma.gl-3.0.0-alpha.4.tgz#71e454bbbbc09596e8dff8f287abb136394905a2"
+luma.gl@3.0.0-beta.9:
+  version "3.0.0-beta.9"
+  resolved "https://registry.yarnpkg.com/luma.gl/-/luma.gl-3.0.0-beta.9.tgz#58f93035d365a56615235285c53491e168df1b78"
   dependencies:
-    babel-polyfill "^6.5.0"
     gl-constants "^1.0.0"
     gl-matrix "^2.3.2"
     webgl-debug "^1.0.2"
@@ -1727,17 +1736,17 @@ magic-string@^0.14.0:
   dependencies:
     vlq "^0.2.1"
 
-"mapbox-gl-function@github:mapbox/mapbox-gl-function#111a2b442be0689a65f5818dd2603c9b06962be0":
+mapbox-gl-function@mapbox/mapbox-gl-function#111a2b442be0689a65f5818dd2603c9b06962be0:
   version "1.3.0"
   resolved "https://codeload.github.com/mapbox/mapbox-gl-function/tar.gz/111a2b442be0689a65f5818dd2603c9b06962be0"
 
-"mapbox-gl-shaders@github:mapbox/mapbox-gl-shaders#44b65f8090a74cbb0319664d010b8d8a8a1512b0":
+mapbox-gl-shaders@mapbox/mapbox-gl-shaders#44b65f8090a74cbb0319664d010b8d8a8a1512b0:
   version "1.0.0"
   resolved "https://codeload.github.com/mapbox/mapbox-gl-shaders/tar.gz/44b65f8090a74cbb0319664d010b8d8a8a1512b0"
   dependencies:
     brfs "^1.4.0"
 
-"mapbox-gl-style-spec@github:mapbox/mapbox-gl-style-spec#7d330d2abf1775abc95ab8b889089cf5ff579357":
+mapbox-gl-style-spec@mapbox/mapbox-gl-style-spec#7d330d2abf1775abc95ab8b889089cf5ff579357:
   version "8.9.0"
   resolved "https://codeload.github.com/mapbox/mapbox-gl-style-spec/tar.gz/7d330d2abf1775abc95ab8b889089cf5ff579357"
   dependencies:
@@ -2170,6 +2179,12 @@ point-geometry@0.0.0, point-geometry@^0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/point-geometry/-/point-geometry-0.0.0.tgz#6fcbcad7a803b6418247dd6e49c2853c584daff7"
 
+polyline-miter-util@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/polyline-miter-util/-/polyline-miter-util-1.0.1.tgz#b693f2389ea0ded36a6bcf5ecd2ece4b6917d957"
+  dependencies:
+    gl-vec2 "^1.0.0"
+
 portfinder@^1.0.9:
   version "1.0.13"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.13.tgz#bb32ecd87c27104ae6ee44b5a3ccbf0ebb1aede9"
@@ -2305,6 +2320,10 @@ rc@~1.1.6:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~1.0.4"
+
+react-autobind@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/react-autobind/-/react-autobind-1.0.6.tgz#936bb58edf6b89b619c50f82f0e617159fdfd4f1"
 
 react-dom@^15.4.1:
   version "15.4.2"


### PR DESCRIPTION
@Pessimistress @gnavvy @shaojingli 

Idea is to have a separate example that contains a bunch of sample layers (with the same layer property browsing UI as the `main` example has for the core layers). 

At the moment it copies a number of files from the `main` example, in order for this `layer-samples` example to remain as stand alone as possible.
