### PR TITLE
Consistently handle picking in composite layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Ref: http://keepachangelog.com/en/0.3.0/
 
 ## Latest Beta Releases
 
+#### [TBD]
+
+- Fix bug where `onHover` and `onClick` props do not work on `GridLayer` and `HexagonLayer`
+- Picking info from `GeoJsonLayer` and `PolygonLayer` now have `layer` property point to the
+  composite layer instead of a sublayer
+
 #### [v4.0.0-rc.3]
 
 - Disable implicit props forwarding between the composite layer and its underlying layers.

--- a/src/layers/core/geojson-layer/geojson-layer.js
+++ b/src/layers/core/geojson-layer/geojson-layer.js
@@ -59,7 +59,9 @@ const getCoordinates = f => get(f, 'geometry.coordinates');
 export default class GeoJsonLayer extends CompositeLayer {
   initializeState() {
     this.state = {
-      features: {}
+      features: {},
+      onHover: this._onPickSubLayer.bind(this, 'onHover'),
+      onClick: this._onPickSubLayer.bind(this, 'onClick')
     };
   }
 
@@ -71,18 +73,18 @@ export default class GeoJsonLayer extends CompositeLayer {
     }
   }
 
-  _onHoverSubLayer(info) {
-    info.object = (info.object && info.object.feature) || info.object;
-    this.props.onHover(info);
-  }
+  _onPickSubLayer(handler, info) {
+    Object.assign(info, {
+      layer: this,
+      // override object with picked feature
+      object: (info.object && info.object.feature) || info.object
+    });
 
-  _onClickSubLayer(info) {
-    info.object = (info.object && info.object.feature) || info.object;
-    this.props.onClick(info);
+    this.props[handler](info);
   }
 
   renderLayers() {
-    const {features} = this.state;
+    const {features, onHover, onClick} = this.state;
     const {pointFeatures, lineFeatures, polygonFeatures, polygonOutlineFeatures} = features;
 
     const {getLineColor, getFillColor, getRadius,
@@ -100,9 +102,6 @@ export default class GeoJsonLayer extends CompositeLayer {
     const drawLines = lineFeatures && lineFeatures.length > 0;
     const hasPolygonLines = polygonOutlineFeatures && polygonOutlineFeatures.length > 0;
     const hasPolygon = polygonFeatures && polygonFeatures.length > 0;
-
-    const onHover = this._onHoverSubLayer.bind(this);
-    const onClick = this._onClickSubLayer.bind(this);
 
     // Filled Polygon Layer
     const polygonFillLayer = filled &&

--- a/src/layers/core/geojson-layer/geojson-layer.js
+++ b/src/layers/core/geojson-layer/geojson-layer.js
@@ -80,7 +80,7 @@ export default class GeoJsonLayer extends CompositeLayer {
       object: (info.object && info.object.feature) || info.object
     });
 
-    this.props[handler](info);
+    return this.props[handler](info);
   }
 
   renderLayers() {

--- a/src/layers/core/grid-layer/grid-layer.js
+++ b/src/layers/core/grid-layer/grid-layer.js
@@ -76,7 +76,7 @@ export default class GridLayer extends Layer {
       object: pickedCell
     });
 
-    this.props[handler](info);
+    return this.props[handler](info);
   }
 
   _onGetSublayerColor(cell) {

--- a/src/layers/core/grid-layer/grid-layer.js
+++ b/src/layers/core/grid-layer/grid-layer.js
@@ -41,8 +41,6 @@ const defaultProps = {
   fp64: false
 };
 
-function noop() {}
-
 function _needsReProjectPoints(oldProps, props) {
   return oldProps.cellSize !== props.cellSize;
 }
@@ -52,8 +50,7 @@ export default class GridLayer extends Layer {
     this.state = {
       gridOffset: {yOffset: 0.0089, xOffset: 0.0113},
       layerData: [],
-      countRange: null,
-      pickedCell: null
+      countRange: null
     };
   }
 
@@ -68,24 +65,18 @@ export default class GridLayer extends Layer {
     }
   }
 
-  getPickingInfo(opts) {
-    const info = super.getPickingInfo(opts);
-    const pickedCell = this.state.pickedCell;
+  _onPickSubLayer(handler, info) {
+    const pickedCell = info.picked && info.index > -1 ?
+      this.state.layerData[info.index] : null;
 
-    return Object.assign(info, {
+    Object.assign(info, {
       layer: this,
-      // override index with cell index
-      index: pickedCell ? pickedCell.index : -1,
       picked: Boolean(pickedCell),
       // override object with picked cell
       object: pickedCell
     });
-  }
 
-  _onHoverSublayer(info) {
-
-    this.state.pickedCell = info.picked && info.index > -1 ?
-      this.state.layerData[info.index] : null;
+    this.props[handler](info);
   }
 
   _onGetSublayerColor(cell) {
@@ -123,8 +114,8 @@ export default class GridLayer extends Layer {
       getElevation: this._onGetSublayerElevation.bind(this),
       getPosition: d => d.position,
       // Override user's onHover and onClick props
-      onHover: this._onHoverSublayer.bind(this),
-      onClick: noop,
+      onHover: this._onPickSubLayer.bind(this, 'onHover'),
+      onClick: this._onPickSubLayer.bind(this, 'onClick'),
       updateTriggers: {
         getColor: {colorRange: this.props.colorRange},
         getElevation: {elevationRange: this.props.elevationRange}

--- a/src/layers/core/hexagon-layer/hexagon-layer.js
+++ b/src/layers/core/hexagon-layer/hexagon-layer.js
@@ -94,7 +94,7 @@ export default class HexagonLayer extends Layer {
       object: pickedCell
     });
 
-    this.props[handler](info);
+    return this.props[handler](info);
   }
 
   _onGetSublayerColor(cell) {

--- a/src/layers/core/hexagon-layer/hexagon-layer.js
+++ b/src/layers/core/hexagon-layer/hexagon-layer.js
@@ -41,8 +41,6 @@ const defaultProps = {
   //
 };
 
-function noop() {}
-
 function _needsReProjectPoints(oldProps, props) {
   return oldProps.radius !== props.radius;
 }
@@ -69,8 +67,7 @@ export default class HexagonLayer extends Layer {
   initializeState() {
     this.state = {
       hexagons: [],
-      countRange: null,
-      pickedCell: null
+      countRange: null
     };
   }
 
@@ -86,24 +83,18 @@ export default class HexagonLayer extends Layer {
     }
   }
 
-  getPickingInfo(opts) {
-    const info = super.getPickingInfo(opts);
-    const pickedCell = this.state.pickedCell;
+  _onPickSubLayer(handler, info) {
+    const pickedCell = info.picked && info.index > -1 ?
+      this.state.hexagons[info.index] : null;
 
-    return Object.assign(info, {
+    Object.assign(info, {
       layer: this,
-      // override index with cell index
-      index: pickedCell ? pickedCell.index : -1,
       picked: Boolean(pickedCell),
       // override object with picked cell
       object: pickedCell
     });
-  }
 
-  _onHoverSublayer(info) {
-
-    this.state.pickedCell = info.picked && info.index > -1 ?
-      this.state.hexagons[info.index] : null;
+    this.props[handler](info);
   }
 
   _onGetSublayerColor(cell) {
@@ -140,8 +131,8 @@ export default class HexagonLayer extends Layer {
       getColor: this._onGetSublayerColor.bind(this),
       getElevation: this._onGetSublayerElevation.bind(this),
       // Override user's onHover and onClick props
-      onHover: this._onHoverSublayer.bind(this),
-      onClick: noop,
+      onHover: this._onPickSubLayer.bind(this, 'onHover'),
+      onClick: this._onPickSubLayer.bind(this, 'onClick'),
       updateTriggers: {
         getColor: {colorRange: this.props.colorRange},
         getElevation: {elevationRange: this.props.elevationRange}

--- a/src/layers/core/polygon-layer/polygon-layer.js
+++ b/src/layers/core/polygon-layer/polygon-layer.js
@@ -77,7 +77,7 @@ export default class PolygonLayer extends CompositeLayer {
     Object.assign(info, {
       layer: this,
       // override object with picked feature
-      object: (info.object && info.object.feature) || info.object
+      object: (info.object && info.object.object) || info.object
     });
 
     return this.props[handler](info);

--- a/src/layers/core/polygon-layer/polygon-layer.js
+++ b/src/layers/core/polygon-layer/polygon-layer.js
@@ -80,7 +80,7 @@ export default class PolygonLayer extends CompositeLayer {
       object: (info.object && info.object.feature) || info.object
     });
 
-    this.props[handler](info);
+    return this.props[handler](info);
   }
 
   renderLayers() {

--- a/src/layers/core/polygon-layer/polygon-layer.js
+++ b/src/layers/core/polygon-layer/polygon-layer.js
@@ -54,8 +54,8 @@ export default class PolygonLayer extends CompositeLayer {
   initializeState() {
     this.state = {
       paths: [],
-      onHover: this._onHoverSubLayer.bind(this),
-      onClick: this._onClickSubLayer.bind(this)
+      onHover: this._onPickSubLayer.bind(this, 'onHover'),
+      onClick: this._onPickSubLayer.bind(this, 'onClick')
     };
   }
 
@@ -73,14 +73,14 @@ export default class PolygonLayer extends CompositeLayer {
     }
   }
 
-  _onHoverSubLayer(info) {
-    info.object = (info.object && info.object.feature) || info.object;
-    this.props.onHover(info);
-  }
+  _onPickSubLayer(handler, info) {
+    Object.assign(info, {
+      layer: this,
+      // override object with picked feature
+      object: (info.object && info.object.feature) || info.object
+    });
 
-  _onClickSubLayer(info) {
-    info.object = (info.object && info.object.feature) || info.object;
-    this.props.onClick(info);
+    this.props[handler](info);
   }
 
   renderLayers() {


### PR DESCRIPTION
- Because composite layers do not render anything themselves, they must manually trigger `onHover` and `onClick` callbacks by listening to sublayer events. This was a bug on `GridLayer` and `HexagonLayer`.
- Hover and click events on composite layers should have `info.layer` point to the composite layer and `info.object` point to user data, instead of sublayer and intermediate data. This was a bug on `GeoJsonLayer` and `PolygonLayer`.