### PR TITLE
🐛  Fixed default hexagonAggregator radius being set to default value even when it is passed in.

### DIFF
--- a/src/layers/core/hexagon-layer/hexagon-layer.js
+++ b/src/layers/core/hexagon-layer/hexagon-layer.js
@@ -69,7 +69,7 @@ function _needsReSortBins(oldProps, props) {
 
 export default class HexagonLayer extends Layer {
   constructor(props) {
-    if (!props.radius || !props.hexagonAggregator) {
+    if (!props.hexagonAggregator && !props.radius) {
       log.once(0, 'HexagonLayer: Default hexagonAggregator requires radius prop to be set, ' +
         'Now using 1000 meter as default');
 


### PR DESCRIPTION
The condition was flipped. If there is no customer aggregator (``!props.hexagonAggregator``) **AND** no radius (``!props.radius``), only then enforce the default radius of ``1000``.