### PR TITLE
Fix bug where `mousemove` event is fired twice during drag

### DIFF
--- a/src/utils/events/event-manager.js
+++ b/src/utils/events/event-manager.js
@@ -153,8 +153,7 @@ export default class EventManager {
    * and pipe back out through same (Hammer) channel used by other events.
    */
   _onOtherEvent(event) {
-    const {srcEvent: {type}} = event;
-    this.manager.emit(type, event);
+    this.manager.emit(event.type, event);
   }
 
   /**

--- a/src/utils/events/move-input.js
+++ b/src/utils/events/move-input.js
@@ -1,4 +1,4 @@
-const MOVE_EVENTS = ['pointermove', 'touchmove', 'mousemove'];
+const MOUSE_EVENTS = ['mousedown', 'mousemove', 'mouseup'];
 
 /**
  * Hammer.js swallows 'move' events (for pointer/touch/mouse)
@@ -10,10 +10,11 @@ const MOVE_EVENTS = ['pointermove', 'touchmove', 'mousemove'];
  */
 export default class MoveInput {
 
-  constructor(element, callback, events = MOVE_EVENTS) {
+  constructor(element, callback, events = MOUSE_EVENTS) {
     this.element = element;
     this.callback = callback;
     this.events = events;
+    this.pressed = false;
 
     this.handler = this.handler.bind(this);
     this.events.forEach(event => element.addEventListener(event, this.handler));
@@ -24,9 +25,28 @@ export default class MoveInput {
   }
 
   handler(event) {
-    this.callback({
-      srcEvent: event,
-      target: this.element
-    });
+    switch (event.type) {
+    case 'mousedown':
+      if (event.button === 0) {
+        this.pressed = true;
+      }
+      break;
+    case 'mousemove':
+      if (event.which !== 1) {
+        this.pressed = false;
+      }
+      if (!this.pressed) {
+        // Drag events are emitted by hammer already, we just need the hover event
+        this.callback({
+          srcEvent: event,
+          target: this.element
+        });
+      }
+      break;
+    case 'mouseup':
+      this.pressed = false;
+      break;
+    default:
+    }
   }
 }

--- a/src/utils/events/move-input.js
+++ b/src/utils/events/move-input.js
@@ -1,5 +1,5 @@
 const MOUSE_EVENTS = ['mousedown', 'mousemove', 'mouseup'];
-const EVENT_TYPES = ['mousemove', 'pointermove'];
+const MOVE_EVENT_TYPES = ['mousemove', 'pointermove'];
 
 /**
  * Hammer.js swallows 'move' events (for pointer/touch/mouse)
@@ -17,28 +17,32 @@ export default class MoveInput {
     this.events = events;
     this.pressed = false;
 
-    this.handler = this.handler.bind(this);
-    this.events.forEach(event => element.addEventListener(event, this.handler));
+    this.handleEvent = this.handleEvent.bind(this);
+    this.events.forEach(event => element.addEventListener(event, this.handleEvent));
   }
 
   destroy() {
-    this.events.forEach(event => this.element.removeEventListener(event, this.handler));
+    this.events.forEach(event => this.element.removeEventListener(event, this.handleEvent));
   }
 
-  handler(event) {
+  handleEvent(event) {
     switch (event.type) {
     case 'mousedown':
       if (event.button === 0) {
+        // Left button is down
         this.pressed = true;
       }
       break;
     case 'mousemove':
+      // Move events use `which` to track the button being pressed
       if (event.which !== 1) {
+        // Left button is not down
         this.pressed = false;
       }
       if (!this.pressed) {
-        // Drag events are emitted by hammer already, we just need the hover event
-        EVENT_TYPES.forEach(type => this.callback({
+        // Drag events are emitted by hammer already
+        // we just need to emit the move event on hover
+        MOVE_EVENT_TYPES.forEach(type => this.callback({
           type,
           srcEvent: event,
           target: this.element

--- a/src/utils/events/move-input.js
+++ b/src/utils/events/move-input.js
@@ -1,4 +1,5 @@
 const MOUSE_EVENTS = ['mousedown', 'mousemove', 'mouseup'];
+const EVENT_TYPES = ['mousemove', 'pointermove'];
 
 /**
  * Hammer.js swallows 'move' events (for pointer/touch/mouse)
@@ -37,10 +38,11 @@ export default class MoveInput {
       }
       if (!this.pressed) {
         // Drag events are emitted by hammer already, we just need the hover event
-        this.callback({
+        EVENT_TYPES.forEach(type => this.callback({
+          type,
           srcEvent: event,
           target: this.element
-        });
+        }));
       }
       break;
     case 'mouseup':

--- a/src/utils/events/wheel-input.js
+++ b/src/utils/events/wheel-input.js
@@ -12,6 +12,7 @@ const WHEEL_EVENTS = [
   // legacy Firefox
   'DOMMouseScroll'
 ];
+const EVENT_TYPE = 'wheel';
 
 // Constants for normalizing input delta
 const WHEEL_DELTA_MAGIC_SCALER = 4.000244140625;
@@ -118,6 +119,7 @@ export default class WheelInput {
 
   _onWheel(srcEvent, delta, position) {
     this.callback({
+      type: EVENT_TYPE,
       center: position,
       delta,
       srcEvent,

--- a/src/utils/events/wheel-input.js
+++ b/src/utils/events/wheel-input.js
@@ -28,9 +28,9 @@ export default class WheelInput {
     this.element = element;
     this.callback = callback;
 
-    this.handler = this.handler.bind(this);
+    this.handleEvent = this.handleEvent.bind(this);
 
-    WHEEL_EVENTS.forEach(eventName => element.addEventListener(eventName, this.handler));
+    WHEEL_EVENTS.forEach(eventName => element.addEventListener(eventName, this.handleEvent));
 
     this.time = 0;
     this.wheelPosition = null;
@@ -41,11 +41,11 @@ export default class WheelInput {
 
   destroy() {
     const {element} = this;
-    WHEEL_EVENTS.forEach(eventName => element.removeEventListener(eventName, this.handler));
+    WHEEL_EVENTS.forEach(eventName => element.removeEventListener(eventName, this.handleEvent));
   }
 
   /* eslint-disable complexity, max-statements */
-  handler(event) {
+  handleEvent(event) {
 
     event.preventDefault();
     let value = event.deltaY;


### PR DESCRIPTION
This bug is causing major performance regression when interacting with the map.
Also fixed a bug in event aliasing (always use registered event types instead of source event type).

@ericsoco We are currently firing all three of `pointermove`, `mousemove` and `touchmove` events on any pointer move, which is technically incorrect. `touchmove` should not be fired on `mousemove`, for example. In the case of `pointermove`, we will need to do some poking to determine the source input device. Yet we do not need to make that differentiation in any of our built-in interactions. I propose we remove the `mouse*` and `touch*` aliases and only surface `pointer*` events to avoid confusion. 