### PR TITLE
separate out more methods in hexagon-layer, use valueAccessor in BinSorter to enable color / elevation by value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,10 @@ Ref: http://keepachangelog.com/en/0.3.0/
 - DEMO: Fix the scrolling on iPhone (#546)
 - DEMO: Reorganized the examples (#547)
 - DEMO: Misc fixed form demo site (#548, #549)
-- `HexagonLayer` create `getHexagons` and `getSortedCounts` methods, make it easier to create layer subclass
+- `HexagonLayer` add interval `getHexagons`, `getSortedCounts` `getUpdateTriggers` methods, make it easier to create layer subclass
+- `HexagonLayer` add `getColorValue` (optional) prop, returns a value to base bin color on.
+- `HexagonLayer` change default `hexagonAggregator` output to `{hexagons: [], hexagonVertices: []}`
+- `HexagonLayer` add `getValue` to `BiinSorter` to support color / elevation by value
 
 ## Official Releases
 

--- a/docs/layers/hexagon-layer.md
+++ b/docs/layers/hexagon-layer.md
@@ -77,14 +77,14 @@ to number of counts by passing in an arbitrary color domain. This property is ex
 Hexagon color ranges as an array of colors formatted as `[[255, 255, 255, 255]]`. Default is
 [colorbrewer](http://colorbrewer2.org/#type=sequential&scheme=YlOrRd&n=6) `6-class YlOrRd`.
 
-##### `colorValueAccessor` (Function, optional)
+##### `getColorValue` (Function, optional)
 
-- Default: `undefined`
+- Default: `points => points.length`
 
-`colorValueAccessor` is the accessor function to get the value that bin color is based on. 
+`getColorValue` is the accessor function to get the value that bin color is based on. 
 It takes an array of points inside each bin as arguments, returns a value. For example, 
-You can use `colorValueAccessor`to color the bins by avg/mean/max of a specific attributes of each point.
-When not specified, color of bins will based on count of points.
+You can pass in `getColorValue`to color the bins by avg/mean/max of a specific attributes of each point.
+By default `getColorValue` is undefined, color of bins will based on count of points.
 
 ##### `coverage` (Number, optional)
 

--- a/docs/layers/hexagon-layer.md
+++ b/docs/layers/hexagon-layer.md
@@ -83,8 +83,8 @@ Hexagon color ranges as an array of colors formatted as `[[255, 255, 255, 255]]`
 
 `getColorValue` is the accessor function to get the value that bin color is based on. 
 It takes an array of points inside each bin as arguments, returns a value. For example, 
-You can pass in `getColorValue`to color the bins by avg/mean/max of a specific attributes of each point.
-By default `getColorValue` is undefined, color of bins will based on count of points.
+You can pass in `getColorValue` to color the bins by avg/mean/max of a specific attributes of each point.
+By default `getColorValue` returns the length of the points array.
 
 ##### `coverage` (Number, optional)
 

--- a/docs/layers/hexagon-layer.md
+++ b/docs/layers/hexagon-layer.md
@@ -77,6 +77,15 @@ to number of counts by passing in an arbitrary color domain. This property is ex
 Hexagon color ranges as an array of colors formatted as `[[255, 255, 255, 255]]`. Default is
 [colorbrewer](http://colorbrewer2.org/#type=sequential&scheme=YlOrRd&n=6) `6-class YlOrRd`.
 
+##### `colorValueAccessor` (Function, optional)
+
+- Default: `undefined`
+
+`colorValueAccessor` is the accessor function to get the value that bin color is based on. 
+It takes an array of points inside each bin as arguments, returns a value. For example, 
+You can use `colorValueAccessor`to color the bins by avg/mean/max of a specific attributes of each point.
+When not specified, color of bins will based on count of points.
+
 ##### `coverage` (Number, optional)
 
 - Default: `1`

--- a/docs/layers/hexagon-layer.md
+++ b/docs/layers/hexagon-layer.md
@@ -50,10 +50,12 @@ Radius of hexagon bin in meters. The hexagons are pointy-topped (rather than fla
 
 - Default: `d3-hexbin`
 
-`hexagonAggregator` is the function to aggregate data into hexagonal bins.
-The `hexagonAggregator` takes props of the layer and current viewport as input.
-The output should be an array of hexagons with each formatted as `{centroid: [], points: []}`, where
-`centroid` is the center of the hexagon, and `points` is an array of points that contained by it.
+`hexagonAggregator` is a function to aggregate data into hexagonal bins.
+The `hexagonAggregator` takes props of the layer and current viewport as arguments.
+The output should be `{hexagons: [], hexagonVertices: []}`. `hexagons` is 
+an array of `{centroid: [], points: []}`, where `centroid` is the 
+center of the hexagon, and `points` is an array of points that contained by it.  `hexagonVertices` 
+(optional) is an array of points define the primitive hexagon geometry.
 
 By default, the `HexagonLayer` uses
 [d3-hexbin](https://github.com/d3/d3-hexbin) as `hexagonAggregator`,

--- a/src/layers/core/hexagon-layer/hexagon-aggregator.js
+++ b/src/layers/core/hexagon-layer/hexagon-aggregator.js
@@ -45,10 +45,10 @@ export function pointToHexbin({data, radius, getPosition}, viewport) {
 
   const hexagonBins = newHexbin(screenPoints);
 
-  return hexagonBins.map(hex => ({
+  return {hexagons: hexagonBins.map(hex => ({
     centroid: viewport.unprojectFlat([hex.x, hex.y]),
     points: hex
-  }));
+  }))};
 }
 
 /**

--- a/src/layers/core/hexagon-layer/hexagon-aggregator.js
+++ b/src/layers/core/hexagon-layer/hexagon-aggregator.js
@@ -45,10 +45,12 @@ export function pointToHexbin({data, radius, getPosition}, viewport) {
 
   const hexagonBins = newHexbin(screenPoints);
 
-  return {hexagons: hexagonBins.map(hex => ({
-    centroid: viewport.unprojectFlat([hex.x, hex.y]),
-    points: hex
-  }))};
+  return {
+    hexagons: hexagonBins.map(hex => ({
+      centroid: viewport.unprojectFlat([hex.x, hex.y]),
+      points: hex
+    }))
+  };
 }
 
 /**

--- a/src/layers/core/hexagon-layer/hexagon-layer.js
+++ b/src/layers/core/hexagon-layer/hexagon-layer.js
@@ -31,7 +31,7 @@ import BinSorter from '../../../utils/bin-sorter';
 const defaultProps = {
   colorDomain: null,
   colorRange: defaultColorRange,
-  getColorValue: undefined,
+  getColorValue: points => points.length,
   elevationDomain: null,
   elevationRange: [0, 1000],
   elevationScale: 1,
@@ -69,9 +69,9 @@ function _needsReSortBins(oldProps, props) {
 
 export default class HexagonLayer extends Layer {
   constructor(props) {
-    if (!props.radius || !typeof props.hexagonAggregator === 'function') {
-      log.once(0, 'HexagonLayer: radius or hexagonAggregator is needed to aggregate points into ' +
-        'hexagonal bins, Now using 1000 meter as default radius');
+    if (!props.radius || !props.hexagonAggregator) {
+      log.once(0, 'HexagonLayer: rDefault hexagonAggregator requires radius prop to be set, ' +
+        'Now using 1000 meter as default');
 
       props.radius = defaultProps.radius;
     }

--- a/src/layers/core/hexagon-layer/hexagon-layer.js
+++ b/src/layers/core/hexagon-layer/hexagon-layer.js
@@ -160,6 +160,7 @@ export default class HexagonLayer extends Layer {
       getColor: {
         colorRange: this.props.colorRange,
         colorDomain: this.props.colorDomain,
+        getColorValue: this.props.getColorValue,
         lowerPercentile: this.props.lowerPercentile,
         upperPercentile: this.props.upperPercentile
       },

--- a/src/layers/core/hexagon-layer/hexagon-layer.js
+++ b/src/layers/core/hexagon-layer/hexagon-layer.js
@@ -70,7 +70,7 @@ function _needsReSortBins(oldProps, props) {
 export default class HexagonLayer extends Layer {
   constructor(props) {
     if (!props.radius || !props.hexagonAggregator) {
-      log.once(0, 'HexagonLayer: rDefault hexagonAggregator requires radius prop to be set, ' +
+      log.once(0, 'HexagonLayer: Default hexagonAggregator requires radius prop to be set, ' +
         'Now using 1000 meter as default');
 
       props.radius = defaultProps.radius;

--- a/src/layers/core/hexagon-layer/hexagon-layer.js
+++ b/src/layers/core/hexagon-layer/hexagon-layer.js
@@ -31,7 +31,7 @@ import BinSorter from '../../../utils/bin-sorter';
 const defaultProps = {
   colorDomain: null,
   colorRange: defaultColorRange,
-  colorValueAccessor: undefined,
+  getColorValue: undefined,
   elevationDomain: null,
   elevationRange: [0, 1000],
   elevationScale: 1,
@@ -64,7 +64,7 @@ function _percentileChanged(oldProps, props) {
 }
 
 function _needsReSortBins(oldProps, props) {
-  return oldProps.colorValueAccessor !== props.colorValueAccessor;
+  return oldProps.getColorValue !== props.getColorValue;
 }
 
 export default class HexagonLayer extends Layer {
@@ -140,7 +140,7 @@ export default class HexagonLayer extends Layer {
   }
 
   getSortedCounts() {
-    const sortedCounts = new BinSorter(this.state.hexagons || [], this.props.colorValueAccessor);
+    const sortedCounts = new BinSorter(this.state.hexagons || [], this.props.getColorValue);
     this.setState({sortedCounts});
   }
 
@@ -155,7 +155,7 @@ export default class HexagonLayer extends Layer {
     });
   }
 
-  getUpdateTrigger() {
+  getUpdateTriggers() {
     return {
       getColor: {
         colorRange: this.props.colorRange,
@@ -229,7 +229,7 @@ export default class HexagonLayer extends Layer {
       modelMatrix,
       getColor: this._onGetSublayerColor.bind(this),
       getElevation: this._onGetSublayerElevation.bind(this),
-      updateTriggers: this.getUpdateTrigger()
+      updateTriggers: this.getUpdateTriggers()
     });
   }
 }

--- a/src/utils/bin-sorter.js
+++ b/src/utils/bin-sorter.js
@@ -17,36 +17,48 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+import {log} from '../lib/utils';
+
+// valueAccessor takes an array of points returns a value to sort the bins on.
+// by default it returns the number of points
+// this is where to pass in a function to color the bins by
+// avg/mean/max of specific value of the point
+const defaultValueAccessor = points => points.length;
 
 export default class BinSorter {
-  constructor(bins) {
-    this.sortedBins = this.getSortedCounts(bins);
+  constructor(bins = [], valueAccessor = defaultValueAccessor) {
+    this.sortedBins = this.getSortedBins(bins, valueAccessor);
+    this.maxCount = this.getMaxCount();
   }
 
   /**
-   * Get an array of object with sorted count and index of bins
+   * Get an array of object with sorted values and index of bins
    * @param {Array} bins
-   * @return {Array} array of count and index lookup
+   * @param {Function} valueAccessor
+   * @return {Array} array of values and index lookup
    */
-  getSortedCounts(bins) {
+  getSortedBins(bins, valueAccessor) {
     return bins
-      .map((h, i) => ({i, counts: h.points.length}))
-      .sort((a, b) => a.counts - b.counts);
+      .map((h, i) => ({i, value: valueAccessor(h.points), counts: h.points.length}))
+      .sort((a, b) => a.value - b.value);
   }
 
   /**
-   * Get an array of object with sorted count and index of bins
+   * Get range of values of all bins
    * @param {Number[]} range
    * @param {Number} range[0] - lower bound
    * @param {Number} range[1] - upper bound
-   * @return {Array} array of nuw count range
+   * @return {Array} array of new value range
    */
-  getCountRange([lower, upper]) {
+  getValueRange([lower, upper]) {
     const len = this.sortedBins.length;
+    if (!len) {
+      return [0, 0];
+    }
     const lowerIdx = Math.ceil(lower / 100 * (len - 1));
     const upperIdx = Math.floor(upper / 100 * (len - 1));
 
-    return [this.sortedBins[lowerIdx].counts, this.sortedBins[upperIdx].counts];
+    return [this.sortedBins[lowerIdx].value, this.sortedBins[upperIdx].value];
   }
 
   /**
@@ -54,6 +66,11 @@ export default class BinSorter {
    * @return {Number | Boolean} max count
    */
   getMaxCount() {
-    return this.sortedBins.length && this.sortedBins[this.sortedBins.length - 1].counts;
+    return Math.max.apply(null, this.sortedBins.map(b => b.counts));
+  }
+
+  getCountRange(args) {
+    log.once(0, 'HexagonLayer: BinSorter.getCountRange is deprecated, use getValueRange instead');
+    return this.getValueRange(args);
   }
 }

--- a/src/utils/bin-sorter.js
+++ b/src/utils/bin-sorter.js
@@ -17,29 +17,28 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-import {log} from '../lib/utils';
 
-// valueAccessor takes an array of points returns a value to sort the bins on.
+// getValue takes an array of points returns a value to sort the bins on.
 // by default it returns the number of points
 // this is where to pass in a function to color the bins by
 // avg/mean/max of specific value of the point
-const defaultValueAccessor = points => points.length;
+const defaultGetValue = points => points.length;
 
 export default class BinSorter {
-  constructor(bins = [], valueAccessor = defaultValueAccessor) {
-    this.sortedBins = this.getSortedBins(bins, valueAccessor);
+  constructor(bins = [], getValue = defaultGetValue) {
+    this.sortedBins = this.getSortedBins(bins, getValue);
     this.maxCount = this.getMaxCount();
   }
 
   /**
    * Get an array of object with sorted values and index of bins
    * @param {Array} bins
-   * @param {Function} valueAccessor
+   * @param {Function} getValue
    * @return {Array} array of values and index lookup
    */
-  getSortedBins(bins, valueAccessor) {
+  getSortedBins(bins, getValue) {
     return bins
-      .map((h, i) => ({i, value: valueAccessor(h.points), counts: h.points.length}))
+      .map((h, i) => ({i, value: getValue(h.points), counts: h.points.length}))
       .sort((a, b) => a.value - b.value);
   }
 
@@ -67,10 +66,5 @@ export default class BinSorter {
    */
   getMaxCount() {
     return Math.max.apply(null, this.sortedBins.map(b => b.counts));
-  }
-
-  getCountRange(args) {
-    log.once(0, 'HexagonLayer: BinSorter.getCountRange is deprecated, use getValueRange instead');
-    return this.getValueRange(args);
   }
 }


### PR DESCRIPTION
- add internal `getUpdateTrigger` method
- add `colorValueAccessor` as hexagon layer prop to get the value for bin colors. When undefined, layer will use points.length to calculate color
- change default `hexagonAggregator` output to be `{hexagons: [], hexagonVertices: []}`
- add valueAccessor to bin-sorter to support color / elevation by value