### PR TITLE
Composite layer interface and props transfer

### DIFF
--- a/examples/layer-browser/src/examples/core-layers.js
+++ b/examples/layer-browser/src/examples/core-layers.js
@@ -78,15 +78,15 @@ const GeoJsonLayerExample = {
       const opacity = (f.properties['fill-opacity'] || 1) * 255;
       return setOpacity(color, opacity);
     },
-    getColor: f => {
+    getLineColor: f => {
       const color = parseColor(f.properties.stroke);
       const opacity = (f.properties['stroke-opacity'] || 1) * 255;
       return setOpacity(color, opacity);
     },
-    getWidth: f => f.properties['stroke-width'],
+    getLineWidth: f => f.properties['stroke-width'],
     getElevation: f => 500,
-    widthScale: 10,
-    widthMinPixels: 1,
+    lineWidthScale: 10,
+    lineWidthMinPixels: 1,
     pickable: true
   }
 };
@@ -98,8 +98,7 @@ const GeoJsonLayerExtrudedExample = {
     id: 'geojsonLayer-extruded',
     getElevation: f => get(f, 'properties.ZIP_CODE') * 10 % 127 * 10,
     getFillColor: f => [0, 255, get(f, 'properties.ZIP_CODE') * 23 % 100 + 155],
-    getColor: f => [200, 0, 80],
-    drawPolygons: true,
+    getLineColor: f => [200, 0, 80],
     extruded: true,
     wireframe: true,
     pickable: true
@@ -112,7 +111,7 @@ const PolygonLayerExample = {
   props: {
     getPolygon: f => f,
     getFillColor: f => [Math.random() % 256, 0, 0],
-    getColor: f => [0, 0, 0, 255],
+    getLineColor: f => [0, 0, 0, 255],
     getWidth: f => 20,
     getHeight: f => Math.random() * 1000,
     opacity: 0.8,

--- a/src/layers/core/geojson-layer/geojson-layer.js
+++ b/src/layers/core/geojson-layer/geojson-layer.js
@@ -92,7 +92,7 @@ export default class GeoJsonLayer extends CompositeLayer {
 
     const drawPoints = pointFeatures && pointFeatures.length > 0;
     const drawLines = lineFeatures && lineFeatures.length > 0;
-    const hasPolygonLine = polygonOutlineFeatures && polygonOutlineFeatures.length > 0;
+    const hasPolygonLines = polygonOutlineFeatures && polygonOutlineFeatures.length > 0;
     const hasPolygon = polygonFeatures && polygonFeatures.length > 0;
 
     const onHover = this._onHoverSubLayer.bind(this);
@@ -140,7 +140,7 @@ export default class GeoJsonLayer extends CompositeLayer {
 
     const polygonLineLayer = !extruded &&
       stroked &&
-      hasPolygonLine &&
+      hasPolygonLines &&
       new PathLayer({
         id: `${id}-polygon-outline`,
         data: polygonOutlineFeatures,

--- a/src/layers/core/geojson-layer/geojson-layer.js
+++ b/src/layers/core/geojson-layer/geojson-layer.js
@@ -26,7 +26,7 @@ import SolidPolygonLayer from '../solid-polygon-layer/solid-polygon-layer';
 
 import {getGeojsonFeatures, separateGeojsonFeatures} from './geojson';
 
-const defaultStrokeColor = [0xBD, 0xE2, 0x7A, 0xFF];
+const defaultLineColor = [0xBD, 0xE2, 0x7A, 0xFF];
 const defaultFillColor = [0xBD, 0xE2, 0x7A, 0xFF];
 
 const defaultProps = {
@@ -34,18 +34,22 @@ const defaultProps = {
   filled: true,
   extruded: false,
   wireframe: false,
+
+  lineWidthScale: 1,
+  lineWidthMinPixels: 0,
+  lineWidthMaxPixels: Number.MAX_SAFE_INTEGER,
+  lineJointRounded: false,
+  lineMiterLimit: 4,
   fp64: false,
 
-  // TODO: Missing props: radiusMinPixels, strokeWidthMinPixels, ...
-
   // Line and polygon outline color
-  getColor: f => get(f, 'properties.strokeColor') || defaultStrokeColor,
+  getLineColor: f => get(f, 'properties.lineColor') || defaultLineColor,
   // Point and polygon fill color
   getFillColor: f => get(f, 'properties.fillColor') || defaultFillColor,
   // Point radius
   getRadius: f => get(f, 'properties.radius') || get(f, 'properties.size') || 5,
   // Line and polygon outline accessors
-  getWidth: f => get(f, 'properties.strokeWidth') || 1,
+  getLineWidth: f => get(f, 'properties.lineWidth') || 1,
   // Polygon extrusion accessor
   getElevation: f => 1000
 };
@@ -80,13 +84,15 @@ export default class GeoJsonLayer extends CompositeLayer {
   renderLayers() {
     const {features} = this.state;
     const {pointFeatures, lineFeatures, polygonFeatures, polygonOutlineFeatures} = features;
-    const {getColor, getFillColor, getRadius, getWidth, getElevation, updateTriggers} = this.props;
+    const {getLineColor, getFillColor, getRadius,
+      getLineWidth, getElevation, updateTriggers} = this.props;
     const {id, stroked, filled, extruded, wireframe} = this.props;
+    const {lineWidthScale, lineWidthMinPixels, lineWidthMaxPixels,
+      lineJointRounded, lineMiterLimit, fp64} = this.props;
 
-    let {} = this.props;
     const drawPoints = pointFeatures && pointFeatures.length > 0;
     const drawLines = lineFeatures && lineFeatures.length > 0;
-    const hasPolygonOutline = polygonOutlineFeatures && polygonOutlineFeatures.length > 0;
+    const hasPolygonLine = polygonOutlineFeatures && polygonOutlineFeatures.length > 0;
     const hasPolygon = polygonFeatures && polygonFeatures.length > 0;
 
     const onHover = this._onHoverSubLayer.bind(this);
@@ -95,91 +101,106 @@ export default class GeoJsonLayer extends CompositeLayer {
     // Filled Polygon Layer
     const polygonFillLayer = filled &&
       hasPolygon &&
-      new SolidPolygonLayer(Object.assign({}, this.props, {
+      new SolidPolygonLayer({
         id: `${id}-polygon-fill`,
         data: polygonFeatures,
         extruded,
         wireframe: false,
+        fp64,
         getPolygon: getCoordinates,
         getElevation,
         getColor: getFillColor,
+        onHover,
+        onClick,
         updateTriggers: {
           getElevation: updateTriggers.getElevation,
           getColor: updateTriggers.getFillColor
-        },
-        onHover,
-        onClick
-      }));
+        }
+      });
 
     const polygonWireframeLayer = wireframe &&
       extruded &&
       hasPolygon &&
-      new SolidPolygonLayer(Object.assign({}, this.props, {
+      new SolidPolygonLayer({
         id: `${id}-polygon-wireframe`,
         data: polygonFeatures,
         extruded,
         wireframe: true,
+        fp64,
         getPolygon: getCoordinates,
         getElevation,
-        getColor,
+        getColor: getLineColor,
         updateTriggers: {
           getElevation: updateTriggers.getElevation,
-          getColor: updateTriggers.getColor
+          getColor: updateTriggers.getLineColor
         },
         onHover,
         onClick
-      }));
+      });
 
-    const polygonOutlineLayer = !extruded &&
+    const polygonLineLayer = !extruded &&
       stroked &&
-      hasPolygonOutline &&
-      new PathLayer(Object.assign({}, this.props, {
+      hasPolygonLine &&
+      new PathLayer({
         id: `${id}-polygon-outline`,
         data: polygonOutlineFeatures,
+        widthScale: lineWidthScale,
+        widthMinPixels: lineWidthMinPixels,
+        widthMaxPixels: lineWidthMaxPixels,
+        rounded: lineJointRounded,
+        miterLimit: lineMiterLimit,
+        fp64,
         getPath: getCoordinates,
-        getColor,
-        getWidth,
-        updateTriggers: {
-          getColor: updateTriggers.getColor,
-          getWidth: updateTriggers.getWidth
-        },
+        getColor: getLineColor,
+        getWidth: getLineWidth,
         onHover,
-        onClick
-      }));
+        onClick,
+        updateTriggers: {
+          getColor: updateTriggers.getLineColor,
+          getWidth: updateTriggers.getLineWidth
+        }
+      });
 
-    const lineLayer = drawLines && new PathLayer(Object.assign({}, this.props, {
+    const pathLayer = drawLines && new PathLayer({
       id: `${id}-line-paths`,
       data: lineFeatures,
+      widthScale: lineWidthScale,
+      widthMinPixels: lineWidthMinPixels,
+      widthMaxPixels: lineWidthMaxPixels,
+      rounded: lineJointRounded,
+      miterLimit: lineMiterLimit,
+      fp64,
       getPath: getCoordinates,
-      getColor,
-      getWidth,
+      getColor: getLineColor,
+      getWidth: getLineWidth,
       onHover,
       onClick,
       updateTriggers: {
-        getColor: updateTriggers.getColor,
-        getWidth: updateTriggers.getWidth
+        getColor: updateTriggers.getLineColor,
+        getWidth: updateTriggers.getLineWidth
       }
-    }));
+    });
 
-    const pointLayer = drawPoints && new ScatterplotLayer(Object.assign({}, this.props, {
+    const pointLayer = drawPoints && new ScatterplotLayer({
       id: `${id}-points`,
       data: pointFeatures,
+      fp64,
       getPosition: getCoordinates,
       getColor: getFillColor,
       getRadius,
+      onHover,
+      onClick,
       updateTriggers: {
         getColor: updateTriggers.getFillColor,
         getRadius: updateTriggers.getRadius
-      },
-      onHover,
-      onClick
-    }));
+      }
+    });
 
     return [
       polygonFillLayer,
       polygonWireframeLayer,
-      polygonOutlineLayer,
-      lineLayer,
+      polygonLineLayer,
+      pathLayer,
       pointLayer
     ].filter(Boolean);
   }

--- a/src/layers/core/grid-layer/grid-layer.js
+++ b/src/layers/core/grid-layer/grid-layer.js
@@ -37,7 +37,6 @@ const defaultProps = {
   getPosition: x => x.position,
   extruded: false,
   fp64: false
-  // AUDIT - getWeight ?
 };
 
 function noop() {}

--- a/src/layers/core/grid-layer/grid-layer.js
+++ b/src/layers/core/grid-layer/grid-layer.js
@@ -35,6 +35,7 @@ const defaultProps = {
   elevationRange: defaultElevationRange,
   elevationScale: defaultElevationScale,
   getPosition: x => x.position,
+  extruded: false,
   fp64: false
   // AUDIT - getWeight ?
 };
@@ -100,25 +101,26 @@ export default class GridLayer extends Layer {
   }
 
   renderLayers() {
-    const {id} = this.props;
+    const {id, fp64, extruded} = this.props;
 
-    return new GridCellLayer(Object.assign({},
-      this.props, {
-        id: `${id}-density-grid`,
-        data: this.state.layerData,
-        latOffset: this.state.gridOffset.yOffset,
-        lonOffset: this.state.gridOffset.xOffset,
-        getColor: this._onGetSublayerColor.bind(this),
-        getElevation: this._onGetSublayerElevation.bind(this),
-        getPosition: d => d.position,
-        // Override user's onHover and onClick props
-        onHover: this._onHoverSublayer.bind(this),
-        onClick: noop,
-        updateTriggers: {
-          getColor: {colorRange: this.props.colorRange},
-          getElevation: {elevationRange: this.props.elevationRange}
-        }
-      }));
+    return new GridCellLayer({
+      id: `${id}-grid-cell`,
+      data: this.state.layerData,
+      latOffset: this.state.gridOffset.yOffset,
+      lonOffset: this.state.gridOffset.xOffset,
+      extruded,
+      fp64,
+      getColor: this._onGetSublayerColor.bind(this),
+      getElevation: this._onGetSublayerElevation.bind(this),
+      getPosition: d => d.position,
+      // Override user's onHover and onClick props
+      onHover: this._onHoverSublayer.bind(this),
+      onClick: noop,
+      updateTriggers: {
+        getColor: {colorRange: this.props.colorRange},
+        getElevation: {elevationRange: this.props.elevationRange}
+      }
+    });
   }
 }
 

--- a/src/layers/core/hexagon-layer/hexagon-layer.js
+++ b/src/layers/core/hexagon-layer/hexagon-layer.js
@@ -32,6 +32,7 @@ const defaultProps = {
   elevationScale: 1,
   radius: 1000,
   coverage: 1,
+  extruded: false,
   hexagonAggregator: pointToHexbin,
   getPosition: x => x.position,
   fp64: false
@@ -117,24 +118,25 @@ export default class HexagonLayer extends Layer {
   }
 
   renderLayers() {
-    const {id, radius} = this.props;
+    const {id, radius, extruded, fp64} = this.props;
 
-    return new HexagonCellLayer(Object.assign({},
-      this.props, {
-        id: `${id}-density-hexagon`,
-        data: this.state.hexagons,
-        radius,
-        angle: Math.PI,
-        getColor: this._onGetSublayerColor.bind(this),
-        getElevation: this._onGetSublayerElevation.bind(this),
-        // Override user's onHover and onClick props
-        onHover: this._onHoverSublayer.bind(this),
-        onClick: noop,
-        updateTriggers: {
-          getColor: {colorRange: this.props.colorRange},
-          getElevation: {elevationRange: this.props.elevationRange}
-        }
-      }));
+    return new HexagonCellLayer({
+      id: `${id}-hexagon-cell`,
+      data: this.state.hexagons,
+      radius,
+      angle: Math.PI,
+      extruded,
+      fp64,
+      getColor: this._onGetSublayerColor.bind(this),
+      getElevation: this._onGetSublayerElevation.bind(this),
+      // Override user's onHover and onClick props
+      onHover: this._onHoverSublayer.bind(this),
+      onClick: noop,
+      updateTriggers: {
+        getColor: {colorRange: this.props.colorRange},
+        getElevation: {elevationRange: this.props.elevationRange}
+      }
+    });
   }
 }
 

--- a/src/layers/core/path-layer/path-layer.js
+++ b/src/layers/core/path-layer/path-layer.js
@@ -31,7 +31,6 @@ import pathFragment from './path-layer-fragment.glsl';
 const DEFAULT_COLOR = [0, 0, 0, 255];
 
 const defaultProps = {
-  opacity: 1,
   widthScale: 1, // stroke width in meters
   widthMinPixels: 0, //  min stroke width in pixels
   widthMaxPixels: Number.MAX_SAFE_INTEGER, // max stroke width in pixels


### PR DESCRIPTION
Change the interface of GeoJson layer and Polygon layer to clear the confusion
Change the way composite layers pass their props to their underlying layers. Now it requires explicitly passing. Layers affected are the GeoJsonLayer, PolygonLayer, GridLayer, and HexagonLayer.

Docs change will be in an updated #436 

@Pessimistress @ibgreen @gnavvy 