### PR TITLE
Remove destructuring from examples webpack configs so they run in Nod…

### DIFF
--- a/examples/3d-heatmap/webpack.config.js
+++ b/examples/3d-heatmap/webpack.config.js
@@ -1,3 +1,7 @@
+// NOTE: To use this example standalone (e.g. outside of deck.gl repo)
+// delete the local development overrides at the bottom of this file
+
+// avoid destructuring for older Node version support
 const resolve = require('path').resolve;
 const webpack = require('webpack');
 

--- a/examples/3d-heatmap/webpack.config.js
+++ b/examples/3d-heatmap/webpack.config.js
@@ -1,4 +1,4 @@
-const {resolve} = require('path');
+const resolve = require('path').resolve;
 const webpack = require('webpack');
 
 module.exports = {

--- a/examples/arc/webpack.config.js
+++ b/examples/arc/webpack.config.js
@@ -1,3 +1,7 @@
+// NOTE: To use this example standalone (e.g. outside of deck.gl repo)
+// delete the local development overrides at the bottom of this file
+
+// avoid destructuring for older Node version support
 const resolve = require('path').resolve;
 const webpack = require('webpack');
 

--- a/examples/arc/webpack.config.js
+++ b/examples/arc/webpack.config.js
@@ -1,4 +1,4 @@
-const {resolve} = require('path');
+const resolve = require('path').resolve;
 const webpack = require('webpack');
 
 module.exports = {

--- a/examples/geojson/webpack.config.js
+++ b/examples/geojson/webpack.config.js
@@ -1,3 +1,7 @@
+// NOTE: To use this example standalone (e.g. outside of deck.gl repo)
+// delete the local development overrides at the bottom of this file
+
+// avoid destructuring for older Node version support
 const resolve = require('path').resolve;
 const webpack = require('webpack');
 

--- a/examples/geojson/webpack.config.js
+++ b/examples/geojson/webpack.config.js
@@ -1,4 +1,4 @@
-const {resolve} = require('path');
+const resolve = require('path').resolve;
 const webpack = require('webpack');
 
 module.exports = {

--- a/examples/hello-world-webpack2/webpack.config.js
+++ b/examples/hello-world-webpack2/webpack.config.js
@@ -1,3 +1,7 @@
+// NOTE: To use this example standalone (e.g. outside of deck.gl repo)
+// delete the local development overrides at the bottom of this file
+
+// avoid destructuring for older Node version support
 const resolve = require('path').resolve;
 const webpack = require('webpack');
 

--- a/examples/hello-world-webpack2/webpack.config.js
+++ b/examples/hello-world-webpack2/webpack.config.js
@@ -1,4 +1,4 @@
-const {resolve} = require('path');
+const resolve = require('path').resolve;
 const webpack = require('webpack');
 
 module.exports = {

--- a/examples/icon/webpack.config.js
+++ b/examples/icon/webpack.config.js
@@ -1,3 +1,7 @@
+// NOTE: To use this example standalone (e.g. outside of deck.gl repo)
+// delete the local development overrides at the bottom of this file
+
+// avoid destructuring for older Node version support
 const resolve = require('path').resolve;
 const webpack = require('webpack');
 

--- a/examples/icon/webpack.config.js
+++ b/examples/icon/webpack.config.js
@@ -1,4 +1,4 @@
-const {resolve} = require('path');
+const resolve = require('path').resolve;
 const webpack = require('webpack');
 
 module.exports = {

--- a/examples/jsx-layers/webpack.config.js
+++ b/examples/jsx-layers/webpack.config.js
@@ -1,3 +1,7 @@
+// NOTE: To use this example standalone (e.g. outside of deck.gl repo)
+// delete the local development overrides at the bottom of this file
+
+// avoid destructuring for older Node version support
 const resolve = require('path').resolve;
 const webpack = require('webpack');
 

--- a/examples/jsx-layers/webpack.config.js
+++ b/examples/jsx-layers/webpack.config.js
@@ -1,4 +1,4 @@
-const {resolve} = require('path');
+const resolve = require('path').resolve;
 const webpack = require('webpack');
 
 module.exports = {

--- a/examples/layer-browser/webpack.config.js
+++ b/examples/layer-browser/webpack.config.js
@@ -1,6 +1,6 @@
 // NOTE: To use this example standalone (e.g. outside of deck.gl repo)
 // delete the local development overrides at the bottom of this file
-const {resolve} = require('path');
+const resolve = require('path').resolve;
 const webpack = require('webpack');
 
 module.exports = {

--- a/examples/layer-browser/webpack.config.js
+++ b/examples/layer-browser/webpack.config.js
@@ -1,5 +1,7 @@
 // NOTE: To use this example standalone (e.g. outside of deck.gl repo)
 // delete the local development overrides at the bottom of this file
+
+// avoid destructuring for older Node version support
 const resolve = require('path').resolve;
 const webpack = require('webpack');
 

--- a/examples/line/webpack.config.js
+++ b/examples/line/webpack.config.js
@@ -1,3 +1,7 @@
+// NOTE: To use this example standalone (e.g. outside of deck.gl repo)
+// delete the local development overrides at the bottom of this file
+
+// avoid destructuring for older Node version support
 const resolve = require('path').resolve;
 const webpack = require('webpack');
 

--- a/examples/line/webpack.config.js
+++ b/examples/line/webpack.config.js
@@ -1,4 +1,4 @@
-const {resolve} = require('path');
+const resolve = require('path').resolve;
 const webpack = require('webpack');
 
 module.exports = {

--- a/examples/plot/webpack.config.js
+++ b/examples/plot/webpack.config.js
@@ -1,3 +1,7 @@
+// NOTE: To use this example standalone (e.g. outside of deck.gl repo)
+// delete the local development overrides at the bottom of this file
+
+// avoid destructuring for older Node version support
 const resolve = require('path').resolve;
 const webpack = require('webpack');
 

--- a/examples/plot/webpack.config.js
+++ b/examples/plot/webpack.config.js
@@ -1,4 +1,4 @@
-const {resolve} = require('path');
+const resolve = require('path').resolve;
 const webpack = require('webpack');
 
 module.exports = {

--- a/examples/scatterplot/webpack.config.js
+++ b/examples/scatterplot/webpack.config.js
@@ -1,3 +1,7 @@
+// NOTE: To use this example standalone (e.g. outside of deck.gl repo)
+// delete the local development overrides at the bottom of this file
+
+// avoid destructuring for older Node version support
 const resolve = require('path').resolve;
 const webpack = require('webpack');
 

--- a/examples/scatterplot/webpack.config.js
+++ b/examples/scatterplot/webpack.config.js
@@ -1,4 +1,4 @@
-const {resolve} = require('path');
+const resolve = require('path').resolve;
 const webpack = require('webpack');
 
 module.exports = {

--- a/examples/screen-grid/webpack.config.js
+++ b/examples/screen-grid/webpack.config.js
@@ -1,3 +1,7 @@
+// NOTE: To use this example standalone (e.g. outside of deck.gl repo)
+// delete the local development overrides at the bottom of this file
+
+// avoid destructuring for older Node version support
 const resolve = require('path').resolve;
 const webpack = require('webpack');
 

--- a/examples/screen-grid/webpack.config.js
+++ b/examples/screen-grid/webpack.config.js
@@ -1,4 +1,4 @@
-const {resolve} = require('path');
+const resolve = require('path').resolve;
 const webpack = require('webpack');
 
 module.exports = {

--- a/examples/svg-interoperability/webpack.config.js
+++ b/examples/svg-interoperability/webpack.config.js
@@ -1,3 +1,7 @@
+// NOTE: To use this example standalone (e.g. outside of deck.gl repo)
+// delete the local development overrides at the bottom of this file
+
+// avoid destructuring for older Node version support
 const resolve = require('path').resolve;
 const webpack = require('webpack');
 

--- a/examples/svg-interoperability/webpack.config.js
+++ b/examples/svg-interoperability/webpack.config.js
@@ -1,4 +1,4 @@
-const {resolve} = require('path');
+const resolve = require('path').resolve;
 const webpack = require('webpack');
 
 module.exports = {

--- a/examples/tree-shaking/webpack.config.js
+++ b/examples/tree-shaking/webpack.config.js
@@ -1,3 +1,4 @@
+// avoid destructuring for older Node version support
 const resolve = require('path').resolve;
 const webpack = require('webpack');
 

--- a/examples/tree-shaking/webpack.config.js
+++ b/examples/tree-shaking/webpack.config.js
@@ -1,4 +1,4 @@
-const {resolve} = require('path');
+const resolve = require('path').resolve;
 const webpack = require('webpack');
 
 const CONFIG = {

--- a/examples/trips/webpack.config.js
+++ b/examples/trips/webpack.config.js
@@ -1,3 +1,7 @@
+// NOTE: To use this example standalone (e.g. outside of deck.gl repo)
+// delete the local development overrides at the bottom of this file
+
+// avoid destructuring for older Node version support
 const resolve = require('path').resolve;
 const webpack = require('webpack');
 

--- a/examples/trips/webpack.config.js
+++ b/examples/trips/webpack.config.js
@@ -1,4 +1,4 @@
-const {resolve} = require('path');
+const resolve = require('path').resolve;
 const webpack = require('webpack');
 
 module.exports = {

--- a/examples/webpack.config.local.js
+++ b/examples/webpack.config.local.js
@@ -5,7 +5,7 @@
 // This enables using the examples to debug the main deck.gl library source
 // without publishing or npm linking, with conveniences such hot reloading etc.
 
-const {resolve} = require('path');
+const resolve = require('path').resolve;
 const webpack = require('webpack');
 
 const LIB_DIR = resolve(__dirname, '..');

--- a/examples/webpack.config.local.js
+++ b/examples/webpack.config.local.js
@@ -5,6 +5,7 @@
 // This enables using the examples to debug the main deck.gl library source
 // without publishing or npm linking, with conveniences such hot reloading etc.
 
+// avoid destructuring for older Node version support
 const resolve = require('path').resolve;
 const webpack = require('webpack');
 


### PR DESCRIPTION
…e < 6.

Per discussion [here](https://github.com/uber/deck.gl/issues/505#issuecomment-290460139).