### PR TITLE
Strip undefined values from props to avoid unintentionally shadowing defaults

### DIFF
--- a/src/lib/layer.js
+++ b/src/lib/layer.js
@@ -56,6 +56,13 @@ export default class Layer {
   constructor(props) {
     // If sublayer has static defaultProps member, getDefaultProps will return it
     const mergedDefaultProps = getDefaultProps(this);
+    // Strip undefined values from supplied props to avoid unintentionally shadowing defaults
+    props = Object.keys(props)
+      .filter(k => typeof props[k] !== 'undefined')
+      .reduce((acc, k) => {
+        acc[k] = props[k];
+        return acc;
+      }, {});
     // Merge supplied props with pre-merged default props
     props = Object.assign({}, mergedDefaultProps, props);
     // Accept null as data - otherwise apps and layers need to add ugly checks

--- a/src/lib/layer.js
+++ b/src/lib/layer.js
@@ -56,15 +56,17 @@ export default class Layer {
   constructor(props) {
     // If sublayer has static defaultProps member, getDefaultProps will return it
     const mergedDefaultProps = getDefaultProps(this);
-    // Strip undefined values from supplied props to avoid unintentionally shadowing defaults
-    props = Object.keys(props)
-      .filter(k => typeof props[k] !== 'undefined')
-      .reduce((acc, k) => {
-        acc[k] = props[k];
-        return acc;
-      }, {});
-    // Merge supplied props with pre-merged default props
-    props = Object.assign({}, mergedDefaultProps, props);
+
+    // merge all but undefined props
+    let k;
+    const mergedProps = Object.assign({}, mergedDefaultProps);
+    for (k in props) {
+      if (typeof props[k] !== 'undefined') {
+        mergedProps[k] = props[k];
+      }
+    }
+    props = mergedProps;
+
     // Accept null as data - otherwise apps and layers need to add ugly checks
     props.data = props.data || [];
     // Props are immutable


### PR DESCRIPTION
Ran into a problem when creating a new layer in which passing props that are `undefined` shadow defaults, requiring application-layer or CompositeLayers to run checks to avoid passing a prop at all if it's `undefined`.

E.g.:
```js
class FooLayer extends Layer {
  // ...
  renderLayers() {
    const valueNeededForRender = this.props.someAccessor();
    // ...
  }
}
FooLayer.defaultProps = {
  someAccessor: () => true
};

// application code:
// ...
render() {
  // `someAccessor` not passed in or defined due to some valid condition/use case...
  const {someAccessor} = this.props;
  new FooLayer({
    someAccessor
  });
}
```

In this case, the expectation is that omitting `someAccessor` will allow `FooLayer` to fall back to its default definition for `someAccessor`. Instead, the default is shadowed by the `undefined` value passed as a `prop`, causing a runtime error.

This PR fixes that case, but I can easily imagine it will surface other bugs in which that shadowing is unintentionally expected / accounted for and unshadowing will cause other errors. So...not sure how best to proceed, but figured I'd put this out to see what you think.