### PR TITLE
chore(lint): simplify command

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "build": "npm run build-clean && npm run build-es6 && npm run build-es5 && webpack -d --display-modules",
     "cover": "NODE_ENV=test nyc --reporter html --reporter cobertura --reporter=lcov npm run test-cover",
     "lint": "eslint src test examples && npm run lint-yarn",
-    "lint-yarn": "!(find . -name yarn.lock -exec grep -l unpm.u {} \\; | egrep '.*')",
+    "lint-yarn": "! grep -q unpm.u yarn.lock",
     "publish-prod": "npm run build && npm run test && npm run test-dist && npm publish",
     "publish-beta": "npm run build && npm run test && npm run test-dist && npm publish --tag beta",
     "test": "npm run lint && npm run build && npm run test-node",


### PR DESCRIPTION
Since we don't need to lookup the other lockfiles now, better this way and won't fail if you still using yarn with the private registry on examples