### PR TITLE
Fix rendering test

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "tape-catch": "^1.0.4",
     "transform-loader": "^0.2.3",
     "uglify-js": "^2.6.1",
-    "url-loader": "^0.5.7",
     "webpack": "^2.4.0",
     "webpack-dev-server": "^2.4.0"
   },

--- a/test/rendering-test/color-delta.js
+++ b/test/rendering-test/color-delta.js
@@ -1,0 +1,38 @@
+// From the pixelmatch package https://github.com/mapbox/pixelmatch
+// ISC License
+// Copyright (c) 2015, Mapbox
+
+/* eslint-disable */
+// calculate color difference according to the paper "Measuring perceived color difference
+// using YIQ NTSC transmission color space in mobile applications" by Y. Kotsarenko and F. Ramos
+
+export default function colorDelta(img1, img2, k, m, yOnly) {
+    var a1 = img1[k + 3] / 255,
+        a2 = img2[m + 3] / 255,
+
+        r1 = blend(img1[k + 0], a1),
+        g1 = blend(img1[k + 1], a1),
+        b1 = blend(img1[k + 2], a1),
+
+        r2 = blend(img2[m + 0], a2),
+        g2 = blend(img2[m + 1], a2),
+        b2 = blend(img2[m + 2], a2),
+
+        y = rgb2y(r1, g1, b1) - rgb2y(r2, g2, b2);
+
+    if (yOnly) return y; // brightness difference only
+
+    var i = rgb2i(r1, g1, b1) - rgb2i(r2, g2, b2),
+        q = rgb2q(r1, g1, b1) - rgb2q(r2, g2, b2);
+
+    return 0.5053 * y * y + 0.299 * i * i + 0.1957 * q * q;
+}
+
+function rgb2y(r, g, b) { return r * 0.29889531 + g * 0.58662247 + b * 0.11448223; }
+function rgb2i(r, g, b) { return r * 0.59597799 - g * 0.27417610 - b * 0.32180189; }
+function rgb2q(r, g, b) { return r * 0.21147017 - g * 0.52261711 + b * 0.31114694; }
+
+// blend semi-transparent color with white
+function blend(c, a) {
+    return 255 + (c - 255) * a;
+}

--- a/test/rendering-test/data-generator.js
+++ b/test/rendering-test/data-generator.js
@@ -18,6 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+import {WebMercatorViewport} from 'deck.gl';
+
 // generate points in a grid
 function pointGrid(N, bbox) {
   const dLon = bbox[2] - bbox[0];
@@ -45,9 +47,23 @@ function pointGrid(N, bbox) {
   return points;
 }
 
+function lngLatToMeterOffset(points, center) {
+  const viewport = new WebMercatorViewport({longitude: center[0], latitude: center[1], zoom: 10});
+  return points.map(point =>
+    viewport.lngLatDeltaToMeters([point[0] - center[0], point[1] - center[1]]));
+}
+
 let _points100K = null;
+let _points100KMeters = null;
+
+export const positionOrigin = [-122.4, 37.7];
 
 export function getPoints100K() {
   _points100K = _points100K || pointGrid(1e5, [-122.9, 36.6, -121.9, 38.9]);
   return _points100K;
+}
+
+export function getPoints100KMeters() {
+  _points100KMeters = _points100KMeters || lngLatToMeterOffset(getPoints100K(), positionOrigin);
+  return _points100KMeters;
 }

--- a/test/rendering-test/test-config.js
+++ b/test/rendering-test/test-config.js
@@ -1,0 +1,114 @@
+import {getPoints100K, getPoints100KMeters, positionOrigin} from './data-generator';
+
+import {
+  COORDINATE_SYSTEM,
+
+  ScatterplotLayer
+  // ArcLayer,
+  // LineLayer,
+  // HexagonLayer,
+
+  // ScreenGridLayer,
+  // IconLayer,
+  // GridLayer,
+  // GeoJsonLayer,
+  // PolygonLayer,
+  // PathLayer
+
+} from 'deck.gl';
+
+export const WIDTH = 1600;
+export const HEIGHT = 900;
+
+// Max color delta in the YIQ difference metric for two pixels to be considered the same
+export const COLOR_DELTA_THRESHOLD = 255 * 0.05;
+// Percentage of pixels that must be the same for the test to pass
+export const TEST_PASS_THRESHOLD = 0.99;
+
+export const TEST_CASES = [
+  {
+    name: 'scatterplot-1',
+    // viewport params
+    mapViewState: {
+      latitude: 37.751537058389985,
+      longitude: -122.42694203247012,
+      zoom: 10,
+      pitch: 30,
+      bearing: 0
+    },
+    // layer list
+    layersList: [{
+      type: ScatterplotLayer,
+      props: {
+        id: 'scatterplot-1',
+        data: getPoints100K(),
+        getPosition: d => d,
+        getColor: d => [255, 128, 0],
+        getRadius: d => 5.0,
+        opacity: 0.5,
+        pickable: true,
+        radiusMinPixels: 5,
+        radiusMaxPixels: 5
+      }
+    }],
+    referecenResult: './golden-images/1.png'
+  },
+
+  {
+    name: 'scatterplot-2',
+    // viewport params
+    mapViewState: {
+      latitude: 37.751537058389985,
+      longitude: -122.42694203247012,
+      zoom: 12,
+      pitch: 0,
+      bearing: 0
+    },
+    // layer list
+    layersList: [{
+      type: ScatterplotLayer,
+      props: {
+        id: 'scatterplot-2',
+        data: getPoints100K(),
+        getPosition: d => d,
+        getColor: d => [255, 128, 0],
+        getRadius: d => 5.0,
+        opacity: 0.5,
+        pickable: true,
+        radiusMinPixels: 5,
+        radiusMaxPixels: 5
+      }
+    }],
+    referecenResult: './golden-images/2.png'
+  },
+
+  {
+    name: 'scatterplot-1-meters',
+    // viewport params
+    mapViewState: {
+      latitude: 37.751537058389985,
+      longitude: -122.42694203247012,
+      zoom: 10,
+      pitch: 30,
+      bearing: 0
+    },
+    // layer list
+    layersList: [{
+      type: ScatterplotLayer,
+      props: {
+        id: 'scatterplot-1-meters',
+        data: getPoints100KMeters(),
+        projectionMode: COORDINATE_SYSTEM.METERS,
+        positionOrigin,
+        getPosition: d => d,
+        getColor: d => [255, 128, 0],
+        getRadius: d => 5.0,
+        opacity: 0.5,
+        pickable: true,
+        radiusMinPixels: 5,
+        radiusMaxPixels: 5
+      }
+    }],
+    referecenResult: './golden-images/1.png'
+  }
+];

--- a/test/rendering-test/test-rendering.js
+++ b/test/rendering-test/test-rendering.js
@@ -52,7 +52,7 @@ import {join} from 'path';
 import {readFileSync} from 'fs';
 
 import DeckGL from 'deck.gl';
-import colorDelta from './color-delta';
+import {colorDeltaSq} from './color-delta';
 import * as CONFIG from './test-config';
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
@@ -98,7 +98,7 @@ class RenderingTest extends Component {
     const maxDeltaSq = CONFIG.COLOR_DELTA_THRESHOLD * CONFIG.COLOR_DELTA_THRESHOLD;
     let badPixels = 0;
     for (let i = 0; i < pixelCount; i++) {
-      const delta = colorDelta(resultPixelData.data, referencePixelData.data, i * 4, i * 4);
+      const delta = colorDeltaSq(resultPixelData.data, referencePixelData.data, i);
       if (delta > maxDeltaSq) {
         badPixels++;
       }

--- a/test/rendering-test/webpack.config.test-rendering.js
+++ b/test/rendering-test/webpack.config.test-rendering.js
@@ -30,12 +30,7 @@ module.exports = {
   },
 
   module: {
-    rules: [
-      {
-        test: /\.png$/,
-        loader: 'url-loader?mimetype=image/png'
-      }
-    ]
+    rules: []
   },
 
   node: {


### PR DESCRIPTION
- Only run each test case once
- Proper image diffing
- Add a test case for `METER_OFFSET` mode

Threshold set at 99% of pixels have <5% perceived color difference. Current test result:
```
scatterplot-1: 99.268% PASS
scatterplot-2: 99.925% PASS
scatterplot-1-meters: 12.306% FAIL
```
(expected to be fixed by [607](https://github.com/uber/deck.gl/pull/607))