### PR TITLE
Improve z handling and blending in composite layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Ref: http://keepachangelog.com/en/0.3.0/
 
 ## Beta Releases
 
+[TBD]
+- FIX: Composite layers now pass `getPolygonOffset` prop to children
+- FIX: `PolygonLayer` and `GeoJsonLayer` orders sublayers dynamicly for better blending behavior
+
 ### deck.gl v4.1.0-alpha.5
 
 - NEW: `getPolygonOffset` prop of the base Layer class (#649)

--- a/src/layers/core/geojson-layer/geojson-layer.js
+++ b/src/layers/core/geojson-layer/geojson-layer.js
@@ -104,7 +104,7 @@ export default class GeoJsonLayer extends CompositeLayer {
       getLineWidth, getElevation, updateTriggers} = this.props;
 
     // base layer props
-    const {opacity, pickable, visible} = this.props;
+    const {opacity, pickable, visible, getPolygonOffset} = this.props;
 
     // viewport props
     const {positionOrigin, projectionMode, modelMatrix} = this.props;
@@ -127,6 +127,7 @@ export default class GeoJsonLayer extends CompositeLayer {
         opacity,
         pickable,
         visible,
+        getPolygonOffset,
         projectionMode,
         positionOrigin,
         modelMatrix,
@@ -151,6 +152,7 @@ export default class GeoJsonLayer extends CompositeLayer {
         opacity,
         pickable,
         visible,
+        getPolygonOffset,
         projectionMode,
         positionOrigin,
         modelMatrix,
@@ -178,6 +180,7 @@ export default class GeoJsonLayer extends CompositeLayer {
         opacity,
         pickable,
         visible,
+        getPolygonOffset,
         projectionMode,
         positionOrigin,
         modelMatrix,
@@ -202,6 +205,7 @@ export default class GeoJsonLayer extends CompositeLayer {
       opacity,
       pickable,
       visible,
+      getPolygonOffset,
       projectionMode,
       positionOrigin,
       modelMatrix,
@@ -221,6 +225,7 @@ export default class GeoJsonLayer extends CompositeLayer {
       opacity,
       pickable,
       visible,
+      getPolygonOffset,
       projectionMode,
       positionOrigin,
       modelMatrix,
@@ -234,11 +239,14 @@ export default class GeoJsonLayer extends CompositeLayer {
     });
 
     return [
-      polygonFillLayer,
+      // If not extruded: flat fill layer is drawn below outlines
+      !extruded && polygonFillLayer,
       polygonWireframeLayer,
       polygonLineLayer,
       pathLayer,
-      pointLayer
+      pointLayer,
+      // If extruded: draw fill layer last for correct blending behavior
+      extruded && polygonFillLayer
     ].filter(Boolean);
   }
 }

--- a/src/layers/core/grid-layer/grid-layer.js
+++ b/src/layers/core/grid-layer/grid-layer.js
@@ -170,7 +170,7 @@ export default class GridLayer extends CompositeLayer {
     const {id, elevationScale, fp64, extruded, cellSize, coverage, lightSettings} = this.props;
 
     // base layer props
-    const {opacity, pickable, visible} = this.props;
+    const {opacity, pickable, visible, getPolygonOffset} = this.props;
 
     // viewport props
     const {positionOrigin, projectionMode, modelMatrix} = this.props;
@@ -187,6 +187,7 @@ export default class GridLayer extends CompositeLayer {
       opacity,
       pickable,
       visible,
+      getPolygonOffset,
       projectionMode,
       positionOrigin,
       modelMatrix,

--- a/src/layers/core/hexagon-layer/hexagon-layer.js
+++ b/src/layers/core/hexagon-layer/hexagon-layer.js
@@ -208,7 +208,7 @@ export default class HexagonLayer extends CompositeLayer {
     const {id, radius, elevationScale, extruded, coverage, lightSettings, fp64} = this.props;
 
     // base layer props
-    const {opacity, pickable, visible} = this.props;
+    const {opacity, pickable, visible, getPolygonOffset} = this.props;
 
     // viewport props
     const {positionOrigin, projectionMode, modelMatrix} = this.props;
@@ -227,6 +227,7 @@ export default class HexagonLayer extends CompositeLayer {
       opacity,
       pickable,
       visible,
+      getPolygonOffset,
       projectionMode,
       positionOrigin,
       modelMatrix,

--- a/src/layers/core/polygon-layer/polygon-layer.js
+++ b/src/layers/core/polygon-layer/polygon-layer.js
@@ -101,7 +101,7 @@ export default class PolygonLayer extends CompositeLayer {
       getPolygon, updateTriggers, lightSettings} = this.props;
 
     // base layer props
-    const {opacity, pickable, visible} = this.props;
+    const {opacity, pickable, visible, getPolygonOffset} = this.props;
 
     // viewport props
     const {positionOrigin, projectionMode, modelMatrix} = this.props;
@@ -120,6 +120,7 @@ export default class PolygonLayer extends CompositeLayer {
       opacity,
       pickable,
       visible,
+      getPolygonOffset,
       projectionMode,
       positionOrigin,
       modelMatrix,
@@ -145,6 +146,7 @@ export default class PolygonLayer extends CompositeLayer {
         opacity,
         pickable,
         visible,
+        getPolygonOffset,
         projectionMode,
         positionOrigin,
         modelMatrix,
@@ -173,6 +175,7 @@ export default class PolygonLayer extends CompositeLayer {
         opacity,
         pickable,
         visible,
+        getPolygonOffset,
         projectionMode,
         positionOrigin,
         modelMatrix,
@@ -186,9 +189,12 @@ export default class PolygonLayer extends CompositeLayer {
       });
 
     return [
-      polygonLayer,
+      // If not extruded: flat fill layer is drawn below outlines
+      !extruded && polygonLayer,
       polygonWireframeLayer,
-      polygonLineLayer
+      polygonLineLayer,
+      // If extruded: draw fill layer last for correct blending behavior
+      extruded && polygonLayer
     ].filter(Boolean);
   }
 }


### PR DESCRIPTION
- Composite layers now pass `getPolygonOffset` prop to children
- `PolygonLayer` and `GeoJsonLayer` orders sublayers dynamically. 3D layers should be drawn last for correct blending with 2D layers.