### PR TITLE
Change the relative path to absolute path

### DIFF
--- a/demo/webpack/prod.js
+++ b/demo/webpack/prod.js
@@ -1,5 +1,5 @@
 const config = require('./config');
-
+const path = require('path');
 // transpile mapbox-gl utils imported by react-map-gl@2
 // these files are ES6 and break UglifyJS
 config.module.rules.push({
@@ -10,7 +10,7 @@ config.module.rules.push({
 module.exports = Object.assign(config, {
 
   output: {
-    path: __dirname + '/dist',
+    path: path.resolve(__dirname, 'dist'),
     filename: 'bundle.js'
   }
 

--- a/demo/webpack/prod.js
+++ b/demo/webpack/prod.js
@@ -10,7 +10,7 @@ config.module.rules.push({
 module.exports = Object.assign(config, {
 
   output: {
-    path: './dist',
+    path: __dirname + '/dist',
     filename: 'bundle.js'
   }
 


### PR DESCRIPTION
in the webpack build script in the demo folder. Webpack 2.3.0 and above no longer handles relative path for build

@Pessimistress @ibgreen