### PR TITLE
- Add coverage percentiles getColorValue prop to grid layer 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Ref: http://keepachangelog.com/en/0.3.0/
 
 - BREAKING: Only composite layers have `renderLayer` methods
 - BREAKING: Only primitive layers' `draw` methods are called during render
+- `GridLayer` add `coverage`, `lowerPercentile`, `upperPercentile` and `getColorValue` to layer prop
+- HOTFIX: fix `HexagonLayer` hex color calculation, use `bin.value` instead of `bin.points.count` to calculate color
 
 ### deck.gl v4.1-alpha.1
 

--- a/docs/layers/grid-layer.md
+++ b/docs/layers/grid-layer.md
@@ -62,6 +62,23 @@ Color scale domain, default is set to the range of point counts in each cell.
 Color ranges as an array of colors formatted as `[255, 255, 255]`. Default is
 [colorbrewer](http://colorbrewer2.org/#type=sequential&scheme=YlOrRd&n=6) `6-class YlOrRd`.
 
+##### `getColorValue` (Function, optional)
+
+- Default: `points => points.length`
+
+`getColorValue` is the accessor function to get the value that cell color is based on. 
+It takes an array of points inside each cell as arguments, returns a value. For example, 
+You can pass in `getColorValue` to color the cells by avg/mean/max of a specific attributes of each point.
+By default `getColorValue` returns the length of the points array.
+
+##### `coverage` (Number, optional)
+
+- Default: `1`
+
+Cell size multiplier, clamped between 0 - 1. The final size of cell
+is calculated by `coverage * cellSize`. Note: coverage does not affect how points
+are binned.
+
 ##### `elevationDomain` (Array, optional)
 
 - Default: `[0, max(count)]`
@@ -87,6 +104,20 @@ Cell elevation multiplier. The elevation of cell is calculated by
 - Default: `true`
 
 Whether to enable cell elevation. Cell elevation scale by count of points in each cell. If set to false, all cell will be flat.
+
+##### `upperPercentile` (Number, optional)
+
+- Default: `100`
+
+Filter cells and re-calculate color by `upperPercentile`. Cells with value
+larger than the upperPercentile will be hidden.
+
+##### `lowerPercentile` (Number, optional)
+
+- Default: `0`
+
+Filter bins and re-calculate color by `lowerPercentile`. Cells with value
+smaller than the lowerPercentile will be hidden.
 
 ##### `fp64` (Boolean, optional)
 

--- a/docs/layers/grid-layer.md
+++ b/docs/layers/grid-layer.md
@@ -67,9 +67,31 @@ Color ranges as an array of colors formatted as `[255, 255, 255]`. Default is
 - Default: `points => points.length`
 
 `getColorValue` is the accessor function to get the value that cell color is based on. 
-It takes an array of points inside each cell as arguments, returns a value. For example, 
+It takes an array of points inside each cell as arguments, returns a number. For example, 
 You can pass in `getColorValue` to color the cells by avg/mean/max of a specific attributes of each point.
 By default `getColorValue` returns the length of the points array.
+
+Note: grid layer compares whether `getColorValue` has changed to
+recalculate the value for each bin that its color based on. You should
+pass in the function defined outside the render function so it doesn't create a 
+new function on every rendering pass. 
+
+```
+ class MyGridLayer {
+    getColorValue (points) {
+        return points.length;
+    }
+    
+    renderLayers() {
+      return new GridLayer({
+        id: 'grid-layer',
+        getColorValue: this.getColorValue // instead of getColorValue: () => { return points.length; }
+        data,
+        cellSize: 500
+      });
+    }
+ }
+```
 
 ##### `coverage` (Number, optional)
 
@@ -77,7 +99,7 @@ By default `getColorValue` returns the length of the points array.
 
 Cell size multiplier, clamped between 0 - 1. The final size of cell
 is calculated by `coverage * cellSize`. Note: coverage does not affect how points
-are binned.
+are binned. Coverage are linear based.
 
 ##### `elevationDomain` (Array, optional)
 

--- a/docs/layers/grid-layer.md
+++ b/docs/layers/grid-layer.md
@@ -85,7 +85,7 @@ new function on every rendering pass.
     renderLayers() {
       return new GridLayer({
         id: 'grid-layer',
-        getColorValue: this.getColorValue // instead of getColorValue: () => { return points.length; }
+        getColorValue: this.getColorValue // instead of getColorValue: (points) => { return points.length; }
         data,
         cellSize: 500
       });

--- a/docs/layers/hexagon-layer.md
+++ b/docs/layers/hexagon-layer.md
@@ -84,9 +84,31 @@ Hexagon color ranges as an array of colors formatted as `[[255, 255, 255, 255]]`
 - Default: `points => points.length`
 
 `getColorValue` is the accessor function to get the value that bin color is based on. 
-It takes an array of points inside each bin as arguments, returns a value. For example, 
+It takes an array of points inside each bin as arguments, returns a number. For example, 
 You can pass in `getColorValue` to color the bins by avg/mean/max of a specific attributes of each point.
 By default `getColorValue` returns the length of the points array.
+
+Note: hexagon layer compares whether `getColorValue` has changed to
+recalculate the value for each bin that its color based on. You should
+pass in the function defined outside the render function so it doesn't create a 
+new function on every rendering pass. 
+
+```
+ class MyHexagonLayer {
+    getColorValue (points) {
+        return points.length;
+    }
+    
+    renderLayers() {
+      return new HexagonLayer({
+        id: 'hexagon-layer',
+        getColorValue: this.getColorValue // instead of getColorValue: () => { return points.length; }
+        data,
+        radius: 500
+      });
+    }
+ }
+```
 
 ##### `coverage` (Number, optional)
 
@@ -94,8 +116,7 @@ By default `getColorValue` returns the length of the points array.
 
 Hexagon radius multiplier, clamped between 0 - 1. The final radius of hexagon
 is calculated by `coverage * radius`. Note: coverage does not affect how points
-are binned.
-The radius of the bin is determined only by the `radius` property.
+are binned. The radius of the bin is determined only by the `radius` property.
 
 ##### `elevationDomain` (Array, optional)
 

--- a/docs/layers/hexagon-layer.md
+++ b/docs/layers/hexagon-layer.md
@@ -102,7 +102,7 @@ new function on every rendering pass.
     renderLayers() {
       return new HexagonLayer({
         id: 'hexagon-layer',
-        getColorValue: this.getColorValue // instead of getColorValue: () => { return points.length; }
+        getColorValue: this.getColorValue // instead of getColorValue: (points) => { return points.length; }
         data,
         radius: 500
       });

--- a/docs/layers/hexagon-layer.md
+++ b/docs/layers/hexagon-layer.md
@@ -131,15 +131,15 @@ Whether to enable cell elevation. Cell elevation scale by count of points in eac
 
 - Default: `100`
 
-Filter bins and re-calculate color by `upperPercentile`. Hexagons with counts
-bigger than the upperPercentile counts will be hidden.
+Filter bins and re-calculate color by `upperPercentile`. Hexagons with value
+larger than the upperPercentile will be hidden.
 
 ##### `lowerPercentile` (Number, optional)
 
 - Default: `0`
 
-Filter bins and re-calculate color by `lowerPercentile`. Hexagons with counts
-smaller than the lowerPercentile counts will be hidden.
+Filter bins and re-calculate color by `lowerPercentile`. Hexagons with value
+smaller than the lowerPercentile will be hidden.
 
 ##### `fp64` (Boolean, optional)
 

--- a/examples/layer-browser/src/examples/core-layers.js
+++ b/examples/layer-browser/src/examples/core-layers.js
@@ -31,9 +31,9 @@ const MARKER_SIZE_MAP = {
 
 const LIGHT_SETTINGS = {
   lightsPosition: [-122.45, 37.66, 8000, -122.0, 38.00, 8000],
-  ambientRatio: 0.4,
+  ambientRatio: 0.3,
   diffuseRatio: 0.6,
-  specularRatio: 0.6,
+  specularRatio: 0.4,
   lightsStrength: [1, 0.0, 0.8, 0.0],
   numberOfLights: 2
 };
@@ -209,14 +209,29 @@ const GridCellLayerExample = {
   }
 };
 
+function getMean(pts, key) {
+  const filtered = pts.filter(pt => Number.isFinite(pt[key]));
+
+  return filtered.length ?
+    filtered.reduce((accu, curr) => accu + curr[key], 0) / filtered.length : null;
+}
+
+function getColorValue(points) {
+  return getMean(points, 'SPACES');
+}
+
 const GridLayerExample = {
   layer: GridLayer,
   propTypes: {
-    cellSize: {type: 'number', min: 0, max: 1000}
+    cellSize: {type: 'number', min: 0, max: 1000},
+    coverage: {type: 'number', min: 0, max: 1},
+    lowerPercentile: {type: 'number', min: 0, max: 100},
+    upperPercentile: {type: 'number', min: 0, max: 100}
   },
   props: {
     id: 'gridLayer',
     data: dataSamples.points,
+    getColorValue,
     cellSize: 200,
     opacity: 1,
     extruded: true,

--- a/examples/layer-browser/src/examples/core-layers.js
+++ b/examples/layer-browser/src/examples/core-layers.js
@@ -216,6 +216,10 @@ function getMean(pts, key) {
     filtered.reduce((accu, curr) => accu + curr[key], 0) / filtered.length : null;
 }
 
+// grid layer compares whether getColorValue has changed to
+// call out bin sorting. Here we pass in the function defined
+// outside props, so it doesn't create a new function on
+// every rendering pass
 function getColorValue(points) {
   return getMean(points, 'SPACES');
 }
@@ -231,6 +235,9 @@ const GridLayerExample = {
   props: {
     id: 'gridLayer',
     data: dataSamples.points,
+    // instead of doing getColorValue = () => {}
+    // defined the function outside and pass in here
+    // so it doesn't generate a new function on every render
     getColorValue,
     cellSize: 200,
     opacity: 1,

--- a/src/layers/core/grid-cell-layer/grid-cell-layer-vertex.glsl.js
+++ b/src/layers/core/grid-cell-layer/grid-cell-layer-vertex.glsl.js
@@ -38,6 +38,7 @@ uniform vec3 selectedPickingColor;
 // Custom uniforms
 uniform float extruded;
 uniform float cellSize;
+uniform float coverage;
 uniform float opacity;
 uniform float elevationScale;
 
@@ -57,10 +58,14 @@ float isPicked(vec3 pickingColors, vec3 selectedColor) {
 void main(void) {
 
   vec2 topLeftPos = project_position(instancePositions.xy);
+  
+  // if ahpha == 0.0, do not render element
+  float finalCellSize = cellSize * mix(1.0, 0.0, float(instanceColors.a == 0.0));
 
   // cube gemoetry vertics are between -1 to 1, scale and transform it to between 0, 1
-  vec2 pos = topLeftPos + vec2((positions.x + 1.0) * cellSize
-     / 2.0, (positions.y + 1.0) * cellSize / 2.0);
+  vec2 pos = topLeftPos + vec2(
+  (positions.x * coverage + 1.0) / 2.0 * finalCellSize, 
+  (positions.y * coverage + 1.0) / 2.0 * finalCellSize);
 
   float elevation = 0.0;
 

--- a/src/layers/core/grid-cell-layer/grid-cell-layer.js
+++ b/src/layers/core/grid-cell-layer/grid-cell-layer.js
@@ -32,6 +32,7 @@ const DEFAULT_COLOR = [255, 0, 255, 255];
 
 const defaultProps = {
   cellSize: 1000,
+  coverage: 1,
   elevationScale: 1,
   extruded: true,
   fp64: false,
@@ -133,7 +134,7 @@ export default class GridCellLayer extends Layer {
   }
 
   updateUniforms() {
-    const {opacity, extruded, elevationScale, cellSize, lightSettings} = this.props;
+    const {opacity, extruded, elevationScale, cellSize, coverage, lightSettings} = this.props;
     const {viewport} = this.context;
     const {pixelsPerMeter} = viewport.getDistanceScales();
 
@@ -141,7 +142,8 @@ export default class GridCellLayer extends Layer {
       extruded,
       elevationScale,
       opacity,
-      cellSize: cellSize * pixelsPerMeter[0]
+      cellSize: cellSize * pixelsPerMeter[0],
+      coverage
     },
     lightSettings));
   }

--- a/src/layers/core/grid-layer/grid-aggregator.js
+++ b/src/layers/core/grid-layer/grid-aggregator.js
@@ -30,12 +30,10 @@ export function pointToDensityGridData(points, cellSize, getPosition) {
 
   const {gridHash, gridOffset} = _pointsToGridHashing(points, cellSize, getPosition);
   const layerData = _getGridLayerDataFromGridHash(gridHash, gridOffset);
-  const countRange = _getCellCountExtent(layerData);
 
   return {
     gridOffset,
-    layerData,
-    countRange
+    layerData
   };
 }
 
@@ -92,13 +90,6 @@ function _getGridLayerDataFromGridHash(gridHash, gridOffset) {
 
     return accu;
   }, []);
-}
-
-function _getCellCountExtent(data) {
-  return data.length ? [
-    Math.min.apply(null, data.map(d => d.count)),
-    Math.max.apply(null, data.map(d => d.count))
-  ] : [0, 1];
 }
 
 /**

--- a/src/layers/core/grid-layer/grid-layer.js
+++ b/src/layers/core/grid-layer/grid-layer.js
@@ -151,7 +151,10 @@ export default class GridLayer extends CompositeLayer {
     const alpha = value >= valueDomain[0] && value <= valueDomain[1] ?
       (Number.isFinite(color[3]) ? color[3] : 255) : 0;
 
-    return color.concat([alpha]);
+    // add final alpha to color
+    color[3] = alpha;
+
+    return color;
   }
 
   _onGetSublayerElevation(cell) {

--- a/src/layers/core/grid-layer/grid-layer.js
+++ b/src/layers/core/grid-layer/grid-layer.js
@@ -38,7 +38,7 @@ const defaultProps = {
   upperPercentile: 100,
   coverage: 1,
   getPosition: x => x.position,
-  getColorValue: points => points.length,
+  c: points => points.length,
   extruded: false,
   fp64: false,
   // Optional settings for 'lighting' shader module

--- a/src/layers/core/grid-layer/grid-layer.js
+++ b/src/layers/core/grid-layer/grid-layer.js
@@ -81,15 +81,15 @@ export default class GridLayer extends CompositeLayer {
       this.getSortedBins();
 
       // this needs sortedBins to be set
-      this.onPercentileChange();
+      this.getValueDomain();
     } else if (_needsReSortBins(oldProps, props)) {
 
       this.getSortedBins();
-      this.onPercentileChange();
+      this.getValueDomain();
 
     } else if (_percentileChanged(oldProps, props)) {
 
-      this.onPercentileChange();
+      this.getValueDomain();
     }
   }
 
@@ -105,7 +105,7 @@ export default class GridLayer extends CompositeLayer {
     this.setState({sortedBins});
   }
 
-  onPercentileChange() {
+  getValueDomain() {
     const {lowerPercentile, upperPercentile} = this.props;
 
     this.state.valueDomain = this.state.sortedBins

--- a/src/layers/core/grid-layer/grid-layer.js
+++ b/src/layers/core/grid-layer/grid-layer.js
@@ -38,7 +38,7 @@ const defaultProps = {
   upperPercentile: 100,
   coverage: 1,
   getPosition: x => x.position,
-  c: points => points.length,
+  getColorValue: points => points.length,
   extruded: false,
   fp64: false,
   // Optional settings for 'lighting' shader module

--- a/src/layers/core/hexagon-layer/hexagon-aggregator.js
+++ b/src/layers/core/hexagon-layer/hexagon-aggregator.js
@@ -46,9 +46,10 @@ export function pointToHexbin({data, radius, getPosition}, viewport) {
   const hexagonBins = newHexbin(screenPoints);
 
   return {
-    hexagons: hexagonBins.map(hex => ({
+    hexagons: hexagonBins.map((hex, index) => ({
       centroid: viewport.unprojectFlat([hex.x, hex.y]),
-      points: hex
+      points: hex,
+      index
     }))
   };
 }

--- a/src/layers/core/hexagon-layer/hexagon-layer.js
+++ b/src/layers/core/hexagon-layer/hexagon-layer.js
@@ -189,7 +189,10 @@ export default class HexagonLayer extends CompositeLayer {
     const alpha = value >= valueDomain[0] && value <= valueDomain[1] ?
       (Number.isFinite(color[3]) ? color[3] : 255) : 0;
 
-    return color.concat([alpha]);
+    // add final alpha to color
+    color[3] = alpha;
+
+    return color;
   }
 
   _onGetSublayerElevation(cell) {

--- a/src/layers/core/hexagon-layer/hexagon-layer.js
+++ b/src/layers/core/hexagon-layer/hexagon-layer.js
@@ -118,16 +118,16 @@ export default class HexagonLayer extends CompositeLayer {
       this.getSortedBins();
 
       // this needs sortedBins to be set
-      this.onPercentileChange();
+      this.getValueDomain();
 
     } else if (_needsReSortBins(oldProps, props)) {
 
       this.getSortedBins();
-      this.onPercentileChange();
+      this.getValueDomain();
 
     } else if (_percentileChanged(oldProps, props)) {
 
-      this.onPercentileChange();
+      this.getValueDomain();
     }
   }
 
@@ -170,7 +170,7 @@ export default class HexagonLayer extends CompositeLayer {
     };
   }
 
-  onPercentileChange() {
+  getValueDomain() {
     const {lowerPercentile, upperPercentile} = this.props;
 
     this.state.valueDomain = this.state.sortedBins

--- a/src/layers/core/hexagon-layer/hexagon-layer.js
+++ b/src/layers/core/hexagon-layer/hexagon-layer.js
@@ -106,29 +106,28 @@ export default class HexagonLayer extends CompositeLayer {
     this.state = {
       hexagons: [],
       hexagonVertices: null,
-      countRange: null,
-      sortedCounts: null,
+      sortedBins: null,
       valueDomain: null
     };
   }
 
   updateState({oldProps, props, changeFlags}) {
     if (changeFlags.dataChanged || _needsReProjectPoints(oldProps, props)) {
-      // project data into hexagons, and get sortedCounts
+      // project data into hexagons, and get sortedBins
       this.getHexagons();
-      this.getSortedCounts();
+      this.getSortedBins();
 
-      // this needs sortedCounts to be set
-      this._onPercentileChange();
+      // this needs sortedBins to be set
+      this.onPercentileChange();
 
     } else if (_needsReSortBins(oldProps, props)) {
 
-      this.getSortedCounts();
-      this._onPercentileChange();
+      this.getSortedBins();
+      this.onPercentileChange();
 
     } else if (_percentileChanged(oldProps, props)) {
 
-      this._onPercentileChange();
+      this.onPercentileChange();
     }
   }
 
@@ -139,9 +138,9 @@ export default class HexagonLayer extends CompositeLayer {
     this.setState({hexagons, hexagonVertices});
   }
 
-  getSortedCounts() {
-    const sortedCounts = new BinSorter(this.state.hexagons || [], this.props.getColorValue);
-    this.setState({sortedCounts});
+  getSortedBins() {
+    const sortedBins = new BinSorter(this.state.hexagons || [], this.props.getColorValue);
+    this.setState({sortedBins});
   }
 
   getPickingInfo({info}) {
@@ -171,23 +170,23 @@ export default class HexagonLayer extends CompositeLayer {
     };
   }
 
-  _onPercentileChange() {
+  onPercentileChange() {
     const {lowerPercentile, upperPercentile} = this.props;
 
-    this.state.valueDomain = this.state.sortedCounts
+    this.state.valueDomain = this.state.sortedBins
       .getValueRange([lowerPercentile, upperPercentile]);
   }
 
   _onGetSublayerColor(cell) {
     const {colorRange} = this.props;
-    const {valueDomain} = this.state;
+    const {valueDomain, sortedBins} = this.state;
+    const value = sortedBins.binMap[cell.index] && sortedBins.binMap[cell.index].value;
 
     const colorDomain = this.props.colorDomain || valueDomain;
-    const count = cell.points.length;
-    const color = quantizeScale(colorDomain, colorRange, count);
+    const color = quantizeScale(colorDomain, colorRange, value);
 
-    // if cell count is outside domain, set alpha to 0
-    const alpha = count >= valueDomain[0] && count <= valueDomain[1] ?
+    // if cell value is outside domain, set alpha to 0
+    const alpha = value >= valueDomain[0] && value <= valueDomain[1] ?
       (Number.isFinite(color[3]) ? color[3] : 255) : 0;
 
     return color.concat([alpha]);
@@ -195,10 +194,10 @@ export default class HexagonLayer extends CompositeLayer {
 
   _onGetSublayerElevation(cell) {
     const {elevationDomain, elevationRange} = this.props;
-    const {sortedCounts} = this.state;
+    const {sortedBins} = this.state;
 
     // elevation is based on counts, it is not affected by percentile
-    const domain = elevationDomain || [0, sortedCounts.maxCount];
+    const domain = elevationDomain || [0, sortedBins.maxCount];
     return linearScale(domain, elevationRange, cell.points.length);
   }
 

--- a/src/utils/bin-sorter.js
+++ b/src/utils/bin-sorter.js
@@ -28,6 +28,7 @@ export default class BinSorter {
   constructor(bins = [], getValue = defaultGetValue) {
     this.sortedBins = this.getSortedBins(bins, getValue);
     this.maxCount = this.getMaxCount();
+    this.binMap = this.getBinMap();
   }
 
   /**
@@ -38,7 +39,11 @@ export default class BinSorter {
    */
   getSortedBins(bins, getValue) {
     return bins
-      .map((h, i) => ({i, value: getValue(h.points), counts: h.points.length}))
+      .map((h, i) => ({
+        i: Number.isFinite(h.index) ? h.index : i,
+        value: getValue(h.points),
+        counts: h.points.length
+      }))
       .sort((a, b) => a.value - b.value);
   }
 
@@ -66,5 +71,16 @@ export default class BinSorter {
    */
   getMaxCount() {
     return Math.max.apply(null, this.sortedBins.map(b => b.counts));
+  }
+
+  /**
+   * Get a mapping from cell/hexagon index to sorted bin
+   * This is used to retrieve bin value for color calculation
+   * @return {Object} bin index to sortedBins
+   */
+  getBinMap() {
+    return this.sortedBins.reduce((mapper, curr) => Object.assign(mapper, {
+      [curr.i]: curr
+    }), {});
   }
 }

--- a/test/layers/grid-layer.spec.js
+++ b/test/layers/grid-layer.spec.js
@@ -20,10 +20,14 @@
 import test from 'tape-catch';
 import sinon from 'sinon';
 
-import * as data from '../data';
+import * as FIXTURES from '../data';
+
 import {
+  testCreateEmptyLayer,
+  testCreateLayer,
   testInitializeLayer,
   testLayerUpdates,
+  testNullLayer,
   testSubLayerUpdateTriggers
 } from '../test-utils';
 
@@ -35,7 +39,7 @@ const getPosition = d => d.COORDINATES;
 const TEST_CASES = {
   // props to initialize layer with
   INITIAL_PROPS: {
-    data: data.points,
+    data: FIXTURES.points,
     cellSize: 400,
     getPosition,
     pickable: true
@@ -89,17 +93,14 @@ const TEST_CASES = {
 const SUBLAYER_TEST_CASES = {
   // props to initialize layer with
   INITIAL_PROPS: {
-    data: data.points,
+    data: FIXTURES.points,
     cellSize: 400,
     getPosition
   },
   // list of update props to call and asserts on the resulting layer
   UPDATES: [{
-    newProps: {
-      data: data.points,
-      // change radius
-      cellSize: 800,
-      getPosition
+    updateProps: {
+      cellSize: 800
     },
     assert: (subLayer, spies, t) => {
       t.ok(spies._onGetSublayerColor.called,
@@ -108,12 +109,8 @@ const SUBLAYER_TEST_CASES = {
         'update radius should call _onGetSublayerElevation');
     }
   }, {
-    newProps: {
-      data: data.points,
-      cellSize: 800,
-      // change opacity
-      opacity: 0.1,
-      getPosition
+    updateProps: {
+      opacity: 0.1
     },
     assert: (subLayer, spies, t) => {
       t.ok(spies._onGetSublayerColor.notCalled,
@@ -122,12 +119,8 @@ const SUBLAYER_TEST_CASES = {
         'update opacity  should not call _onGetSublayerElevation');
     }
   }, {
-    newProps: {
-      data: data.points,
-      cellSize: 800,
-      // change getColorValue
-      getColorValue,
-      getPosition
+    updateProps: {
+      getColorValue
     },
     assert: (subLayer, spies, t) => {
       t.ok(spies._onGetSublayerColor.called,
@@ -136,13 +129,8 @@ const SUBLAYER_TEST_CASES = {
         'update getColorValue  should not call _onGetSublayerElevation');
     }
   }, {
-    newProps: {
-      data: data.points,
-      cellSize: 800,
-      getColorValue,
-      // change upperPercentile
-      upperPercentile: 90,
-      getPosition
+    updateProps: {
+      upperPercentile: 90
     },
     assert: (subLayer, spies, t) => {
       t.ok(spies._onGetSublayerColor.called,
@@ -151,14 +139,8 @@ const SUBLAYER_TEST_CASES = {
         'update upperPercentile should not call _onGetSublayerElevation');
     }
   }, {
-    newProps: {
-      data: data.points,
-      cellSize: 800,
-      getColorValue,
-      upperPercentile: 90,
-      // change elevationRange
-      elevationRange: [0, 100],
-      getPosition
+    updateProps: {
+      elevationRange: [0, 100]
     },
     assert: (subLayer, spies, t) => {
       t.ok(spies._onGetSublayerColor.notCalled,
@@ -170,25 +152,16 @@ const SUBLAYER_TEST_CASES = {
 };
 
 test('GridLayer#constructor', t => {
-  let layer = new GridLayer({
-    id: 'emptyGeoJsonLayer',
-    data: [],
-    pickable: true
-  });
-  t.ok(layer instanceof GridLayer, 'Empty GridLayer created');
-  t.ok(layer instanceof GridLayer, 'Empty GridLayer created');
+  const LayerComponent = GridLayer;
+  const props = TEST_CASES.INITIAL_PROPS;
 
-  layer = new GridLayer({
-    data: data.points,
-    cellSize: 400,
-    getPosition,
-    pickable: true
-  });
-  t.ok(layer instanceof GridLayer, 'GridLayer created');
+  testCreateEmptyLayer(t, LayerComponent);
+  testNullLayer(t, LayerComponent);
+  const layer = testCreateLayer(t, LayerComponent, props);
 
   testInitializeLayer({layer});
 
-  const {layerData} = layer.state;
+  const {layerData, sortedBins, valueDomain} = layer.state;
 
   t.ok(layerData.length > 0, 'GridLayer.state.layerDate calculated');
   t.ok(sortedBins, 'GridLayer.state.sortedBins calculated');
@@ -206,24 +179,6 @@ test('GridLayer#constructor', t => {
   const subLayer = layer.renderLayers();
   t.ok(subLayer instanceof GridCellLayer, 'GridCellLayer rendered');
 
-  testUpdateLayer({layer, newProps: {
-    data: data.points,
-
-    // change cell Size
-    cellSize: 1000,
-    getPosition: d => d.COORDINATES,
-    pickable: true
-  }});
-
-  t.doesNotThrow(
-    () => new GridLayer({
-      id: 'nullGridLayer',
-      data: null,
-      pickable: true
-    }),
-    'Null GridLayer did not throw exception'
-  );
-
   t.end();
 });
 
@@ -232,7 +187,7 @@ test('GridLayer#renderSubLayer', t => {
   sinon.spy(GridLayer.prototype, '_onGetSublayerElevation');
 
   const layer = new GridLayer({
-    data: data.points,
+    data: FIXTURES.points,
     cellSize: 500,
     getPosition,
     pickable: true
@@ -259,7 +214,7 @@ test('GridLayer#renderSubLayer', t => {
 });
 
 test('GridLayer#updateLayer', t => {
-  testLayerUpdates({LayerComponent: GridLayer, testCases: TEST_CASES, t});
+  testLayerUpdates(t, {LayerComponent: GridLayer, testCases: TEST_CASES});
   t.end();
 });
 

--- a/test/layers/grid-layer.spec.js
+++ b/test/layers/grid-layer.spec.js
@@ -17,7 +17,6 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-/* eslint-disable no-unused-vars */
 import test from 'tape-catch';
 import sinon from 'sinon';
 
@@ -192,29 +191,29 @@ test('GridLayer#constructor', t => {
   const {layerData} = layer.state;
 
   t.ok(layerData.length > 0, 'GridLayer.state.layerDate calculated');
-  // t.ok(sortedBins, 'GridLayer.state.sortedBins calculated');
-  // t.ok(Array.isArray(valueDomain), 'GridLayer.state.valueDomain calculated');
+  t.ok(sortedBins, 'GridLayer.state.sortedBins calculated');
+  t.ok(Array.isArray(valueDomain), 'GridLayer.state.valueDomain calculated');
 
-  // t.ok(Array.isArray(sortedBins.sortedBins), 'GridLayer.state.sortedBins.sortedBins calculated');
-  // t.ok(Number.isFinite(sortedBins.maxCount), 'GridLayer.state.sortedBins.maxCount calculated');
+  t.ok(Array.isArray(sortedBins.sortedBins), 'GridLayer.state.sortedBins.sortedBins calculated');
+  t.ok(Number.isFinite(sortedBins.maxCount), 'GridLayer.state.sortedBins.maxCount calculated');
 
-  // const firstSortedBin = sortedBins.sortedBins[0];
-  // const binTocell = layerData.find(d => d.index === firstSortedBin.i);
+  const firstSortedBin = sortedBins.sortedBins[0];
+  const binTocell = layerData.find(d => d.index === firstSortedBin.i);
 
-  // t.ok(sortedBins.binMap[binTocell.index] === firstSortedBin,
-  //   'Correct GridLayer.state.sortedBins.binMap created');
+  t.ok(sortedBins.binMap[binTocell.index] === firstSortedBin,
+    'Correct GridLayer.state.sortedBins.binMap created');
 
-  // const subLayer = layer.renderLayers();
-  // t.ok(subLayer instanceof GridCellLayer, 'GridCellLayer rendered');
-  //
-  // testUpdateLayer({layer, newProps: {
-  //   data: data.points,
-  //
-  //   // change cell Size
-  //   cellSize: 1000,
-  //   getPosition: d => d.COORDINATES,
-  //   pickable: true
-  // }});
+  const subLayer = layer.renderLayers();
+  t.ok(subLayer instanceof GridCellLayer, 'GridCellLayer rendered');
+
+  testUpdateLayer({layer, newProps: {
+    data: data.points,
+
+    // change cell Size
+    cellSize: 1000,
+    getPosition: d => d.COORDINATES,
+    pickable: true
+  }});
 
   t.doesNotThrow(
     () => new GridLayer({
@@ -259,7 +258,6 @@ test('GridLayer#renderSubLayer', t => {
   t.end();
 });
 
-/*
 test('GridLayer#updateLayer', t => {
   testLayerUpdates({LayerComponent: GridLayer, testCases: TEST_CASES, t});
   t.end();
@@ -280,5 +278,3 @@ test('GridLayer#updateTriggers', t => {
 
   t.end();
 });
-*/
-/* eslint-enable no-unused-vars */

--- a/test/layers/hexagon-layer.spec.js
+++ b/test/layers/hexagon-layer.spec.js
@@ -49,9 +49,8 @@ const TEST_CASES = {
       t.ok(oldState.hexagons !== layer.state.hexagons,
         'should update layer data');
 
-      // TODO: add it back with grid/hex PR
-      // t.ok(oldState.sortedBins !== layer.state.sortedBins,
-      //   'should update sortedBins');
+      t.ok(oldState.sortedBins !== layer.state.sortedBins,
+        'should update sortedBins');
 
       t.ok(oldState.valueDomain !== layer.state.valueDomain,
         'should update valueDomain');
@@ -64,9 +63,8 @@ const TEST_CASES = {
       t.ok(oldState.hexagons === layer.state.hexagons,
         'should not update layer data');
 
-      // TODO: add it back with grid/hex PR
-      // t.ok(oldState.sortedBins !== layer.state.sortedBins,
-      //  'should update sortedBins');
+      t.ok(oldState.sortedBins !== layer.state.sortedBins,
+       'should update sortedBins');
 
       t.ok(oldState.valueDomain !== layer.state.valueDomain,
         'should re calculate valueDomain');
@@ -79,9 +77,8 @@ const TEST_CASES = {
       t.ok(oldState.hexagons === layer.state.hexagons,
         'should not update layer data');
 
-      // TODO: add it back with grid/hex PR
-      // t.ok(oldState.sortedBins === layer.state.sortedBins,
-      //  'should not update sortedBins');
+      t.ok(oldState.sortedBins === layer.state.sortedBins,
+       'should not update sortedBins');
 
       t.ok(oldState.valueDomain !== layer.state.valueDomain,
         'should re calculate valueDomain');
@@ -99,10 +96,7 @@ const SUBLAYER_TEST_CASES = {
   // list of update props to call and asserts on the resulting layer
   UPDATES: [{
     updateProps: {
-      data: data.points,
-      // change radius
-      radius: 800,
-      getPosition
+      radius: 800
     },
     assert: (subLayer, spies, t) => {
       t.ok(spies._onGetSublayerColor.called,
@@ -121,21 +115,16 @@ const SUBLAYER_TEST_CASES = {
         'update opacity  should not call _onGetSublayerElevation');
     }
   }, {
-  // TODO: add it back with hex/grid PR
-  //   newProps: {
-  //     data: data.points,
-  //     radius: 800,
-  //     // change getColorValue
-  //     getColorValue,
-  //     getPosition
-  //   },
-  //   assert: (subLayer, spies, t) => {
-  //     t.ok(spies._onGetSublayerColor.called,
-  //       'update getColorValue should call _onGetSublayerColor');
-  //     t.ok(spies._onGetSublayerElevation.notCalled,
-  //       'update getColorValue  should not call _onGetSublayerElevation');
-  //   }
-  // }, {
+    updateProps: {
+      getColorValue
+    },
+    assert: (subLayer, spies, t) => {
+      t.ok(spies._onGetSublayerColor.called,
+        'update getColorValue should call _onGetSublayerColor');
+      t.ok(spies._onGetSublayerElevation.notCalled,
+        'update getColorValue  should not call _onGetSublayerElevation');
+    }
+  }, {
     updateProps: {
       upperPercentile: 90
     },

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -238,16 +238,20 @@ export function testSubLayerUpdateTriggers(t, {FunctionsToSpy, LayerComponent, t
 
 export function testCreateLayer(t, LayerComponent, props = {}) {
   let failures = false;
+  let layer = null;
+
   try {
-    const layer = new LayerComponent(Object.assign({
+    layer = new LayerComponent(Object.assign({
       id: `${LayerComponent.layerName}-0`
     }, props));
-    t.ok(layer instanceof LayerComponent, `${LayerComponent.layerName} created`);
 
+    t.ok(layer instanceof LayerComponent, `${LayerComponent.layerName} created`);
   } catch (error) {
     failures = true;
   }
   t.ok(!failures, `creating ${LayerComponent.layerName} should not fail`);
+
+  return layer;
 }
 
 export function testCreateEmptyLayer(t, LayerComponent, props = {}) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+abab@^1.0.3:
+  version "1.0.3"
+  resolved "https://unpm.uberinternal.com/abab/-/abab-1.0.3.tgz#b81de5f7274ec4e756d797cd834f303642724e5d"
+
 abbrev@1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
@@ -23,6 +27,12 @@ acorn-es7-plugin@~1.1.0:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/acorn-es7-plugin/-/acorn-es7-plugin-1.1.5.tgz#f31e1a618f439bfdde8851dd875a3a163ca8201f"
 
+acorn-globals@^3.1.0:
+  version "3.1.0"
+  resolved "https://unpm.uberinternal.com/acorn-globals/-/acorn-globals-3.1.0.tgz#fd8270f71fbb4996b004fa880ee5d46573a731bf"
+  dependencies:
+    acorn "^4.0.4"
+
 acorn-jsx@^3.0.0, acorn-jsx@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
@@ -43,7 +53,7 @@ acorn@^3.0.4, acorn@^3.1.0, acorn@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
-acorn@^4.0.3, acorn@~4.0.5:
+acorn@^4.0.3, acorn@^4.0.4, acorn@~4.0.5:
   version "4.0.11"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.11.tgz#edcda3bd937e7556410d42ed5860f67399c794c0"
 
@@ -141,6 +151,10 @@ arr-diff@^2.0.0:
 arr-flatten@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.0.1.tgz#e5ffe54d45e19f32f216e91eb99c8ce892bb604b"
+
+array-equal@^1.0.0:
+  version "1.0.0"
+  resolved "https://unpm.uberinternal.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
 
 array-find-index@^1.0.1:
   version "1.0.2"
@@ -1078,6 +1092,10 @@ content-disposition@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
 
+content-type-parser@^1.0.1:
+  version "1.0.1"
+  resolved "https://unpm.uberinternal.com/content-type-parser/-/content-type-parser-1.0.1.tgz#c3e56988c53c65127fb46d4032a3a900246fdc94"
+
 content-type@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.2.tgz#b7d113aee7a8dd27bd21133c4dc2529df1721eed"
@@ -1174,6 +1192,16 @@ crypto-browserify@^3.11.0:
     pbkdf2 "^3.0.3"
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
+
+cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
+  version "0.3.2"
+  resolved "https://unpm.uberinternal.com/cssom/-/cssom-0.3.2.tgz#b8036170c79f07a90ff2f16e22284027a243848b"
+
+"cssstyle@>= 0.2.37 < 0.3.0":
+  version "0.2.37"
+  resolved "https://unpm.uberinternal.com/cssstyle/-/cssstyle-0.2.37.tgz#541097234cb2513c83ceed3acddc27ff27987d54"
+  dependencies:
+    cssom "0.3.x"
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -1298,6 +1326,10 @@ detect-indent@^4.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
   dependencies:
     repeating "^2.0.0"
+
+diff@^3.1.0:
+  version "3.2.0"
+  resolved "https://unpm.uberinternal.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
 diffie-hellman@^5.0.0:
   version "5.0.2"
@@ -1476,6 +1508,17 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
+escodegen@^1.6.1:
+  version "1.8.1"
+  resolved "https://unpm.uberinternal.com/escodegen/-/escodegen-1.8.1.tgz#5a5b53af4693110bebb0867aa3430dd3b70a1018"
+  dependencies:
+    esprima "^2.7.1"
+    estraverse "^1.9.1"
+    esutils "^2.0.2"
+    optionator "^0.8.1"
+  optionalDependencies:
+    source-map "~0.2.0"
+
 escope@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/escope/-/escope-3.6.0.tgz#e01975e812781a163a6dadfdd80398dc64c889c3"
@@ -1555,7 +1598,7 @@ espree@^3.4.0:
     acorn "4.0.4"
     acorn-jsx "^3.0.0"
 
-esprima@^2.6.0:
+esprima@^2.6.0, esprima@^2.7.1:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
 
@@ -1565,6 +1608,10 @@ esrecurse@^4.1.0:
   dependencies:
     estraverse "~4.1.0"
     object-assign "^4.0.1"
+
+estraverse@^1.9.1:
+  version "1.9.3"
+  resolved "https://unpm.uberinternal.com/estraverse/-/estraverse-1.9.3.tgz#af67f2dc922582415950926091a4005d29c9bb44"
 
 estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
@@ -1836,6 +1883,12 @@ form-data@~2.1.1:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
+
+formatio@1.2.0:
+  version "1.2.0"
+  resolved "https://unpm.uberinternal.com/formatio/-/formatio-1.2.0.tgz#f3b2167d9068c4698a8d51f4f760a39a54d818eb"
+  dependencies:
+    samsam "1.x"
 
 forwarded@~0.1.0:
   version "0.1.0"
@@ -2125,6 +2178,12 @@ hpack.js@^2.1.6:
     readable-stream "^2.0.1"
     wbuf "^1.1.0"
 
+html-encoding-sniffer@^1.0.1:
+  version "1.0.1"
+  resolved "https://unpm.uberinternal.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz#79bf7a785ea495fe66165e734153f363ff5437da"
+  dependencies:
+    whatwg-encoding "^1.0.1"
+
 html-entities@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.0.tgz#41948caf85ce82fed36e4e6a0ed371a6664379e2"
@@ -2184,6 +2243,10 @@ hyperquest@~1.2.0:
   dependencies:
     duplexer2 "~0.0.2"
     through2 "~0.6.3"
+
+iconv-lite@0.4.13:
+  version "0.4.13"
+  resolved "https://unpm.uberinternal.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
 
 iconv-lite@~0.4.13:
   version "0.4.15"
@@ -2519,6 +2582,30 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
 
+jsdom@^9.11.0:
+  version "9.12.0"
+  resolved "https://unpm.uberinternal.com/jsdom/-/jsdom-9.12.0.tgz#e8c546fffcb06c00d4833ca84410fed7f8a097d4"
+  dependencies:
+    abab "^1.0.3"
+    acorn "^4.0.4"
+    acorn-globals "^3.1.0"
+    array-equal "^1.0.0"
+    content-type-parser "^1.0.1"
+    cssom ">= 0.3.2 < 0.4.0"
+    cssstyle ">= 0.2.37 < 0.3.0"
+    escodegen "^1.6.1"
+    html-encoding-sniffer "^1.0.1"
+    nwmatcher ">= 1.3.9 < 2.0.0"
+    parse5 "^1.5.1"
+    request "^2.79.0"
+    sax "^1.2.1"
+    symbol-tree "^3.2.1"
+    tough-cookie "^2.3.2"
+    webidl-conversions "^4.0.0"
+    whatwg-encoding "^1.0.1"
+    whatwg-url "^4.3.0"
+    xml-name-validator "^2.0.1"
+
 jsesc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
@@ -2672,6 +2759,10 @@ lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.2.0, lo
 log-driver@1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.5.tgz#7ae4ec257302fd790d557cb10c97100d857b0056"
+
+lolex@^1.6.0:
+  version "1.6.0"
+  resolved "https://unpm.uberinternal.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -2868,6 +2959,10 @@ nan@^2.3.0, nan@^2.3.3:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.5.1.tgz#d5b01691253326a97a2bbee9e61c55d8d60351e2"
 
+native-promise-only@^0.8.1:
+  version "0.8.1"
+  resolved "https://unpm.uberinternal.com/native-promise-only/-/native-promise-only-0.8.1.tgz#20a318c30cb45f71fe7adfbf7b21c99c1472ef11"
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -3010,6 +3105,10 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
+"nwmatcher@>= 1.3.9 < 2.0.0":
+  version "1.3.9"
+  resolved "https://unpm.uberinternal.com/nwmatcher/-/nwmatcher-1.3.9.tgz#8bab486ff7fa3dfd086656bbe8b17116d3692d2a"
+
 nyc@^10.2.0:
   version "10.2.2"
   resolved "https://registry.yarnpkg.com/nyc/-/nyc-10.2.2.tgz#1b1c8ca4636d810cb3e281558dc9fcb08389f204"
@@ -3113,7 +3212,7 @@ optimist@^0.6.1:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
 
-optionator@^0.8.2:
+optionator@^0.8.1, optionator@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
   dependencies:
@@ -3206,6 +3305,10 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
+parse5@^1.5.1:
+  version "1.5.1"
+  resolved "https://unpm.uberinternal.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
+
 parseurl@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.1.tgz#c8ab8c9223ba34888aa64a297b28853bec18da56"
@@ -3252,6 +3355,12 @@ path-parse@^1.0.5:
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://unpm.uberinternal.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -3745,6 +3854,14 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
+samsam@1.x, samsam@^1.1.3:
+  version "1.2.1"
+  resolved "https://unpm.uberinternal.com/samsam/-/samsam-1.2.1.tgz#edd39093a3184370cb859243b2bdf255e7d8ea67"
+
+sax@^1.2.1:
+  version "1.2.2"
+  resolved "https://unpm.uberinternal.com/sax/-/sax-1.2.2.tgz#fd8631a23bc7826bef5d871bdb87378c95647828"
+
 seer@^0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/seer/-/seer-0.0.4.tgz#d17b3db111f60171d0a85a7fb9bac183eb955b98"
@@ -3860,6 +3977,19 @@ simple-mime@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/simple-mime/-/simple-mime-0.1.0.tgz#95f517c4f466d7cff561a71fc9dab2596ea9ef2e"
 
+sinon@^2.1.0:
+  version "2.1.0"
+  resolved "https://unpm.uberinternal.com/sinon/-/sinon-2.1.0.tgz#e057a9d2bf1b32f5d6dd62628ca9ee3961b0cafb"
+  dependencies:
+    diff "^3.1.0"
+    formatio "1.2.0"
+    lolex "^1.6.0"
+    native-promise-only "^0.8.1"
+    path-to-regexp "^1.7.0"
+    samsam "^1.1.3"
+    text-encoding "0.6.4"
+    type-detect "^4.0.0"
+
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
@@ -3915,6 +4045,12 @@ source-map@^0.4.4:
 source-map@^0.5.0, source-map@^0.5.3, source-map@~0.5.1, source-map@~0.5.3:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+
+source-map@~0.2.0:
+  version "0.2.0"
+  resolved "https://unpm.uberinternal.com/source-map/-/source-map-0.2.0.tgz#dab73fbcfc2ba819b4de03bd6f6eaa48164b3f9d"
+  dependencies:
+    amdefine ">=0.0.4"
 
 spawn-sync@^1.0.15:
   version "1.0.15"
@@ -4079,6 +4215,10 @@ supports-color@^3.1.0, supports-color@^3.1.1, supports-color@^3.1.2:
   dependencies:
     has-flag "^1.0.0"
 
+symbol-tree@^3.2.1:
+  version "3.2.2"
+  resolved "https://unpm.uberinternal.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
+
 table@^3.7.8:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/table/-/table-3.8.3.tgz#2bbc542f0fda9861a755d3947fefd8b3f513855f"
@@ -4189,6 +4329,10 @@ test-exclude@^4.0.0, test-exclude@^4.0.3:
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
 
+text-encoding@0.6.4:
+  version "0.6.4"
+  resolved "https://unpm.uberinternal.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
+
 text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -4232,11 +4376,15 @@ to-fast-properties@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.2.tgz#f3f5c0c3ba7299a7ef99427e44633257ade43320"
 
-tough-cookie@~2.3.0:
+tough-cookie@^2.3.2, tough-cookie@~2.3.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
   dependencies:
     punycode "^1.4.1"
+
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://unpm.uberinternal.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
 
 transform-loader@^0.2.3:
   version "0.2.4"
@@ -4273,6 +4421,10 @@ type-check@~0.3.2:
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
+
+type-detect@^4.0.0:
+  version "4.0.3"
+  resolved "https://unpm.uberinternal.com/type-detect/-/type-detect-4.0.3.tgz#0e3f2670b44099b0b46c284d136a7ef49c74c2ea"
 
 type-is@~1.6.14:
   version "1.6.14"
@@ -4433,6 +4585,14 @@ webgl-debug@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/webgl-debug/-/webgl-debug-1.0.2.tgz#93bac5aed181343a136ad34f249920d3b9ccc69a"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://unpm.uberinternal.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+
+webidl-conversions@^4.0.0:
+  version "4.0.1"
+  resolved "https://unpm.uberinternal.com/webidl-conversions/-/webidl-conversions-4.0.1.tgz#8015a17ab83e7e1b311638486ace81da6ce206a0"
+
 webpack-dev-middleware@^1.10.2:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-1.10.2.tgz#2e252ce1dfb020dbda1ccb37df26f30ab014dbd1"
@@ -4507,9 +4667,22 @@ websocket-extensions@>=0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.1.tgz#76899499c184b6ef754377c2dbb0cd6cb55d29e7"
 
+whatwg-encoding@^1.0.1:
+  version "1.0.1"
+  resolved "https://unpm.uberinternal.com/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz#3c6c451a198ee7aec55b1ec61d0920c67801a5f4"
+  dependencies:
+    iconv-lite "0.4.13"
+
 whatwg-fetch@>=0.10.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
+
+whatwg-url@^4.3.0:
+  version "4.7.1"
+  resolved "https://unpm.uberinternal.com/whatwg-url/-/whatwg-url-4.7.1.tgz#df4dc2e3f25a63b1fa5b32ed6d6c139577d690de"
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 which-module@^1.0.0:
   version "1.0.0"
@@ -4563,6 +4736,10 @@ write@^0.2.1:
   resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
   dependencies:
     mkdirp "^0.5.1"
+
+xml-name-validator@^2.0.1:
+  version "2.0.1"
+  resolved "https://unpm.uberinternal.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
 
 "xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,6 @@
 # yarn lockfile v1
 
 
-abab@^1.0.3:
-  version "1.0.3"
-  resolved "https://unpm.uberinternal.com/abab/-/abab-1.0.3.tgz#b81de5f7274ec4e756d797cd834f303642724e5d"
-
 abbrev@1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
@@ -27,12 +23,6 @@ acorn-es7-plugin@~1.1.0:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/acorn-es7-plugin/-/acorn-es7-plugin-1.1.5.tgz#f31e1a618f439bfdde8851dd875a3a163ca8201f"
 
-acorn-globals@^3.1.0:
-  version "3.1.0"
-  resolved "https://unpm.uberinternal.com/acorn-globals/-/acorn-globals-3.1.0.tgz#fd8270f71fbb4996b004fa880ee5d46573a731bf"
-  dependencies:
-    acorn "^4.0.4"
-
 acorn-jsx@^3.0.0, acorn-jsx@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
@@ -53,7 +43,7 @@ acorn@^3.0.4, acorn@^3.1.0, acorn@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
-acorn@^4.0.3, acorn@^4.0.4, acorn@~4.0.5:
+acorn@^4.0.3, acorn@~4.0.5:
   version "4.0.11"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.11.tgz#edcda3bd937e7556410d42ed5860f67399c794c0"
 
@@ -151,10 +141,6 @@ arr-diff@^2.0.0:
 arr-flatten@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.0.1.tgz#e5ffe54d45e19f32f216e91eb99c8ce892bb604b"
-
-array-equal@^1.0.0:
-  version "1.0.0"
-  resolved "https://unpm.uberinternal.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
 
 array-find-index@^1.0.1:
   version "1.0.2"
@@ -1092,10 +1078,6 @@ content-disposition@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
 
-content-type-parser@^1.0.1:
-  version "1.0.1"
-  resolved "https://unpm.uberinternal.com/content-type-parser/-/content-type-parser-1.0.1.tgz#c3e56988c53c65127fb46d4032a3a900246fdc94"
-
 content-type@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.2.tgz#b7d113aee7a8dd27bd21133c4dc2529df1721eed"
@@ -1192,16 +1174,6 @@ crypto-browserify@^3.11.0:
     pbkdf2 "^3.0.3"
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
-
-cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
-  version "0.3.2"
-  resolved "https://unpm.uberinternal.com/cssom/-/cssom-0.3.2.tgz#b8036170c79f07a90ff2f16e22284027a243848b"
-
-"cssstyle@>= 0.2.37 < 0.3.0":
-  version "0.2.37"
-  resolved "https://unpm.uberinternal.com/cssstyle/-/cssstyle-0.2.37.tgz#541097234cb2513c83ceed3acddc27ff27987d54"
-  dependencies:
-    cssom "0.3.x"
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -1326,10 +1298,6 @@ detect-indent@^4.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
   dependencies:
     repeating "^2.0.0"
-
-diff@^3.1.0:
-  version "3.2.0"
-  resolved "https://unpm.uberinternal.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
 diffie-hellman@^5.0.0:
   version "5.0.2"
@@ -1508,17 +1476,6 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
-escodegen@^1.6.1:
-  version "1.8.1"
-  resolved "https://unpm.uberinternal.com/escodegen/-/escodegen-1.8.1.tgz#5a5b53af4693110bebb0867aa3430dd3b70a1018"
-  dependencies:
-    esprima "^2.7.1"
-    estraverse "^1.9.1"
-    esutils "^2.0.2"
-    optionator "^0.8.1"
-  optionalDependencies:
-    source-map "~0.2.0"
-
 escope@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/escope/-/escope-3.6.0.tgz#e01975e812781a163a6dadfdd80398dc64c889c3"
@@ -1598,7 +1555,7 @@ espree@^3.4.0:
     acorn "4.0.4"
     acorn-jsx "^3.0.0"
 
-esprima@^2.6.0, esprima@^2.7.1:
+esprima@^2.6.0:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
 
@@ -1608,10 +1565,6 @@ esrecurse@^4.1.0:
   dependencies:
     estraverse "~4.1.0"
     object-assign "^4.0.1"
-
-estraverse@^1.9.1:
-  version "1.9.3"
-  resolved "https://unpm.uberinternal.com/estraverse/-/estraverse-1.9.3.tgz#af67f2dc922582415950926091a4005d29c9bb44"
 
 estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
@@ -1883,12 +1836,6 @@ form-data@~2.1.1:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
-
-formatio@1.2.0:
-  version "1.2.0"
-  resolved "https://unpm.uberinternal.com/formatio/-/formatio-1.2.0.tgz#f3b2167d9068c4698a8d51f4f760a39a54d818eb"
-  dependencies:
-    samsam "1.x"
 
 forwarded@~0.1.0:
   version "0.1.0"
@@ -2178,12 +2125,6 @@ hpack.js@^2.1.6:
     readable-stream "^2.0.1"
     wbuf "^1.1.0"
 
-html-encoding-sniffer@^1.0.1:
-  version "1.0.1"
-  resolved "https://unpm.uberinternal.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz#79bf7a785ea495fe66165e734153f363ff5437da"
-  dependencies:
-    whatwg-encoding "^1.0.1"
-
 html-entities@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.0.tgz#41948caf85ce82fed36e4e6a0ed371a6664379e2"
@@ -2243,10 +2184,6 @@ hyperquest@~1.2.0:
   dependencies:
     duplexer2 "~0.0.2"
     through2 "~0.6.3"
-
-iconv-lite@0.4.13:
-  version "0.4.13"
-  resolved "https://unpm.uberinternal.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
 
 iconv-lite@~0.4.13:
   version "0.4.15"
@@ -2582,30 +2519,6 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
 
-jsdom@^9.11.0:
-  version "9.12.0"
-  resolved "https://unpm.uberinternal.com/jsdom/-/jsdom-9.12.0.tgz#e8c546fffcb06c00d4833ca84410fed7f8a097d4"
-  dependencies:
-    abab "^1.0.3"
-    acorn "^4.0.4"
-    acorn-globals "^3.1.0"
-    array-equal "^1.0.0"
-    content-type-parser "^1.0.1"
-    cssom ">= 0.3.2 < 0.4.0"
-    cssstyle ">= 0.2.37 < 0.3.0"
-    escodegen "^1.6.1"
-    html-encoding-sniffer "^1.0.1"
-    nwmatcher ">= 1.3.9 < 2.0.0"
-    parse5 "^1.5.1"
-    request "^2.79.0"
-    sax "^1.2.1"
-    symbol-tree "^3.2.1"
-    tough-cookie "^2.3.2"
-    webidl-conversions "^4.0.0"
-    whatwg-encoding "^1.0.1"
-    whatwg-url "^4.3.0"
-    xml-name-validator "^2.0.1"
-
 jsesc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
@@ -2759,10 +2672,6 @@ lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.2.0, lo
 log-driver@1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.5.tgz#7ae4ec257302fd790d557cb10c97100d857b0056"
-
-lolex@^1.6.0:
-  version "1.6.0"
-  resolved "https://unpm.uberinternal.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -2959,10 +2868,6 @@ nan@^2.3.0, nan@^2.3.3:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.5.1.tgz#d5b01691253326a97a2bbee9e61c55d8d60351e2"
 
-native-promise-only@^0.8.1:
-  version "0.8.1"
-  resolved "https://unpm.uberinternal.com/native-promise-only/-/native-promise-only-0.8.1.tgz#20a318c30cb45f71fe7adfbf7b21c99c1472ef11"
-
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -3105,10 +3010,6 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-"nwmatcher@>= 1.3.9 < 2.0.0":
-  version "1.3.9"
-  resolved "https://unpm.uberinternal.com/nwmatcher/-/nwmatcher-1.3.9.tgz#8bab486ff7fa3dfd086656bbe8b17116d3692d2a"
-
 nyc@^10.2.0:
   version "10.2.2"
   resolved "https://registry.yarnpkg.com/nyc/-/nyc-10.2.2.tgz#1b1c8ca4636d810cb3e281558dc9fcb08389f204"
@@ -3212,7 +3113,7 @@ optimist@^0.6.1:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
 
-optionator@^0.8.1, optionator@^0.8.2:
+optionator@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
   dependencies:
@@ -3305,10 +3206,6 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
-parse5@^1.5.1:
-  version "1.5.1"
-  resolved "https://unpm.uberinternal.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
-
 parseurl@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.1.tgz#c8ab8c9223ba34888aa64a297b28853bec18da56"
@@ -3355,12 +3252,6 @@ path-parse@^1.0.5:
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
-
-path-to-regexp@^1.7.0:
-  version "1.7.0"
-  resolved "https://unpm.uberinternal.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
-  dependencies:
-    isarray "0.0.1"
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -3854,14 +3745,6 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
-samsam@1.x, samsam@^1.1.3:
-  version "1.2.1"
-  resolved "https://unpm.uberinternal.com/samsam/-/samsam-1.2.1.tgz#edd39093a3184370cb859243b2bdf255e7d8ea67"
-
-sax@^1.2.1:
-  version "1.2.2"
-  resolved "https://unpm.uberinternal.com/sax/-/sax-1.2.2.tgz#fd8631a23bc7826bef5d871bdb87378c95647828"
-
 seer@^0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/seer/-/seer-0.0.4.tgz#d17b3db111f60171d0a85a7fb9bac183eb955b98"
@@ -3977,19 +3860,6 @@ simple-mime@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/simple-mime/-/simple-mime-0.1.0.tgz#95f517c4f466d7cff561a71fc9dab2596ea9ef2e"
 
-sinon@^2.1.0:
-  version "2.1.0"
-  resolved "https://unpm.uberinternal.com/sinon/-/sinon-2.1.0.tgz#e057a9d2bf1b32f5d6dd62628ca9ee3961b0cafb"
-  dependencies:
-    diff "^3.1.0"
-    formatio "1.2.0"
-    lolex "^1.6.0"
-    native-promise-only "^0.8.1"
-    path-to-regexp "^1.7.0"
-    samsam "^1.1.3"
-    text-encoding "0.6.4"
-    type-detect "^4.0.0"
-
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
@@ -4045,12 +3915,6 @@ source-map@^0.4.4:
 source-map@^0.5.0, source-map@^0.5.3, source-map@~0.5.1, source-map@~0.5.3:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
-
-source-map@~0.2.0:
-  version "0.2.0"
-  resolved "https://unpm.uberinternal.com/source-map/-/source-map-0.2.0.tgz#dab73fbcfc2ba819b4de03bd6f6eaa48164b3f9d"
-  dependencies:
-    amdefine ">=0.0.4"
 
 spawn-sync@^1.0.15:
   version "1.0.15"
@@ -4215,10 +4079,6 @@ supports-color@^3.1.0, supports-color@^3.1.1, supports-color@^3.1.2:
   dependencies:
     has-flag "^1.0.0"
 
-symbol-tree@^3.2.1:
-  version "3.2.2"
-  resolved "https://unpm.uberinternal.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
-
 table@^3.7.8:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/table/-/table-3.8.3.tgz#2bbc542f0fda9861a755d3947fefd8b3f513855f"
@@ -4329,10 +4189,6 @@ test-exclude@^4.0.0, test-exclude@^4.0.3:
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
 
-text-encoding@0.6.4:
-  version "0.6.4"
-  resolved "https://unpm.uberinternal.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
-
 text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -4376,15 +4232,11 @@ to-fast-properties@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.2.tgz#f3f5c0c3ba7299a7ef99427e44633257ade43320"
 
-tough-cookie@^2.3.2, tough-cookie@~2.3.0:
+tough-cookie@~2.3.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
   dependencies:
     punycode "^1.4.1"
-
-tr46@~0.0.3:
-  version "0.0.3"
-  resolved "https://unpm.uberinternal.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
 
 transform-loader@^0.2.3:
   version "0.2.4"
@@ -4421,10 +4273,6 @@ type-check@~0.3.2:
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
-
-type-detect@^4.0.0:
-  version "4.0.3"
-  resolved "https://unpm.uberinternal.com/type-detect/-/type-detect-4.0.3.tgz#0e3f2670b44099b0b46c284d136a7ef49c74c2ea"
 
 type-is@~1.6.14:
   version "1.6.14"
@@ -4585,14 +4433,6 @@ webgl-debug@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/webgl-debug/-/webgl-debug-1.0.2.tgz#93bac5aed181343a136ad34f249920d3b9ccc69a"
 
-webidl-conversions@^3.0.0:
-  version "3.0.1"
-  resolved "https://unpm.uberinternal.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
-
-webidl-conversions@^4.0.0:
-  version "4.0.1"
-  resolved "https://unpm.uberinternal.com/webidl-conversions/-/webidl-conversions-4.0.1.tgz#8015a17ab83e7e1b311638486ace81da6ce206a0"
-
 webpack-dev-middleware@^1.10.2:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-1.10.2.tgz#2e252ce1dfb020dbda1ccb37df26f30ab014dbd1"
@@ -4667,22 +4507,9 @@ websocket-extensions@>=0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.1.tgz#76899499c184b6ef754377c2dbb0cd6cb55d29e7"
 
-whatwg-encoding@^1.0.1:
-  version "1.0.1"
-  resolved "https://unpm.uberinternal.com/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz#3c6c451a198ee7aec55b1ec61d0920c67801a5f4"
-  dependencies:
-    iconv-lite "0.4.13"
-
 whatwg-fetch@>=0.10.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
-
-whatwg-url@^4.3.0:
-  version "4.7.1"
-  resolved "https://unpm.uberinternal.com/whatwg-url/-/whatwg-url-4.7.1.tgz#df4dc2e3f25a63b1fa5b32ed6d6c139577d690de"
-  dependencies:
-    tr46 "~0.0.3"
-    webidl-conversions "^3.0.0"
 
 which-module@^1.0.0:
   version "1.0.0"
@@ -4736,10 +4563,6 @@ write@^0.2.1:
   resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
   dependencies:
     mkdirp "^0.5.1"
-
-xml-name-validator@^2.0.1:
-  version "2.0.1"
-  resolved "https://unpm.uberinternal.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
 
 "xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.1"


### PR DESCRIPTION
- To make grid layer consistent with hexagon layer, add `coverage`, `lowerPercentile`, `upperPercentile` and `getColorValue` to layer prop
- Fix bug in hex `_onGetSublayerColor`, use bin.value instead of bin.points.length to calculate color