### PR TITLE
Attribute loggers

### DIFF
--- a/docs/api-reference/attribute-manager.md
+++ b/docs/api-reference/attribute-manager.md
@@ -13,6 +13,22 @@ Limitations:
   There are currently no provisions for only invalidating a range of
   indices in an attribute.
 
+## Static Functions
+
+### AttributeManager.setDefaultLogFunctions (static)
+
+Sets log functions to help trace or time attribute updates.
+Default logging uses the luma.gl logger.
+
+Note that the app may not be in control of when update is called,
+so hooks are provided for update start and end.
+
+* opts (Object) - named parameters
+* opts.onLog (Function) - callback, called to print
+* opts.onUpdateStart= (Function) - callback, called before update() starts
+* opts.onUpdateEnd= (Function) - callback, called after update() ends
+
+
 ## Methods
 
 ### Constructor
@@ -42,16 +58,3 @@ Takes a map of attribute descriptor objects
         update: calculateColors
       }
     });
-
-### AttributeManager.setLogFunctions
-
-Sets log functions to help trace or time attribute updates.
-Default logging uses the luma.gl logger.
-
-Note that the app may not be in control of when update is called,
-so hooks are provided for update start and end.
-
-* opts (Object) - named parameters
-* opts.onLog (Function) - callback, called to print
-* opts.onUpdateStart= (Function) - callback, called before update() starts
-* opts.onUpdateEnd= (Function) - callback, called after update() ends

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -47,6 +47,19 @@ are using older layers, they need a small addition to their attribute
 definitions, see below.
 
 
+### AttributeManager
+
+* Removed method: `AttributeManager.addDynamic`
+
+This method has been deprecated since version 2.5 and is now removed, use
+`AttributeManager.add()` instead
+
+* Removed method: `AttributeManager.setLogFunctions`
+
+Use the new static function `AttributeManager.setDefaultLogFunctions` to set
+loggers for all layers.
+
+
 ### Deprecated/Removed Layers
 
 | Layer            | Status       | Replacement         |

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -24,18 +24,27 @@ import DeckGL from 'deck.gl/react';
 | ScreenGridLayer  | `unitWidth`    | `cellSizePixels` | |
 | ScreenGridLayer  | `unitHeight`   | `cellSizePixels` | | |
 
-#### `Layer.dataIterator` prop (Removed)
+#### Removed prop: `Layer.dataIterator`
 
 This prop has been removed in deck.gl v4. Note that it was not functioning
 as documented in deck.gl v3.
 
-#### Props with `Scale` suffix
+#### Removed lifecycle method: `Layer.willReceiveProps`
+
+This lifecycle was deprecated in v3 and is now removed. Use `Layer.updateState`
+instead.
+
+
+#### Renamed Props: The `...Scale` suffix
 
 Props that have their name end of `Scale` is a set of props that
-multiply some existing value for all objects in the layers. These props usually correspond
-to WebGL shader uniforms that "scaling" all values of specific attributes simultaneously.
+multiply some existing value for all objects in the layers.
+These props usually correspond to WebGL shader uniforms that "scaling" all
+values of specific attributes simultaneously.
 
-For API consistency reasons these have all been renamed with the suffix `..Scale`
+For API consistency reasons these have all been renamed with the suffix `..Scale`.
+See the property table above.
+
 
 #### updateTriggers
 
@@ -47,17 +56,17 @@ are using older layers, they need a small addition to their attribute
 definitions, see below.
 
 
-### AttributeManager
+### AttributeManager changes
 
-* Removed method: `AttributeManager.addDynamic`
+#### Removed method: `AttributeManager.setLogFunctions`
+
+Use the new static function `AttributeManager.setDefaultLogFunctions` to set
+loggers for all AttributeManagers (i.e. for all layers).
+
+#### Removed method: `AttributeManager.addDynamic`
 
 This method has been deprecated since version 2.5 and is now removed, use
 `AttributeManager.add()` instead
-
-* Removed method: `AttributeManager.setLogFunctions`
-
-Use the new static function `AttributeManager.setDefaultLogFunctions` to set
-loggers for all layers.
 
 
 ### Deprecated/Removed Layers

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -139,10 +139,15 @@ since deck.gl v3.0 was launched. While many are not new in v4.0, cumulatively
 they enable noticeably better framerates and a lighter footprint when big data
 sets are loaded, compared to the initial v3.0.0 version.
 
-The `AttributeManager` now has default timing of attribute updates that can be
-activated by setting `deck.log.priority` in the console. The new function
-`AttributeManager.setDefaultLogFunctions` allows the app to install its own
-loggers to provide detailed statistics for attribute updates.
+The `AttributeManager` class now supports default logging of timings for attribute
+updates. This logging can be activated by simply setting `deck.log.priority=2`
+in the console (levels 1 and 2 provide different amounts of detail).
+This can be very helpful in verifying that your application is not triggering
+unnecessary attribute updates.
+
+In addition, the new function `AttributeManager.setDefaultLogFunctions` allows
+the app to install its own custom logging functions to take even more control
+over logging of attribute updates.
 
 
 ## Library Improvements

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -137,7 +137,12 @@ object. Layers can block the execution of callback functions by returning `null`
 A number of performance improvements and fixes have been gradually introduced
 since deck.gl v3.0 was launched. While many are not new in v4.0, cumulatively
 they enable noticeably better framerates and a lighter footprint when big data
-sets are loaded, compared to the initial v3.0.0 version
+sets are loaded, compared to the initial v3.0.0 version.
+
+The `AttributeManager` now has default timing of attribute updates that can be
+activated by setting `deck.log.priority` in the console. The new function
+`AttributeManager.setDefaultLogFunctions` allows the app to install its own
+loggers to provide detailed statistics for attribute updates.
 
 
 ## Library Improvements

--- a/examples/trips/trips-layer/trips-layer.js
+++ b/examples/trips/trips-layer/trips-layer.js
@@ -20,7 +20,7 @@ export default class TripsLayer extends Layer {
 
     const model = this.getModel(gl);
 
-    attributeManager.addDynamic({
+    attributeManager.add({
       indices: {size: 1, update: this.calculateIndices, isIndexed: true},
       positions: {size: 3, update: this.calculatePositions},
       colors: {size: 3, update: this.calculateColors}

--- a/src/layers/deprecated/choropleth-layer-64/choropleth-layer-64.js
+++ b/src/layers/deprecated/choropleth-layer-64/choropleth-layer-64.js
@@ -34,7 +34,7 @@ export default class ChoroplethLayer64 extends ChoroplethLayer {
   initializeState() {
     super.initializeState();
 
-    this.state.attributeManager.addDynamic({
+    this.state.attributeManager.add({
       positions64: {size: 4, update: this.calculatePositions64},
       heights64: {size: 2, update: this.calculateHeights64}
     });

--- a/src/layers/deprecated/choropleth-layer/choropleth-layer.js
+++ b/src/layers/deprecated/choropleth-layer/choropleth-layer.js
@@ -54,7 +54,7 @@ export default class ChoroplethLayer extends Layer {
     const {gl} = this.context;
 
     const {attributeManager} = this.state;
-    attributeManager.addDynamic({
+    attributeManager.add({
       // Primtive attributes
       indices: {size: 1, update: this.calculateIndices, isIndexed: true},
       positions: {size: 3, update: this.calculatePositions},

--- a/src/lib/attribute-manager.js
+++ b/src/lib/attribute-manager.js
@@ -3,8 +3,8 @@ import {GL} from 'luma.gl';
 import {log} from './utils';
 import assert from 'assert';
 
-const LOG_START_END_PRIORITY = 2;
-const LOG_DETAIL_PRIORITY = 3;
+const LOG_START_END_PRIORITY = 1;
+const LOG_DETAIL_PRIORITY = 2;
 
 function noop() {}
 
@@ -38,13 +38,12 @@ export function glArrayFromType(glType, {clamped = true} = {}) {
 // Default loggers
 const logFunctions = {
   onUpdateStart: ({level, id}) => {
-    log.log(level, `Updated attributes for ${id}`);
     log.time(level, `Updated attributes for ${id}`);
   },
-  onLog: ({level, label}) => {
-    log.log(level, label);
+  onLog: ({level, message}) => {
+    log.log(level, message);
   },
-  onUpdateEnd: ({level, label, id}) => {
+  onUpdateEnd: ({level, id}) => {
     log.timeEnd(level, `Updated attributes for ${id}`);
   }
 };

--- a/src/lib/attribute-manager.js
+++ b/src/lib/attribute-manager.js
@@ -3,6 +3,9 @@ import {GL} from 'luma.gl';
 import {log} from './utils';
 import assert from 'assert';
 
+const LOG_START_END_PRIORITY = 2;
+const LOG_DETAIL_PRIORITY = 3;
+
 function noop() {}
 
 /* eslint-disable complexity */
@@ -32,7 +35,51 @@ export function glArrayFromType(glType, {clamped = true} = {}) {
 }
 /* eslint-enable complexity */
 
+// Default loggers
+const logFunctions = {
+  onUpdateStart: ({level, id}) => {
+    log.log(level, `Updated attributes for ${id}`);
+    log.time(level, `Updated attributes for ${id}`);
+  },
+  onLog: ({level, label}) => {
+    log.log(level, label);
+  },
+  onUpdateEnd: ({level, label, id}) => {
+    log.timeEnd(level, `Updated attributes for ${id}`);
+  }
+};
+
 export default class AttributeManager {
+  /**
+   * Sets log functions to help trace or time attribute updates.
+   * Default logging uses deck logger.
+   *
+   * `onLog` is called for each attribute.
+   *
+   * To enable detailed control of timming and e.g. hierarchical logging,
+   * hooks are also provided for update start and end.
+   *
+   * @param {Object} [opts]
+   * @param {String} [opts.onLog=] - called to print
+   * @param {String} [opts.onUpdateStart=] - called before update() starts
+   * @param {String} [opts.onUpdateEnd=] - called after update() ends
+   */
+  static setDefaultLogFunctions({
+    onLog,
+    onUpdateStart,
+    onUpdateEnd
+  } = {}) {
+    if (onLog !== undefined) {
+      logFunctions.onLog = onLog || noop;
+    }
+    if (onUpdateStart !== undefined) {
+      logFunctions.onUpdateStart = onUpdateStart || noop;
+    }
+    if (onUpdateEnd !== undefined) {
+      logFunctions.onUpdateEnd = onUpdateEnd || noop;
+    }
+  }
+
   /**
    * @classdesc
    * Automated attribute generation and management. Suitable when a set of
@@ -77,10 +124,6 @@ export default class AttributeManager {
     this.allocedInstances = -1;
     this.needsRedraw = true;
     this.userData = {};
-
-    this.onUpdateStart = noop;
-    this.onUpdateEnd = noop;
-    this.onLog = this._defaultLog;
 
     // For debugging sanity, prevent uninitialized members
     Object.seal(this);
@@ -149,7 +192,11 @@ export default class AttributeManager {
       }
     });
     // For performance tuning
-    this.onLog(1, `invalidated attribute ${attributesToUpdate} for ${this.id}`);
+    logFunctions.onLog({
+      level: LOG_DETAIL_PRIORITY,
+      message: `invalidated attribute ${attributesToUpdate} for ${this.id}`,
+      id: this.identifier
+    });
   }
 
   invalidateAll() {
@@ -187,34 +234,10 @@ export default class AttributeManager {
 
     // Only initiate alloc/update (and logging) if actually needed
     if (this._analyzeBuffers({numInstances})) {
-      this.onUpdateStart(this.id);
+      logFunctions.onUpdateStart({level: LOG_START_END_PRIORITY, id: this.id});
       this._updateBuffers({numInstances, data, props, context});
-      this.onUpdateEnd(this.id);
+      logFunctions.onUpdateEnd({level: LOG_START_END_PRIORITY, id: this.id});
     }
-  }
-
-  /**
-   * Sets log functions to help trace or time attribute updates.
-   * Default logging uses luma logger.
-   *
-   * Note that the app may not be in control of when update is called,
-   * so hooks are provided for update start and end.
-   *
-   * @param {Object} [opts]
-   * @param {String} [opts.onLog=] - called to print
-   * @param {String} [opts.onUpdateStart=] - called before update() starts
-   * @param {String} [opts.onUpdateEnd=] - called after update() ends
-   */
-  setLogFunctions({
-    onLog,
-    onUpdateStart,
-    onUpdateEnd
-  } = {}) {
-    this.onLog = onLog !== undefined ? onLog : this.onLog;
-    this.onUpdateStart =
-      onUpdateStart !== undefined ? onUpdateStart : this.onUpdateStart;
-    this.onUpdateEnd =
-      onUpdateEnd !== undefined ? onUpdateEnd : this.onUpdateEnd;
   }
 
   /**
@@ -278,26 +301,11 @@ export default class AttributeManager {
    * @param {Object} attributes - attribute map (see above)
    * @param {Object} updaters - separate map of update functions (deprecated)
    */
-  addDynamic(attributes, updaters = {}) {
-    this._add(attributes, updaters);
-  }
-
-  /**
-   * @deprecated since version 2.5, use add() instead
-   * Adds attributes
-   * @param {Object} attributes - attribute map (see above)
-   * @param {Object} updaters - separate map of update functions (deprecated)
-   */
   addInstanced(attributes, updaters = {}) {
     this._add(attributes, updaters, {instanced: 1});
   }
 
   // PRIVATE METHODS
-
-  // Default logger
-  _defaultLog(level, message) {
-    log.log(level, message);
-  }
 
   // Used to register an attribute
   _add(attributes, updaters = {}, _extraProps = {}) {
@@ -505,7 +513,11 @@ export default class AttributeManager {
       if (attribute.needsAlloc) {
         const ArrayType = glArrayFromType(attribute.type || GL.FLOAT);
         attribute.value = new ArrayType(attribute.size * allocCount);
-        this.onLog(2, `${this.id}:${attributeName} allocated ${allocCount}`);
+        logFunctions.onLog({
+          level: LOG_DETAIL_PRIORITY,
+          message: `${this.id}:${attributeName} allocated ${allocCount}`,
+          id: this.id
+        });
         attribute.needsAlloc = false;
         attribute.needsUpdate = true;
       }
@@ -523,7 +535,11 @@ export default class AttributeManager {
     const {update, accessor} = attribute;
     if (update) {
       // Custom updater - typically for non-instanced layers
-      this.onLog(2, `${this.id}:${attributeName} updating ${numInstances}`);
+      logFunctions.onLog({
+        level: LOG_DETAIL_PRIORITY,
+        message: `${this.id}:${attributeName} updating ${numInstances}`,
+        id: this.id
+      });
       update.call(context, attribute, {data, props, numInstances});
       this._checkAttributeArray(attribute, attributeName);
     } else if (accessor) {
@@ -531,7 +547,11 @@ export default class AttributeManager {
       this._updateBufferViaStandardAccessor({attribute, data, props});
       this._checkAttributeArray(attribute, attributeName);
     } else {
-      this.onLog(2, `${this.id}:${attributeName} missing update function`);
+      logFunctions.onLog({
+        level: LOG_DETAIL_PRIORITY,
+        message: `${this.id}:${attributeName} missing update function`,
+        id: this.id
+      });
     }
 
     attribute.needsUpdate = false;

--- a/src/lib/draw-and-pick.js
+++ b/src/lib/draw-and-pick.js
@@ -7,7 +7,7 @@ const EMPTY_PIXEL = new Uint8Array(4);
 let renderCount = 0;
 
 export function drawLayers({layers, pass}) {
-  log.log(2, `DRAWING ${layers.length} layers`);
+  log.log(3, `DRAWING ${layers.length} layers`);
 
   // render layers in normal colors
   let visibleCount = 0;
@@ -26,7 +26,7 @@ export function drawLayers({layers, pass}) {
     }
   });
 
-  log.log(1, `RENDER PASS ${pass}: ${renderCount++}
+  log.log(3, `RENDER PASS ${pass}: ${renderCount++}
     ${visibleCount} visible, ${layers.length} total`);
 }
 

--- a/src/lib/layer-manager.js
+++ b/src/lib/layer-manager.js
@@ -35,6 +35,9 @@ import {Viewport} from './viewports';
 
 import {FramebufferObject} from 'luma.gl';
 
+const LOG_PRIORITY_LIFECYCLE = 2;
+const LOG_PRIORITY_LIFECYCLE_MINOR = 3;
+
 export default class LayerManager {
   constructor({gl}) {
     this.prevLayers = [];
@@ -214,7 +217,8 @@ export default class LayerManager {
         // Only transfer state at this stage. We must not generate exceptions
         // until all layers' state have been transferred
         if (oldLayer) {
-          log(3, `matched ${layerName(newLayer)}`, oldLayer, '=>', newLayer);
+          log(LOG_PRIORITY_LIFECYCLE_MINOR,
+            `matched ${layerName(newLayer)}`, oldLayer, '=>', newLayer);
           this._transferLayerState(oldLayer, newLayer);
           this._updateLayer(newLayer);
         } else {
@@ -289,7 +293,7 @@ export default class LayerManager {
     let error = null;
     // Check if new layer, and initialize it's state
     if (!layer.state) {
-      log(1, `initializing ${layerName(layer)}`);
+      log(LOG_PRIORITY_LIFECYCLE, `initializing ${layerName(layer)}`);
       try {
         layer.initializeLayer({
           oldProps: {},
@@ -335,7 +339,7 @@ export default class LayerManager {
         // Save first error
         error = err;
       }
-      log(2, `updating ${layerName(layer)}`);
+      log(LOG_PRIORITY_LIFECYCLE_MINOR, `updating ${layerName(layer)}`);
     }
     return error;
   }
@@ -355,7 +359,7 @@ export default class LayerManager {
       }
       // layer.state = null;
       layer.lifecycle = 'Finalized! Awaiting garbage collection';
-      log(1, `finalizing ${layerName(layer)}`);
+      log(LOG_PRIORITY_LIFECYCLE, `finalizing ${layerName(layer)}`);
     }
     return error;
   }

--- a/src/lib/layer.js
+++ b/src/lib/layer.js
@@ -334,9 +334,6 @@ export default class Layer {
       dataChanged: true
     });
 
-    // Add attribute manager loggers if provided
-    this.state.attributeManager.setLogFunctions(this.props);
-
     const {attributeManager} = this.state;
     // All instanced layers get instancePickingColors attribute by default
     // Their shaders can use it to render a picking scene

--- a/src/lib/layer.js
+++ b/src/lib/layer.js
@@ -24,6 +24,8 @@ import {log, compareProps, count} from './utils';
 import {GL} from 'luma.gl';
 import assert from 'assert';
 
+const LOG_PRIORITY_UPDATE = 2;
+
 /*
  * @param {string} props.id - layer name
  * @param {array}  props.data - array of data instances
@@ -377,22 +379,6 @@ export default class Layer {
     // End lifecycle method
 
     if (stateNeedsUpdate) {
-
-      // Call deprecated lifecycle method if defined
-      const hasRedefinedMethod = this.willReceiveProps &&
-        this.willReceiveProps !== Layer.prototype.willReceiveProps;
-      if (hasRedefinedMethod) {
-        log.once(0, `deck.gl v3 willReceiveProps deprecated. Use updateState in ${this}`);
-        const {oldProps, props, changeFlags} = updateParams;
-        this.setState(changeFlags);
-        this.willReceiveProps(oldProps, props, changeFlags);
-        this.setState({
-          dataChanged: false,
-          viewportChanged: false
-        });
-      }
-      // End lifecycle method
-
       // Call subclass lifecycle method
       this.updateState(updateParams);
       // End lifecycle method
@@ -451,7 +437,7 @@ export default class Layer {
     if (!dataChanged) {
       this._diffUpdateTriggers(oldProps, newProps);
     } else {
-      log.log(1, `dataChanged: ${dataChanged}`);
+      log.log(2, `dataChanged: ${dataChanged}`);
     }
 
     return {
@@ -520,11 +506,13 @@ export default class Layer {
       });
       if (diffReason) {
         if (propName === 'all') {
-          log.log(1, `updateTriggers invalidating all attributes: ${diffReason}`);
+          log.log(LOG_PRIORITY_UPDATE,
+            `updateTriggers invalidating all attributes: ${diffReason}`);
           this.invalidateAttribute('all');
           change = true;
         } else {
-          log.log(1, `updateTriggers invalidating attribute ${propName}: ${diffReason}`);
+          log.log(LOG_PRIORITY_UPDATE,
+            `updateTriggers invalidating attribute ${propName}: ${diffReason}`);
           this.invalidateAttribute(propName);
           change = true;
         }
@@ -566,10 +554,6 @@ export default class Layer {
   }
 
   // DEPRECATED METHODS
-  // shouldUpdate() {}
-
-  willReceiveProps() {
-  }
 
   // Updates selected state members and marks the object for redraw
   setUniforms(uniformMap) {

--- a/src/lib/utils/log.js
+++ b/src/lib/utils/log.js
@@ -2,10 +2,10 @@
 /* global console */
 import assert from 'assert';
 
-export default function log(priority, ...args) {
+function log(priority, ...args) {
   assert(Number.isFinite(priority), 'log priority must be a number');
   if (priority <= log.priority) {
-    // Node doesn't have console.debug, but looks better in browser consoles
+    // Node doesn't have console.debug, but using it looks better in browser consoles
     if (console.debug) {
       console.debug(...args);
     } else {
@@ -23,6 +23,35 @@ function once(priority, arg, ...args) {
   }
 }
 
+// Logs a message with a time
+function time(priority, label) {
+  assert(Number.isFinite(priority), 'log priority must be a number');
+  if (priority <= log.priority) {
+    // In case the platform doesn't have console.time
+    if (console.time) {
+      console.time(label);
+    } else {
+      console.info(label);
+    }
+  }
+}
+
+function timeEnd(priority, label) {
+  assert(Number.isFinite(priority), 'log priority must be a number');
+  if (priority <= log.priority) {
+    // In case the platform doesn't have console.timeEnd
+    if (console.timeEnd) {
+      console.timeEnd(label);
+    } else {
+      console.info(label);
+    }
+  }
+}
+
 log.priority = 0;
 log.log = log;
 log.once = once;
+log.time = time;
+log.timeEnd = timeEnd;
+
+export default log;

--- a/test/lib/attribute-manager.spec.js
+++ b/test/lib/attribute-manager.spec.js
@@ -17,14 +17,21 @@ const fixture = {
   positions: new Float32Array([0, 1, 0, -1, -1, 0, 1, -1, 0])
 };
 
-test('Core#AttributeManager constructor', t => {
+test('AttributeManager imports', t => {
+  t.equals(typeof AttributeManager, 'function', 'AttributeManager import successful');
+  t.ok(AttributeManager.setDefaultLogFunctions,
+    'AttributeManager.setDefaultLogFunctions available');
+  t.end();
+});
+
+test('AttributeManager constructor', t => {
   const attributeManager = new AttributeManager();
 
   t.ok(attributeManager, 'AttributeManager construction successful');
   t.end();
 });
 
-test('Core#AttributeManager.add', t => {
+test('AttributeManager.add', t => {
   const attributeManager = new AttributeManager();
 
   t.throws(
@@ -46,7 +53,7 @@ test('Core#AttributeManager.add', t => {
   t.end();
 });
 
-test('Core#AttributeManager.update', t => {
+test('AttributeManager.update', t => {
   const attributeManager = new AttributeManager();
   attributeManager.add({positions: {size: 2, update}});
 
@@ -90,7 +97,7 @@ test('Core#AttributeManager.update', t => {
   t.end();
 });
 
-test('Core#AttributeManager.update - 0 numInstances', t => {
+test('AttributeManager.update - 0 numInstances', t => {
   const attributeManager = new AttributeManager();
   attributeManager.add({positions: {size: 2, update}});
 
@@ -106,7 +113,7 @@ test('Core#AttributeManager.update - 0 numInstances', t => {
   t.end();
 });
 
-test('Core#AttributeManager.invalidate', t => {
+test('AttributeManager.invalidate', t => {
   const attributeManager = new AttributeManager();
   attributeManager.add({positions: {size: 2, update}});
   attributeManager.add({colors: {size: 2, accessor: 'getColor', update}});
@@ -128,5 +135,38 @@ test('Core#AttributeManager.invalidate', t => {
     'throws on unmatched attribute name'
   );
 
+  t.end();
+});
+
+test('AttributeManager.setDefaultLogFunctions', t => {
+  // track which updaters were called
+  const updaterCalled = {};
+  AttributeManager.setDefaultLogFunctions({
+    onUpdateStart: () => {
+      updaterCalled.start = true;
+    },
+    onLog: () => {
+      updaterCalled.log = true;
+    },
+    onUpdateEnd: () => {
+      updaterCalled.end = true;
+    }
+  });
+
+  const attributeManager = new AttributeManager();
+  attributeManager.add({positions: {size: 2, update}});
+
+  // First update, should autoalloc and update the value array
+  attributeManager.update({
+    numInstances: 1,
+    data: [{}]
+  });
+
+  const attribute = attributeManager.getAttributes()['positions'];
+  t.ok(ArrayBuffer.isView(attribute.value), 'logged attribute has typed array');
+
+  t.ok(updaterCalled.start, 'onUpdateStart called');
+  t.ok(updaterCalled.log, 'onLog called');
+  t.ok(updaterCalled.end, 'onUpdateEnd called');
   t.end();
 });


### PR DESCRIPTION
Attribute logging was broken for a couple of reasons. Most importantly layers no longer pass through props so it was not possible to set logging functions using props on composite layers.

Changed to a set of global loggers for all attribute managers (layers).

Gave these loggers nice defaults that collect timings for attribute updates when `deck.log.priority = 1` or higher (see screenshot).

Carefully went through docs and upgrade guide. Added new test coverage for the logging functionality.

Overhauled chaotic logging priorities to reduce noise in console and defined priority constants for various log items.

Found a couple of things that were deprecated in v3, removed them and updated the "Upgrade guide:

<img width="579" alt="screen shot 2017-03-29 at 4 03 49 pm" src="https://cloud.githubusercontent.com/assets/7025232/24480481/6fc87138-1499-11e7-9f66-5bc627823f59.png">
