### PR TITLE
update webpack config for start-local scripts

### DIFF
--- a/examples/svg-interoperability/webpack.config.js
+++ b/examples/svg-interoperability/webpack.config.js
@@ -17,10 +17,11 @@ module.exports = {
       }
     }]
   },
-  node: {
-    fs: 'empty'
-  },
   plugins: [
     new webpack.HotModuleReplacementPlugin()
   ]
 };
+
+// DELETE THIS LINE WHEN COPYING THIS EXAMPLE FOLDER OUTSIDE OF DECK.GL
+// It enables bundling against src in this repo rather than installed deck.gl module
+module.exports = require('../webpack.config.local')(module.exports);

--- a/examples/webpack.config.local.js
+++ b/examples/webpack.config.local.js
@@ -46,7 +46,16 @@ const LOCAL_DEVELOPMENT_CONFIG = {
 };
 
 function addLocalDevSettings(config) {
-  Object.assign(config.resolve.alias, LOCAL_DEVELOPMENT_CONFIG.resolve.alias);
+  if (config.resolve) {
+    Object.assign(config.resolve, {
+      alias: LOCAL_DEVELOPMENT_CONFIG.resolve.alias
+    });
+  } else {
+    Object.assign(config, {
+      resolve: LOCAL_DEVELOPMENT_CONFIG.resolve
+    });
+  }
+
   config.module.rules = config.module.rules.concat(LOCAL_DEVELOPMENT_CONFIG.module.rules);
   return config;
 }

--- a/examples/webpack.config.local.js
+++ b/examples/webpack.config.local.js
@@ -12,7 +12,7 @@ const LIB_DIR = resolve(__dirname, '..');
 const SRC_DIR = resolve(LIB_DIR, './src');
 
 // Support for hot reloading changes to the deck.gl library:
-const LOCAL_DEVELOPMENT_CONFIG = {
+const LOCAL_DEV_CONFIG = {
   // suppress warnings about bundle size
   devServer: {
     stats: {
@@ -46,17 +46,13 @@ const LOCAL_DEVELOPMENT_CONFIG = {
 };
 
 function addLocalDevSettings(config) {
-  if (config.resolve) {
-    Object.assign(config.resolve, {
-      alias: LOCAL_DEVELOPMENT_CONFIG.resolve.alias
-    });
-  } else {
-    Object.assign(config, {
-      resolve: LOCAL_DEVELOPMENT_CONFIG.resolve
-    });
-  }
+  config.resolve = config.resolve || {};
+  Object.assign(config.resolve, {alias: LOCAL_DEV_CONFIG.resolve.alias});
 
-  config.module.rules = config.module.rules.concat(LOCAL_DEVELOPMENT_CONFIG.module.rules);
+  config.module = config.module || {};
+  Object.assign(config.module, {
+    rules: (config.module.rules || []).concat(LOCAL_DEV_CONFIG.module.rules)
+  });
   return config;
 }
 


### PR DESCRIPTION
add start-local (run against source code) for the svg-compatibility example.
minor change on the addLocalDevSettings logic in webpack.config.local.js.
(^ resolve is not a must have field in webpack configs)