### PR TITLE
Polygon layer fix

### DIFF
--- a/examples/layer-browser/data/sample.geo.json
+++ b/examples/layer-browser/data/sample.geo.json
@@ -4,7 +4,7 @@
     "type": "Feature",
     "properties": {
       "marker-color": "#ff0000",
-      "marker-size": "small",
+      "marker-size": "medium",
       "marker-symbol": ""
     },
     "geometry": {
@@ -24,7 +24,9 @@
     }
   }, {
     "type": "Feature",
-    "properties": {},
+    "properties": {
+      "marker-size": "small"
+    },
     "geometry": {
       "type": "MultiPoint",
       "coordinates": [

--- a/examples/layer-browser/src/examples/core-layers.js
+++ b/examples/layer-browser/src/examples/core-layers.js
@@ -24,9 +24,9 @@ import dataSamples from '../immutable-data-samples';
 import {parseColor, setOpacity} from '../utils/color';
 
 const MARKER_SIZE_MAP = {
-  small: 2,
-  medium: 5,
-  large: 10
+  small: 200,
+  medium: 500,
+  large: 1000
 };
 
 const LIGHT_SETTINGS = {

--- a/examples/layer-browser/src/examples/core-layers.js
+++ b/examples/layer-browser/src/examples/core-layers.js
@@ -84,7 +84,7 @@ const GeoJsonLayerExample = {
       return setOpacity(color, opacity);
     },
     getWidth: f => f.properties['stroke-width'],
-    getHeight: f => Math.random() * 1000,
+    getElevation: f => 500,
     widthScale: 10,
     widthMinPixels: 1,
     pickable: true
@@ -96,7 +96,7 @@ const GeoJsonLayerExtrudedExample = {
   getData: () => dataSamples.choropleths,
   props: {
     id: 'geojsonLayer-extruded',
-    getHeight: f => get(f, 'properties.ZIP_CODE') * 10 % 127 * 10,
+    getElevation: f => get(f, 'properties.ZIP_CODE') * 10 % 127 * 10,
     getFillColor: f => [0, 255, get(f, 'properties.ZIP_CODE') * 23 % 100 + 155],
     getColor: f => [200, 0, 80],
     drawPolygons: true,

--- a/src/layers/core/arc-layer/arc-layer.js
+++ b/src/layers/core/arc-layer/arc-layer.js
@@ -89,7 +89,12 @@ export default class ArcLayer extends Layer {
   }
 
   updateState({props, oldProps, changeFlags}) {
-    this.updateModel({props, oldProps, changeFlags});
+    super.updateState({props, oldProps, changeFlags});
+    // Re-generate model if geometry changed
+    if (props.fp64 !== oldProps.fp64) {
+      const {gl} = this.context;
+      this.setState({model: this._getModel(gl)});
+    }
     this.updateAttribute({props, oldProps, changeFlags});
   }
 

--- a/src/layers/core/geojson-layer/geojson-layer.js
+++ b/src/layers/core/geojson-layer/geojson-layer.js
@@ -86,7 +86,7 @@ export default class GeoJsonLayer extends CompositeLayer {
     let {} = this.props;
     const drawPoints = pointFeatures && pointFeatures.length > 0;
     const drawLines = lineFeatures && lineFeatures.length > 0;
-    const drawPolygons = stroked && polygonOutlineFeatures && polygonOutlineFeatures.length > 0;
+    const drawPolygons = polygonOutlineFeatures && polygonOutlineFeatures.length > 0;
     const fillPolygons = filled && polygonFeatures && polygonFeatures.length > 0;
 
     const onHover = this._onHoverSubLayer.bind(this);
@@ -111,7 +111,8 @@ export default class GeoJsonLayer extends CompositeLayer {
 
     // Polygon outline or wireframe
     let polygonOutlineLayer = null;
-    if (drawPolygons && extruded && wireframe) {
+    // If extruded, check the "wireframe" prop
+    if (extruded && wireframe && drawPolygons) {
       polygonOutlineLayer = new SolidPolygonLayer(Object.assign({}, this.props, {
         id: `${id}-polygon-wireframe`,
         data: polygonFeatures,
@@ -127,7 +128,8 @@ export default class GeoJsonLayer extends CompositeLayer {
         onHover,
         onClick
       }));
-    } else if (drawPolygons) {
+    // If non-extruded, check the "stroked" prop
+    } else if (!extruded && stroked && drawPolygons) {
       polygonOutlineLayer = new PathLayer(Object.assign({}, this.props, {
         id: `${id}-polygon-outline`,
         data: polygonOutlineFeatures,

--- a/src/layers/core/geojson-layer/geojson-layer.js
+++ b/src/layers/core/geojson-layer/geojson-layer.js
@@ -87,13 +87,12 @@ export default class GeoJsonLayer extends CompositeLayer {
     const drawPoints = pointFeatures && pointFeatures.length > 0;
     const drawLines = lineFeatures && lineFeatures.length > 0;
     const drawPolygons = polygonOutlineFeatures && polygonOutlineFeatures.length > 0;
-    const fillPolygons = filled && polygonFeatures && polygonFeatures.length > 0;
 
     const onHover = this._onHoverSubLayer.bind(this);
     const onClick = this._onClickSubLayer.bind(this);
 
     // Filled Polygon Layer
-    const polygonFillLayer = fillPolygons && new SolidPolygonLayer(Object.assign({}, this.props, {
+    const polygonFillLayer = filled && drawPolygons && new SolidPolygonLayer(Object.assign({}, this.props, {
       id: `${id}-polygon-fill`,
       data: polygonFeatures,
       extruded,

--- a/src/layers/core/geojson-layer/geojson-layer.js
+++ b/src/layers/core/geojson-layer/geojson-layer.js
@@ -86,50 +86,54 @@ export default class GeoJsonLayer extends CompositeLayer {
     let {} = this.props;
     const drawPoints = pointFeatures && pointFeatures.length > 0;
     const drawLines = lineFeatures && lineFeatures.length > 0;
-    const drawPolygons = polygonOutlineFeatures && polygonOutlineFeatures.length > 0;
+    const hasPolygonOutline = polygonOutlineFeatures && polygonOutlineFeatures.length > 0;
+    const hasPolygon = polygonFeatures && polygonFeatures.length > 0;
 
     const onHover = this._onHoverSubLayer.bind(this);
     const onClick = this._onClickSubLayer.bind(this);
 
     // Filled Polygon Layer
-    const polygonFillLayer = filled && drawPolygons && new SolidPolygonLayer(Object.assign({}, this.props, {
-      id: `${id}-polygon-fill`,
-      data: polygonFeatures,
-      extruded,
-      wireframe: false,
-      getPolygon: getCoordinates,
-      getElevation,
-      getColor: getFillColor,
-      updateTriggers: {
-        getElevation: updateTriggers.getElevation,
-        getColor: updateTriggers.getFillColor
-      },
-      onHover,
-      onClick
-    }));
+    const polygonFillLayer = filled &&
+      hasPolygon &&
+      new SolidPolygonLayer(Object.assign({}, this.props, {
+        id: `${id}-polygon-fill`,
+        data: polygonFeatures,
+        extruded,
+        wireframe: false,
+        getPolygon: getCoordinates,
+        getElevation,
+        getColor: getFillColor,
+        updateTriggers: {
+          getElevation: updateTriggers.getElevation,
+          getColor: updateTriggers.getFillColor
+        },
+        onHover,
+        onClick
+      }));
 
-    // Polygon outline or wireframe
-    let polygonOutlineLayer = null;
-    // If extruded, check the "wireframe" prop
-    if (extruded && wireframe && drawPolygons) {
-      polygonOutlineLayer = new SolidPolygonLayer(Object.assign({}, this.props, {
+    const polygonWireframeLayer = wireframe &&
+      extruded &&
+      hasPolygon &&
+      new SolidPolygonLayer(Object.assign({}, this.props, {
         id: `${id}-polygon-wireframe`,
         data: polygonFeatures,
-        extruded: true,
+        extruded,
         wireframe: true,
         getPolygon: getCoordinates,
         getElevation,
         getColor,
         updateTriggers: {
           getElevation: updateTriggers.getElevation,
-          getColor: updateTriggers.getColor
+          getColor: updateTriggers.getFillColor
         },
         onHover,
         onClick
       }));
-    // If non-extruded, check the "stroked" prop
-    } else if (!extruded && stroked && drawPolygons) {
-      polygonOutlineLayer = new PathLayer(Object.assign({}, this.props, {
+
+    const polygonOutlineLayer = !extruded &&
+      stroked &&
+      hasPolygonOutline &&
+      new PathLayer(Object.assign({}, this.props, {
         id: `${id}-polygon-outline`,
         data: polygonOutlineFeatures,
         getPath: getCoordinates,
@@ -142,7 +146,6 @@ export default class GeoJsonLayer extends CompositeLayer {
         onHover,
         onClick
       }));
-    }
 
     const lineLayer = drawLines && new PathLayer(Object.assign({}, this.props, {
       id: `${id}-line-paths`,
@@ -174,6 +177,7 @@ export default class GeoJsonLayer extends CompositeLayer {
 
     return [
       polygonFillLayer,
+      polygonWireframeLayer,
       polygonOutlineLayer,
       lineLayer,
       pointLayer

--- a/src/layers/core/grid-cell-layer/grid-cell-layer.js
+++ b/src/layers/core/grid-cell-layer/grid-cell-layer.js
@@ -116,7 +116,11 @@ export default class GridCellLayer extends Layer {
 
   updateState({props, oldProps, changeFlags}) {
     super.updateState({props, oldProps, changeFlags});
-    this.updateModel({props, oldProps, changeFlags});
+    // Re-generate model if geometry changed
+    if (props.fp64 !== oldProps.fp64) {
+      const {gl} = this.context;
+      this.setState({model: this._getModel(gl)});
+    }
     this.updateAttribute({props, oldProps, changeFlags});
     this.updateUniforms();
   }

--- a/src/layers/core/hexagon-cell-layer/hexagon-cell-layer.js
+++ b/src/layers/core/hexagon-cell-layer/hexagon-cell-layer.js
@@ -143,7 +143,10 @@ export default class HexagonCellLayer extends Layer {
 
   updateState({props, oldProps, changeFlags}) {
     super.updateState({props, oldProps, changeFlags});
-    this.updateModel({props, oldProps, changeFlags});
+    if (props.fp64 !== oldProps.fp64) {
+      const {gl} = this.context;
+      this.setState({model: this._getModel(gl)});
+    }
     this.updateAttribute({props, oldProps, changeFlags});
 
     const viewportChanged = changeFlags.viewportChanged;

--- a/src/layers/core/icon-layer/icon-layer.js
+++ b/src/layers/core/icon-layer/icon-layer.js
@@ -103,6 +103,8 @@ export default class IconLayer extends Layer {
   }
 
   updateState({oldProps, props, changeFlags}) {
+    super.updateState({props, oldProps, changeFlags});
+
     const {iconAtlas} = props;
 
     if (oldProps.iconAtlas !== iconAtlas) {
@@ -121,7 +123,10 @@ export default class IconLayer extends Layer {
       }
     }
 
-    this.updateModel({props, oldProps, changeFlags});
+    if (props.fp64 !== oldProps.fp64) {
+      const {gl} = this.context;
+      this.setState({model: this._getModel(gl)});
+    }
     this.updateAttribute({props, oldProps, changeFlags});
 
   }

--- a/src/layers/core/line-layer/line-layer.js
+++ b/src/layers/core/line-layer/line-layer.js
@@ -88,7 +88,12 @@ export default class LineLayer extends Layer {
   }
 
   updateState({props, oldProps, changeFlags}) {
-    this.updateModel({props, oldProps, changeFlags});
+    super.updateState({props, oldProps, changeFlags});
+
+    if (props.fp64 !== oldProps.fp64) {
+      const {gl} = this.context;
+      this.setState({model: this._getModel(gl)});
+    }
     this.updateAttribute({props, oldProps, changeFlags});
   }
 

--- a/src/layers/core/path-layer/path-layer.js
+++ b/src/layers/core/path-layer/path-layer.js
@@ -81,9 +81,14 @@ export default class PathLayer extends Layer {
   }
 
   updateState({oldProps, props, changeFlags}) {
+    super.updateState({props, oldProps, changeFlags});
+
     const {getPath} = this.props;
     const {attributeManager} = this.state;
-    this.updateModel({props, oldProps, changeFlags});
+    if (props.fp64 !== oldProps.fp64) {
+      const {gl} = this.context;
+      this.setState({model: this._getModel(gl)});
+    }
     this.updateAttribute({props, oldProps, changeFlags});
 
     if (changeFlags.dataChanged) {
@@ -94,7 +99,6 @@ export default class PathLayer extends Layer {
       this.setState({paths, numInstances});
       attributeManager.invalidateAll();
     }
-
   }
 
   draw({uniforms}) {

--- a/src/layers/core/point-cloud-layer/point-cloud-layer.js
+++ b/src/layers/core/point-cloud-layer/point-cloud-layer.js
@@ -95,7 +95,11 @@ export default class PointCloudLayer extends Layer {
   }
 
   updateState({props, oldProps, changeFlags}) {
-    this.updateModel({props, oldProps, changeFlags});
+    super.updateState({props, oldProps, changeFlags});
+    if (props.fp64 !== oldProps.fp64) {
+      const {gl} = this.context;
+      this.setState({model: this._getModel(gl)});
+    }
     this.updateAttribute({props, oldProps, changeFlags});
   }
 

--- a/src/layers/core/polygon-layer/polygon-layer.js
+++ b/src/layers/core/polygon-layer/polygon-layer.js
@@ -83,18 +83,17 @@ export default class PolygonLayer extends CompositeLayer {
     const {data, id, stroked, filled, extruded, wireframe} = this.props;
     const {paths, onHover, onClick} = this.state;
 
-    const strokePolygons = stroked && data && data.length > 0;
-    const fillPolygons = filled && data && data.length > 0;
+    const polygon = data && data.length > 0;
 
     // Filled Polygon Layer
-    const polygonFillLayer = fillPolygons && new SolidPolygonLayer(Object.assign({},
+    const polygonFillLayer = filled && polygon && new SolidPolygonLayer(Object.assign({},
       this.props, {
         id: `${id}-fill`,
         data,
         getElevation,
         getColor: getFillColor,
         extruded,
-        wireframe,
+        wireframe: false,
         updateTriggers: {
           getElevation: updateTriggers.getElevation,
           getColor: updateTriggers.getFillColor
@@ -103,7 +102,7 @@ export default class PolygonLayer extends CompositeLayer {
 
     // Polygon outline layer
     let polygonOutlineLayer = null;
-    if (strokePolygons) {
+    if (!extruded && stroked && polygon) {
       polygonOutlineLayer = new PathLayer(Object.assign({}, this.props, {
         id: `${id}-stroke`,
         data: paths,
@@ -115,6 +114,20 @@ export default class PolygonLayer extends CompositeLayer {
         updateTriggers: {
           getWidth: updateTriggers.getWidth,
           getColor: updateTriggers.getColor
+        }
+      }));
+    } else if (extruded && wireframe && polygon) {
+      polygonOutlineLayer = new SolidPolygonLayer(Object.assign({},
+      this.props, {
+        id: `${id}-wireframe`,
+        data,
+        getElevation,
+        getColor: getFillColor,
+        extruded,
+        wireframe: true,
+        updateTriggers: {
+          getElevation: updateTriggers.getElevation,
+          getColor: updateTriggers.getFillColor
         }
       }));
     }

--- a/src/layers/core/polygon-layer/polygon-layer.js
+++ b/src/layers/core/polygon-layer/polygon-layer.js
@@ -83,10 +83,10 @@ export default class PolygonLayer extends CompositeLayer {
     const {data, id, stroked, filled, extruded, wireframe} = this.props;
     const {paths, onHover, onClick} = this.state;
 
-    const polygon = data && data.length > 0;
+    const hasData = data && data.length > 0;
 
     // Filled Polygon Layer
-    const polygonFillLayer = filled && polygon && new SolidPolygonLayer(Object.assign({},
+    const polygonLayer = filled && hasData && new SolidPolygonLayer(Object.assign({},
       this.props, {
         id: `${id}-fill`,
         data,
@@ -100,10 +100,28 @@ export default class PolygonLayer extends CompositeLayer {
         }
       }));
 
+    const polygonWireframeLayer = extruded &&
+      wireframe &&
+      hasData &&
+      new SolidPolygonLayer(Object.assign({},
+      this.props, {
+        id: `${id}-wireframe`,
+        data,
+        getElevation,
+        getColor,
+        extruded: true,
+        wireframe: true,
+        updateTriggers: {
+          getElevation: updateTriggers.getElevation,
+          getColor: updateTriggers.getColor
+        }
+      }));
+
     // Polygon outline layer
-    let polygonOutlineLayer = null;
-    if (!extruded && stroked && polygon) {
-      polygonOutlineLayer = new PathLayer(Object.assign({}, this.props, {
+    const polygonOutlineLayer = !extruded &&
+      stroked &&
+      hasData &&
+      new PathLayer(Object.assign({}, this.props, {
         id: `${id}-stroke`,
         data: paths,
         getPath: x => x.path,
@@ -116,24 +134,10 @@ export default class PolygonLayer extends CompositeLayer {
           getColor: updateTriggers.getColor
         }
       }));
-    } else if (extruded && wireframe && polygon) {
-      polygonOutlineLayer = new SolidPolygonLayer(Object.assign({},
-      this.props, {
-        id: `${id}-wireframe`,
-        data,
-        getElevation,
-        getColor: getFillColor,
-        extruded,
-        wireframe: true,
-        updateTriggers: {
-          getElevation: updateTriggers.getElevation,
-          getColor: updateTriggers.getFillColor
-        }
-      }));
-    }
 
     return [
-      polygonFillLayer,
+      polygonLayer,
+      polygonWireframeLayer,
       polygonOutlineLayer
     ].filter(Boolean);
   }

--- a/src/layers/core/scatterplot-layer/scatterplot-layer.js
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer.js
@@ -95,7 +95,10 @@ export default class ScatterplotLayer extends Layer {
   }
 
   updateState({props, oldProps, changeFlags}) {
-    this.updateModel({props, oldProps, changeFlags});
+    if (props.fp64 !== oldProps.fp64) {
+      const {gl} = this.context;
+      this.setState({model: this._getModel(gl)});
+    }
     this.updateAttribute({props, oldProps, changeFlags});
   }
 

--- a/src/layers/core/screen-grid-layer/screen-grid-layer.js
+++ b/src/layers/core/screen-grid-layer/screen-grid-layer.js
@@ -63,6 +63,7 @@ export default class ScreenGridLayer extends Layer {
   }
 
   updateState({oldProps, props, changeFlags}) {
+    super.updateState({props, oldProps, changeFlags});
     const cellSizeChanged =
       props.cellSizePixels !== oldProps.cellSizePixels;
 

--- a/src/layers/core/solid-polygon-layer/solid-polygon-layer.js
+++ b/src/layers/core/solid-polygon-layer/solid-polygon-layer.js
@@ -109,13 +109,12 @@ export default class PolygonLayer extends Layer {
   }
 
   draw({uniforms}) {
-    const {
-      extruded
-    } = this.props;
+    const {extruded, lightSettings} = this.props;
 
     this.state.model.render(Object.assign({}, uniforms, {
-      extruded
-    }));
+      extruded: extruded ? 1.0 : 0.0
+    },
+    lightSettings));
   }
 
   updateState({props, oldProps, changeFlags}) {
@@ -129,14 +128,6 @@ export default class PolygonLayer extends Layer {
       this.setState({model: this._getModel(gl)});
     }
     this.updateAttribute({props, oldProps, changeFlags});
-
-    const {opacity, extruded, lightSettings} = props;
-
-    this.setUniforms(Object.assign({}, {
-      extruded: extruded ? 1.0 : 0.0,
-      opacity
-    },
-    lightSettings));
   }
 
   updateGeometry({props, oldProps, changeFlags}) {

--- a/src/layers/core/solid-polygon-layer/solid-polygon-layer.js
+++ b/src/layers/core/solid-polygon-layer/solid-polygon-layer.js
@@ -83,7 +83,7 @@ export default class PolygonLayer extends Layer {
     /* eslint-disable max-len */
     attributeManager.add({
       indices: {size: 1, isIndexed: true, update: this.calculateIndices, noAlloc},
-      positions: {size: 3, accessor: 'getHeight', update: this.calculatePositions, noAlloc},
+      positions: {size: 3, accessor: 'getElevation', update: this.calculatePositions, noAlloc},
       normals: {size: 3, update: this.calculateNormals, noAlloc},
       colors: {size: 4, type: GL.UNSIGNED_BYTE, accessor: 'getColor', update: this.calculateColors, noAlloc},
       pickingColors: {size: 3, type: GL.UNSIGNED_BYTE, update: this.calculatePickingColors, noAlloc}
@@ -128,7 +128,7 @@ export default class PolygonLayer extends Layer {
       props.wireframe !== oldProps.wireframe || props.fp64 !== oldProps.fp64;
 
     if (changeFlags.dataChanged || geometryChanged) {
-      const {getPolygon, extruded, wireframe, getHeight} = props;
+      const {getPolygon, extruded, wireframe, getElevation} = props;
 
       // TODO - avoid creating a temporary array here: let the tesselator iterate
       const polygons = props.data.map(getPolygon);
@@ -137,7 +137,7 @@ export default class PolygonLayer extends Layer {
         polygonTesselator: !extruded ?
           new PolygonTesselator({polygons, fp64: this.props.fp64}) :
           new PolygonTesselatorExtruded({polygons, wireframe,
-            getHeight: polygonIndex => getHeight(this.props.data[polygonIndex]),
+            getHeight: polygonIndex => getElevation(this.props.data[polygonIndex]),
             fp64: this.props.fp64
           })
       });

--- a/src/lib/layer.js
+++ b/src/lib/layer.js
@@ -150,13 +150,6 @@ export default class Layer {
     }
   }
 
-  updateModel({props, oldProps, changeFlags}) {
-    if (props.fp64 !== oldProps.fp64) {
-      const {gl} = this.context;
-      this.setState({model: this._getModel(gl)});
-    }
-  }
-
   // Calls attribute manager to update any WebGL attributes, can be redefined
   updateAttributes(props) {
     const {attributeManager, model} = this.state;


### PR DESCRIPTION
Fix the GeoJSON layer demo after the change of default value of the scatterplot layer
Update the GeoJSON layer accessor names according to the API audit
Fix the layer props of the GeoJSON layer and the Polygon layer
Also, removed the updateModel in the base Layer and put the code to each subclassed layer because the criteria for updating models are different for each layer.