### PR TITLE
Use Uint8ClampedArray for both extruded and non-extruded polygon colors

### DIFF
--- a/src/layers/core/solid-polygon-layer/polygon-tesselator.js
+++ b/src/layers/core/solid-polygon-layer/polygon-tesselator.js
@@ -211,7 +211,7 @@ function calculateNormals({polygons, pointCount}) {
 }
 
 function calculateColors({polygons, pointCount, getColor}) {
-  const attribute = new Uint8Array(pointCount * 4);
+  const attribute = new Uint8ClampedArray(pointCount * 4);
   let i = 0;
   polygons.forEach((complexPolygon, polygonIndex) => {
     // Calculate polygon color
@@ -226,7 +226,7 @@ function calculateColors({polygons, pointCount, getColor}) {
 }
 
 function calculatePickingColors({polygons, pointCount}) {
-  const attribute = new Uint8Array(pointCount * 3);
+  const attribute = new Uint8ClampedArray(pointCount * 3);
   let i = 0;
   polygons.forEach((complexPolygon, polygonIndex) => {
     const color = getPickingColor(polygonIndex);


### PR DESCRIPTION
@Pessimistress 

So, the root cause here is that extruded and non-extruded polygon tessellator use different typed arrays to store color. 

Now, both of them are using Uint8ClampedArray now. The color in the polygon layer demo is out of [0, 255] so now both extruded and non-extruded render a single yellow color now - we need to fix that instead.