### PR TITLE
Add on-screen warning when no Mapbox token exists.

### DIFF
--- a/examples/layer-browser/app.css
+++ b/examples/layer-browser/app.css
@@ -22,6 +22,17 @@ h4 {
   pointer-events: none;
 }
 
+#no-token-warning {
+	position: absolute;
+	left: 50%;
+	top: 50%;
+	transform: translate(-50%, -50%);
+	padding: 20px;
+	max-width: 240px;
+	text-align: center;
+	background: rgba(255, 255, 255, 0.5);
+}
+
 #control-panel {
 	position: fixed;
 	z-index: 9;

--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -35,7 +35,9 @@ class App extends PureComponent {
         pitch: 30,
         bearing: 0
       },
-      activeExamples: {},
+      activeExamples: {
+        ScatterplotLayer: true
+      },
       settings: {
         // immutable: false,
         // Effects are experimental for now. Will be enabled in the future
@@ -176,7 +178,7 @@ class App extends PureComponent {
     const {width, height, mapViewState, settings: {effects}} = this.state;
     return (
       <MapboxGLMap
-        mapboxApiAccessToken={MAPBOX_ACCESS_TOKEN}
+        mapboxApiAccessToken={MAPBOX_ACCESS_TOKEN || 'no_token'}
         width={width} height={height}
         perspectiveEnabled
         { ...mapViewState }
@@ -199,12 +201,24 @@ class App extends PureComponent {
     );
   }
 
+  _renderNoTokenWarning() {
+    /* eslint-disable max-len */
+    return (
+      <div id="no-token-warning">
+        <h3>No Mapbox access token found.</h3>
+        Read <a href="http://uber.github.io/deck.gl/#/documentation/overview/getting-started#note-on-map-tokens-">"Note on Map Tokens"</a> for information on setting up your basemap.
+      </div>
+    );
+    /* eslint-disable max-len */
+  }
+
   render() {
     const {settings, activeExamples, hoveredItem, clickedItem} = this.state;
 
     return (
       <div>
         { this._renderMap() }
+        { !MAPBOX_ACCESS_TOKEN && this._renderNoTokenWarning() }
         <div id="control-panel">
           <LayerControls
             title="Composite Settings"


### PR DESCRIPTION
Also turn on ScatterplotLayer by default; without anything visible on the map, the example feels unfinished IMO. (Especially when there's no basemap visible.) But open to disagreement on that.

Supercedes #509, which had an errant commit from another branch.