### PR TITLE
When the iconMapping changes we must invalid any dependent attributes

### DIFF
--- a/src/layers/core/icon-layer/icon-layer.js
+++ b/src/layers/core/icon-layer/icon-layer.js
@@ -107,7 +107,14 @@ export default class IconLayer extends Layer {
   updateState({oldProps, props, changeFlags}) {
     super.updateState({props, oldProps, changeFlags});
 
-    const {iconAtlas} = props;
+    const {iconAtlas, iconMapping} = props;
+
+    if (oldProps.iconMapping !== iconMapping) {
+      const {attributeManager} = this.state;
+      attributeManager.invalidate('instanceOffsets');
+      attributeManager.invalidate('instanceIconFrames');
+      attributeManager.invalidate('instanceColorModes');
+    }
 
     if (oldProps.iconAtlas !== iconAtlas) {
       const icons = {};


### PR DESCRIPTION
This is a thin PR.  I don't see any existing tests for the icon layer.  So I will add one and test the call to accessors when the state changes.
