### PR TITLE
Fix the bug that Layer's invalidateAttribute get called for CompositeLayer

### DIFF
--- a/examples/layer-browser/src/examples/core-layers.js
+++ b/examples/layer-browser/src/examples/core-layers.js
@@ -87,17 +87,7 @@ const GeoJsonLayerExample = {
     getHeight: f => Math.random() * 1000,
     widthScale: 10,
     widthMinPixels: 1,
-    pickable: true,
-
-    // TODO - Old accessors
-    getPointColor: f => parseColor(f.properties['marker-color']),
-    getPointRadius: f => MARKER_SIZE_MAP[f.properties['marker-size']],
-    getStrokeColor: f => {
-      const color = parseColor(f.properties.stroke);
-      const opacity = (f.properties['stroke-opacity'] || 1) * 255;
-      return setOpacity(color, opacity);
-    },
-    getStrokeWidth: f => f.properties['stroke-width']
+    pickable: true
   }
 };
 
@@ -108,7 +98,7 @@ const GeoJsonLayerExtrudedExample = {
     id: 'geojsonLayer-extruded',
     getHeight: f => get(f, 'properties.ZIP_CODE') * 10 % 127 * 10,
     getFillColor: f => [0, 255, get(f, 'properties.ZIP_CODE') * 23 % 100 + 155],
-    getStrokeColor: f => [200, 0, 80],
+    getColor: f => [200, 0, 80],
     drawPolygons: true,
     extruded: true,
     wireframe: true,
@@ -122,7 +112,8 @@ const PolygonLayerExample = {
   props: {
     getPolygon: f => f,
     getFillColor: f => [Math.random() % 256, 0, 0],
-    getStrokeColor: f => [0, 0, 0, 255],
+    getColor: f => [0, 0, 0, 255],
+    getWidth: f => 20,
     getHeight: f => Math.random() * 1000,
     opacity: 0.8,
     pickable: true

--- a/src/layers/core/geojson-layer/geojson-layer.js
+++ b/src/layers/core/geojson-layer/geojson-layer.js
@@ -80,7 +80,7 @@ export default class GeoJsonLayer extends CompositeLayer {
   renderLayers() {
     const {features} = this.state;
     const {pointFeatures, lineFeatures, polygonFeatures, polygonOutlineFeatures} = features;
-    const {getColor, getFillColor, getRadius, getStrokeWidth, getElevation} = this.props;
+    const {getColor, getFillColor, getRadius, getWidth, getElevation} = this.props;
     const {id, stroked, filled, extruded, wireframe} = this.props;
 
     let {} = this.props;
@@ -132,7 +132,7 @@ export default class GeoJsonLayer extends CompositeLayer {
         data: polygonOutlineFeatures,
         getPath: getCoordinates,
         getColor,
-        getStrokeWidth,
+        getWidth,
         onHover,
         onClick
       }));
@@ -143,7 +143,7 @@ export default class GeoJsonLayer extends CompositeLayer {
       data: lineFeatures,
       getPath: getCoordinates,
       getColor,
-      getStrokeWidth,
+      getWidth,
       onHover,
       onClick
     }));

--- a/src/layers/core/polygon-layer/polygon-layer.js
+++ b/src/layers/core/polygon-layer/polygon-layer.js
@@ -38,9 +38,9 @@ const defaultProps = {
   // Polygon fill color
   getFillColor: f => get(f, 'fillColor') || defaultFillColor,
   // Point, line and polygon outline color
-  getStrokeColor: f => get(f, 'color') || get(f, 'strokeColor') || defaultColor,
+  getColor: f => get(f, 'color') || get(f, 'strokeColor') || defaultColor,
   // Line and polygon outline accessors
-  getStrokeWidth: f => get(f, 'strokeWidth') || 1,
+  getWidth: f => get(f, 'strokeWidth') || 1,
   // Polygon extrusion accessor
   getElevation: f => 1000
 };
@@ -79,7 +79,7 @@ export default class PolygonLayer extends CompositeLayer {
   }
 
   renderLayers() {
-    const {getFillColor, getStrokeColor, getStrokeWidth, getElevation, updateTriggers} = this.props;
+    const {getFillColor, getColor, getWidth, getElevation, updateTriggers} = this.props;
     const {data, id, stroked, filled, extruded, wireframe} = this.props;
     const {paths, onHover, onClick} = this.state;
 
@@ -107,12 +107,12 @@ export default class PolygonLayer extends CompositeLayer {
         id: `${id}-stroke`,
         data: paths,
         getPath: x => x.path,
-        getColor: getStrokeColor,
-        getStrokeWidth,
+        getColor,
+        getWidth,
         onHover,
         onClick,
         updateTriggers: Object.assign({}, updateTriggers, {
-          getColor: updateTriggers.getStrokeColor
+          getColor: updateTriggers.getColor
         })
       }));
     }

--- a/src/lib/composite-layer.js
+++ b/src/lib/composite-layer.js
@@ -7,7 +7,15 @@ export default class CompositeLayer extends Layer {
 
   // initializeState is usually not needed for composite layers
   // Provide empty definition to disable check for missing definition
-  initializeState() {}
+  initializeState() {
+
+  }
+
+  // No-op for the invalidateAttribute function as the composite
+  // layer has no AttributeManager
+  invalidateAttribute() {
+
+  }
 
   getPickingInfo(opts) {
     // do not call onHover/onClick on the container

--- a/src/lib/composite-layer.js
+++ b/src/lib/composite-layer.js
@@ -8,13 +8,11 @@ export default class CompositeLayer extends Layer {
   // initializeState is usually not needed for composite layers
   // Provide empty definition to disable check for missing definition
   initializeState() {
-
   }
 
   // No-op for the invalidateAttribute function as the composite
   // layer has no AttributeManager
   invalidateAttribute() {
-
   }
 
   getPickingInfo(opts) {


### PR DESCRIPTION
, which has no AttributeManager so no attribute to invalidate;
Clean up the accessor and prop names for Polygon layer and GeoJson layer