### PR TITLE
Shader workaround for Intel Iris Pro GPU

### DIFF
--- a/docs/advanced/subclassed-layers.md
+++ b/docs/advanced/subclassed-layers.md
@@ -204,7 +204,8 @@ void main(void) {
   gl_Position = project_to_clipspace(position_worldspace) + vec4(vertex, 0.0, 0.0);
 
   // Apply lighting
-  float lightWeight = getLightWeight(position_worldspace.xyz / position_worldspace.w, instanceNormals);
+  float lightWeight = getLightWeight(position_worldspace.xyz, // the w component is always 1.0
+    instanceNormals);
 
   // Apply opacity to instance color, or return instance picking color
   vColor = vec4(lightWeight * instanceColors.rgb, instanceColors.a * opacity) / 255.;

--- a/docs/advanced/subclassed-layers.md
+++ b/docs/advanced/subclassed-layers.md
@@ -204,7 +204,7 @@ void main(void) {
   gl_Position = project_to_clipspace(position_worldspace) + vec4(vertex, 0.0, 0.0);
 
   // Apply lighting
-  float lightWeight = getLightWeight(position_worldspace, instanceNormals);
+  float lightWeight = getLightWeight(position_worldspace.xyz / position_worldspace.w, instanceNormals);
 
   // Apply opacity to instance color, or return instance picking color
   vColor = vec4(lightWeight * instanceColors.rgb, instanceColors.a * opacity) / 255.;

--- a/src/layers/core/grid-cell-layer/grid-cell-layer-vertex-64.glsl.js
+++ b/src/layers/core/grid-cell-layer/grid-cell-layer-vertex-64.glsl.js
@@ -99,7 +99,7 @@ void main(void) {
 
     if (extruded > 0.5) {
       lightWeight = getLightWeight(
-        position_worldspace.xyz / position_worldspace.w,
+        position_worldspace.xyz, // the w component is always 1.0
         normals
       );
     }

--- a/src/layers/core/grid-cell-layer/grid-cell-layer-vertex.glsl.js
+++ b/src/layers/core/grid-cell-layer/grid-cell-layer-vertex.glsl.js
@@ -21,7 +21,7 @@
 // Inspired by screen-grid-layer vertex shader in deck.gl
 
 export default `\
-#define SHADER_NAME grid-layer-vs
+#define SHADER_NAME grid-cell-layer-vs
 
 attribute vec3 positions;
 attribute vec3 normals;
@@ -84,7 +84,7 @@ void main(void) {
 
     if (extruded > 0.5) {
       lightWeight = getLightWeight(
-        position_worldspace,
+        position_worldspace.xyz / position_worldspace.w,
         normals
       );
     }

--- a/src/layers/core/grid-cell-layer/grid-cell-layer-vertex.glsl.js
+++ b/src/layers/core/grid-cell-layer/grid-cell-layer-vertex.glsl.js
@@ -84,7 +84,7 @@ void main(void) {
 
     if (extruded > 0.5) {
       lightWeight = getLightWeight(
-        position_worldspace.xyz / position_worldspace.w,
+        position_worldspace.xyz, // the w component is always 1.0
         normals
       );
     }

--- a/src/layers/core/hexagon-cell-layer/hexagon-cell-layer-vertex-64.glsl.js
+++ b/src/layers/core/hexagon-cell-layer/hexagon-cell-layer-vertex-64.glsl.js
@@ -115,7 +115,7 @@ void main(void) {
 
     if (extruded > 0.5) {
       lightWeight = getLightWeight(
-        position_worldspace.xyz / position_worldspace.w,
+        position_worldspace.xyz, // the w component is always 1.0
         normals_worldspace
       );
     }

--- a/src/layers/core/hexagon-cell-layer/hexagon-cell-layer-vertex-64.glsl.js
+++ b/src/layers/core/hexagon-cell-layer/hexagon-cell-layer-vertex-64.glsl.js
@@ -115,7 +115,7 @@ void main(void) {
 
     if (extruded > 0.5) {
       lightWeight = getLightWeight(
-        position_worldspace,
+        position_worldspace.xyz / position_worldspace.w,
         normals_worldspace
       );
     }

--- a/src/layers/core/hexagon-cell-layer/hexagon-cell-layer-vertex.glsl.js
+++ b/src/layers/core/hexagon-cell-layer/hexagon-cell-layer-vertex.glsl.js
@@ -100,7 +100,7 @@ void main(void) {
 
     if (extruded > 0.5) {
       lightWeight = getLightWeight(
-        position_worldspace,
+        position_worldspace.xyz / position_worldspace.w,
         normals_worldspace
       );
     }

--- a/src/layers/core/hexagon-cell-layer/hexagon-cell-layer-vertex.glsl.js
+++ b/src/layers/core/hexagon-cell-layer/hexagon-cell-layer-vertex.glsl.js
@@ -100,7 +100,7 @@ void main(void) {
 
     if (extruded > 0.5) {
       lightWeight = getLightWeight(
-        position_worldspace.xyz / position_worldspace.w,
+        position_worldspace.xyz, // the w component is always 1.0
         normals_worldspace
       );
     }

--- a/src/layers/core/point-cloud-layer/point-cloud-layer-vertex-64.glsl.js
+++ b/src/layers/core/point-cloud-layer/point-cloud-layer-vertex-64.glsl.js
@@ -68,7 +68,7 @@ void main(void) {
     vColor = vec4(instancePickingColors / 255., 1.);
   } else {
     // Apply lighting
-    float lightWeight = getLightWeight(position_worldspace.xyz / position_worldspace.w,
+    float lightWeight = getLightWeight(position_worldspace.xyz, // the w component is always 1.0
       instanceNormals);
 
     // Apply opacity to instance color, or return instance picking color

--- a/src/layers/core/point-cloud-layer/point-cloud-layer-vertex-64.glsl.js
+++ b/src/layers/core/point-cloud-layer/point-cloud-layer-vertex-64.glsl.js
@@ -68,7 +68,8 @@ void main(void) {
     vColor = vec4(instancePickingColors / 255., 1.);
   } else {
     // Apply lighting
-    float lightWeight = getLightWeight(position_worldspace, instanceNormals);
+    float lightWeight = getLightWeight(position_worldspace.xyz / position_worldspace.w,
+      instanceNormals);
 
     // Apply opacity to instance color, or return instance picking color
     vColor = vec4(lightWeight * instanceColors.rgb, instanceColors.a * opacity) / 255.;

--- a/src/layers/core/point-cloud-layer/point-cloud-layer-vertex.glsl.js
+++ b/src/layers/core/point-cloud-layer/point-cloud-layer-vertex.glsl.js
@@ -46,7 +46,7 @@ void main(void) {
   gl_Position = project_to_clipspace(position_worldspace) + vec4(vertex, 0.0, 0.0);
 
   // Apply lighting
-  float lightWeight = getLightWeight(position_worldspace.xyz / position_worldspace.w,
+  float lightWeight = getLightWeight(position_worldspace.xyz, // the w component is always 1.0
     instanceNormals);
 
   // Apply opacity to instance color, or return instance picking color

--- a/src/layers/core/point-cloud-layer/point-cloud-layer-vertex.glsl.js
+++ b/src/layers/core/point-cloud-layer/point-cloud-layer-vertex.glsl.js
@@ -46,7 +46,8 @@ void main(void) {
   gl_Position = project_to_clipspace(position_worldspace) + vec4(vertex, 0.0, 0.0);
 
   // Apply lighting
-  float lightWeight = getLightWeight(position_worldspace, instanceNormals);
+  float lightWeight = getLightWeight(position_worldspace.xyz / position_worldspace.w,
+    instanceNormals);
 
   // Apply opacity to instance color, or return instance picking color
   vec4 color = vec4(lightWeight * instanceColors.rgb, instanceColors.a * opacity) / 255.;

--- a/src/layers/core/solid-polygon-layer/solid-polygon-layer-vertex-64.glsl.js
+++ b/src/layers/core/solid-polygon-layer/solid-polygon-layer-vertex-64.glsl.js
@@ -60,7 +60,7 @@ void main(void) {
 
     if (extruded > 0.5) {
       lightWeight = getLightWeight(
-        position_worldspace,
+        position_worldspace.xyz / position_worldspace.w,
         normals
       );
     }

--- a/src/layers/core/solid-polygon-layer/solid-polygon-layer-vertex-64.glsl.js
+++ b/src/layers/core/solid-polygon-layer/solid-polygon-layer-vertex-64.glsl.js
@@ -60,7 +60,7 @@ void main(void) {
 
     if (extruded > 0.5) {
       lightWeight = getLightWeight(
-        position_worldspace.xyz / position_worldspace.w,
+        position_worldspace.xyz, // the w component is always 1.0
         normals
       );
     }

--- a/src/layers/core/solid-polygon-layer/solid-polygon-layer-vertex.glsl.js
+++ b/src/layers/core/solid-polygon-layer/solid-polygon-layer-vertex.glsl.js
@@ -44,8 +44,16 @@ void main(void) {
     float lightWeight = 1.0;
 
     if (extruded > 0.5) {
+      // Here, the input parameters should be
+      // position_worldspace.xyz / position_worldspace.w.
+      // However, this calculation generates all zeros on
+      // MacBook Pro with Intel Iris Pro GPUs for unclear reasons.
+      // (see https://github.com/uber/deck.gl/issues/559)
+      // Since the w component is always 1.0 in our shaders,
+      // we decided to just provide xyz component of position_worldspace
+      // to the getLightWeight() function
       lightWeight = getLightWeight(
-        position_worldspace.xyz, // the w component is always 1.0
+        position_worldspace.xyz,
         normals
       );
     }

--- a/src/layers/core/solid-polygon-layer/solid-polygon-layer-vertex.glsl.js
+++ b/src/layers/core/solid-polygon-layer/solid-polygon-layer-vertex.glsl.js
@@ -45,7 +45,7 @@ void main(void) {
 
     if (extruded > 0.5) {
       lightWeight = getLightWeight(
-        position_worldspace,
+        position_worldspace.xyz / position_worldspace.w,
         normals
       );
     }

--- a/src/layers/core/solid-polygon-layer/solid-polygon-layer-vertex.glsl.js
+++ b/src/layers/core/solid-polygon-layer/solid-polygon-layer-vertex.glsl.js
@@ -45,7 +45,7 @@ void main(void) {
 
     if (extruded > 0.5) {
       lightWeight = getLightWeight(
-        position_worldspace.xyz / position_worldspace.w,
+        position_worldspace.xyz, // the w component is always 1.0
         normals
       );
     }

--- a/src/shaderlib/lighting/lighting.glsl.js
+++ b/src/shaderlib/lighting/lighting.glsl.js
@@ -29,10 +29,9 @@ uniform float ambientRatio;
 uniform float diffuseRatio;
 uniform float specularRatio;
 
-float getLightWeight(vec4 position_worldspace, vec3 normals_worldspace) {
+float getLightWeight(vec3 position_worldspace_vec3, vec3 normals_worldspace) {
   float lightWeight = 0.0;
 
-  vec3 position_worldspace_vec3 = position_worldspace.xyz / position_worldspace.w;
   vec3 normals_worldspace_vec3 = normals_worldspace.xzy;
 
   vec3 camera_pos_worldspace = cameraPos;


### PR DESCRIPTION
For issue #559 

Change getLightWeight() interface: now it takes a vec3 for the worldspace position (this is a workaround required for Intel GPU)
Update the 64-bit vertex shader according to 32-bit vertex shader (remove LatOffst, LonOffset)

This is a high risk / high reward change I plan to also land into 4.0-release. I tested through layer browser and demo site but I need independent verifications and tests. @Pessimistress @ericsoco @ibgreen

