### PR TITLE
fix(seer): improve invalidate and log

### DIFF
--- a/src/debug/seer-integration.js
+++ b/src/debug/seer-integration.js
@@ -96,7 +96,7 @@ const transformData = data => {
 };
 
 /**
- * Log a layer properties to Seer
+ * Log layer's properties to Seer
  */
 export const logLayer = layer => {
   if (!window.__SEER_INITIALIZED__) {

--- a/src/debug/seer-integration.js
+++ b/src/debug/seer-integration.js
@@ -48,6 +48,7 @@ export const getOverrides = props => {
 
   overs.forEach((value, valuePath) => {
     recursiveSet(props, valuePath, value);
+    // Invalidate data array if we have a data override
     if (valuePath[0] === 'data') {
       props.data = [...props.data];
     }
@@ -72,8 +73,13 @@ export const layerEditListener = cb => {
   });
 };
 
+// Blacklist some properties that can't be stringified (eg: circular dependencies)
 const dataBlackList = ['zoomLevels'];
 
+/**
+ * Transform the data passed to Seer for performance purposes.
+ * Slice the data array to the first 20 items
+ */
 const transformData = data => {
   if (!data) {
     return [];


### PR DESCRIPTION
Only invalidate the `data` if it has been set as an override.
Also log a limit of 20 data items instead of the full list.