### PR TITLE
Fix meter offset mode

### DIFF
--- a/src/lib/viewport-uniforms.js
+++ b/src/lib/viewport-uniforms.js
@@ -64,7 +64,7 @@ function calculateMatrixAndOffset({
     projectionCenter = viewProjectionMatrix
       .transformVector([positionPixels[0], positionPixels[1], 0.0, 1.0]);
 
-    // Always apply uncentered projection matrix (shader adds center)
+    // Always apply uncentered projection matrix if available (shader adds center)
     modelViewMatrix = new Matrix4(viewMatrixUncentered || viewMatrix)
       // Zero out 4th coordinate ("after" model matrix) - avoids further translations
       .multiplyRight(VECTOR_TO_POINT_MATRIX);

--- a/src/lib/viewport-uniforms.js
+++ b/src/lib/viewport-uniforms.js
@@ -65,7 +65,7 @@ function calculateMatrixAndOffset({
       .transformVector([positionPixels[0], positionPixels[1], 0.0, 1.0]);
 
     // Always apply uncentered projection matrix (shader adds center)
-    modelViewMatrix = new Matrix4(viewMatrixUncentered)
+    modelViewMatrix = new Matrix4(viewMatrixUncentered || viewMatrix)
       // Zero out 4th coordinate ("after" model matrix) - avoids further translations
       .multiplyRight(VECTOR_TO_POINT_MATRIX);
     break;

--- a/src/lib/viewports/web-mercator-viewport.js
+++ b/src/lib/viewports/web-mercator-viewport.js
@@ -119,6 +119,10 @@ export default class WebMercatorViewport extends Viewport {
       farZMultiplier
     });
 
+    // The uncentered matrix allows us two move the center addition to the
+    // shader (cheap) which gives a coordinate system that has its center in
+    // the layer's center position. This makes rotations and other modelMatrx
+    // transforms much more useful.
     const viewMatrixUncentered = makeUncenteredViewMatrixFromMercatorParams({
       width,
       height,
@@ -131,6 +135,7 @@ export default class WebMercatorViewport extends Viewport {
       distanceScales
     });
 
+    // Make a centered version of the matrix for projection modes without an offset
     const center = projectFlat([longitude, latitude], scale);
 
     const viewMatrix = mat4.translate(


### PR DESCRIPTION
Meter offset mode was broken in #519.

This fix should let us finally close #291 

Point Cloud Layer (in Layer Browser) before and after the fix

<img width="397" alt="screen shot 2017-04-03 at 9 07 28 am" src="https://cloud.githubusercontent.com/assets/7025232/24618786/025092d6-184d-11e7-9438-0866d5560b58.png">

<img width="438" alt="screen shot 2017-04-03 at 9 06 47 am" src="https://cloud.githubusercontent.com/assets/7025232/24618789/04933080-184d-11e7-8add-d84ca4c903fb.png">
