### PR TITLE
Merge 64-bit and 32-bit scatterplot layer

### DIFF
--- a/examples/main/src/layer-examples.js
+++ b/examples/main/src/layer-examples.js
@@ -14,7 +14,6 @@ import {
   // PolygonLayer,
   PathLayer,
 
-  ScatterplotLayer64,
   ArcLayer64,
   LineLayer64,
 
@@ -336,20 +335,6 @@ const LineLayer64Example = {
   }
 };
 
-const ScatterplotLayer64Example = {
-  layer: ScatterplotLayer64,
-  props: {
-    id: 'scatterplotLayer64',
-    data: dataSamples.points,
-    getPosition: d => d.COORDINATES,
-    getColor: d => [255, 128, 0],
-    getRadius: d => d.SPACES,
-    pickable: true,
-    radiusMinPixels: 1,
-    radiusMaxPixels: 30
-  }
-};
-
 const ChoroplethLayerContourExample = {
   layer: ChoroplethLayer,
   props: {
@@ -435,7 +420,7 @@ const ScatterplotLayerPerfExample = (id, getData) => ({
 });
 
 const ScatterplotLayer64PerfExample = (id, getData) => ({
-  layer: ScatterplotLayer64,
+  layer: ScatterplotLayer,
   getData,
   props: {
     id: `scatterplotLayer64Perf-${id}`,
@@ -443,7 +428,8 @@ const ScatterplotLayer64PerfExample = (id, getData) => ({
     getColor: d => [0, 128, 0],
     // pickable: true,
     radiusMinPixels: 1,
-    radiusMaxPixels: 5
+    radiusMaxPixels: 5,
+    fp64: true
   }
 });
 
@@ -469,9 +455,7 @@ export default {
 
   '64-bit Layers': {
     ArcLayer64: ArcLayer64Example,
-    ScatterplotLayer64: ScatterplotLayer64Example,
-    LineLayer64: LineLayer64Example,
-    GeoJsonLayer64: GeoJsonLayer64Example
+    LineLayer64: LineLayer64Example
   },
 
   'Deprecated Layers': {

--- a/examples/main/src/layer-examples.js
+++ b/examples/main/src/layer-examples.js
@@ -99,32 +99,6 @@ const GeoJsonLayerExample = {
   }
 };
 
-const GeoJsonLayer64Example = {
-  layer: GeoJsonLayer,
-  props: {
-    id: 'geojsonLayer',
-    data: dataSamples.geojson,
-    // TODO change to use the color util when it is landed
-    getPointColor: f => parseColor(f.properties['marker-color']),
-    getPointSize: f => MARKER_SIZE_MAP[f.properties['marker-size']],
-    getStrokeColor: f => {
-      const color = parseColor(f.properties.stroke);
-      const opacity = f.properties['stroke-opacity'] * 255;
-      return setOpacity(color, opacity);
-    },
-    getStrokeWidth: f => f.properties['stroke-width'],
-    getFillColor: f => {
-      const color = parseColor(f.properties.fill);
-      const opacity = f.properties['fill-opacity'] * 255;
-      return setOpacity(color, opacity);
-    },
-    strokeWidth: 10,
-    strokeWidthMinPixels: 1,
-    pickable: true,
-    fp64: true
-  }
-};
-
 const GeoJsonLayerExtrudedExample = {
   layer: GeoJsonLayer,
   props: {

--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,6 @@ export {default as GeoJsonLayer} from './layers/core/geojson-layer/geojson-layer
 export {default as ScatterplotLayer64} from './layers/fp64/scatterplot-layer/scatterplot-layer-64';
 export {default as ArcLayer64} from './layers/fp64/arc-layer/arc-layer-64';
 export {default as LineLayer64} from './layers/fp64/line-layer/line-layer-64';
-// export {default as GeoJsonLayer64} from './layers/fp64/geojson-layer/geojson-layer-64';
 
 // Deprecated Layers
 export {default as ChoroplethLayer} from './layers/deprecated/choropleth-layer/choropleth-layer';

--- a/src/layers/core/geojson-layer/geojson-layer.js
+++ b/src/layers/core/geojson-layer/geojson-layer.js
@@ -185,7 +185,8 @@ export default class GeoJsonLayer extends CompositeLayer {
         updateTriggers: {
           getColor: this.props.updateTriggers.getPointColor,
           getRadius: this.props.updateTriggers.getPointSize
-        }
+        },
+        fp64: this.props.fp64
       }));
 
     return [

--- a/src/layers/core/geojson-layer/geojson-layer.js
+++ b/src/layers/core/geojson-layer/geojson-layer.js
@@ -125,7 +125,6 @@ export default class GeoJsonLayer extends CompositeLayer {
         getColor: getFillColor,
         extruded,
         wireframe: false,
-        fp64: this.props.fp64,
         updateTriggers: {
           getElevation: this.props.updateTriggers.getElevation,
           getColor: this.props.updateTriggers.getFillColor
@@ -143,7 +142,6 @@ export default class GeoJsonLayer extends CompositeLayer {
         getColor: getStrokeColor,
         extruded: true,
         wireframe: true,
-        fp64: this.props.fp64,
         updateTriggers: {
           getColor: this.props.updateTriggers.getStrokeColor
         }

--- a/src/layers/core/polygon-layer/polygon-layer.js
+++ b/src/layers/core/polygon-layer/polygon-layer.js
@@ -105,6 +105,8 @@ export default class PolygonLayer extends Layer {
   updateAttribute({props, oldProps, changeFlags}) {
     if (props.fp64 !== oldProps.fp64) {
       const {attributeManager} = this.state;
+      attributeManager.invalidateAll();
+
       if (props.fp64 === true) {
         attributeManager.add({
           positions64xyLow: {size: 2, update: this.calculatePositionsLow}

--- a/src/layers/core/scatterplot-layer/scatterplot-layer-64-vertex.glsl
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer-64-vertex.glsl
@@ -1,0 +1,84 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#define SHADER_NAME scatterplot-layer-64-vertex-shader
+
+attribute vec3 positions;
+
+attribute vec3 instancePositions;
+attribute vec2 instancePositions64xyLow;
+attribute float instanceRadius;
+attribute vec4 instanceColors;
+attribute vec3 instancePickingColors;
+
+// Only one-dimensional arrays may be declared in GLSL ES 1.0. specs p.24
+uniform float opacity;
+uniform float radiusScale;
+uniform float radiusMinPixels;
+uniform float radiusMaxPixels;
+uniform float renderPickingBuffer;
+uniform float outline;
+uniform float strokeWidth;
+
+varying vec4 vColor;
+varying vec2 unitPosition;
+varying float innerUnitRadius;
+
+void main(void) {
+  // Multiply out radius and clamp to limits
+  float outerRadiusPixels = clamp(
+    project_scale(radiusScale * instanceRadius),
+    radiusMinPixels, radiusMaxPixels
+  );
+
+  // outline is centered at the radius
+  // outer radius needs to offset by half stroke width
+  outerRadiusPixels += outline * strokeWidth / 2.0;
+
+  // position on the containing square in [-1, 1] space
+  unitPosition = positions.xy;
+  // 0 - solid circle, 1 - stroke with lineWidth=0
+  innerUnitRadius = outline * (1.0 - strokeWidth / outerRadiusPixels);
+
+  vec4 instancePositions64xy = vec4(instancePositions.x, instancePositions64xyLow.x, instancePositions.y, instancePositions64xyLow.y);
+  vec2 projected_coord_xy[2];
+  project_position_fp64(instancePositions64xy, projected_coord_xy);
+
+  vec2 vertex_pos_localspace[4];
+  vec4_fp64(vec4(positions * outerRadiusPixels, 0.0), vertex_pos_localspace);
+
+  vec2 vertex_pos_modelspace[4];
+  vertex_pos_modelspace[0] = sum_fp64(vertex_pos_localspace[0], projected_coord_xy[0]);
+  vertex_pos_modelspace[1] = sum_fp64(vertex_pos_localspace[1], projected_coord_xy[1]);
+  vertex_pos_modelspace[2] = sum_fp64(vertex_pos_localspace[2], vec2(project_scale(positions.z), 0.0));
+  vertex_pos_modelspace[3] = vec2(1.0, 0.0);
+
+  gl_Position = project_to_clipspace_fp64(vertex_pos_modelspace);
+
+  if (renderPickingBuffer > 0.5) {
+    vColor = vec4(instancePickingColors / 255., 1.);
+  } else {
+    vColor = vec4(instanceColors.rgb, instanceColors.a * opacity) / 255.;
+  }
+  // // Apply opacity to instance color, or return instance picking color
+  // vec4 color = vec4(instanceColors.rgb, instanceColors.a * opacity) / 255.;
+  // vec4 pickingColor = vec4(instancePickingColors / 255., 1.);
+  // vColor = mix(color, pickingColor, renderPickingBuffer);
+}

--- a/src/layers/core/scatterplot-layer/scatterplot-layer.js
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer.js
@@ -91,20 +91,22 @@ export default class ScatterplotLayer extends Layer {
   updateAttribute({props, oldProps, changeFlags}) {
     if (props.fp64 !== oldProps.fp64) {
       const {attributeManager} = this.state;
-
-      // all attributes needs to be set again after the model changes
-      this.state.attributeManager.addInstanced({
-        instancePositions: {size: 3, accessor: 'getPosition', update: this.calculateInstancePositions},
-        instanceRadius: {size: 1, accessor: 'getRadius', defaultValue: 1, update: this.calculateInstanceRadius},
-        instanceColors: {size: 4, type: GL.UNSIGNED_BYTE, accessor: 'getColor', update: this.calculateInstanceColors},
-        instancePickingColors: {type: GL.UNSIGNED_BYTE, size: 3, update: this.calculateInstancePickingColors}
-      });
+      attributeManager.invalidateAll();
 
       if (props.fp64 === true) {
         attributeManager.addInstanced({
-          instancePositions64xyLow: {size: 2, accessor: 'getPosition', update: this.calculateInstancePositions64xyLow}
+          instancePositions64xyLow: {
+            size: 2,
+            accessor: 'getPosition',
+            update: this.calculateInstancePositions64xyLow
+          }
         });
+      } else {
+        attributeManager.remove([
+          'positions64xyLow'
+        ]);
       }
+
     }
   }
 

--- a/src/layers/core/scatterplot-layer/scatterplot-layer.js
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer.js
@@ -43,14 +43,15 @@ const defaultProps = {
 export default class ScatterplotLayer extends Layer {
   getShaders(id) {
 
-    const shaders = this.props.fp64 ? {
+    return this.props.fp64 ? {
       vs: readFileSync(join(__dirname, './scatterplot-layer-64-vertex.glsl'), 'utf8'),
       fs: readFileSync(join(__dirname, './scatterplot-layer-fragment.glsl'), 'utf8'),
-      modules: ['lighting', 'fp64', 'project64']} : {
-        vs: readFileSync(join(__dirname, './scatterplot-layer-vertex.glsl'), 'utf8'),
-        fs: readFileSync(join(__dirname, './scatterplot-layer-fragment.glsl'), 'utf8'),
-        modules: ['lighting']};
-    return shaders;
+      modules: ['lighting', 'fp64', 'project64']
+    } : {
+      vs: readFileSync(join(__dirname, './scatterplot-layer-vertex.glsl'), 'utf8'),
+      fs: readFileSync(join(__dirname, './scatterplot-layer-fragment.glsl'), 'utf8'),
+      modules: ['lighting']
+    };
   }
 
   initializeState() {


### PR DESCRIPTION
The user can switch between two versions using props.fp64.

This PR is on top of #379. It should be merged after #379 got merged. 