### PR TITLE
Implement code coverage with nyc and coverall report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ dist/
 dist-es6/
 dist-demo/
 node_modules/
+coverage/
+.nyc_output/
 
 dist-bundle.js
 examples/winds/data/*.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,9 @@ node_js:
   - 7
 before_script:
   - export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start
+script:
+  - npm run lint
+  - npm run cover
+after_success:
+  - npm install -g coveralls
+  - cat coverage/lcov.info | coveralls

--- a/package.json
+++ b/package.json
@@ -27,11 +27,13 @@
     "build-es5": "rm -fr dist && babel src --out-dir dist --plugins=static-fs,transform-es2015-modules-commonjs --source-maps inline",
     "build-buble": "buble dist-es6 -o dist --no modules --y dangerousForOf --objectAssign",
     "build": "npm run build-clean && npm run build-es6 && npm run build-es5 && webpack -d --display-modules",
+    "cover": "NODE_ENV=test nyc --reporter html --reporter cobertura --reporter=lcov npm run test-cover",
     "lint": "eslint src test examples && npm run lint-yarn",
     "lint-yarn": "!(find . -name yarn.lock -exec grep -l unpm.u {} \\; | egrep '.*')",
     "publish-prod": "npm run build && npm run test && npm run test-dist && npm publish",
     "publish-beta": "npm run build && npm run test && npm run test-dist && npm publish --tag beta",
     "test": "npm run lint && npm run test-node",
+    "test-cover": "NODE_ENV=test npm run lint && tape -r babel-register test/node.js",
     "test-node": "node test/node.js",
     "test-dist": "node test/node-dist.js",
     "test-browser": "webpack-dev-server --config webpack.config.test-browser.js --progress --hot --open --port 3010",
@@ -50,6 +52,7 @@
     "babel-cli": "^6.22.2",
     "babel-core": "^6.22.1",
     "babel-loader": "^6.2.10",
+    "babel-plugin-istanbul": "^4.1.1",
     "babel-plugin-static-fs": "^1.1.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.22.0",
     "babel-polyfill": "^6.20.0",
@@ -59,6 +62,7 @@
     "buble": "^0.15.1",
     "buble-loader": "^0.4.0",
     "colorbrewer": "^1.0.0",
+    "coveralls": "^2.13.0",
     "eslint": "^3.0.0",
     "eslint-config-uber-es2015": "^3.0.0",
     "eslint-config-uber-jsx": "^3.0.0",
@@ -69,6 +73,7 @@
     "immutable": "^3.8.1",
     "luma.gl": "^3.0.0",
     "module-alias": "^2.0.0",
+    "nyc": "^10.2.0",
     "path-exists-cli": "^1.0.0",
     "pre-commit": "^1.2.2",
     "raw-loader": "^0.5.1",
@@ -90,6 +95,17 @@
     "react": "0.14.x - 15.x",
     "react-dom": "0.14.x - 15.x"
   },
+  "nyc": {
+    "sourceMap": false,
+    "instrument": false,
+    "include": [
+      "src/**/*.js",
+      "examples/**/*.js"
+    ],
+    "exclude": [
+      "test/**/*.js"
+    ]
+  },
   "babel": {
     "presets": [
       [
@@ -98,6 +114,13 @@
           "modules": false
         }
       ]
-    ]
+    ],
+    "env": {
+      "test": {
+        "plugins": [
+          "istanbul"
+        ]
+      }
+    }
   }
 }


### PR DESCRIPTION
- `npm run cover` run test and report code coverage at coverage/index.html
- coverall.io integrate with travis CI to report code coverage
