### PR TITLE
Simplify picking inplementation in CompositeLayer

### DIFF
--- a/docs/layer-lifecycle.md
+++ b/docs/layer-lifecycle.md
@@ -78,13 +78,19 @@ and calls `draw` on that model.
 
 The pick method should return an object with optional fields about
 what was picked. This `info` object is then passed to the layer's `onHover`
-or `onPick` callbacks.
+or `onClick` callbacks.
 
 The received `info` argument contains fields `color` as the picked pixel
 and `index` calculated using `layer.decodePickingColor()`.
 
 The default implementation populates the `info` object with an `object` field
 that is indexed from `layer.props.data`.
+
+Composite layers can further augment the `info` object after it is processed
+by the picked sublayer. This allows the composite layer to hide implementation
+details and expose only user-friendly information.
+
+If this method returns `null`, the corresponding event is cancelled.
 
 ### Comparison with React's Lifecycle
 

--- a/src/layers/core/geojson-layer/geojson-layer.js
+++ b/src/layers/core/geojson-layer/geojson-layer.js
@@ -59,9 +59,7 @@ const getCoordinates = f => get(f, 'geometry.coordinates');
 export default class GeoJsonLayer extends CompositeLayer {
   initializeState() {
     this.state = {
-      features: {},
-      onHover: this._onPickSubLayer.bind(this, 'onHover'),
-      onClick: this._onPickSubLayer.bind(this, 'onClick')
+      features: {}
     };
   }
 
@@ -73,18 +71,15 @@ export default class GeoJsonLayer extends CompositeLayer {
     }
   }
 
-  _onPickSubLayer(handler, info) {
-    Object.assign(info, {
-      layer: this,
+  getPickingInfo({info}) {
+    return Object.assign(info, {
       // override object with picked feature
       object: (info.object && info.object.feature) || info.object
     });
-
-    return this.props[handler](info);
   }
 
   renderLayers() {
-    const {features, onHover, onClick} = this.state;
+    const {features} = this.state;
     const {pointFeatures, lineFeatures, polygonFeatures, polygonOutlineFeatures} = features;
 
     const {getLineColor, getFillColor, getRadius,
@@ -119,8 +114,6 @@ export default class GeoJsonLayer extends CompositeLayer {
         getPolygon: getCoordinates,
         getElevation,
         getColor: getFillColor,
-        onHover,
-        onClick,
         updateTriggers: {
           getElevation: updateTriggers.getElevation,
           getColor: updateTriggers.getFillColor
@@ -146,9 +139,7 @@ export default class GeoJsonLayer extends CompositeLayer {
         updateTriggers: {
           getElevation: updateTriggers.getElevation,
           getColor: updateTriggers.getLineColor
-        },
-        onHover,
-        onClick
+        }
       });
 
     const polygonLineLayer = !extruded &&
@@ -170,8 +161,6 @@ export default class GeoJsonLayer extends CompositeLayer {
         getPath: getCoordinates,
         getColor: getLineColor,
         getWidth: getLineWidth,
-        onHover,
-        onClick,
         updateTriggers: {
           getColor: updateTriggers.getLineColor,
           getWidth: updateTriggers.getLineWidth
@@ -194,8 +183,6 @@ export default class GeoJsonLayer extends CompositeLayer {
       getPath: getCoordinates,
       getColor: getLineColor,
       getWidth: getLineWidth,
-      onHover,
-      onClick,
       updateTriggers: {
         getColor: updateTriggers.getLineColor,
         getWidth: updateTriggers.getLineWidth
@@ -213,8 +200,6 @@ export default class GeoJsonLayer extends CompositeLayer {
       getPosition: getCoordinates,
       getColor: getFillColor,
       getRadius,
-      onHover,
-      onClick,
       updateTriggers: {
         getColor: updateTriggers.getFillColor,
         getRadius: updateTriggers.getRadius

--- a/src/layers/core/grid-layer/grid-layer.js
+++ b/src/layers/core/grid-layer/grid-layer.js
@@ -65,18 +65,15 @@ export default class GridLayer extends Layer {
     }
   }
 
-  _onPickSubLayer(handler, info) {
+  getPickingInfo({info}) {
     const pickedCell = info.picked && info.index > -1 ?
       this.state.layerData[info.index] : null;
 
-    Object.assign(info, {
-      layer: this,
+    return Object.assign(info, {
       picked: Boolean(pickedCell),
       // override object with picked cell
       object: pickedCell
     });
-
-    return this.props[handler](info);
   }
 
   _onGetSublayerColor(cell) {
@@ -113,9 +110,6 @@ export default class GridLayer extends Layer {
       getColor: this._onGetSublayerColor.bind(this),
       getElevation: this._onGetSublayerElevation.bind(this),
       getPosition: d => d.position,
-      // Override user's onHover and onClick props
-      onHover: this._onPickSubLayer.bind(this, 'onHover'),
-      onClick: this._onPickSubLayer.bind(this, 'onClick'),
       updateTriggers: {
         getColor: {colorRange: this.props.colorRange},
         getElevation: {elevationRange: this.props.elevationRange}

--- a/src/layers/core/hexagon-layer/hexagon-layer.js
+++ b/src/layers/core/hexagon-layer/hexagon-layer.js
@@ -83,18 +83,15 @@ export default class HexagonLayer extends Layer {
     }
   }
 
-  _onPickSubLayer(handler, info) {
+  getPickingInfo({info}) {
     const pickedCell = info.picked && info.index > -1 ?
       this.state.hexagons[info.index] : null;
 
-    Object.assign(info, {
-      layer: this,
+    return Object.assign(info, {
       picked: Boolean(pickedCell),
       // override object with picked cell
       object: pickedCell
     });
-
-    return this.props[handler](info);
   }
 
   _onGetSublayerColor(cell) {
@@ -130,9 +127,6 @@ export default class HexagonLayer extends Layer {
       projectionMode,
       getColor: this._onGetSublayerColor.bind(this),
       getElevation: this._onGetSublayerElevation.bind(this),
-      // Override user's onHover and onClick props
-      onHover: this._onPickSubLayer.bind(this, 'onHover'),
-      onClick: this._onPickSubLayer.bind(this, 'onClick'),
       updateTriggers: {
         getColor: {colorRange: this.props.colorRange},
         getElevation: {elevationRange: this.props.elevationRange}

--- a/src/layers/core/polygon-layer/polygon-layer.js
+++ b/src/layers/core/polygon-layer/polygon-layer.js
@@ -53,9 +53,7 @@ const defaultProps = {
 export default class PolygonLayer extends CompositeLayer {
   initializeState() {
     this.state = {
-      paths: [],
-      onHover: this._onPickSubLayer.bind(this, 'onHover'),
-      onClick: this._onPickSubLayer.bind(this, 'onClick')
+      paths: []
     };
   }
 
@@ -73,14 +71,11 @@ export default class PolygonLayer extends CompositeLayer {
     }
   }
 
-  _onPickSubLayer(handler, info) {
-    Object.assign(info, {
-      layer: this,
-      // override object with picked feature
+  getPickingInfo({info}) {
+    return Object.assign(info, {
+      // override object with picked data
       object: (info.object && info.object.object) || info.object
     });
-
-    return this.props[handler](info);
   }
 
   renderLayers() {
@@ -91,7 +86,7 @@ export default class PolygonLayer extends CompositeLayer {
       lineJointRounded, lineMiterLimit, fp64} = this.props;
     // base layer props
     const {opacity, pickable, visible, projectionMode} = this.props;
-    const {paths, onHover, onClick} = this.state;
+    const {paths} = this.state;
 
     const hasData = data && data.length > 0;
 
@@ -109,8 +104,6 @@ export default class PolygonLayer extends CompositeLayer {
       getPolygon,
       getElevation,
       getColor: getFillColor,
-      onHover,
-      onClick,
       updateTriggers: {
         getElevation: updateTriggers.getElevation,
         getColor: updateTriggers.getFillColor
@@ -133,8 +126,6 @@ export default class PolygonLayer extends CompositeLayer {
         getPolygon,
         getElevation,
         getColor: getLineColor,
-        onHover,
-        onClick,
         updateTriggers: {
           getElevation: updateTriggers.getElevation,
           getColor: updateTriggers.getLineColor
@@ -161,8 +152,6 @@ export default class PolygonLayer extends CompositeLayer {
         getPath: x => x.path,
         getColor: getLineColor,
         getWidth: getLineWidth,
-        onHover,
-        onClick,
         updateTriggers: {
           getWidth: updateTriggers.getLineWidth,
           getColor: updateTriggers.getLineColor

--- a/src/lib/composite-layer.js
+++ b/src/lib/composite-layer.js
@@ -15,6 +15,10 @@ export default class CompositeLayer extends Layer {
   invalidateAttribute() {
   }
 
+  // called to augment the info object that is bubbled up from a sublayer
+  // override Layer.getPickingInfo() because decoding / setting uniform do
+  // not apply to a composite layer.
+  // @return null to cancel event
   getPickingInfo({info}) {
     return info;
   }

--- a/src/lib/composite-layer.js
+++ b/src/lib/composite-layer.js
@@ -15,8 +15,7 @@ export default class CompositeLayer extends Layer {
   invalidateAttribute() {
   }
 
-  getPickingInfo(opts) {
-    // do not call onHover/onClick on the container
-    return null;
+  getPickingInfo({info}) {
+    return info;
   }
 }

--- a/src/lib/draw-and-pick.js
+++ b/src/lib/draw-and-pick.js
@@ -136,7 +136,6 @@ export function pickLayers(gl, {
 
     affectedLayers.forEach(layer => {
       let info = Object.assign({}, baseInfo);
-      info.layer = layer;
 
       if (layer === pickedLayer) {
         info.color = pickedColor;
@@ -144,8 +143,15 @@ export function pickLayers(gl, {
         info.picked = true;
       }
 
-      // Let layers populate its own info object
-      info = layer.pickLayer({info, mode});
+      // walk up the composite chain and find the owner of the event
+      // sublayers are never directly exposed to the user
+      while (layer) {
+        // Let layers populate its own info object
+        info = layer.pickLayer({info, mode});
+        info.layer = layer;
+        layer = layer.parentLayer;
+      }
+      layer = info.layer;
 
       // If layer.getPickingInfo() returns null, do not proceed
       if (info) {

--- a/src/lib/draw-and-pick.js
+++ b/src/lib/draw-and-pick.js
@@ -145,13 +145,12 @@ export function pickLayers(gl, {
 
       // walk up the composite chain and find the owner of the event
       // sublayers are never directly exposed to the user
-      while (layer) {
+      while (layer && info) {
+        info.layer = layer;
         // Let layers populate its own info object
         info = layer.pickLayer({info, mode});
-        info.layer = layer;
         layer = layer.parentLayer;
       }
-      layer = info.layer;
 
       // If layer.getPickingInfo() returns null, do not proceed
       if (info) {
@@ -160,8 +159,8 @@ export function pickLayers(gl, {
         // Calling callbacks can have async interactions with React
         // which nullifies layer.state.
         switch (mode) {
-        case 'click': handled = layer.props.onClick(info); break;
-        case 'hover': handled = layer.props.onHover(info); break;
+        case 'click': handled = info.layer.props.onClick(info); break;
+        case 'hover': handled = info.layer.props.onHover(info); break;
         default: throw new Error('unknown pick type');
         }
 

--- a/src/lib/layer-manager.js
+++ b/src/lib/layer-manager.js
@@ -228,6 +228,12 @@ export default class LayerManager {
 
         if (sublayers) {
           sublayers = Array.isArray(sublayers) ? sublayers : [sublayers];
+
+          // populate reference to parent layer
+          sublayers.forEach(layer => {
+            layer.parentLayer = newLayer;
+          });
+
           this._matchSublayers({
             newLayers: sublayers,
             oldLayerMap,

--- a/src/lib/layer.js
+++ b/src/lib/layer.js
@@ -66,6 +66,7 @@ export default class Layer {
     this.oldProps = null;
     this.state = null;
     this.context = null;
+    this.parentLayer = null;
     this.count = counter++;
     Object.seal(this);
   }


### PR DESCRIPTION
- add `parentLayer` reference to sublayers
- `pickLayers()` only trigger callbacks on top level layers
- remove the requirement for `onHover` and `onClick` overrides
- use consistent interface (`getPickingInfo`) with the `Layer` class