### PR TITLE
Fix the updateTrigger transfer from composite layer to its child layers

### DIFF
--- a/src/layers/core/geojson-layer/geojson-layer.js
+++ b/src/layers/core/geojson-layer/geojson-layer.js
@@ -80,7 +80,7 @@ export default class GeoJsonLayer extends CompositeLayer {
   renderLayers() {
     const {features} = this.state;
     const {pointFeatures, lineFeatures, polygonFeatures, polygonOutlineFeatures} = features;
-    const {getColor, getFillColor, getRadius, getWidth, getElevation} = this.props;
+    const {getColor, getFillColor, getRadius, getWidth, getElevation, updateTriggers} = this.props;
     const {id, stroked, filled, extruded, wireframe} = this.props;
 
     let {} = this.props;
@@ -102,8 +102,8 @@ export default class GeoJsonLayer extends CompositeLayer {
       getElevation,
       getColor: getFillColor,
       updateTriggers: {
-        getElevation: this.props.updateTriggers.getElevation,
-        getColor: this.props.updateTriggers.getFillColor
+        getElevation: updateTriggers.getElevation,
+        getColor: updateTriggers.getFillColor
       },
       onHover,
       onClick
@@ -120,9 +120,10 @@ export default class GeoJsonLayer extends CompositeLayer {
         getPolygon: getCoordinates,
         getElevation,
         getColor,
-        updateTriggers: Object.assign({}, this.props.updateTriggers, {
-          getColor: this.props.updateTriggers.getFillColor
-        }),
+        updateTriggers: {
+          getElevation: updateTriggers.getElevation,
+          getColor: updateTriggers.getColor
+        },
         onHover,
         onClick
       }));
@@ -133,6 +134,10 @@ export default class GeoJsonLayer extends CompositeLayer {
         getPath: getCoordinates,
         getColor,
         getWidth,
+        updateTriggers: {
+          getColor: updateTriggers.getColor,
+          getWidth: updateTriggers.getWidth
+        },
         onHover,
         onClick
       }));
@@ -145,7 +150,11 @@ export default class GeoJsonLayer extends CompositeLayer {
       getColor,
       getWidth,
       onHover,
-      onClick
+      onClick,
+      updateTriggers: {
+        getColor: updateTriggers.getColor,
+        getWidth: updateTriggers.getWidth
+      }
     }));
 
     const pointLayer = drawPoints && new ScatterplotLayer(Object.assign({}, this.props, {
@@ -154,9 +163,10 @@ export default class GeoJsonLayer extends CompositeLayer {
       getPosition: getCoordinates,
       getColor: getFillColor,
       getRadius,
-      updateTriggers: Object.assign({}, this.props.updateTriggers, {
-        getColor: this.props.updateTriggers.getFillColor
-      }),
+      updateTriggers: {
+        getColor: updateTriggers.getFillColor,
+        getRadius: updateTriggers.getRadius
+      },
       onHover,
       onClick
     }));

--- a/src/layers/core/polygon-layer/polygon-layer.js
+++ b/src/layers/core/polygon-layer/polygon-layer.js
@@ -95,9 +95,10 @@ export default class PolygonLayer extends CompositeLayer {
         getColor: getFillColor,
         extruded,
         wireframe,
-        updateTriggers: Object.assign({}, updateTriggers, {
+        updateTriggers: {
+          getElevation: updateTriggers.getElevation,
           getColor: updateTriggers.getFillColor
-        })
+        }
       }));
 
     // Polygon outline layer
@@ -111,9 +112,10 @@ export default class PolygonLayer extends CompositeLayer {
         getWidth,
         onHover,
         onClick,
-        updateTriggers: Object.assign({}, updateTriggers, {
+        updateTriggers: {
+          getWidth: updateTriggers.getWidth,
           getColor: updateTriggers.getColor
-        })
+        }
       }));
     }
 


### PR DESCRIPTION
Now the composite layer needs to handle which updateTriggers it's sending to the child layers. 

It can no longer dump all updateTriggers it receives from the user to all of its child layers, which leads to assertions being fired from AttributeManager.invalidate(triggerName)