### PR TITLE
explicit import instead of import from '.'

### DIFF
--- a/src/lib/utils/fp64.js
+++ b/src/lib/utils/fp64.js
@@ -1,6 +1,6 @@
 // TODO - move to shaderlib utilities
-import {log} from '.';
-import {COORDINATE_SYSTEM} from '..';
+import log from './log';
+import {COORDINATE_SYSTEM} from '../constants';
 
 export function fp64ify(a) {
   const hiPart = Math.fround(a);


### PR DESCRIPTION
CI (Jenkins) tools complains about module '.'

module.js:340
    throw err;
    ^
Error: Cannot find module '.'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    **at Object.<anonymous> (.../deck.gl/dist/lib/utils/fp64.js:9:9)**