### PR TITLE
feat(dev): seer integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "earcut": "^2.0.6",
     "gl-matrix": "^2.3.2",
     "lodash.flattendeep": "^4.4.0",
-    "prop-types": "^15.5.8"
+    "prop-types": "^15.5.8",
+    "seer": "^0.0.4"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",

--- a/src/debug/seer-integration.js
+++ b/src/debug/seer-integration.js
@@ -1,0 +1,91 @@
+import seer from 'seer';
+import {window} from '../lib/utils/globals';
+
+/**
+ * Recursively set a nested property of an object given a properties array and a value
+ */
+const recursiveSet = (obj, path, value) => {
+  if (path.length > 1) {
+    recursiveSet(obj[path[0]], path.slice(1), value);
+  } else {
+    obj[path[0]] = value;
+  }
+};
+
+const overrides = new Map();
+
+/**
+ * Create an override on the specify layer, indexed by a valuePath array.
+ * Do nothing in case Seer as not been initialized to prevent any preformance drawback.
+ */
+export const setOverride = (id, valuePath, value) => {
+  if (!window.__SEER_INITIALIZED__) {
+    return;
+  }
+
+  if (!overrides.has(id)) {
+    overrides.set(id, new Map());
+  }
+
+  const props = overrides.get(id);
+  props.set(valuePath, value);
+
+};
+
+/**
+ * Get the props overrides of a specific layer if Seer as been initialized
+ * Invalidates the data to be sure new ones are always picked up.
+ */
+export const getOverrides = props => {
+  if (!window.__SEER_INITIALIZED__ || !props.id) {
+    return;
+  }
+
+  const overs = overrides.get(props.id);
+  if (!overs) {
+    return;
+  }
+
+  overs.forEach((value, valuePath) => {
+    recursiveSet(props, valuePath, value);
+  });
+
+  props.data = [...props.data];
+
+};
+
+/**
+ * Listen for deck.gl edit events
+ */
+export const layerEditListener = cb => {
+  if (!window.__SEER_INITIALIZED__) {
+    return;
+  }
+
+  seer.listenFor('deck.gl', payload => {
+    if (payload.type !== 'edit') {
+      return;
+    }
+
+    cb(payload);
+  });
+};
+
+/**
+ * Log a layer properties to Seer
+ */
+export const logLayer = layer => {
+  if (!window.__SEER_INITIALIZED__) {
+    return;
+  }
+
+  const simpleProps = Object.keys(layer.props).reduce((acc, key) => {
+    if (typeof layer.props[key] === 'function') {
+      return acc;
+    }
+    acc[key] = layer.props[key];
+    return acc;
+  }, {});
+
+  seer.indexedListItem('deck.gl', layer.id, simpleProps);
+};

--- a/src/lib/layer.js
+++ b/src/lib/layer.js
@@ -22,6 +22,7 @@
 import {COORDINATE_SYSTEM, LIFECYCLE} from './constants';
 import AttributeManager from './attribute-manager';
 import {log, compareProps, count} from './utils';
+import {getOverrides} from '../debug/seer-integration';
 import {GL} from 'luma.gl';
 import assert from 'assert';
 
@@ -66,6 +67,8 @@ export default class Layer {
     props = Object.assign({}, mergedDefaultProps, props);
     // Accept null as data - otherwise apps and layers need to add ugly checks
     props.data = props.data || [];
+    // Get the overrides from the extension if it's active
+    getOverrides(props);
     // Props are immutable
     Object.freeze(props);
 

--- a/test/node.js
+++ b/test/node.js
@@ -21,6 +21,10 @@
 // Enables ES2015 import/export in Node.js
 require('reify');
 
+// Mock addEventListener on window, required for seer
+const {window} = require('../src/lib/utils/globals');
+window.addEventListener = () => {};
+
 // Enables import of glsl
 const fs = require('fs');
 require.extensions['.glsl'] = function readShader(module, filename) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3745,6 +3745,10 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
+seer@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/seer/-/seer-0.0.4.tgz#d17b3db111f60171d0a85a7fb9bac183eb955b98"
+
 select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"


### PR DESCRIPTION
Add integration with the soon-to-be born seer.
No performance drawback for production on normal users given the checks over its presence. 

Pass the layer props and allow their edition with an override object that will persist across renders.
Also invalidate the data to be sure we got the latest version of it.