### PR TITLE
Fix single/double tap workaround.

### DIFF
--- a/src/utils/events/constants.js
+++ b/src/utils/events/constants.js
@@ -80,7 +80,7 @@ export const RECOGNIZERS = [
   [Swipe, {enable: false}],
   [Press, {enable: false}],
   [Tap, {event: 'doubletap', taps: 2, enable: false}],
-  [Tap, {enable: false, interval: 0}]
+  [Tap, {enable: false, interval: 0}, null, 'doubletap']
 ];
 
 /**

--- a/src/utils/events/constants.js
+++ b/src/utils/events/constants.js
@@ -80,7 +80,7 @@ export const RECOGNIZERS = [
   [Swipe, {enable: false}],
   [Press, {enable: false}],
   [Tap, {event: 'doubletap', taps: 2, enable: false}],
-  [Tap, {enable: false, interval: 0}, null, 'doubletap']
+  [Tap, {enable: false}]
 ];
 
 /**

--- a/src/utils/events/event-manager.js
+++ b/src/utils/events/event-manager.js
@@ -64,9 +64,6 @@ export default class EventManager {
         // Enable recognizer for this event.
         this.manager.get(recognizerEvent).set({enable: true});
 
-        // Handle concurrent single and double tap registration as necessary.
-        this._reconcileSingleAndDoubleTap(recognizerEvent);
-
         // Alias to a recognized gesture as necessary.
         const eventAlias = GESTURE_EVENT_ALIASES[event];
         if (eventAlias && !this.aliasedEventHandlers[event]) {
@@ -150,22 +147,5 @@ export default class EventManager {
    */
   _aliasEventHandler(eventAlias) {
     return event => this.manager.emit(eventAlias, event);
-  }
-
-  /**
-   * For speedy single tap/click recognition,
-   * the single tap recognizer is set to an interval of 0.
-   * If doubletap is also enabled, the singletap interval
-   * must be bumped up to match doubletap;
-   * this allows doubletap to resolve as expected.
-   */
-  _reconcileSingleAndDoubleTap(event) {
-    if (event === 'tap' || event === 'doubletap') {
-      const singletapRecognizer = this.manager.get('tap');
-      const doubletapRecognizer = this.manager.get('doubletap');
-      if (singletapRecognizer.options.enable && doubletapRecognizer.options.enable) {
-        singletapRecognizer.options.interval = doubletapRecognizer.options.interval;
-      }
-    }
   }
 }

--- a/src/utils/events/event-manager.js
+++ b/src/utils/events/event-manager.js
@@ -153,17 +153,18 @@ export default class EventManager {
   }
 
   /**
-   * If single and double tap are both enabled,
-   * The single tap recognizer must wait for the double tap recognizer
-   * to fail before resolving. Note that enabling both incurs a slight delay
-   * on tap/click handler resolution.
+   * For speedy single tap/click recognition,
+   * the single tap recognizer is set to an interval of 0.
+   * If doubletap is also enabled, the singletap interval
+   * must be bumped up to match doubletap;
+   * this allows doubletap to resolve as expected.
    */
   _reconcileSingleAndDoubleTap(event) {
     if (event === 'tap' || event === 'doubletap') {
       const singletapRecognizer = this.manager.get('tap');
       const doubletapRecognizer = this.manager.get('doubletap');
       if (singletapRecognizer.options.enable && doubletapRecognizer.options.enable) {
-        singletapRecognizer.requireFailure('doubletap');
+        singletapRecognizer.options.interval = doubletapRecognizer.options.interval;
       }
     }
   }


### PR DESCRIPTION
This update to the single/double-tap workaround from `events-refactor` allows hammer.js to handle `requireFailure()` on its own, and instead drops the single tap / click recognizer interval to 0 by default and bumps it up when doubletap functionality is required.