### PR TITLE
getViewportUniforms Optimization

### DIFF
--- a/src/lib/viewport-uniforms.js
+++ b/src/lib/viewport-uniforms.js
@@ -41,7 +41,7 @@ function calculateMatrixAndOffset({
   viewport,
   modelMatrix
 }) {
-  const {viewMatrixUncentered, viewMatrix, projectionMatrix} = viewport;
+  const {viewMatrixUncentered, viewMatrix, projectionMatrix, viewProjectionMatrix} = viewport;
 
   let projectionCenter;
   let modelViewMatrix;
@@ -60,7 +60,6 @@ function calculateMatrixAndOffset({
     // This is the key to offset mode precision (avoids doing this
     // addition in 32 bit precision)
     const positionPixels = viewport.projectFlat(positionOrigin);
-    const viewProjectionMatrix = mat4.multiply([], projectionMatrix, viewMatrix);
     projectionCenter = vec4.transformMat4([],
       [positionPixels[0], positionPixels[1], 0.0, 1.0],
       viewProjectionMatrix);

--- a/src/lib/viewport-uniforms.js
+++ b/src/lib/viewport-uniforms.js
@@ -26,7 +26,7 @@ import {COORDINATE_SYSTEM} from './constants';
 
 function fp64ify(a) {
   const hiPart = Math.fround(a);
-  const loPart = a - Math.fround(a);
+  const loPart = a - hiPart;
   return [hiPart, loPart];
 }
 

--- a/test/bench/index.js
+++ b/test/bench/index.js
@@ -33,16 +33,29 @@ import {
 
 import {parseColor} from 'deck.gl/lib/utils/color';
 
+import {COORDINATE_SYSTEM} from '../../src/lib/constants';
+import {getUniformsFromViewport} from '../../src/lib/viewport-uniforms';
 import {testInitializeLayer} from '../test-utils';
 
 const suite = new Suite();
-const lines = data.choropleths.features.map(f => ({path: f.geometry.coordinates[0]}));
 
 const COLOR_STRING = '#FFEEBB';
 const COLOR_ARRAY = [222, 222, 222];
 
 // add tests
 suite
+.add('getUniformsFromViewport#LNGLAT', () => {
+  return getUniformsFromViewport(data.sampleViewport, {
+    modelMatrix: data.sampleModelMatrix,
+    projectionMode: COORDINATE_SYSTEM.LNGLAT
+  });
+})
+.add('getUniformsFromViewport#METER_OFFSETS', () => {
+  return getUniformsFromViewport(data.sampleViewport, {
+    modelMatrix: data.sampleModelMatrix,
+    projectionMode: COORDINATE_SYSTEM.METER_OFFSETS
+  });
+})
 .add('color#parseColor (string)', () => {
   return parseColor(COLOR_STRING);
 })
@@ -63,7 +76,7 @@ suite
   testInitializeLayer({layer});
 })
 .add('PathLayer#initialize', () => {
-  const layer = new PathLayer({data: lines});
+  const layer = new PathLayer({data: data.lines});
   testInitializeLayer({layer});
 })
 .add('ChoroplethLayer#initialize', () => {

--- a/test/data/index.js
+++ b/test/data/index.js
@@ -19,8 +19,10 @@
 // THE SOFTWARE.
 
 export * from '../../examples/layer-browser/src/data-samples';
+export * from './viewport';
 
 import * as data from '../../examples/layer-browser/src/data-samples';
+export const lines = data.choropleths.features.map(f => ({path: f.geometry.coordinates[0]}));
 
 import Immutable from 'immutable';
 export const immutableChoropleths = Immutable.fromJS(data.choropleths);

--- a/test/data/viewport.js
+++ b/test/data/viewport.js
@@ -1,0 +1,14 @@
+import {WebMercatorViewport} from 'deck.gl';
+import {Matrix4} from 'luma.gl';
+
+export const sampleViewport = new WebMercatorViewport({
+  width: 1024,
+  height: 768,
+  longitude: -122.4,
+  latitude: 37.7,
+  zoom: 11,
+  pitch: 30,
+  bearing: 0
+});
+
+export const sampleModelMatrix = new Matrix4().rotateX(0.1).rotateY(-0.2).translate([1, 1, 0]);


### PR DESCRIPTION
Changes:
- Switch from using custom math class to `gl-matrix`
- Add benchmark

Before:
```
getUniformsFromViewport#LNGLAT x 54,286 ops/sec ±2.77% (84 runs sampled)
getUniformsFromViewport#METER_OFFSETS x 37,155 ops/sec ±2.44% (84 runs sampled)
```
After:
```
getUniformsFromViewport#LNGLAT x 155,845 ops/sec ±1.70% (88 runs sampled)
getUniformsFromViewport#METER_OFFSETS x 123,868 ops/sec ±0.86% (90 runs sampled)
```