### PR TITLE
Render all picking buffers in one pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Ref: http://keepachangelog.com/en/0.3.0/
 
 #### [v4.0.0-beta.3]
 - Add PointCloudLayer
+- BREAKING: `layer.pick()` is renamed to `layer.getPickingInfo()`, must return info object
 
 #### [v4.0.0-beta.2]
 - Bumps luma.gl with some hotfixes

--- a/examples/main/src/app.js
+++ b/examples/main/src/app.js
@@ -19,8 +19,6 @@ import LAYER_CATEGORIES from './layer-examples';
 const MAPBOX_ACCESS_TOKEN = process.env.MAPBOX_ACCESS_TOKEN || // eslint-disable-line
   'Set MAPBOX_ACCESS_TOKEN environment variable or put your token here.';
 
-const noop = () => {};
-
 // ---- View ---- //
 class App extends PureComponent {
   constructor(props) {
@@ -91,17 +89,17 @@ class App extends PureComponent {
     this.setState({settings});
   }
 
+  _onHover(info) {
+    this.refs.infoPanel.onItemHovered(info);
+  }
+
+  _onClick(info) {
+    this.refs.infoPanel.onItemClicked(info);
+  }
+
   _renderExampleLayer(example, settings, index) {
     const {layer: Layer, props, getData} = example;
-    const {infoPanel} = this.refs;
     const layerProps = Object.assign({}, props, settings);
-
-    if (props.pickable) {
-      Object.assign(layerProps, {
-        onHover: infoPanel ? infoPanel.onItemHovered : noop,
-        onClick: infoPanel ? infoPanel.onItemClicked : noop
-      });
-    }
 
     if (getData) {
       Object.assign(layerProps, {data: getData()});
@@ -170,6 +168,8 @@ class App extends PureComponent {
           width={width} height={height}
           {...mapViewState}
           onWebGLInitialized={ this._onWebGLInitialized }
+          onLayerHover={ this._onHover }
+          onLayerClick={ this._onClick }
           layers={this._renderExamples()}
           effects={effects ? this._effects : []}
         />

--- a/examples/main/src/app.js
+++ b/examples/main/src/app.js
@@ -39,7 +39,9 @@ class App extends PureComponent {
         separation: 0,
         rotationZ: 0,
         rotationX: 0
-      }
+      },
+      hoveredItem: null,
+      clickedItem: null
     };
 
     this._effects = [new ReflectionEffect()];
@@ -90,11 +92,11 @@ class App extends PureComponent {
   }
 
   _onHover(info) {
-    this.refs.infoPanel.onItemHovered(info);
+    this.setState({hoveredItem: info});
   }
 
   _onClick(info) {
-    this.refs.infoPanel.onItemClicked(info);
+    this.setState({clickedItem: info});
   }
 
   _renderExampleLayer(example, settings, index) {
@@ -180,7 +182,7 @@ class App extends PureComponent {
   }
 
   render() {
-    const {settings, activeExamples} = this.state;
+    const {settings, activeExamples, hoveredItem, clickedItem} = this.state;
 
     return (
       <div>
@@ -196,7 +198,7 @@ class App extends PureComponent {
             onToggleLayer={this._onToggleLayer}
             onUpdateLayer={this._onUpdateLayerSettings} />
         </div>
-        <LayerInfo ref="infoPanel"/>
+        <LayerInfo ref="infoPanel" hovered={hoveredItem} clicked={clickedItem} />
       </div>
     );
   }

--- a/examples/main/src/layer-examples.js
+++ b/examples/main/src/layer-examples.js
@@ -93,6 +93,7 @@ const GeoJsonLayerExample = {
       const opacity = f.properties['fill-opacity'] * 255;
       return setOpacity(color, opacity);
     },
+    strokeWidthScale: 10,
     strokeWidthMinPixels: 1,
     pickable: true
   }

--- a/examples/main/src/layer-examples.js
+++ b/examples/main/src/layer-examples.js
@@ -93,7 +93,6 @@ const GeoJsonLayerExample = {
       const opacity = f.properties['fill-opacity'] * 255;
       return setOpacity(color, opacity);
     },
-    strokeWidth: 10,
     strokeWidthMinPixels: 1,
     pickable: true
   }

--- a/examples/main/src/layer-info.js
+++ b/examples/main/src/layer-info.js
@@ -14,9 +14,6 @@ export default class LayerInfo extends PureComponent {
   }
 
   _onMouseEvent(name, info) {
-    if (info.index < 0) {
-      info = null;
-    }
     this.setState({[name]: info});
   }
 

--- a/examples/main/src/layer-info.js
+++ b/examples/main/src/layer-info.js
@@ -2,21 +2,6 @@ import React, {PureComponent} from 'react';
 
 export default class LayerInfo extends PureComponent {
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      hovered: null,
-      clicked: null
-    };
-
-    this.onItemHovered = this._onMouseEvent.bind(this, 'hovered');
-    this.onItemClicked = this._onMouseEvent.bind(this, 'clicked');
-  }
-
-  _onMouseEvent(name, info) {
-    this.setState({[name]: info});
-  }
-
   _infoToString(info) {
     const object = info.feature || info.object;
     if (!object) {
@@ -27,7 +12,7 @@ export default class LayerInfo extends PureComponent {
   }
 
   render() {
-    const {hovered, clicked} = this.state;
+    const {hovered, clicked} = this.props;
 
     return (
       <div id="layer-info">

--- a/src/layers/core/geojson-layer/geojson-layer.js
+++ b/src/layers/core/geojson-layer/geojson-layer.js
@@ -97,7 +97,7 @@ export default class GeoJsonLayer extends CompositeLayer {
     // this is called before the onHover/onClick of sublayers
     // pickInfo is used to collect the pick results of all sublayers
     this.state.pickInfos.length = 0;
-    return null;
+    return true;
   }
 
   renderLayers() {

--- a/src/layers/core/geojson-layer/geojson-layer.js
+++ b/src/layers/core/geojson-layer/geojson-layer.js
@@ -53,14 +53,13 @@ const defaultProps = {
   fp64: false
 };
 
-function noop() {}
-
 const getCoordinates = f => get(f, 'geometry.coordinates');
 
 export default class GeoJsonLayer extends CompositeLayer {
   initializeState() {
     this.state = {
       subLayers: null,
+      subLayerCount: 0,
       pickInfos: []
     };
   }
@@ -73,27 +72,32 @@ export default class GeoJsonLayer extends CompositeLayer {
     }
   }
 
-  _onHoverSublayer(info) {
-    this.state.pickInfos.push(info);
+  _onPickSublayer(mode, info) {
+    const {pickInfos, subLayerCount} = this.state;
+    pickInfos.push(info);
+
+    if (pickInfos.length === subLayerCount) {
+      // all sublayers have been accounted for
+      let pickInfo = pickInfos.find(i => i.index >= 0) || pickInfos[0];
+
+      pickInfo = Object.assign({}, pickInfo, {
+        layer: this,
+        feature: get(pickInfo, 'object.feature') || pickInfo.object
+      });
+
+      switch (mode) {
+      case 'click': this.props.onClick(pickInfo); break;
+      case 'hover': this.props.onHover(pickInfo); break;
+      default: throw new Error('unknown pick type');
+      }
+    }
   }
 
   pick(opts) {
-    super.pick(opts);
-
-    const info = this.state.pickInfos.find(i => i.index >= 0);
-
-    if (opts.mode === 'hover') {
-      this.state.pickInfos = [];
-    }
-
-    if (!info) {
-      return;
-    }
-
-    Object.assign(opts.info, info, {
-      layer: this,
-      feature: get(info, 'object.feature') || info.object
-    });
+    // this is called before the onHover/onClick of sublayers
+    // pickInfo is used to collect the pick results of all sublayers
+    this.state.pickInfos.length = 0;
+    return null;
   }
 
   renderLayers() {
@@ -111,8 +115,8 @@ export default class GeoJsonLayer extends CompositeLayer {
 
     // Override user's onHover and onClick props
     const handlers = {
-      onHover: this._onHoverSublayer.bind(this),
-      onClick: noop
+      onHover: this._onPickSublayer.bind(this, 'hover'),
+      onClick: this._onPickSublayer.bind(this, 'click')
     };
 
     // Filled Polygon Layer
@@ -152,10 +156,10 @@ export default class GeoJsonLayer extends CompositeLayer {
         data: polygonOutlineFeatures,
         getPath: getCoordinates,
         getColor: getStrokeColor,
-        getWidth: getStrokeWidth,
+        getStrokeWidth,
         updateTriggers: {
           getColor: this.props.updateTriggers.getStrokeColor,
-          getWidth: this.props.updateTriggers.getStrokeWidth
+          getStrokeWidth: this.props.updateTriggers.getStrokeWidth
         }
       }));
     }
@@ -166,10 +170,10 @@ export default class GeoJsonLayer extends CompositeLayer {
         data: lineFeatures,
         getPath: getCoordinates,
         getColor: getStrokeColor,
-        getWidth: getStrokeWidth,
+        getStrokeWidth,
         updateTriggers: {
           getColor: this.props.updateTriggers.getStrokeColor,
-          getWidth: this.props.updateTriggers.getStrokeWidth
+          getStrokeWidth: this.props.updateTriggers.getStrokeWidth
         }
       }));
 
@@ -187,12 +191,16 @@ export default class GeoJsonLayer extends CompositeLayer {
         fp64: this.props.fp64
       }));
 
-    return [
+    const layers = [
       polygonFillLayer,
       polygonOutlineLayer,
       lineLayer,
       pointLayer
     ].filter(Boolean);
+
+    this.state.subLayerCount = layers.length;
+
+    return layers;
   }
 }
 

--- a/src/layers/core/geojson-layer/geojson-layer.js
+++ b/src/layers/core/geojson-layer/geojson-layer.js
@@ -93,11 +93,11 @@ export default class GeoJsonLayer extends CompositeLayer {
     }
   }
 
-  pick(opts) {
+  getPickingInfo(opts) {
     // this is called before the onHover/onClick of sublayers
     // pickInfo is used to collect the pick results of all sublayers
     this.state.pickInfos.length = 0;
-    return true;
+    return null;
   }
 
   renderLayers() {

--- a/src/layers/core/point-density-grid-layer/point-density-grid-layer.js
+++ b/src/layers/core/point-density-grid-layer/point-density-grid-layer.js
@@ -65,11 +65,9 @@ export default class PointDensityGridLayer extends Layer {
   }
 
   pick(opts) {
-    super.pick(opts);
-
     const pickedCell = this.state.pickedCell;
 
-    return Object.assign(opts.info, {
+    Object.assign(opts.info, {
       layer: this,
       // override index with cell index
       index: pickedCell ? pickedCell.index : -1,
@@ -77,6 +75,8 @@ export default class PointDensityGridLayer extends Layer {
       // override object with picked cell
       object: pickedCell
     });
+
+    return super.pick(opts);
   }
 
   _onHoverSublayer(info) {

--- a/src/layers/core/point-density-grid-layer/point-density-grid-layer.js
+++ b/src/layers/core/point-density-grid-layer/point-density-grid-layer.js
@@ -69,7 +69,7 @@ export default class PointDensityGridLayer extends Layer {
 
     const pickedCell = this.state.pickedCell;
 
-    Object.assign(opts.info, {
+    return Object.assign(opts.info, {
       layer: this,
       // override index with cell index
       index: pickedCell ? pickedCell.index : -1,

--- a/src/layers/core/point-density-grid-layer/point-density-grid-layer.js
+++ b/src/layers/core/point-density-grid-layer/point-density-grid-layer.js
@@ -64,10 +64,11 @@ export default class PointDensityGridLayer extends Layer {
     }
   }
 
-  pick(opts) {
+  getPickingInfo(opts) {
+    const info = super.getPickingInfo(opts);
     const pickedCell = this.state.pickedCell;
 
-    Object.assign(opts.info, {
+    return Object.assign(info, {
       layer: this,
       // override index with cell index
       index: pickedCell ? pickedCell.index : -1,
@@ -75,8 +76,6 @@ export default class PointDensityGridLayer extends Layer {
       // override object with picked cell
       object: pickedCell
     });
-
-    return super.pick(opts);
   }
 
   _onHoverSublayer(info) {

--- a/src/layers/core/point-density-hexagon-layer/point-density-hexagon-layer.js
+++ b/src/layers/core/point-density-hexagon-layer/point-density-hexagon-layer.js
@@ -92,7 +92,7 @@ export default class PointDensityHexagonLayer extends Layer {
 
     const pickedCell = this.state.pickedCell;
 
-    Object.assign(opts.info, {
+    return Object.assign(opts.info, {
       layer: this,
       // override index with cell index
       index: pickedCell ? pickedCell.index : -1,

--- a/src/layers/core/point-density-hexagon-layer/point-density-hexagon-layer.js
+++ b/src/layers/core/point-density-hexagon-layer/point-density-hexagon-layer.js
@@ -88,11 +88,9 @@ export default class PointDensityHexagonLayer extends Layer {
   }
 
   pick(opts) {
-    super.pick(opts);
-
     const pickedCell = this.state.pickedCell;
 
-    return Object.assign(opts.info, {
+    Object.assign(opts.info, {
       layer: this,
       // override index with cell index
       index: pickedCell ? pickedCell.index : -1,
@@ -100,6 +98,8 @@ export default class PointDensityHexagonLayer extends Layer {
       // override object with picked cell
       object: pickedCell
     });
+
+    return super.pick(opts);
   }
 
   _onHoverSublayer(info) {

--- a/src/layers/core/point-density-hexagon-layer/point-density-hexagon-layer.js
+++ b/src/layers/core/point-density-hexagon-layer/point-density-hexagon-layer.js
@@ -87,10 +87,11 @@ export default class PointDensityHexagonLayer extends Layer {
     }
   }
 
-  pick(opts) {
+  getPickingInfo(opts) {
+    const info = super.getPickingInfo(opts);
     const pickedCell = this.state.pickedCell;
 
-    Object.assign(opts.info, {
+    return Object.assign(info, {
       layer: this,
       // override index with cell index
       index: pickedCell ? pickedCell.index : -1,
@@ -98,8 +99,6 @@ export default class PointDensityHexagonLayer extends Layer {
       // override object with picked cell
       object: pickedCell
     });
-
-    return super.pick(opts);
   }
 
   _onHoverSublayer(info) {

--- a/src/layers/deprecated/choropleth-layer/choropleth-layer.js
+++ b/src/layers/deprecated/choropleth-layer/choropleth-layer.js
@@ -97,10 +97,11 @@ export default class ChoroplethLayer extends Layer {
   pick(opts) {
     super.pick(opts);
     const {info} = opts;
-    const index = this.decodePickingColor(info.color);
+    const {index} = info;
     const feature = index >= 0 ? Container.get(this.props.data, ['features', index]) : null;
     info.feature = feature;
     info.object = feature;
+    return info;
   }
 
   getModel(gl) {

--- a/src/layers/deprecated/choropleth-layer/choropleth-layer.js
+++ b/src/layers/deprecated/choropleth-layer/choropleth-layer.js
@@ -96,7 +96,7 @@ export default class ChoroplethLayer extends Layer {
 
   pick(opts) {
     const {info} = opts;
-    const {index} = info;
+    const index = this.decodePickingColor(info.color);
     const feature = index >= 0 ? Container.get(this.props.data, ['features', index]) : null;
     info.feature = feature;
     info.object = feature;

--- a/src/layers/deprecated/choropleth-layer/choropleth-layer.js
+++ b/src/layers/deprecated/choropleth-layer/choropleth-layer.js
@@ -95,13 +95,12 @@ export default class ChoroplethLayer extends Layer {
   }
 
   pick(opts) {
-    super.pick(opts);
     const {info} = opts;
     const {index} = info;
     const feature = index >= 0 ? Container.get(this.props.data, ['features', index]) : null;
     info.feature = feature;
     info.object = feature;
-    return info;
+    return super.pick(opts);
   }
 
   getModel(gl) {

--- a/src/layers/deprecated/choropleth-layer/choropleth-layer.js
+++ b/src/layers/deprecated/choropleth-layer/choropleth-layer.js
@@ -94,13 +94,13 @@ export default class ChoroplethLayer extends Layer {
     gl.lineWidth(1.0);
   }
 
-  pick(opts) {
-    const {info} = opts;
+  getPickingInfo(opts) {
+    const info = super.getPickingInfo(opts);
     const index = this.decodePickingColor(info.color);
     const feature = index >= 0 ? Container.get(this.props.data, ['features', index]) : null;
     info.feature = feature;
     info.object = feature;
-    return super.pick(opts);
+    return info;
   }
 
   getModel(gl) {

--- a/src/layers/deprecated/extruded-choropleth-layer-64/extruded-choropleth-layer-64.js
+++ b/src/layers/deprecated/extruded-choropleth-layer-64/extruded-choropleth-layer-64.js
@@ -93,13 +93,12 @@ export default class ExtrudedChoroplethLayer64 extends Layer {
   }
 
   pick(opts) {
-    super.pick(opts);
     const {info} = opts;
     const {index} = info;
     const feature = index >= 0 ? this.props.data.features[index] : null;
     info.feature = feature;
     info.object = feature;
-    return info;
+    return super.pick(opts);
   }
 
   getShaders() {

--- a/src/layers/deprecated/extruded-choropleth-layer-64/extruded-choropleth-layer-64.js
+++ b/src/layers/deprecated/extruded-choropleth-layer-64/extruded-choropleth-layer-64.js
@@ -95,10 +95,11 @@ export default class ExtrudedChoroplethLayer64 extends Layer {
   pick(opts) {
     super.pick(opts);
     const {info} = opts;
-    const index = this.decodePickingColor(info.color);
+    const {index} = info;
     const feature = index >= 0 ? this.props.data.features[index] : null;
     info.feature = feature;
     info.object = feature;
+    return info;
   }
 
   getShaders() {

--- a/src/layers/deprecated/extruded-choropleth-layer-64/extruded-choropleth-layer-64.js
+++ b/src/layers/deprecated/extruded-choropleth-layer-64/extruded-choropleth-layer-64.js
@@ -94,7 +94,7 @@ export default class ExtrudedChoroplethLayer64 extends Layer {
 
   pick(opts) {
     const {info} = opts;
-    const {index} = info;
+    const index = this.decodePickingColor(info.color);
     const feature = index >= 0 ? this.props.data.features[index] : null;
     info.feature = feature;
     info.object = feature;

--- a/src/layers/deprecated/extruded-choropleth-layer-64/extruded-choropleth-layer-64.js
+++ b/src/layers/deprecated/extruded-choropleth-layer-64/extruded-choropleth-layer-64.js
@@ -92,13 +92,13 @@ export default class ExtrudedChoroplethLayer64 extends Layer {
     this.state.model.render(uniforms);
   }
 
-  pick(opts) {
-    const {info} = opts;
+  getPickingInfo(opts) {
+    const info = super.getPickingInfo(opts);
     const index = this.decodePickingColor(info.color);
     const feature = index >= 0 ? this.props.data.features[index] : null;
     info.feature = feature;
     info.object = feature;
-    return super.pick(opts);
+    return info;
   }
 
   getShaders() {

--- a/src/lib/draw-and-pick.js
+++ b/src/lib/draw-and-pick.js
@@ -60,12 +60,10 @@ export function pickLayers(gl, {
     gl.clear(GL.COLOR_BUFFER_BIT | GL.DEPTH_BUFFER_BIT);
     // Save current blend settings
     const oldBlendMode = getBlendMode(gl);
-    // Set blend mode for picking: overwrite
+    // Set blend mode for picking
+    // always overwrite existing pixel with [r,g,b,layerIndex]
     gl.enable(gl.BLEND);
-    gl.blendFuncSeparate(
-      gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA,
-      gl.CONSTANT_ALPHA, gl.ONE_MINUS_SRC_ALPHA
-    );
+    gl.blendFuncSeparate(gl.ONE, gl.ZERO, gl.CONSTANT_ALPHA, gl.ZERO);
     gl.blendEquation(gl.FUNC_ADD);
 
     // Render all pickable layers

--- a/src/lib/draw-and-pick.js
+++ b/src/lib/draw-and-pick.js
@@ -1,29 +1,31 @@
 /* global window */
 import {GL, glContextWithState} from 'luma.gl';
 import {getUniformsFromViewport} from './viewport-uniforms';
-import {log} from './utils';
+import {log, getBlendMode, setBlendMode} from './utils';
 
+const EMPTY_PIXEL = new Uint8Array(4);
 let renderCount = 0;
 
 export function drawLayers({layers, pass}) {
   log.log(2, `DRAWING ${layers.length} layers`);
 
-  let layerIndex = 0;
-  for (const layer of layers) {
+  let visibleCount = 0;
+  layers.forEach((layer, layerIndex) => {
     if (layer.props.visible) {
       layer.drawLayer({
         uniforms: Object.assign(
-          {},
+          {renderPickingBuffer: 0, pickingEnabled: 0},
           layer.context.uniforms,
           getUniformsFromViewport(layer.context.viewport, layer.props),
           {layerIndex}
         )
       });
-      layerIndex++;
+      visibleCount++;
     }
-  }
+  });
 
-  log.log(1, `RENDER PASS ${pass}: ${renderCount++} ${layerIndex} visible, ${layers.length} total`);
+  log.log(1, `RENDER PASS ${pass}: ${renderCount++} 
+    ${visibleCount} visible, ${layers.length} total`);
 }
 
 /* eslint-disable max-depth, max-statements */
@@ -33,6 +35,7 @@ export function pickLayers(gl, {
   uniforms = {},
   x,
   y,
+  viewport,
   mode
 }) {
   // Convert from canvas top-left to WebGL bottom-left coordinates
@@ -43,7 +46,7 @@ export function pickLayers(gl, {
   const deviceY = gl.canvas.height - y * pixelRatio;
 
   // TODO - just return glContextWithState once luma updates
-  const pickedInfos = [];
+  const unhandledPickInfos = [];
 
   // Make sure we clear scissor test and fbo bindings in case of exceptions
   // We are only interested in one pixel, no need to render anything else
@@ -53,91 +56,90 @@ export function pickLayers(gl, {
     scissorTest: {x: deviceX, y: deviceY, w: 1, h: 1}
   }, () => {
 
-    let layerIndex = 0;
-    let zOrder = 0;
+    // Clear the frame buffer
+    gl.clear(GL.COLOR_BUFFER_BIT | GL.DEPTH_BUFFER_BIT);
+    // Save current blend settings
+    const oldBlendMode = getBlendMode(gl);
+    // Set blend mode for picking: overwrite
+    gl.enable(gl.BLEND);
+    gl.blendFuncSeparate(gl.ONE, gl.ZERO, gl.CONSTANT_ALPHA, gl.ZERO);
+    gl.blendEquation(gl.FUNC_ADD);
 
-    for (let i = layers.length - 1; i >= 0; --i) {
-      const layer = layers[i];
-
-      if (layer.props.visible) {
-        layerIndex++;
-      }
-
+    // Render all pickable layers
+    layers.forEach((layer, layerIndex) => {
       if (layer.props.visible && layer.props.pickable) {
 
-        // Clear the frame buffer, render and sample
-        gl.clear(GL.COLOR_BUFFER_BIT | GL.DEPTH_BUFFER_BIT);
-        const info = createInfo({
-          layer,
-          pixel: [x, y],
-          devicePixel: [deviceX, deviceY],
-          pixelRatio
-        });
+        // Encode layerIndex with alpha
+        gl.blendColor(0, 0, 0, (layerIndex + 1) / 255);
 
-        layer.pickLayer({
-          info,
-          uniforms: Object.assign({},
+        layer.drawLayer({
+          uniforms: Object.assign(
+            {renderPickingBuffer: 1, pickingEnabled: 1},
             layer.context.uniforms,
             getUniformsFromViewport(layer.context.viewport, layer.props),
             {layerIndex}
-          ),
-          pickEnableUniforms: {renderPickingBuffer: 1, pickingEnabled: 1},
-          pickDisableUniforms: {renderPickingBuffer: 0, pickingEnabled: 0},
-          deviceX, deviceY,
-          mode
+          )
         });
-
-        if (info.index >= 0) {
-          info.picked = true;
-          info.zOrder = zOrder++;
-          // If props.data is an indexable array, get the object
-          if (Array.isArray(layer.props.data)) {
-            info.object = layer.props.data[info.index];
-          }
-        }
-
-        pickedInfos.push(info);
       }
-    }
+    });
+
+    // Read color in the central pixel, to be mapped with picking colors
+    const color = new Uint8Array(4);
+    gl.readPixels(deviceX, deviceY, 1, 1, GL.RGBA, GL.UNSIGNED_BYTE, color);
+
+    // Decode alpha to layer index
+    const pickedLayer = layers[color[3] - 1];
+    const baseInfo = Object.assign(
+      createInfo([x, y], viewport),
+      {
+        devicePixel: [deviceX, deviceY],
+        pixelRatio
+      }
+    );
+
+    layers.forEach(layer => {
+      let info = Object.assign({}, baseInfo, {
+        layer,
+        color: layer === pickedLayer ? color : EMPTY_PIXEL
+      });
+
+      info = layer.pickLayer({info, mode});
+
+      if (!info) {
+        return;
+      }
+
+      // Calling callbacks can have async interactions with React
+      // which nullifies layer.state.
+      let handled = null;
+      switch (mode) {
+      case 'click': handled = layer.props.onClick(info); break;
+      case 'hover': handled = layer.props.onHover(info); break;
+      default: throw new Error('unknown pick type');
+      }
+
+      if (!handled) {
+        unhandledPickInfos.push(info);
+      }
+    });
+
+    // restore blend mode
+    setBlendMode(gl, oldBlendMode);
   });
-
-  // Calling callbacks can have async interactions with React
-  // which nullifies layer.state.
-  const unhandledPickInfos = [];
-  for (const info of pickedInfos) {
-    let handled = null;
-    switch (mode) {
-    case 'click': handled = info.layer.props.onClick(info); break;
-    case 'hover': handled = info.layer.props.onHover(info); break;
-    default: throw new Error('unknown pick type');
-    }
-
-    if (!handled) {
-      unhandledPickInfos.push(info);
-    }
-  }
 
   return unhandledPickInfos;
 }
 /* eslint-enable max-depth, max-statements */
 
-function createInfo({
-  info,
-  layer,
-  pixel,
-  devicePixel,
-  pixelRatio
-}) {
+function createInfo(pixel, viewport) {
   // Assign a number of potentially useful props to the "info" object
   return {
-    layer,
+    color: EMPTY_PIXEL,
     index: -1,
     picked: false,
     x: pixel[0],
     y: pixel[1],
     pixel,
-    devicePixel,
-    pixelRatio,
-    lngLat: layer.unproject(pixel)
+    lngLat: viewport.unproject(pixel)
   };
 }

--- a/src/lib/layer-manager.js
+++ b/src/lib/layer-manager.js
@@ -129,6 +129,7 @@ export default class LayerManager {
       },
       layers: this.layers,
       mode,
+      viewport: this.context.viewport,
       pickingFBO: this.context.pickingFBO
     });
   }

--- a/src/lib/layer.js
+++ b/src/lib/layer.js
@@ -116,15 +116,13 @@ export default class Layer {
     }
   }
 
+  // called on mouse event.
+  // @returns {bool} handled
   pick({info, mode}) {
-    const {color} = info;
-    // Index < 0 means nothing selected
-    const index = this.decodePickingColor(color);
-    info.index = index;
-    info.object = Array.isArray(this.props.data) ? this.props.data[index] : null;
 
     // TODO - selectedPickingColor should be removed?
     if (mode === 'hover') {
+      const {color} = info;
       const selectedPickingColor = new Float32Array(3);
       selectedPickingColor[0] = color[0];
       selectedPickingColor[1] = color[1];
@@ -132,8 +130,14 @@ export default class Layer {
       this.setUniforms({selectedPickingColor});
     }
 
-    // return null to cancel the event
-    return info;
+    // Calling callbacks can have async interactions with React
+    // which nullifies layer.state.
+    switch (mode) {
+    case 'click': return this.props.onClick(info);
+    case 'hover': return this.props.onHover(info);
+    default: throw new Error('unknown pick type');
+    }
+
   }
 
   // END LIFECYCLE METHODS

--- a/src/lib/layer.js
+++ b/src/lib/layer.js
@@ -116,37 +116,25 @@ export default class Layer {
     }
   }
 
-  // If state has a model, draw it with supplied uniforms
-  /* eslint-disable max-statements */
-  pick({info, uniforms, pickEnableUniforms, pickDisableUniforms, mode}) {
-    const {gl} = this.context;
-    const {model} = this.state;
+  pick({info, mode}) {
+    const {color} = info;
+    // Index < 0 means nothing selected
+    const index = this.decodePickingColor(color);
+    info.index = index;
+    info.object = Array.isArray(this.props.data) ? this.props.data[index] : null;
 
-    if (model) {
-      model.setUniforms(pickEnableUniforms);
-      model.render(uniforms);
-      model.setUniforms(pickDisableUniforms);
-
-      // Read color in the central pixel, to be mapped with picking colors
-      const [x, y] = info.devicePixel;
-      const color = new Uint8Array(4);
-      gl.readPixels(x, y, 1, 1, GL.RGBA, GL.UNSIGNED_BYTE, color);
-
-      // Index < 0 means nothing selected
-      info.index = this.decodePickingColor(color);
-      info.color = color;
-
-      // TODO - selectedPickingColor should be removed?
-      if (mode === 'hover') {
-        const selectedPickingColor = new Float32Array(3);
-        selectedPickingColor[0] = color[0];
-        selectedPickingColor[1] = color[1];
-        selectedPickingColor[2] = color[2];
-        this.setUniforms({selectedPickingColor});
-      }
+    // TODO - selectedPickingColor should be removed?
+    if (mode === 'hover') {
+      const selectedPickingColor = new Float32Array(3);
+      selectedPickingColor[0] = color[0];
+      selectedPickingColor[1] = color[1];
+      selectedPickingColor[2] = color[2];
+      this.setUniforms({selectedPickingColor});
     }
+
+    // return null to cancel the event
+    return info;
   }
-  /* eslint-enable max-statements */
 
   // END LIFECYCLE METHODS
   // //////////////////////////////////////////////////

--- a/src/lib/layer.js
+++ b/src/lib/layer.js
@@ -116,13 +116,22 @@ export default class Layer {
     }
   }
 
-  // called on mouse event.
-  // @returns {bool} handled
-  pick({info, mode}) {
+  // called to populate the info object that is passed to the event handler
+  // @return null to cancel event
+  getPickingInfo({info, mode}) {
+    const {color} = info;
+    const index = this.decodePickingColor(color);
+
+    info.index = index;
+    if (index >= 0) {
+      // If props.data is an indexable array, get the object
+      if (Array.isArray(this.props.data)) {
+        info.object = this.props.data[index];
+      }
+    }
 
     // TODO - selectedPickingColor should be removed?
     if (mode === 'hover') {
-      const {color} = info;
       const selectedPickingColor = new Float32Array(3);
       selectedPickingColor[0] = color[0];
       selectedPickingColor[1] = color[1];
@@ -130,14 +139,7 @@ export default class Layer {
       this.setUniforms({selectedPickingColor});
     }
 
-    // Calling callbacks can have async interactions with React
-    // which nullifies layer.state.
-    switch (mode) {
-    case 'click': return this.props.onClick(info);
-    case 'hover': return this.props.onHover(info);
-    default: throw new Error('unknown pick type');
-    }
-
+    return info;
   }
 
   // END LIFECYCLE METHODS
@@ -429,7 +431,7 @@ export default class Layer {
   // {uniforms = {}, ...opts}
   pickLayer(opts) {
     // Call subclass lifecycle method
-    return this.pick(opts);
+    return this.getPickingInfo(opts);
     // End lifecycle method
   }
 

--- a/src/lib/utils/blend.js
+++ b/src/lib/utils/blend.js
@@ -1,0 +1,23 @@
+// get current blending settings
+export function getBlendMode(gl) {
+  return {
+    enabled: gl.getParameter(gl.BLEND),
+    equationColor: gl.getParameter(gl.BLEND_EQUATION_RGB),
+    equationAlpha: gl.getParameter(gl.BLEND_EQUATION_ALPHA),
+    srcColor: gl.getParameter(gl.BLEND_SRC_RGB),
+    dstColor: gl.getParameter(gl.BLEND_DST_RGB),
+    srcAlpha: gl.getParameter(gl.BLEND_SRC_ALPHA),
+    dstAlpha: gl.getParameter(gl.BLEND_DST_ALPHA)
+  };
+}
+
+// apply blending settings
+export function setBlendMode(gl, settings) {
+  if (settings.enabled) {
+    gl.enable(gl.BLEND);
+  } else {
+    gl.disable(gl.BLEND);
+  }
+  gl.blendEquationSeparate(settings.equationColor, settings.equationAlpha);
+  gl.blendFuncSeparate(settings.srcColor, settings.dstColor, settings.srcAlpha, settings.dstAlpha);
+}

--- a/src/lib/utils/blend.js
+++ b/src/lib/utils/blend.js
@@ -2,10 +2,10 @@
 export function getBlendMode(gl) {
   return {
     enabled: gl.getParameter(gl.BLEND),
-    equationColor: gl.getParameter(gl.BLEND_EQUATION_RGB),
+    equationRGB: gl.getParameter(gl.BLEND_EQUATION_RGB),
     equationAlpha: gl.getParameter(gl.BLEND_EQUATION_ALPHA),
-    srcColor: gl.getParameter(gl.BLEND_SRC_RGB),
-    dstColor: gl.getParameter(gl.BLEND_DST_RGB),
+    srcRGB: gl.getParameter(gl.BLEND_SRC_RGB),
+    dstRGB: gl.getParameter(gl.BLEND_DST_RGB),
     srcAlpha: gl.getParameter(gl.BLEND_SRC_ALPHA),
     dstAlpha: gl.getParameter(gl.BLEND_DST_ALPHA)
   };
@@ -18,6 +18,6 @@ export function setBlendMode(gl, settings) {
   } else {
     gl.disable(gl.BLEND);
   }
-  gl.blendEquationSeparate(settings.equationColor, settings.equationAlpha);
-  gl.blendFuncSeparate(settings.srcColor, settings.dstColor, settings.srcAlpha, settings.dstAlpha);
+  gl.blendEquationSeparate(settings.equationRGB, settings.equationAlpha);
+  gl.blendFuncSeparate(settings.srcRGB, settings.dstRGB, settings.srcAlpha, settings.dstAlpha);
 }

--- a/src/lib/utils/index.js
+++ b/src/lib/utils/index.js
@@ -7,3 +7,4 @@ export * from './compare-objects';
 export {compareArrays, checkArray} from './compare-arrays';
 export {default as log} from './log';
 export * from './fp64';
+export * from './blend';


### PR DESCRIPTION
- Improve perf by calling `gl.readPixels()` only once
- Breaking: occluded objects can no longer be picked even if on a separate layer.
- Breaking: `onHover` and `onClick` callbacks are invoked by `layer.pick()`. This allows layers to block an event if necessary. Layers that override the default `pick()` method must now call `super.pick()` *after* augmenting the info object, or call the callback functions themselves.