### PR TITLE
Remove BitmapLayer and MeshLayer from layer browser. 

### DIFF
--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -38,8 +38,13 @@ class App extends PureComponent {
       activeExamples: {},
       settings: {
         // immutable: false,
+        // Effects are experimental for now. Will be enabled in the future
         // effects: false,
         separation: 0
+        // the rotation controls works only for layers in
+        // meter offset projection mode. They are commented out
+        // here since layer browser currently only have one layer
+        // in this mode.
         // rotationZ: 0,
         // rotationX: 0
       },

--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -38,10 +38,10 @@ class App extends PureComponent {
       activeExamples: {},
       settings: {
         // immutable: false,
-        effects: false,
-        separation: 0,
-        rotationZ: 0,
-        rotationX: 0
+        // effects: false,
+        separation: 0
+        // rotationZ: 0,
+        // rotationX: 0
       },
       hoveredItem: null,
       clickedItem: null

--- a/examples/layer-browser/src/examples/sample-layers.js
+++ b/examples/layer-browser/src/examples/sample-layers.js
@@ -30,6 +30,8 @@ const EnhancedChoroplethLayerExample = {
   }
 };
 
+// BitmapLayer and MeshLayer examples are current commented out
+// They going to be added in the future.
 // import BitmapLayer from '../../../sample-layers/bitmap-layer/bitmap-layer';
 
 // const BitmapLayerExample = {
@@ -68,6 +70,8 @@ export default {
   'Sample Layers': {
     'S2Layer': S2LayerExample,
     'EnhancedChoroplethLayer': EnhancedChoroplethLayerExample,
+    // BitmapLayer and MeshLayer examples are current commented out
+    // They going to be added in the future.
     // 'BitmapLayer': BitmapLayerExample,
     // 'MeshLayer': MeshLayerExample,
     'LabelLayer': LabelLayerExample

--- a/examples/layer-browser/src/examples/sample-layers.js
+++ b/examples/layer-browser/src/examples/sample-layers.js
@@ -30,23 +30,23 @@ const EnhancedChoroplethLayerExample = {
   }
 };
 
-import BitmapLayer from '../../../sample-layers/bitmap-layer/bitmap-layer';
+// import BitmapLayer from '../../../sample-layers/bitmap-layer/bitmap-layer';
 
-const BitmapLayerExample = {
-  layer: BitmapLayer,
-  props: {
-    data: []
-  }
-};
+// const BitmapLayerExample = {
+//   layer: BitmapLayer,
+//   props: {
+//     data: []
+//   }
+// };
 
-import MeshLayer from '../../../sample-layers/mesh-layer/mesh-layer';
+// import MeshLayer from '../../../sample-layers/mesh-layer/mesh-layer';
 
-const MeshLayerExample = {
-  layer: MeshLayer,
-  props: {
-    data: []
-  }
-};
+// const MeshLayerExample = {
+//   layer: MeshLayer,
+//   props: {
+//     data: []
+//   }
+// };
 
 import LabelLayer from '../../../sample-layers/label-layer/label-layer';
 
@@ -67,11 +67,9 @@ const LabelLayerExample = {
 export default {
   'Sample Layers': {
     'S2Layer': S2LayerExample,
-
     'EnhancedChoroplethLayer': EnhancedChoroplethLayerExample,
-
-    'BitmapLayer': BitmapLayerExample,
-    'MeshLayer': MeshLayerExample,
+    // 'BitmapLayer': BitmapLayerExample,
+    // 'MeshLayer': MeshLayerExample,
     'LabelLayer': LabelLayerExample
   }
 };


### PR DESCRIPTION
Also remove RotationX, RotationZ and effect controls from the layer browser. The only layer in the layer browser that responds to RotationX and RotationZ is the point cloud layer due to projection mode settings. It makes those controls seem like broken while they are not. So I decide to remove them to clear the confusions.

I commented out most of the lines instead of removing them. 