### PR TITLE
Reduce z-fighting between layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Ref: http://keepachangelog.com/en/0.3.0/
 
 [TBD]
 - NEW: `pickingRadius` prop on the `DeckGL` component, enables more tolerant click and hover interaction.
+- NEW: `getPolygonOffset` prop of the base Layer class
 
 Versions 4.1.0 alpha 1, 2 and 3 have been unpublished due to a wrong tagging.
 

--- a/docs/api-reference/base-layer.md
+++ b/docs/api-reference/base-layer.md
@@ -216,6 +216,25 @@ if the app to mint a new object on every render, all attributes will be automati
 updateTriggers cannot block attribute updates, just trigger them. To block the attribute updates,
 developers need to override the updateState.
 
+---
+
+### Render Properties
+
+##### `getPolygonOffset` (Function, optional)
+
+- Default: `({layerIndex}) => [-layerIndex, -1]`
+
+When multiple layers are rendered on the same plane, [z-fighting](https://en.wikipedia.org/wiki/Z-fighting)
+may create undesirable artifects. By default, deck.gl uses `gl.polygonOffset` to offset each layer by
+a small amount to improve the visual quality of composition.
+
+This accessor takes a single parameter `uniform` - an object that contains the current render uniforms,
+and returns an array of two numbers `factor` and `units`. For more information, refer to the
+[documentation](https://www.opengl.org/archives/resources/faq/technical/polygonoffset.htm).
+
+If the accessor is assigned a falsy value, `GL.POLYGON_OFFSET_FILL` will be disabled.
+
+
 ## Members
 
 *Remarks: Layer members are designed to support the creation of new layers or

--- a/docs/api-reference/base-layer.md
+++ b/docs/api-reference/base-layer.md
@@ -222,18 +222,26 @@ developers need to override the updateState.
 
 ##### `getPolygonOffset` (Function, optional)
 
-- Default: `({layerIndex}) => [-layerIndex, -1]`
+- Default: `({layerIndex}) => [0, -layerIndex * 100]`
 
 When multiple layers are rendered on the same plane, [z-fighting](https://en.wikipedia.org/wiki/Z-fighting)
-may create undesirable artifects. By default, deck.gl uses `gl.polygonOffset` to offset each layer by
-a small amount to improve the visual quality of composition.
+may create undesirable artifacts. To improve the visual quality of composition,
+deck.gl allows layers to use `gl.polygonOffset` to apply an offset to its depth.
+By default, each layer is offset a small amount by its index so that layers are cleanly stacked
+from bottom to top.
 
 This accessor takes a single parameter `uniform` - an object that contains the current render uniforms,
-and returns an array of two numbers `factor` and `units`. For more information, refer to the
-[documentation](https://www.opengl.org/archives/resources/faq/technical/polygonoffset.htm).
+and returns an array of two numbers `factor` and `units`.
+Negative values pull layer towards the camera, and positive values push layer away from the camera.
+For more information, refer to the 
+[documentation](https://www.khronos.org/registry/OpenGL-Refpages/es2.0/xhtml/glPolygonOffset.xml) 
+and [FAQ](https://www.opengl.org/archives/resources/faq/technical/polygonoffset.htm).
 
-If the accessor is assigned a falsy value, `GL.POLYGON_OFFSET_FILL` will be disabled.
+If the accessor is assigned a falsy value, polygon offset will be set to `[0, 0]`.
 
+*Remarks: While this feature helps mitigate z-fighting, at close up zoom levels the issue
+might return because of the precision error of 32-bit projection matrices. Try set the
+`fp64` prop to `true` in this case.*
 
 ## Members
 

--- a/src/lib/layer.js
+++ b/src/lib/layer.js
@@ -47,6 +47,10 @@ const defaultProps = {
   onDragMove: noop,
   onDragEnd: noop,
   onDragCancel: noop,
+  // Offset depth based on layer index to avoid z-fighting.
+  // Negative values pull layer towards the camera
+  // https://www.opengl.org/archives/resources/faq/technical/polygonoffset.htm
+  getPolygonOffset: ({layerIndex}) => [-layerIndex, -1],
   // Update triggers: a key change detection mechanism in deck.gl
   // See layer documentation
   updateTriggers: {},
@@ -409,6 +413,18 @@ export default class Layer {
 
   // Calculates uniforms
   drawLayer({uniforms = {}}) {
+    const {gl} = this.context;
+    const {getPolygonOffset} = this.props;
+
+    // Apply polygon offset to avoid z-fighting
+    if (this.props.getPolygonOffset) {
+      gl.enable(GL.POLYGON_OFFSET_FILL);
+      const offset = getPolygonOffset(uniforms);
+      gl.polygonOffset(offset[0], offset[1]);
+    } else {
+      gl.disable(GL.POLYGON_OFFSET_FILL);
+    }
+
     // Call subclass lifecycle method
     this.draw({uniforms});
     // End lifecycle method

--- a/src/lib/layer.js
+++ b/src/lib/layer.js
@@ -50,7 +50,7 @@ const defaultProps = {
   // Offset depth based on layer index to avoid z-fighting.
   // Negative values pull layer towards the camera
   // https://www.opengl.org/archives/resources/faq/technical/polygonoffset.htm
-  getPolygonOffset: ({layerIndex}) => [-layerIndex, -1],
+  getPolygonOffset: ({layerIndex}) => [0, -layerIndex * 100],
   // Update triggers: a key change detection mechanism in deck.gl
   // See layer documentation
   updateTriggers: {},
@@ -414,15 +414,11 @@ export default class Layer {
   // Calculates uniforms
   drawLayer({uniforms = {}}) {
     const {gl} = this.context;
+    const {getPolygonOffset} = this.props;
 
     // Apply polygon offset to avoid z-fighting
-    if (this.props.getPolygonOffset) {
-      gl.enable(GL.POLYGON_OFFSET_FILL);
-      const offset = this.props.getPolygonOffset(uniforms);
-      gl.polygonOffset(offset[0], offset[1]);
-    } else {
-      gl.disable(GL.POLYGON_OFFSET_FILL);
-    }
+    const offset = getPolygonOffset && getPolygonOffset(uniforms) || [0, 0];
+    gl.polygonOffset(offset[0], offset[1]);
 
     // Call subclass lifecycle method
     this.draw({uniforms});

--- a/src/lib/layer.js
+++ b/src/lib/layer.js
@@ -414,12 +414,11 @@ export default class Layer {
   // Calculates uniforms
   drawLayer({uniforms = {}}) {
     const {gl} = this.context;
-    const {getPolygonOffset} = this.props;
 
     // Apply polygon offset to avoid z-fighting
     if (this.props.getPolygonOffset) {
       gl.enable(GL.POLYGON_OFFSET_FILL);
-      const offset = getPolygonOffset(uniforms);
+      const offset = this.props.getPolygonOffset(uniforms);
       gl.polygonOffset(offset[0], offset[1]);
     } else {
       gl.disable(GL.POLYGON_OFFSET_FILL);

--- a/src/react/deckgl.js
+++ b/src/react/deckgl.js
@@ -100,6 +100,9 @@ export default class DeckGL extends React.Component {
     gl.enable(GL.BLEND);
     gl.blendFunc(GL.SRC_ALPHA, GL.ONE_MINUS_SRC_ALPHA);
 
+    // Enable polygon offset
+    gl.enable(GL.POLYGON_OFFSET_FILL);
+
     this.props.onWebGLInitialized(gl);
 
     // Note: avoid React setState due GL animation loop / setState timing issue


### PR DESCRIPTION
When multiple layers are rendered on the same plane, [z-fighting](https://en.wikipedia.org/wiki/Z-fighting) may create undesirable artifects (e.g. [Issue#411](https://github.com/uber/deck.gl/issues/411)). This PR offsets each layer by a small amount to improve the visual quality of composition. Advanced users can modify the default behavior by specifying their own `getPolygonOffset` accesor.

![polygon-offset](https://cloud.githubusercontent.com/assets/2059298/26273061/92c60586-3cdc-11e7-8333-8c3c1ae4d8bc.gif)

Remaining issues:
- Does not solve in-layer z-fighting when objects overlap each other
- At a higher zoom level, this solution is undone by precision error. Can only be fixed by turning on `fp64` flag.
