### PR TITLE
Add support for drag events.

### DIFF
--- a/src/lib/draw-and-pick.js
+++ b/src/lib/draw-and-pick.js
@@ -23,6 +23,11 @@ import {GL, glContextWithState} from 'luma.gl';
 import {getUniformsFromViewport} from './viewport-uniforms';
 import {log, getBlendMode, setBlendMode} from './utils';
 
+// Note: corresponding touch events, once supported, should be included here as well.
+const MOTION_EVENTS = [
+  'dragmove',
+  'dragend'
+];
 const EMPTY_PIXEL = new Uint8Array(4);
 let renderCount = 0;
 
@@ -69,18 +74,154 @@ export function pickLayers(gl, {
   const deviceX = x * pixelRatio;
   const deviceY = gl.canvas.height - y * pixelRatio;
 
-  // TODO - just return glContextWithState once luma updates
+  let pickedColor;
+  let pickedLayer;
+  let pickedObjectIndex;
+  let affectedLayers = [];
+
+  if (MOTION_EVENTS.indexOf(mode) !== -1) {
+    // "Motion events" are those that track the motion of an interaction
+    // after its initiation. In this case, these subsequent events
+    // should be bound to the object that was first picked,
+    // e.g. to enable dragging behaviors.
+    // Therefore, the picking process does not run for these events.
+    const {layerId} = lastPickedInfo;
+    pickedLayer = layers.find(layer => layer.props.id === layerId);
+    if (pickedLayer) {
+      pickedColor = lastPickedInfo.color;
+      pickedObjectIndex = lastPickedInfo.index;
+      affectedLayers.push(pickedLayer);
+    }
+
+  } else {
+    // For all other events, run picking process normally.
+    const pickInfo = pickFromBuffer(gl, {
+      layers,
+      pickingFBO,
+      deviceX,
+      deviceY
+    });
+    pickedColor = pickInfo.pickedColor;
+    pickedLayer = pickInfo.pickedLayer;
+    pickedObjectIndex = pickInfo.pickedObjectIndex;
+    affectedLayers = pickInfo.affectedLayers;
+
+    if (mode === 'hover') {
+      // only invoke onHover events if picked object has changed
+      const lastPickedObjectIndex = lastPickedInfo.index;
+      const lastPickedLayerId = lastPickedInfo.layerId;
+      const pickedLayerId = pickedLayer && pickedLayer.props.id;
+
+      // proceed only if picked object changed
+      if (pickedLayerId !== lastPickedLayerId || pickedObjectIndex !== lastPickedObjectIndex) {
+        if (pickedLayerId !== lastPickedLayerId) {
+          // We cannot store a ref to lastPickedLayer in the context because
+          // the state of an outdated layer is no longer valid
+          // and the props may have changed
+          const lastPickedLayer = layers.find(layer => layer.props.id === lastPickedLayerId);
+          if (lastPickedLayer) {
+            // Let leave event fire before enter event
+            affectedLayers.unshift(lastPickedLayer);
+          }
+        }
+
+        // Update layer manager context
+        lastPickedInfo.layerId = pickedLayerId;
+        lastPickedInfo.index = pickedObjectIndex;
+      }
+    }
+  }
+
+  const baseInfo = createInfo([x, y], viewport);
+  baseInfo.devicePixel = [deviceX, deviceY];
+  baseInfo.pixelRatio = pixelRatio;
+
+  // Use a Map to store all picking infos.
+  // The following two forEach loops are the result of
+  // https://github.com/uber/deck.gl/issues/443
+  // Please be very careful when changing this pattern
+  const infos = new Map();
   const unhandledPickInfos = [];
 
+  affectedLayers.forEach(layer => {
+    let info = Object.assign({}, baseInfo);
+
+    if (layer === pickedLayer) {
+      info.color = pickedColor;
+      info.index = pickedObjectIndex;
+      info.picked = true;
+    }
+
+    // Walk up the composite chain and find the owner of the event
+    // sublayers are never directly exposed to the user
+    while (layer && info) {
+      // For a composite layer, sourceLayer will point to the sublayer
+      // where the event originates from.
+      // It provides additional context for the composite layer's
+      // getPickingInfo() method to populate the info object
+      const sourceLayer = info.layer || layer;
+      info.layer = layer;
+      // layer.pickLayer() function requires a non-null ```layer.state```
+      // object to funtion properly. So the layer refereced here
+      // must be the "current" layer, not an "out-dated" / "invalidated" layer
+      info = layer.pickLayer({info, mode, sourceLayer});
+      layer = layer.parentLayer;
+    }
+
+    // This guarantees that there will be only one copy of info for
+    // one composite layer
+    if (info) {
+      infos.set(info.layer.id, info);
+    }
+  });
+
+  infos.forEach(info => {
+    let handled = false;
+    // The onClick and onHover functions are provided by the user
+    // and out of control by deck.gl. It's very much possible that
+    // the user calls React lifecycle methods in these function, such as
+    // ReactComponent.setState(). React lifecycle methods sometimes induce
+    // a re-render and re-generation of props of deck.gl and its layers,
+    // which invalidates all layers currently passed to this very function.
+
+    // Therefore, calls to functions like onClick and onHover need to be done
+    // at the end of the function. NO operation relies on the states of current
+    // layers should be called after this code.
+    switch (mode) {
+    case 'click': handled = info.layer.props.onClick(info); break;
+    case 'dragstart': handled = info.layer.props.onDragStart(info); break;
+    case 'dragmove': handled = info.layer.props.onDragMove(info); break;
+    case 'dragend': handled = info.layer.props.onDragEnd(info); break;
+    case 'dragcancel': handled = info.layer.props.onDragCancel(info); break;
+    case 'hover': handled = info.layer.props.onHover(info); break;
+    default: throw new Error('unknown pick type');
+    }
+
+    if (!handled) {
+      unhandledPickInfos.push(info);
+    }
+  });
+
+  return unhandledPickInfos;
+}
+/* eslint-enable max-depth, max-statements */
+
+function pickFromBuffer(gl, {
+  layers,
+  pickingFBO,
+  deviceX,
+  deviceY
+}) {
+  // TODO - just return glContextWithState once luma updates
   // Make sure we clear scissor test and fbo bindings in case of exceptions
   // We are only interested in one pixel, no need to render anything else
-  glContextWithState(gl, {
+  // Note that the callback here is called synchronously.
+  return glContextWithState(gl, {
     frameBuffer: pickingFBO,
     framebuffer: pickingFBO,
     scissorTest: {x: deviceX, y: deviceY, w: 1, h: 1}
   }, () => {
 
-    // Picking process start
     // Clear the frame buffer
     gl.clear(GL.COLOR_BUFFER_BIT | GL.DEPTH_BUFFER_BIT);
     // Save current blend settings
@@ -115,111 +256,18 @@ export function pickLayers(gl, {
 
     // restore blend mode
     setBlendMode(gl, oldBlendMode);
-    // Picking process end
 
-    // Process picked info start
     // Decode picked color
     const pickedLayerIndex = pickedColor[3] - 1;
     const pickedLayer = pickedLayerIndex >= 0 ? layers[pickedLayerIndex] : null;
-    const pickedObjectIndex = pickedLayer ? pickedLayer.decodePickingColor(pickedColor) : -1;
-    const pickedLayerId = pickedLayer && pickedLayer.props.id;
-    const affectedLayers = pickedLayer ? [pickedLayer] : [];
-
-    if (mode === 'hover') {
-      // only invoke onHover events if picked object has changed
-      const lastPickedObjectIndex = lastPickedInfo.index;
-      const lastPickedLayerId = lastPickedInfo.layerId;
-
-      if (pickedLayerId === lastPickedLayerId && pickedObjectIndex === lastPickedObjectIndex) {
-        // picked object did not change, no need to proceed
-        return;
-      }
-
-      if (pickedLayerId !== lastPickedLayerId) {
-        // We cannot store a ref to lastPickedLayer in the context because
-        // the state of an outdated layer is no longer valid
-        // and the props may have changed
-        const lastPickedLayer = layers.find(l => l.props.id === lastPickedLayerId);
-        if (lastPickedLayer) {
-          // Let leave event fire before enter event
-          affectedLayers.unshift(lastPickedLayer);
-        }
-      }
-
-      // Update layer manager context
-      lastPickedInfo.layerId = pickedLayerId;
-      lastPickedInfo.index = pickedObjectIndex;
-    }
-
-    const baseInfo = createInfo([x, y], viewport);
-    baseInfo.devicePixel = [deviceX, deviceY];
-    baseInfo.pixelRatio = pixelRatio;
-
-    // Use a Map to store all picking infos.
-    // The following two forEach loops are the result of
-    // https://github.com/uber/deck.gl/issues/443
-    // Please be very careful when changing this pattern
-    const infos = new Map();
-
-    affectedLayers.forEach(layer => {
-      let info = Object.assign({}, baseInfo);
-
-      if (layer === pickedLayer) {
-        info.color = pickedColor;
-        info.index = pickedObjectIndex;
-        info.picked = true;
-      }
-
-      // Walk up the composite chain and find the owner of the event
-      // sublayers are never directly exposed to the user
-      while (layer && info) {
-        // For a composite layer, sourceLayer will point to the sublayer
-        // where the event originates from.
-        // It provides additional context for the composite layer's
-        // getPickingInfo() method to populate the info object
-        const sourceLayer = info.layer || layer;
-        info.layer = layer;
-        // layer.pickLayer() function requires a non-null ```layer.state```
-        // object to funtion properly. So the layer refereced here
-        // must be the "current" layer, not an "out-dated" / "invalidated" layer
-        info = layer.pickLayer({info, mode, sourceLayer});
-        layer = layer.parentLayer;
-      }
-
-      // This guarantees that there will be only one copy of info for
-      // one composite layer
-      if (info) {
-        infos.set(info.layer.id, info);
-      }
-    });
-
-    infos.forEach(info => {
-      let handled = false;
-      // The onClick and onHover functions are provided by the user
-      // and out of control by deck.gl. It's very much possible that
-      // the user calls React lifecycle methods in these function, such as
-      // ReactComponent.setState(). React lifecycle methods sometimes induce
-      // a re-render and re-generation of props of deck.gl and its layers,
-      // which invalidates all layers currently passed to this very function.
-
-      // Therefore, calls to functions like onClick and onHover need to be done
-      // at the end of the function. NO operation relies on the states of current
-      // layers should be called after this two lines of code.
-      switch (mode) {
-      case 'click': handled = info.layer.props.onClick(info); break;
-      case 'hover': handled = info.layer.props.onHover(info); break;
-      default: throw new Error('unknown pick type');
-      }
-
-      if (!handled) {
-        unhandledPickInfos.push(info);
-      }
-    });
+    return {
+      pickedColor,
+      pickedLayer,
+      pickedObjectIndex: pickedLayer ? pickedLayer.decodePickingColor(pickedColor) : -1,
+      affectedLayers: pickedLayer ? [pickedLayer] : []
+    };
   });
-
-  return unhandledPickInfos;
 }
-/* eslint-enable max-depth, max-statements */
 
 function createInfo(pixel, viewport) {
   // Assign a number of potentially useful props to the "info" object

--- a/src/lib/layer.js
+++ b/src/lib/layer.js
@@ -27,6 +27,8 @@ import assert from 'assert';
 
 const LOG_PRIORITY_UPDATE = 2;
 
+const noop = () => {};
+
 /*
  * @param {string} props.id - layer name
  * @param {array}  props.data - array of data instances
@@ -38,8 +40,12 @@ const defaultProps = {
   visible: true,
   pickable: false,
   opacity: 0.8,
-  onHover: () => {},
-  onClick: () => {},
+  onHover: noop,
+  onClick: noop,
+  onDragStart: noop,
+  onDragMove: noop,
+  onDragEnd: noop,
+  onDragCancel: noop,
   // Update triggers: a key change detection mechanism in deck.gl
   // See layer documentation
   updateTriggers: {},

--- a/src/react/deckgl.js
+++ b/src/react/deckgl.js
@@ -39,13 +39,13 @@ const propTypes = {
   debug: PropTypes.bool,
   viewport: PropTypes.instanceOf(Viewport),
   onWebGLInitialized: PropTypes.func,
+  onAfterRender: PropTypes.func,
   onLayerClick: PropTypes.func,
   onLayerHover: PropTypes.func,
   onLayerDragStart: PropTypes.func,
   onLayerDragMove: PropTypes.func,
   onLayerDragEnd: PropTypes.func,
-  onLayerDragCancel: PropTypes.func,
-  onAfterRender: PropTypes.func
+  onLayerDragCancel: PropTypes.func
 };
 
 const defaultProps = {
@@ -118,7 +118,7 @@ export default class DeckGL extends React.Component {
     const hasPickableLayer = this.layerManager.layers.map(l => l.props.pickable).includes(true);
     if (this.layerManager.layers.length && hasEvent && !hasPickableLayer) {
       log.once(
-        0,
+        1,
         'You have supplied a mouse event handler but none of your layers set the `pickable` flag.'
       );
     }


### PR DESCRIPTION
Note that many mouse events are already supported by luma.gl; this PR extends the support for a subset of these upwards into deck.gl.

I know that we have grander plans for encapsulating interaction models for different scenarios. I don't believe this runs afoul of those, but it is possible the direction taken in this PR is setting us up for a bigger refactor when we tackle new interaction models.

/cc @gnavvy @Pessimistress as potential consumers of these additions.