### PR TITLE
64-bit polygon layer

### DIFF
--- a/examples/main/src/layer-examples.js
+++ b/examples/main/src/layer-examples.js
@@ -16,6 +16,7 @@ import {
   ScatterplotLayer64,
   ArcLayer64,
   LineLayer64,
+  GeoJsonLayer64,
 
   ChoroplethLayer,
   ChoroplethLayer64,
@@ -67,6 +68,31 @@ const IconLayerExample = {
 
 const GeoJsonLayerExample = {
   layer: GeoJsonLayer,
+  props: {
+    id: 'geojsonLayer',
+    data: dataSamples.geojson,
+    // TODO change to use the color util when it is landed
+    getPointColor: f => parseColor(f.properties['marker-color']),
+    getPointSize: f => MARKER_SIZE_MAP[f.properties['marker-size']],
+    getStrokeColor: f => {
+      const color = parseColor(f.properties.stroke);
+      const opacity = f.properties['stroke-opacity'] * 255;
+      return setOpacity(color, opacity);
+    },
+    getStrokeWidth: f => f.properties['stroke-width'],
+    getFillColor: f => {
+      const color = parseColor(f.properties.fill);
+      const opacity = f.properties['fill-opacity'] * 255;
+      return setOpacity(color, opacity);
+    },
+    strokeWidth: 10,
+    strokeWidthMinPixels: 1,
+    pickable: true
+  }
+};
+
+const GeoJsonLayer64Example = {
+  layer: GeoJsonLayer64,
   props: {
     id: 'geojsonLayer',
     data: dataSamples.geojson,
@@ -411,7 +437,8 @@ export default {
   '64-bit Layers': {
     ArcLayer64: ArcLayer64Example,
     ScatterplotLayer64: ScatterplotLayer64Example,
-    LineLayer64: LineLayer64Example
+    LineLayer64: LineLayer64Example,
+    GeoJsonLayer64: GeoJsonLayer64Example
   },
 
   'Deprecated Layers': {

--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,7 @@ export {default as GeoJsonLayer} from './layers/core/geojson-layer/geojson-layer
 export {default as ScatterplotLayer64} from './layers/fp64/scatterplot-layer';
 export {default as ArcLayer64} from './layers/fp64/arc-layer';
 export {default as LineLayer64} from './layers/fp64/line-layer';
+export {default as GeoJsonLayer64} from './layers/fp64/geojson-layer/geojson-layer-64';
 
 // Deprecated Layers
 export {default as ChoroplethLayer} from './layers/deprecated/choropleth-layer';

--- a/src/layers/core/polygon-layer/polygon-layer-64-vertex.glsl
+++ b/src/layers/core/polygon-layer/polygon-layer-64-vertex.glsl
@@ -1,0 +1,72 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+#define SHADER_NAME polygon-layer-vertex-shader
+
+attribute vec3 positions;
+attribute vec2 positions64xyLow;
+attribute vec3 normals;
+attribute vec4 colors;
+attribute vec3 pickingColors;
+
+uniform float extruded;
+uniform float opacity;
+
+uniform float renderPickingBuffer;
+uniform vec3 selectedPickingColor;
+
+// PICKING
+uniform float pickingEnabled;
+varying vec4 vPickingColor;
+
+void main(void) {
+  vec4 positions64xy = vec4(positions.x, positions64xyLow.x, positions.y, positions64xyLow.y);
+
+  vec2 projected_coord_xy[2];
+  project_position_fp64(positions64xy, projected_coord_xy);
+
+  vec2 vertex_pos_modelspace[4];
+  vertex_pos_modelspace[0] = projected_coord_xy[0];
+  vertex_pos_modelspace[1] = projected_coord_xy[1];
+  vertex_pos_modelspace[2] = vec2(project_scale(positions.z), 0.0);
+  vertex_pos_modelspace[3] = vec2(1.0, 0.0);
+
+  gl_Position = project_to_clipspace_fp64(vertex_pos_modelspace);
+
+  vec4 position_worldspace = vec4(vertex_pos_modelspace[0].x, vertex_pos_modelspace[1].x, vertex_pos_modelspace[2].x, vertex_pos_modelspace[3].x);
+
+  if (pickingEnabled < 0.5) {
+    float lightWeight = 1.0;
+
+    if (extruded > 0.5) {
+      lightWeight = getLightWeight(
+        position_worldspace,
+        normals
+      );
+    }
+
+    vec3 lightWeightedColor = lightWeight * colors.rgb;
+    vec4 color = vec4(lightWeightedColor, colors.a * opacity) / 255.0;
+
+    vPickingColor = color;
+
+  } else {
+    vPickingColor = vec4(pickingColors.rgb / 255.0, 1.0);
+  }
+}

--- a/src/layers/fp64/arc-layer/arc-layer-64.js
+++ b/src/layers/fp64/arc-layer/arc-layer-64.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import ArcLayer from '../../core/arc-layer';
+import ArcLayer from '../../core/arc-layer/arc-layer';
 import {fp64ify} from '../../../lib/utils/fp64';
 import {readFileSync} from 'fs';
 import {join} from 'path';

--- a/src/layers/fp64/geojson-layer/geojson-layer-64.js
+++ b/src/layers/fp64/geojson-layer/geojson-layer-64.js
@@ -17,83 +17,18 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-
-import {Layer, get} from '../../../lib';
-import ScatterplotLayer from '../scatterplot-layer/scatterplot-layer';
-import PathLayer from '../path-layer/path-layer';
-import PolygonLayer from '../polygon-layer/polygon-layer';
-
-import {getGeojsonFeatures, separateGeojsonFeatures} from './geojson';
-
-const defaultPointColor = [0xFF, 0x88, 0x00, 0xFF];
-const defaultStrokeColor = [0x33, 0x33, 0x33, 0xFF];
-const defaultFillColor = [0xBD, 0xE2, 0x7A, 0xFF];
-
-const defaultProps = {
-  drawPoints: true,
-  drawLines: true,
-  drawPolygons: true,
-  fillPolygons: true,
-  // extrudePolygons: false,
-  // wireframe: false,
-
-  // Point accessors
-  getPointColor: f => get(f, 'properties.color') || defaultPointColor,
-  getPointSize: f => get(f, 'properties.size') || 5,
-
-  // Line and polygon outline accessors
-  getStrokeColor: f => get(f, 'properties.strokeColor') || defaultStrokeColor,
-  getStrokeWidth: f => get(f, 'properties.strokeWidth') || 1,
-
-  // Polygon fill accessors
-  getFillColor: f => get(f, 'properties.fillColor') || defaultFillColor,
-
-  // Polygon extrusion accessor
-  getElevation: f => 1000
-};
+import {get} from '../../../lib';
+import GeoJsonLayer from '../../core/geojson-layer/geojson-layer';
+import PathLayer from '../../core/path-layer/path-layer';
+// import PolygonLayer64 from '../polygon-layer/polygon-layer-64';
+import ScatterplotLayer64 from '../scatterplot-layer/scatterplot-layer-64';
+import PolygonLayer from '../../core/polygon-layer/polygon-layer';
 
 function noop() {}
 
 const getCoordinates = f => get(f, 'geometry.coordinates');
 
-export default class GeoJsonLayer extends Layer {
-  initializeState() {
-    this.state = {
-      subLayers: null,
-      pickInfos: []
-    };
-  }
-
-  updateState({oldProps, props, changeFlags}) {
-    if (changeFlags.dataChanged) {
-      const {data} = this.props;
-      const features = getGeojsonFeatures(data);
-      this.state.subLayers = separateGeojsonFeatures(features);
-    }
-  }
-
-  _onHoverSublayer(info) {
-    this.state.pickInfos.push(info);
-  }
-
-  pick(opts) {
-    super.pick(opts);
-
-    const info = this.state.pickInfos.find(i => i.index >= 0);
-
-    if (opts.mode === 'hover') {
-      this.state.pickInfos = [];
-    }
-
-    if (!info) {
-      return;
-    }
-
-    Object.assign(opts.info, info, {
-      layer: this,
-      feature: get(info, 'object.feature') || info.object
-    });
-  }
+export default class GeoJsonLayer64 extends GeoJsonLayer {
 
   renderLayers() {
     const {subLayers: {pointFeatures, lineFeatures, polygonFeatures,
@@ -124,6 +59,7 @@ export default class GeoJsonLayer extends Layer {
         getColor: getFillColor,
         extruded,
         wireframe: false,
+        fp64: true,
         updateTriggers: {
           getElevation: this.props.updateTriggers.getElevation,
           getColor: this.props.updateTriggers.getFillColor
@@ -141,6 +77,7 @@ export default class GeoJsonLayer extends Layer {
         getColor: getStrokeColor,
         extruded: true,
         wireframe: true,
+        fp64: true,
         updateTriggers: {
           getColor: this.props.updateTriggers.getStrokeColor
         }
@@ -172,7 +109,7 @@ export default class GeoJsonLayer extends Layer {
         }
       }));
 
-    const pointLayer = drawPoints && new ScatterplotLayer(Object.assign({},
+    const pointLayer = drawPoints && new ScatterplotLayer64(Object.assign({},
       this.props, handlers, {
         id: `${id}-points`,
         data: pointFeatures,
@@ -194,5 +131,4 @@ export default class GeoJsonLayer extends Layer {
   }
 }
 
-GeoJsonLayer.layerName = 'GeoJsonLayer';
-GeoJsonLayer.defaultProps = defaultProps;
+GeoJsonLayer64.layerName = 'GeoJsonLayer64';

--- a/src/layers/fp64/line-layer/line-layer-64.js
+++ b/src/layers/fp64/line-layer/line-layer-64.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import LineLayer from '../../core/line-layer';
+import LineLayer from '../../core/line-layer/line-layer';
 import {fp64ify} from '../../../lib/utils/fp64';
 import {readFileSync} from 'fs';
 import {join} from 'path';

--- a/test/layers/polygon-tesselation.spec.js
+++ b/test/layers/polygon-tesselation.spec.js
@@ -41,11 +41,14 @@ test('PolygonTesselator#methods', t => {
   t.ok(tesselator instanceof PolygonTesselator, 'PolygonTesselator created');
   const indices = tesselator.indices();
   t.ok(ArrayBuffer.isView(indices), 'PolygonTesselator.indices');
-  const positions = tesselator.positions();
+  const positions = tesselator.positions().positions;
   t.ok(ArrayBuffer.isView(positions), 'PolygonTesselator.positions');
   const colors = tesselator.colors();
   t.ok(ArrayBuffer.isView(colors), 'PolygonTesselator.colors');
   // t.ok(ArrayBuffer.isView(tesselator.normals()), 'PolygonTesselator.normals');
+  const tesselator64 = new PolygonTesselator({polygons: POLYGONS, fp64: true});
+  const positions64xyLow = tesselator64.positions().positions64xyLow;
+  t.ok(ArrayBuffer.isView(positions64xyLow), 'PolygonTesselator.positions64xyLow');
   t.end();
 });
 
@@ -54,10 +57,14 @@ test('PolygonTesselatorExtruded#methods', t => {
   t.ok(tesselator instanceof PolygonTesselatorExtruded, 'PolygonTesselatorExtruded created');
   const indices = tesselator.indices();
   t.ok(ArrayBuffer.isView(indices), 'PolygonTesselatorExtruded.indices');
-  const positions = tesselator.positions();
+  const positions = tesselator.positions().positions;
   t.ok(ArrayBuffer.isView(positions), 'PolygonTesselatorExtruded.positions');
   const colors = tesselator.colors();
   t.ok(ArrayBuffer.isView(colors), 'PolygonTesselatorExtruded.colors');
   t.ok(ArrayBuffer.isView(tesselator.normals()), 'PolygonTesselatorExtruded.normals');
+  const tesselatorExtruded64 = new PolygonTesselator({polygons: POLYGONS, fp64: true});
+  const positionsExtruded64xyLow = tesselatorExtruded64.positions().positions64xyLow;
+  t.ok(ArrayBuffer.isView(positionsExtruded64xyLow), 'PolygonTesselatorExtruded.positions64xyLow');
+
   t.end();
 });


### PR DESCRIPTION
Implemented 64-bit polygon layer and also 64-bit geojson layer (partially, as 64-bit path layer will come later)

The 64-bit version of polygon layer is implemented differently as other 64-bit layers as the polygon tessellator uses a fp64 flag to switch between 32-bit and 64-bit geometries. 

I'm investigating if this approach is the way to go for unifying 64 and 32 bit line, arc and scatterplot layers.

@ibgreen @gnavvy @Pessimistress 