### PR TITLE
Add `pickingRadius` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Ref: http://keepachangelog.com/en/0.3.0/
 
 ## Beta Releases
 
+[TBD]
+- NEW: `pickingRadius` prop on the `DeckGL` component, enables more tolerant click and hover interaction.
+
 ### deck.gl v4.1.0-alpha.1
 
 - PERFORMANCE: Compiled are now cached for reuse so that same shaders are not recompiled for the same type of layers (#613)

--- a/docs/api-reference/deckgl.md
+++ b/docs/api-reference/deckgl.md
@@ -68,6 +68,13 @@ updated properties derived from the current application state.
 
 Css styles for the deckgl-canvas.
 
+##### `pickingRadius` (Number, optional)
+
+Extra pixels around the pointer to include while picking.
+This is helpful when rendered objects are difficult to target, for example
+irregularly shaped icons, small moving circles or interaction by touch.
+Default `0`.
+
 ##### `pixelRatio` (Number, optional)
 
 Will use device ratio by default.

--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -102,6 +102,12 @@ class App extends PureComponent {
     setImmutableDataSamples(settings.immutable);
   }
 
+  _onQueryFeatures() {
+    const {deckgl} = this.refs;
+    const {width, height} = this.state;
+    console.log(deckgl.elementsInScope([0, 0], [width, height])); // eslint-disable-line
+  }
+
   _onHover(info) {
     this.setState({hoveredItem: info});
   }
@@ -186,6 +192,7 @@ class App extends PureComponent {
 
         <DeckGL
           debug
+          ref="deckgl"
           id="default-deckgl-overlay"
           width={width} height={height}
           {...mapViewState}
@@ -220,6 +227,10 @@ class App extends PureComponent {
         { this._renderMap() }
         { !MAPBOX_ACCESS_TOKEN && this._renderNoTokenWarning() }
         <div id="control-panel">
+          <div>
+            <h4 />
+            <button onClick={this._onQueryFeatures} >Query Rendered Features</button>
+          </div>
           <LayerControls
             title="Composite Settings"
             settings={settings}

--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -42,7 +42,8 @@ class App extends PureComponent {
         // immutable: false,
         // Effects are experimental for now. Will be enabled in the future
         // effects: false,
-        separation: 0
+        separation: 0,
+        pickingRadius: 0
         // the rotation controls works only for layers in
         // meter offset projection mode. They are commented out
         // here since layer browser currently only have one layer
@@ -100,12 +101,6 @@ class App extends PureComponent {
   _onUpdateContainerSettings(settings) {
     this.setState({settings});
     setImmutableDataSamples(settings.immutable);
-  }
-
-  _onQueryFeatures() {
-    const {deckgl} = this.refs;
-    const {width, height} = this.state;
-    console.log(deckgl.elementsInScope([0, 0], [width, height])); // eslint-disable-line
   }
 
   _onHover(info) {
@@ -181,7 +176,7 @@ class App extends PureComponent {
   }
 
   _renderMap() {
-    const {width, height, mapViewState, settings: {effects}} = this.state;
+    const {width, height, mapViewState, settings: {effects, pickingRadius}} = this.state;
     return (
       <MapboxGLMap
         mapboxApiAccessToken={MAPBOX_ACCESS_TOKEN || 'no_token'}
@@ -192,10 +187,10 @@ class App extends PureComponent {
 
         <DeckGL
           debug
-          ref="deckgl"
           id="default-deckgl-overlay"
           width={width} height={height}
           {...mapViewState}
+          pickingRadius={pickingRadius}
           onWebGLInitialized={ this._onWebGLInitialized }
           onLayerHover={ this._onHover }
           onLayerClick={ this._onClick }
@@ -227,10 +222,6 @@ class App extends PureComponent {
         { this._renderMap() }
         { !MAPBOX_ACCESS_TOKEN && this._renderNoTokenWarning() }
         <div id="control-panel">
-          <div>
-            <h4 />
-            <button onClick={this._onQueryFeatures} >Query Rendered Features</button>
-          </div>
           <LayerControls
             title="Composite Settings"
             settings={settings}

--- a/examples/layer-browser/src/components/layer-controls.js
+++ b/examples/layer-browser/src/components/layer-controls.js
@@ -46,7 +46,7 @@ export default class LayerControls extends PureComponent {
     if (propType && Number.isFinite(propType.max)) {
       max = propType.max;
 
-    } else if (/radiusScale|elevationScale|width|height|pixel|size|miter/i.test(settingName) &&
+    } else if (/radius|scale|width|height|pixel|size|miter/i.test(settingName) &&
 
       (/^((?!scale).)*$/).test(settingName)) {
       max = 100;

--- a/src/lib/layer-manager.js
+++ b/src/lib/layer-manager.js
@@ -49,7 +49,7 @@
 import Layer from './layer';
 import {log} from './utils';
 import assert from 'assert';
-import {drawLayers, pickLayers, pickLayersByBoundingBox} from './draw-and-pick';
+import {drawLayers, pickLayers} from './draw-and-pick';
 import {LIFECYCLE} from './constants';
 import {Viewport} from './viewports';
 import {setOverride, layerEditListener, logLayer} from '../debug/seer-integration';
@@ -167,26 +167,6 @@ export default class LayerManager {
       viewport: this.context.viewport,
       pickingFBO: this.context.pickingFBO,
       lastPickedInfo: this.context.lastPickedInfo
-    });
-  }
-
-  pickLayerByBoundingBox({x, y, width, height}) {
-    const {gl, uniforms} = this.context;
-
-    // Set up a frame buffer if needed
-    if (this.context.pickingFBO === null ||
-      gl.canvas.width !== this.context.pickingFBO.width ||
-      gl.canvas.height !== this.context.pickingFBO.height) {
-      this.context.pickingFBO = new FramebufferObject(gl, {
-        width: gl.canvas.width,
-        height: gl.canvas.height
-      });
-    }
-    return pickLayersByBoundingBox(gl, {
-      layers: this.layers,
-      viewport: this.context.viewport,
-      pickingFBO: this.context.pickingFBO,
-      boundingBox: {x, y, width, height}
     });
   }
 

--- a/src/react/deckgl.js
+++ b/src/react/deckgl.js
@@ -80,17 +80,6 @@ export default class DeckGL extends React.Component {
     this._updateLayers(nextProps);
   }
 
-  /* Public API */
-  elementsInScope(topLeft, bottomRight) {
-    return this.layerManager.pickLayerByBoundingBox({
-      x: topLeft[0],
-      y: topLeft[1],
-      width: bottomRight[0] - topLeft[0],
-      height: bottomRight[1] - topLeft[1]
-    });
-  }
-  /* End Public API */
-
   _updateLayers(nextProps) {
     const {width, height, latitude, longitude, zoom, pitch, bearing, altitude} = nextProps;
     let {viewport} = nextProps;
@@ -159,12 +148,8 @@ export default class DeckGL extends React.Component {
       return;
     }
     const {event: {offsetX: x, offsetY: y}} = event;
-    const selectedInfos = this.layerManager.pickLayer({
-      x,
-      y,
-      mode: 'click',
-      radius: this.props.pickingRadius
-    });
+    const radius = this.props.pickingRadius;
+    const selectedInfos = this.layerManager.pickLayer({x, y, radius, mode: 'click'});
     if (selectedInfos.length) {
       const firstInfo = selectedInfos.find(info => info.index >= 0);
       // Event.event holds the original MouseEvent object
@@ -179,12 +164,8 @@ export default class DeckGL extends React.Component {
       return;
     }
     const {event: {offsetX: x, offsetY: y}} = event;
-    const selectedInfos = this.layerManager.pickLayer({
-      x,
-      y,
-      mode: 'hover',
-      radius: this.props.pickingRadius
-    });
+    const radius = this.props.pickingRadius;
+    const selectedInfos = this.layerManager.pickLayer({x, y, radius, mode: 'hover'});
     if (selectedInfos.length) {
       const firstInfo = selectedInfos.find(info => info.index >= 0);
       // Event.event holds the original MouseEvent object
@@ -224,12 +205,8 @@ export default class DeckGL extends React.Component {
     }
 
     if (mode) {
-      const selectedInfos = this.layerManager.pickLayer({
-        x,
-        y,
-        mode,
-        radius: this.props.pickingRadius
-      });
+      const radius = this.props.pickingRadius;
+      const selectedInfos = this.layerManager.pickLayer({x, y, radius, mode});
       if (selectedInfos.length) {
         const firstInfo = selectedInfos.find(info => info.index >= 0);
         // Event.event holds the original MouseEvent object

--- a/src/react/deckgl.js
+++ b/src/react/deckgl.js
@@ -38,6 +38,7 @@ const propTypes = {
   effects: PropTypes.arrayOf(PropTypes.instanceOf(Effect)),
   gl: PropTypes.object,
   debug: PropTypes.bool,
+  pickingRadius: PropTypes.number,
   viewport: PropTypes.instanceOf(Viewport),
   onWebGLInitialized: PropTypes.func,
   onAfterRender: PropTypes.func,
@@ -52,6 +53,7 @@ const propTypes = {
 const defaultProps = {
   id: 'deckgl-overlay',
   debug: false,
+  pickingRadius: 0,
   gl: null,
   effects: [],
   onWebGLInitialized: noop,
@@ -77,6 +79,17 @@ export default class DeckGL extends React.Component {
   componentWillReceiveProps(nextProps) {
     this._updateLayers(nextProps);
   }
+
+  /* Public API */
+  elementsInScope(topLeft, bottomRight) {
+    return this.layerManager.pickLayerByBoundingBox({
+      x: topLeft[0],
+      y: topLeft[1],
+      width: bottomRight[0] - topLeft[0],
+      height: bottomRight[1] - topLeft[1]
+    });
+  }
+  /* End Public API */
 
   _updateLayers(nextProps) {
     const {width, height, latitude, longitude, zoom, pitch, bearing, altitude} = nextProps;
@@ -146,7 +159,12 @@ export default class DeckGL extends React.Component {
       return;
     }
     const {event: {offsetX: x, offsetY: y}} = event;
-    const selectedInfos = this.layerManager.pickLayer({x, y, mode: 'click'});
+    const selectedInfos = this.layerManager.pickLayer({
+      x,
+      y,
+      mode: 'click',
+      radius: this.props.pickingRadius
+    });
     if (selectedInfos.length) {
       const firstInfo = selectedInfos.find(info => info.index >= 0);
       // Event.event holds the original MouseEvent object
@@ -161,7 +179,12 @@ export default class DeckGL extends React.Component {
       return;
     }
     const {event: {offsetX: x, offsetY: y}} = event;
-    const selectedInfos = this.layerManager.pickLayer({x, y, mode: 'hover'});
+    const selectedInfos = this.layerManager.pickLayer({
+      x,
+      y,
+      mode: 'hover',
+      radius: this.props.pickingRadius
+    });
     if (selectedInfos.length) {
       const firstInfo = selectedInfos.find(info => info.index >= 0);
       // Event.event holds the original MouseEvent object
@@ -201,7 +224,12 @@ export default class DeckGL extends React.Component {
     }
 
     if (mode) {
-      const selectedInfos = this.layerManager.pickLayer({x, y, mode});
+      const selectedInfos = this.layerManager.pickLayer({
+        x,
+        y,
+        mode,
+        radius: this.props.pickingRadius
+      });
       if (selectedInfos.length) {
         const firstInfo = selectedInfos.find(info => info.index >= 0);
         // Event.event holds the original MouseEvent object


### PR DESCRIPTION
- Add `pickingRadius` prop to `DeckGL` component. The old picking behavior is equivalent to `pickingRadius: 0`. The closest object to the pointer within `pickingRadius` pixels is picked.
