### PR TITLE
Point cloud layer example fix for the layer browser

### DIFF
--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -151,16 +151,24 @@ class App extends PureComponent {
   /* eslint-enable max-depth */
 
   _getModelMatrix(index, offsetMode) {
+    // the rotation controls works only for layers in
+    // meter offset projection mode. They are commented out
+    // here since layer browser currently only have one layer
+    // in this mode.
+
     // const {settings: {separation, rotationZ, rotationX}} = this.state;
     const {settings: {separation}} = this.state;
     // const {mapViewState: {longitude, latitude}} = this.props;
     // const modelMatrix = new Matrix4().fromTranslation([0, 0, 1000 * index * separation]);
+
     const modelMatrix = new Matrix4()
       .fromTranslation([0, 0, 1000 * index * separation]);
+
     // if (offsetMode) {
     //   modelMatrix.rotateZ(index * rotationZ * Math.PI);
     //   modelMatrix.rotateX(index * rotationX * Math.PI);
     // }
+
     return modelMatrix;
   }
 

--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -151,15 +151,16 @@ class App extends PureComponent {
   /* eslint-enable max-depth */
 
   _getModelMatrix(index, offsetMode) {
-    const {settings: {separation, rotationZ, rotationX}} = this.state;
+    // const {settings: {separation, rotationZ, rotationX}} = this.state;
+    const {settings: {separation}} = this.state;
     // const {mapViewState: {longitude, latitude}} = this.props;
     // const modelMatrix = new Matrix4().fromTranslation([0, 0, 1000 * index * separation]);
     const modelMatrix = new Matrix4()
       .fromTranslation([0, 0, 1000 * index * separation]);
-    if (offsetMode) {
-      modelMatrix.rotateZ(index * rotationZ * Math.PI);
-      modelMatrix.rotateX(index * rotationX * Math.PI);
-    }
+    // if (offsetMode) {
+    //   modelMatrix.rotateZ(index * rotationZ * Math.PI);
+    //   modelMatrix.rotateX(index * rotationX * Math.PI);
+    // }
     return modelMatrix;
   }
 


### PR DESCRIPTION
Comment out modelMatrix.rotateZ and modelMatrix.rotateX for the point cloud layer in the layer browser as we removed those controls in a previous commit