### PR TITLE
Conditionally require hammer.js

### DIFF
--- a/src/utils/events/event-manager.js
+++ b/src/utils/events/event-manager.js
@@ -1,13 +1,15 @@
-import {Manager} from 'hammerjs';
+import WheelInput from './wheel-input';
+import MoveInput from './move-input';
 
-import {
+const Manager = (typeof window === 'undefined' || typeof document === 'undefined') ?
+  ManagerMock : require('hammerjs').Manager;
+const {
   BASIC_EVENT_ALIASES,
   EVENT_RECOGNIZER_MAP,
   RECOGNIZERS,
   GESTURE_EVENT_ALIASES
-} from './constants';
-import WheelInput from './wheel-input';
-import MoveInput from './move-input';
+} = (typeof window === 'undefined' || typeof document === 'undefined') ?
+  {} : require('./constants');
 
 /**
  * Single API for subscribing to events about both
@@ -148,4 +150,14 @@ export default class EventManager {
   _aliasEventHandler(eventAlias) {
     return event => this.manager.emit(eventAlias, event);
   }
+}
+
+function ManagerMock(m) {
+  const noop = () => {};
+  return {
+    on: noop,
+    off: noop,
+    destroy: noop,
+    emit: noop
+  };
 }

--- a/src/utils/events/event-manager.js
+++ b/src/utils/events/event-manager.js
@@ -1,15 +1,30 @@
 import WheelInput from './wheel-input';
 import MoveInput from './move-input';
+import {isBrowser} from '../../controllers/globals';
 
-const Manager = (typeof window === 'undefined' || typeof document === 'undefined') ?
-  ManagerMock : require('hammerjs').Manager;
+// Hammer.js directly references `document` and `window`,
+// which means that importing it in environments without
+// those objects throws errors. Therefore, instead of
+// directly `import`ing 'hammerjs' and './constants'
+// (which imports Hammer.js) we conditionally require it
+// depending on support for those globals.
+function ManagerMock(m) {
+  const noop = () => {};
+  return {
+    on: noop,
+    off: noop,
+    destroy: noop,
+    emit: noop
+  };
+}
+
+const Manager = isBrowser ? require('hammerjs').Manager : ManagerMock;
 const {
   BASIC_EVENT_ALIASES,
   EVENT_RECOGNIZER_MAP,
   RECOGNIZERS,
   GESTURE_EVENT_ALIASES
-} = (typeof window === 'undefined' || typeof document === 'undefined') ?
-  {} : require('./constants');
+} = isBrowser ? require('./constants') : {};
 
 /**
  * Single API for subscribing to events about both
@@ -150,14 +165,4 @@ export default class EventManager {
   _aliasEventHandler(eventAlias) {
     return event => this.manager.emit(eventAlias, event);
   }
-}
-
-function ManagerMock(m) {
-  const noop = () => {};
-  return {
-    on: noop,
-    off: noop,
-    destroy: noop,
-    emit: noop
-  };
 }

--- a/src/utils/events/wheel-input.js
+++ b/src/utils/events/wheel-input.js
@@ -1,4 +1,5 @@
-/* global window:false */
+import window from '../../lib/utils/globals';
+
 const ua = typeof window.navigator !== 'undefined' ?
   window.navigator.userAgent.toLowerCase() : '';
 const firefox = ua.indexOf('firefox') !== -1;


### PR DESCRIPTION
Conditionally require hammer.js to avoid failure on server, on `window` and `document` references.

I'm not happy with this solution, but https://github.com/hammerjs/hammer.js/issues/930 suggests there isn't much of a better option for now :/