### PR TITLE
Make composite layers transfer the lightSettings prop

### DIFF
--- a/src/layers/core/geojson-layer/geojson-layer.js
+++ b/src/layers/core/geojson-layer/geojson-layer.js
@@ -83,7 +83,7 @@ export default class GeoJsonLayer extends CompositeLayer {
     const {pointFeatures, lineFeatures, polygonFeatures, polygonOutlineFeatures} = features;
 
     // Layer composition props
-    const {id, stroked, filled, extruded, wireframe} = this.props;
+    const {id, stroked, filled, extruded, wireframe, lightSettings} = this.props;
 
     // Rendering props underlying layer
     const {lineWidthScale, lineWidthMinPixels, lineWidthMaxPixels,
@@ -112,6 +112,7 @@ export default class GeoJsonLayer extends CompositeLayer {
         data: polygonFeatures,
         extruded,
         wireframe: false,
+        lightSettings,
         fp64,
         opacity,
         pickable,

--- a/src/layers/core/grid-layer/grid-layer.js
+++ b/src/layers/core/grid-layer/grid-layer.js
@@ -89,7 +89,7 @@ export default class GridLayer extends Layer {
   }
 
   renderLayers() {
-    const {id, elevationScale, fp64, extruded, cellSize} = this.props;
+    const {id, elevationScale, fp64, extruded, cellSize, lightSettings} = this.props;
 
     // base layer props
     const {opacity, pickable, visible} = this.props;
@@ -101,6 +101,7 @@ export default class GridLayer extends Layer {
       id: `${id}-grid-cell`,
       data: this.state.layerData,
       cellSize,
+      lightSettings,
       elevationScale,
       extruded,
       fp64,

--- a/src/layers/core/hexagon-layer/hexagon-layer.js
+++ b/src/layers/core/hexagon-layer/hexagon-layer.js
@@ -159,7 +159,7 @@ export default class HexagonLayer extends Layer {
   }
 
   renderLayers() {
-    const {id, radius, elevationScale, extruded, coverage, fp64} = this.props;
+    const {id, radius, elevationScale, extruded, coverage, lightSettings, fp64} = this.props;
 
     // base layer props
     const {opacity, pickable, visible} = this.props;
@@ -175,6 +175,7 @@ export default class HexagonLayer extends Layer {
       angle: Math.PI,
       extruded,
       coverage,
+      lightSettings,
       fp64,
       opacity,
       pickable,


### PR DESCRIPTION
to its underlying layer

It slipped through because it's not one of the props defined in base layer's default props...