### PR TITLE
Warning message for using 64-bit mode with projection mode other than LON_LAT

### DIFF
--- a/src/layers/core/arc-layer/arc-layer.js
+++ b/src/layers/core/arc-layer/arc-layer.js
@@ -23,7 +23,7 @@ import {assembleShaders} from '../../../shader-utils';
 import {GL, Model, Geometry} from 'luma.gl';
 import {readFileSync} from 'fs';
 import {join} from 'path';
-import {fp64ify} from '../../../lib/utils/fp64';
+import {fp64ify, enable64bitSupport} from '../../../lib/utils/fp64';
 import {COORDINATE_SYSTEM} from '../../../lib';
 
 const DEFAULT_COLOR = [0, 0, 0, 255];
@@ -39,14 +39,14 @@ const defaultProps = {
 
 export default class ArcLayer extends Layer {
   getShaders() {
-    return this.props.fp64 && this.props.projectionMode === COORDINATE_SYSTEM.LNG_LAT ? {
-      vs: readFileSync(join(__dirname, './arc-layer-64-vertex.glsl'), 'utf8'),
-      fs: readFileSync(join(__dirname, './arc-layer-fragment.glsl'), 'utf8'),
-      modules: ['fp64', 'project64']
+    const vs64 = readFileSync(join(__dirname, './arc-layer-64-vertex.glsl'), 'utf8');
+    const vs32 = readFileSync(join(__dirname, './arc-layer-vertex.glsl'), 'utf8');
+    const fs = readFileSync(join(__dirname, './arc-layer-fragment.glsl'), 'utf8');
+
+    return enable64bitSupport(this.props) ? {
+      vs: vs64, fs, modules: ['fp64', 'project64']
     } : {
-      vs: readFileSync(join(__dirname, './arc-layer-vertex.glsl'), 'utf8'),
-      fs: readFileSync(join(__dirname, './arc-layer-fragment.glsl'), 'utf8'),
-      modules: []
+      vs: vs32, fs, modules: []
     };
   }
 

--- a/src/layers/core/grid-layer/grid-layer.js
+++ b/src/layers/core/grid-layer/grid-layer.js
@@ -23,7 +23,7 @@ import {assembleShaders} from '../../../shader-utils';
 import {GL, Model, CubeGeometry} from 'luma.gl';
 import {readFileSync} from 'fs';
 import {join} from 'path';
-import {fp64ify} from '../../../lib/utils/fp64';
+import {fp64ify, enable64bitSupport} from '../../../lib/utils/fp64';
 import {COORDINATE_SYSTEM} from '../../../lib';
 
 const DEFAULT_COLOR = [255, 0, 255, 255];
@@ -63,14 +63,14 @@ export default class GridLayer extends Layer {
    */
 
   getShaders() {
-    return this.props.fp64 && this.props.projectionMode === COORDINATE_SYSTEM.LNG_LAT ? {
-      vs: readFileSync(join(__dirname, './grid-layer-64-vertex.glsl'), 'utf8'),
-      fs: readFileSync(join(__dirname, './grid-layer-fragment.glsl'), 'utf8'),
-      modules: ['fp64', 'project64', 'lighting']
+    const vs64 = readFileSync(join(__dirname, './grid-layer-64-vertex.glsl'), 'utf8');
+    const vs32 = readFileSync(join(__dirname, './grid-layer-vertex.glsl'), 'utf8');
+    const fs = readFileSync(join(__dirname, './grid-layer-fragment.glsl'), 'utf8');
+
+    return enable64bitSupport(this.props) ? {
+      vs: vs64, fs, modules: ['fp64', 'project64', 'lighting']
     } : {
-      vs: readFileSync(join(__dirname, './grid-layer-vertex.glsl'), 'utf8'),
-      fs: readFileSync(join(__dirname, './grid-layer-fragment.glsl'), 'utf8'),
-      modules: ['lighting']
+      vs: vs32, fs, modules: ['lighting']
     };
   }
 

--- a/src/layers/core/hexagon-layer/hexagon-layer.js
+++ b/src/layers/core/hexagon-layer/hexagon-layer.js
@@ -24,7 +24,7 @@ import {Model, CylinderGeometry} from 'luma.gl';
 import {readFileSync} from 'fs';
 import {join} from 'path';
 import {log} from '../../../lib/utils';
-import {fp64ify} from '../../../lib/utils/fp64';
+import {fp64ify, enable64bitSupport} from '../../../lib/utils/fp64';
 import {COORDINATE_SYSTEM} from '../../../lib';
 
 function positionsAreEqual(v1, v2) {
@@ -86,14 +86,14 @@ export default class HexagonLayer extends Layer {
   }
 
   getShaders() {
-    return this.props.fp64 && this.props.projectionMode === COORDINATE_SYSTEM.LNG_LAT ? {
-      vs: readFileSync(join(__dirname, './hexagon-layer-64-vertex.glsl'), 'utf8'),
-      fs: readFileSync(join(__dirname, './hexagon-layer-fragment.glsl'), 'utf8'),
-      modules: ['fp64', 'project64', 'lighting']
+    const vs64 = readFileSync(join(__dirname, './hexagon-layer-64-vertex.glsl'), 'utf8');
+    const vs32 = readFileSync(join(__dirname, './hexagon-layer-vertex.glsl'), 'utf8');
+    const fs = readFileSync(join(__dirname, './hexagon-layer-fragment.glsl'), 'utf8');
+
+    return enable64bitSupport(this.props) ? {
+      vs: vs64, fs, modules: ['fp64', 'project64', 'lighting']
     } : {
-      vs: readFileSync(join(__dirname, './hexagon-layer-vertex.glsl'), 'utf8'),
-      fs: readFileSync(join(__dirname, './hexagon-layer-fragment.glsl'), 'utf8'),
-      modules: ['lighting']
+      vs: vs32, fs, modules: ['lighting']
     };
   }
 

--- a/src/layers/core/icon-layer/icon-layer-64-vertex.glsl
+++ b/src/layers/core/icon-layer/icon-layer-64-vertex.glsl
@@ -30,8 +30,8 @@ attribute vec4 instanceIconFrames;
 attribute float instanceColorModes;
 attribute vec2 instanceOffsets;
 
-uniform vec2 sizeScale;
-
+uniform vec2 screenSize;
+uniform float sizeScale;
 uniform float renderPickingBuffer;
 uniform vec2 iconsTextureDim;
 
@@ -40,8 +40,14 @@ varying vec4 vColor;
 varying vec2 vTextureCoords;
 
 void main(void) {
+  vec2 iconSize = instanceIconFrames.zw;
+  vec2 iconSize_clipspace = iconSize / screenSize * 2.0;
+  // scale icon height to match instanceSize
+  float instanceScale = iconSize.y == 0.0 ? 0.0 : instanceSizes / iconSize.y;
+
   // The vertex variable is in clip space and should not go through project_to_clipspace call
-  vec2 vertex = (positions + instanceOffsets * 2.0) * sizeScale * instanceSizes;
+  vec2 vertex = (positions / 2.0 + instanceOffsets) * iconSize_clipspace * sizeScale * instanceScale;
+  vertex.y *= -1.0;
 
   vec4 instancePositions64xy = vec4(instancePositions.x, instancePositions64xyLow.x, instancePositions.y, instancePositions64xyLow.y);
   vec2 projected_coord_xy[2];
@@ -57,7 +63,7 @@ void main(void) {
 
   vTextureCoords = mix(
     instanceIconFrames.xy,
-    instanceIconFrames.xy + instanceIconFrames.zw,
+    instanceIconFrames.xy + iconSize,
     (positions.xy + 1.0) / 2.0
   ) / iconsTextureDim;
 

--- a/src/layers/core/icon-layer/icon-layer.js
+++ b/src/layers/core/icon-layer/icon-layer.js
@@ -22,7 +22,7 @@ import {assembleShaders} from '../../../shader-utils';
 import {GL, Model, Geometry, Texture2D, loadTextures} from 'luma.gl';
 import {readFileSync} from 'fs';
 import {join} from 'path';
-import {fp64ify} from '../../../lib/utils/fp64';
+import {fp64ify, enable64bitSupport} from '../../../lib/utils/fp64';
 import {COORDINATE_SYSTEM} from '../../../lib';
 
 const DEFAULT_COLOR = [0, 0, 0, 255];
@@ -140,14 +140,14 @@ export default class IconLayer extends Layer {
   }
 
   getShaders() {
-    return this.props.fp64 && this.props.projectionMode === COORDINATE_SYSTEM.LNG_LAT ? {
-      vs: readFileSync(join(__dirname, './icon-layer-64-vertex.glsl'), 'utf8'),
-      fs: readFileSync(join(__dirname, './icon-layer-fragment.glsl'), 'utf8'),
-      modules: ['fp64', 'project64']
+    const vs64 = readFileSync(join(__dirname, './icon-layer-64-vertex.glsl'), 'utf8');
+    const vs32 = readFileSync(join(__dirname, './icon-layer-vertex.glsl'), 'utf8');
+    const fs = readFileSync(join(__dirname, './icon-layer-fragment.glsl'), 'utf8');
+
+    return enable64bitSupport(this.props) ? {
+      vs: vs64, fs, modules: ['fp64', 'project64']
     } : {
-      vs: readFileSync(join(__dirname, './icon-layer-vertex.glsl'), 'utf8'),
-      fs: readFileSync(join(__dirname, './icon-layer-fragment.glsl'), 'utf8'),
-      modules: []
+      vs: vs32, fs, modules: []
     };
   }
 

--- a/src/layers/core/line-layer/line-layer.js
+++ b/src/layers/core/line-layer/line-layer.js
@@ -23,7 +23,7 @@ import {assembleShaders} from '../../../shader-utils';
 import {GL, Model, Geometry} from 'luma.gl';
 import {readFileSync} from 'fs';
 import {join} from 'path';
-import {fp64ify} from '../../../lib/utils/fp64';
+import {fp64ify, enable64bitSupport} from '../../../lib/utils/fp64';
 import {COORDINATE_SYSTEM} from '../../../lib';
 
 const DEFAULT_COLOR = [0, 0, 0, 255];
@@ -38,14 +38,14 @@ const defaultProps = {
 
 export default class LineLayer extends Layer {
   getShaders() {
-    return this.props.fp64 && this.props.projectionMode === COORDINATE_SYSTEM.LNG_LAT ? {
-      vs: readFileSync(join(__dirname, './line-layer-64-vertex.glsl'), 'utf8'),
-      fs: readFileSync(join(__dirname, './line-layer-fragment.glsl'), 'utf8'),
-      modules: ['fp64', 'project64']
+    const vs64 = readFileSync(join(__dirname, './line-layer-64-vertex.glsl'), 'utf8');
+    const vs32 = readFileSync(join(__dirname, './line-layer-vertex.glsl'), 'utf8');
+    const fs = readFileSync(join(__dirname, './line-layer-fragment.glsl'), 'utf8');
+
+    return enable64bitSupport(this.props) ? {
+      vs: vs64, fs, modules: ['fp64', 'project64']
     } : {
-      vs: readFileSync(join(__dirname, './line-layer-vertex.glsl'), 'utf8'),
-      fs: readFileSync(join(__dirname, './line-layer-fragment.glsl'), 'utf8'),
-      modules: []
+      vs: vs32, fs, modules: []
     };
   }
 

--- a/src/layers/core/path-layer/path-layer.js
+++ b/src/layers/core/path-layer/path-layer.js
@@ -3,7 +3,7 @@ import {assembleShaders} from '../../../shader-utils';
 import {GL, Model, Geometry} from 'luma.gl';
 import {readFileSync} from 'fs';
 import {join} from 'path';
-import {fp64ify} from '../../../lib/utils/fp64';
+import {fp64ify, enable64bitSupport} from '../../../lib/utils/fp64';
 import {COORDINATE_SYSTEM} from '../../../lib';
 
 const DEFAULT_COLOR = [0, 0, 0, 255];
@@ -30,14 +30,14 @@ const isClosed = path => {
 
 export default class PathLayer extends Layer {
   getShaders() {
-    return this.props.fp64 && this.props.projectionMode === COORDINATE_SYSTEM.LNG_LAT ? {
-      vs: readFileSync(join(__dirname, './path-layer-64-vertex.glsl'), 'utf8'),
-      fs: readFileSync(join(__dirname, './path-layer-fragment.glsl'), 'utf8'),
-      modules: ['fp64', 'project64']
+    const vs64 = readFileSync(join(__dirname, './path-layer-64-vertex.glsl'), 'utf8');
+    const vs32 = readFileSync(join(__dirname, './path-layer-vertex.glsl'), 'utf8');
+    const fs = readFileSync(join(__dirname, './path-layer-fragment.glsl'), 'utf8');
+
+    return enable64bitSupport(this.props) ? {
+      vs: vs64, fs, modules: ['fp64', 'project64']
     } : {
-      vs: readFileSync(join(__dirname, './path-layer-vertex.glsl'), 'utf8'),
-      fs: readFileSync(join(__dirname, './path-layer-fragment.glsl'), 'utf8'),
-      modules: []
+      vs: vs32, fs, modules: []
     };
   }
 

--- a/src/layers/core/point-cloud-layer/point-cloud-layer.js
+++ b/src/layers/core/point-cloud-layer/point-cloud-layer.js
@@ -23,7 +23,7 @@ import {assembleShaders} from '../../../shader-utils';
 import {GL, Model, Geometry} from 'luma.gl';
 import {readFileSync} from 'fs';
 import {join} from 'path';
-import {fp64ify} from '../../../lib/utils/fp64';
+import {fp64ify, enable64bitSupport} from '../../../lib/utils/fp64';
 import {COORDINATE_SYSTEM} from '../../../lib';
 
 const DEFAULT_COLOR = [0, 0, 0, 255];
@@ -46,14 +46,14 @@ const defaultProps = {
 
 export default class PointCloudLayer extends Layer {
   getShaders(id) {
-    return this.props.fp64 && this.props.projectionMode === COORDINATE_SYSTEM.LNG_LAT ? {
-      vs: readFileSync(join(__dirname, './point-cloud-layer-64-vertex.glsl'), 'utf8'),
-      fs: readFileSync(join(__dirname, './point-cloud-layer-fragment.glsl'), 'utf8'),
-      modules: ['lighting', 'fp64', 'project64']
+    const vs64 = readFileSync(join(__dirname, './point-cloud-layer-64-vertex.glsl'), 'utf8');
+    const vs32 = readFileSync(join(__dirname, './point-cloud-layer-vertex.glsl'), 'utf8');
+    const fs = readFileSync(join(__dirname, './point-cloud-layer-fragment.glsl'), 'utf8');
+
+    return enable64bitSupport(this.props) ? {
+      vs: vs64, fs, modules: ['fp64', 'project64', 'lighting']
     } : {
-      vs: readFileSync(join(__dirname, './point-cloud-layer-vertex.glsl'), 'utf8'),
-      fs: readFileSync(join(__dirname, './point-cloud-layer-fragment.glsl'), 'utf8'),
-      modules: ['lighting']
+      vs: vs32, fs, modules: ['lighting']
     };
   }
 

--- a/src/layers/core/polygon-layer/polygon-layer.js
+++ b/src/layers/core/polygon-layer/polygon-layer.js
@@ -24,6 +24,7 @@ import {get} from '../../../lib/utils';
 import {GL, Model, Geometry} from 'luma.gl';
 import {readFileSync} from 'fs';
 import {join} from 'path';
+import {enable64bitSupport} from '../../../lib/utils/fp64';
 import {COORDINATE_SYSTEM} from '../../../lib';
 
 // Polygon geometry generation is managed by the polygon tesselator
@@ -58,15 +59,15 @@ const defaultProps = {
 
 export default class PolygonLayer extends Layer {
   getShaders() {
+    const vs64 = readFileSync(join(__dirname, './polygon-layer-64-vertex.glsl'), 'utf8');
+    const vs32 = readFileSync(join(__dirname, './polygon-layer-vertex.glsl'), 'utf8');
+    const fs = readFileSync(join(__dirname, './polygon-layer-fragment.glsl'), 'utf8');
 
-    const shaders = this.props.fp64 && this.props.projectionMode === COORDINATE_SYSTEM.LNG_LAT ? {
-      vs: readFileSync(join(__dirname, './polygon-layer-64-vertex.glsl'), 'utf8'),
-      fs: readFileSync(join(__dirname, './polygon-layer-fragment.glsl'), 'utf8'),
-      modules: ['lighting', 'fp64', 'project64']} : {
-        vs: readFileSync(join(__dirname, './polygon-layer-vertex.glsl'), 'utf8'),
-        fs: readFileSync(join(__dirname, './polygon-layer-fragment.glsl'), 'utf8'),
-        modules: ['lighting']};
-    return shaders;
+    return enable64bitSupport(this.props) ? {
+      vs: vs64, fs, modules: ['fp64', 'project64', 'lighting']
+    } : {
+      vs: vs32, fs, modules: ['lighting']
+    };
   }
 
   initializeState() {

--- a/src/layers/core/scatterplot-layer/scatterplot-layer.js
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer.js
@@ -24,7 +24,7 @@ import {GL, Model, Geometry} from 'luma.gl';
 import {readFileSync} from 'fs';
 import {join} from 'path';
 import {log} from '../../../lib/utils';
-import {fp64ify} from '../../../lib/utils/fp64';
+import {fp64ify, enable64bitSupport} from '../../../lib/utils/fp64';
 import {COORDINATE_SYSTEM} from '../../../lib';
 
 const DEFAULT_COLOR = [0, 0, 0, 255];
@@ -43,14 +43,14 @@ const defaultProps = {
 
 export default class ScatterplotLayer extends Layer {
   getShaders(id) {
-    return (this.props.fp64 && this.props.projectionMode === COORDINATE_SYSTEM.LNG_LAT) ? {
-      vs: readFileSync(join(__dirname, './scatterplot-layer-64-vertex.glsl'), 'utf8'),
-      fs: readFileSync(join(__dirname, './scatterplot-layer-fragment.glsl'), 'utf8'),
-      modules: ['fp64', 'project64']
+    const vs64 = readFileSync(join(__dirname, './scatterplot-layer-64-vertex.glsl'), 'utf8');
+    const vs32 = readFileSync(join(__dirname, './scatterplot-layer-vertex.glsl'), 'utf8');
+    const fs = readFileSync(join(__dirname, './scatterplot-layer-fragment.glsl'), 'utf8');
+
+    return enable64bitSupport(this.props) ? {
+      vs: vs64, fs, modules: ['fp64', 'project64']
     } : {
-      vs: readFileSync(join(__dirname, './scatterplot-layer-vertex.glsl'), 'utf8'),
-      fs: readFileSync(join(__dirname, './scatterplot-layer-fragment.glsl'), 'utf8'),
-      modules: []
+      vs: vs32, fs, modules: []
     };
   }
 

--- a/src/lib/utils/fp64.js
+++ b/src/lib/utils/fp64.js
@@ -12,12 +12,10 @@ export function enable64bitSupport(props) {
   if (props.fp64) {
     if (props.projectionMode === COORDINATE_SYSTEM.LNG_LAT) {
       return true;
-    } else {
-      log.once(0, `64-bit mode only works with projectionMode set to
-       COORDINATE_SYSTEM.LNG_LAT. Rendering in 32-bit mode instead`);
-      return false;
     }
-  } else {
-    return false;
+    log.once(0, `64-bit mode only works with projectionMode set to
+      COORDINATE_SYSTEM.LNG_LAT. Rendering in 32-bit mode instead`);
   }
+
+  return false;
 }

--- a/src/lib/utils/fp64.js
+++ b/src/lib/utils/fp64.js
@@ -1,6 +1,23 @@
 // TODO - move to shaderlib utilities
+import {log} from '.';
+import {COORDINATE_SYSTEM} from '..';
+
 export function fp64ify(a) {
   const hiPart = Math.fround(a);
   const loPart = a - Math.fround(a);
   return [hiPart, loPart];
+}
+
+export function enable64bitSupport(props) {
+  if (props.fp64) {
+    if (props.projectionMode === COORDINATE_SYSTEM.LNG_LAT) {
+      return true;
+    } else {
+      log.once(0, `64-bit mode only works with projectionMode set to
+       COORDINATE_SYSTEM.LNG_LAT. Rendering in 32-bit mode instead`);
+      return false;
+    }
+  } else {
+    return false;
+  }
 }


### PR DESCRIPTION
Add a warning message when user tries to draw 64-bit layers in projection mode other than LON_LAT;

Reorganized the shader loading code to save some redundant load;

Fix the 64-bit IconLayer issue brought by #388