### PR TITLE
Separate composite and non-composite layer APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Ref: http://keepachangelog.com/en/0.3.0/
 
 ## Beta Releases
 
+[TBD]
+
+- BREAKING: Only composite layers have `renderLayer` methods
+- BREAKING: Only primitive layers' `draw` methods are called during render
+
 ### deck.gl v4.1-alpha.1
 
 - HOTFIX: Fix the bug that layer is finalized at every cycle due to an incorrect if check(#552)

--- a/docs/advanced/layer-lifecycle.md
+++ b/docs/advanced/layer-lifecycle.md
@@ -59,7 +59,7 @@ and updating unforms by calling
 `model.setUniforms`.
 By default, when `props.data` changes, all attributes are recalculated.
 
-A layer may use
+A composite layer may use
 [`layer.renderLayers()`](/docs/api-reference/composite-layer.md#-renderlayers-)
 to insert one or more deck.gl layers after itself.
 The generated layers will then be matched and updated,

--- a/docs/advanced/layer-lifecycle.md
+++ b/docs/advanced/layer-lifecycle.md
@@ -60,7 +60,7 @@ and updating unforms by calling
 By default, when `props.data` changes, all attributes are recalculated.
 
 A composite layer may use
-[`layer.renderLayers()`](/docs/api-reference/composite-layer.md#-renderlayers-)
+[`compositeLayer.renderLayers()`](/docs/api-reference/composite-layer.md#-renderlayers-)
 to insert one or more deck.gl layers after itself.
 The generated layers will then be matched and updated,
 allowing the decomposition of the drawing of a complex data set

--- a/docs/api-reference/composite-layer.md
+++ b/docs/api-reference/composite-layer.md
@@ -11,6 +11,11 @@ that you extend this class.
 
 ## Methods
 
+##### `draw`
+
+A composite layer does not render directly into the WebGL context.
+The `draw` method inherited from the base class is therefore never called.
+
 ##### `renderLayers`
 
 Allows a layer to "render" or insert one or more deck.gl layers after itself.

--- a/src/lib/composite-layer.js
+++ b/src/lib/composite-layer.js
@@ -25,6 +25,10 @@ export default class CompositeLayer extends Layer {
     super(props);
   }
 
+  get isComposite() {
+    return true;
+  }
+
   // initializeState is usually not needed for composite layers
   // Provide empty definition to disable check for missing definition
   initializeState() {
@@ -41,5 +45,10 @@ export default class CompositeLayer extends Layer {
   // @return null to cancel event
   getPickingInfo({info}) {
     return info;
+  }
+
+  // Implement to generate sublayers
+  renderLayers() {
+    return null;
   }
 }

--- a/src/lib/draw-and-pick.js
+++ b/src/lib/draw-and-pick.js
@@ -33,7 +33,7 @@ export function drawLayers({layers, pass}) {
   let visibleCount = 0;
   // render layers in normal colors
   layers.forEach((layer, layerIndex) => {
-    if (layer.props.visible) {
+    if (!layer.isComposite && layer.props.visible) {
       layer.drawLayer({
         uniforms: Object.assign(
           {renderPickingBuffer: 0, pickingEnabled: 0},
@@ -93,7 +93,7 @@ export function pickLayers(gl, {
 
     // Render all pickable layers in picking colors
     layers.forEach((layer, layerIndex) => {
-      if (layer.props.visible && layer.props.pickable) {
+      if (!layer.isComposite && layer.props.visible && layer.props.pickable) {
 
         // Encode layerIndex with alpha
         gl.blendColor(0, 0, 0, (layerIndex + 1) / 255);

--- a/src/lib/layer-manager.js
+++ b/src/lib/layer-manager.js
@@ -247,7 +247,7 @@ export default class LayerManager {
         generatedLayers.push(newLayer);
 
         // Call layer lifecycle method: render sublayers
-        let sublayers = newLayer.renderLayers();
+        let sublayers = newLayer.isComposite ? newLayer.renderLayers() : null;
         // End layer lifecycle method: render sublayers
 
         if (sublayers) {

--- a/src/lib/layer.js
+++ b/src/lib/layer.js
@@ -107,11 +107,6 @@ export default class Layer {
   finalizeState() {
   }
 
-  // Implement to generate sublayers
-  renderLayers() {
-    return null;
-  }
-
   // If state has a model, draw it with supplied uniforms
   draw({uniforms = {}}) {
     if (this.state.model) {


### PR DESCRIPTION
Changes:
- Only composite layers have `renderLayer()` methods
- Only non-composite layers' `draw()` methods are called during render

Goal:
- A cleaner interface
- Improve perf by skipping the uniform calculations and parameter updates for composite layers