### PR TITLE
Add queryObjects api to DeckGL component

### DIFF
--- a/docs/api-reference/deckgl.md
+++ b/docs/api-reference/deckgl.md
@@ -121,21 +121,38 @@ are affected.
 
 ### Methods
 
-##### `queryObjects(boundingBox, layerId)`
+##### `queryObject(options)`
+
+Get the closest pickable and visible object at screen coordinate.
+
+Parameters:
+- `options` (Object)
+  + `x` (Number) - x position in pixels
+  + `y` (Number) - y position in pixels
+  + `radius` (Number, optional) - radius of tolerance in pixels. Default `0`.
+  + `layerIds` (Array, optional) - a list of layer ids to query from.
+    If not specified, then all pickable and visible layers are queried.
+
+Returns: a single [`info`](/docs/get-started/interactivity.md#the-picking-info-object) object, or `null` if nothing is found.
+
+##### `queryObjects(options)`
 
 Get all pickable and visible objects within a bounding box.
 
 Parameters:
-- `boundingBox` (Object) - the bounding box in screen coordinates
-  + `x` (Number) - left of the box in pixels
-  + `y` (Number) - top of the box in pixels
-  + `width` (Number) - width of the box in pixels
-  + `height` (Number) - height of the box in pixels
-- `layerIds` (Array, optional) - a list of layer ids to query from.
-  If not specified, then all pickable and visible layers are queried.
+- `options` (Object)
+  + `x` (Number) - left of the bounding box in pixels
+  + `y` (Number) - top of the bouding box in pixels
+  + `width` (Number, optional) - width of the bouding box in pixels. Default `1`.
+  + `height` (Number, optional) - height of the bouding box in pixels. Default `1`.
+  + `layerIds` (Array, optional) - a list of layer ids to query from.
+    If not specified, then all pickable and visible layers are queried.
 
 Returns: an array of unique [`info`](/docs/get-started/interactivity.md#the-picking-info-object) objects
 
+Remarks:
+- This query methods are designed to quickly find objects by utilizing the picking buffer. They offer more flexibility for developers to handle events in addition to the built-in hover and click callbacks.
+- Note there is a limitation in the query methods: occluded objects are not returned. To improve the results, you may try setting the `layerIds` parameter to limit the query to fewer layers.
 
 ## Source
 [src/react/deckgl.js](https://github.com/uber/deck.gl/blob/4.0-release/src/react/deckgl.js)

--- a/docs/api-reference/deckgl.md
+++ b/docs/api-reference/deckgl.md
@@ -119,5 +119,23 @@ object for the topmost picked layer at the coordinate
 are affected.
 - `event` - the original [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) object
 
+### Methods
+
+##### `queryObjects(boundingBox, layerId)`
+
+Get all pickable and visible objects within a bounding box.
+
+Parameters:
+- `boundingBox` (Object) - the bounding box in screen coordinates
+  + `x` (Number) - left of the box in pixels
+  + `y` (Number) - top of the box in pixels
+  + `width` (Number) - width of the box in pixels
+  + `height` (Number) - height of the box in pixels
+- `layerIds` (Array, optional) - a list of layer ids to query from.
+  If not specified, then all pickable and visible layers are queried.
+
+Returns: an array of unique [`info`](/docs/get-started/interactivity.md#the-picking-info-object) objects
+
+
 ## Source
 [src/react/deckgl.js](https://github.com/uber/deck.gl/blob/4.0-release/src/react/deckgl.js)

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -4,6 +4,10 @@
 
 * `CompositeLayer.renderLayers` can now return a nested arrays with `null` values. deck.gl will automatically flatten and filter the array. This is a small convenience that makes the `renderLayers methods in complex composite layers a little more readable.
 
+## Query Methods
+
+* `DeckGL.queryObject` and `DeckGL.queryObjects` allow developers to directly query the picking buffer in addition to the built-in click and hover callbacks.
+
 # deck.gl v4.0
 
 Release date: March 31, 2017

--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -52,7 +52,8 @@ class App extends PureComponent {
         // rotationX: 0
       },
       hoveredItem: null,
-      clickedItem: null
+      clickedItem: null,
+      queriedItems: null
     };
 
     this._effects = [new ReflectionEffect()];
@@ -115,6 +116,7 @@ class App extends PureComponent {
     const {width, height} = this.state;
     const infos = this.refs.deckgl.queryObjects({x: 0, y: 0, width, height});
     console.log(infos); // eslint-disable-line
+    this.setState({queriedItems: infos});
   }
 
   _renderExampleLayer(example, settings, index) {
@@ -221,14 +223,14 @@ class App extends PureComponent {
   }
 
   render() {
-    const {settings, activeExamples, hoveredItem, clickedItem} = this.state;
+    const {settings, activeExamples, hoveredItem, clickedItem, queriedItems} = this.state;
 
     return (
       <div>
         { this._renderMap() }
         { !MAPBOX_ACCESS_TOKEN && this._renderNoTokenWarning() }
         <div id="control-panel">
-          <button onClick={this._onQueryObjects}>Query Rendered Objects</button>
+          <button onClick={this._onQueryObjects}>Query Objects</button>
           <LayerControls
             title="Composite Settings"
             settings={settings}
@@ -239,7 +241,7 @@ class App extends PureComponent {
             onToggleLayer={this._onToggleLayer}
             onUpdateLayer={this._onUpdateLayerSettings} />
         </div>
-        <LayerInfo ref="infoPanel" hovered={hoveredItem} clicked={clickedItem} />
+        <LayerInfo ref="infoPanel" hovered={hoveredItem} clicked={clickedItem} queried={queriedItems} />
       </div>
     );
   }

--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -111,6 +111,12 @@ class App extends PureComponent {
     this.setState({clickedItem: info});
   }
 
+  _onQueryObjects() {
+    const {width, height} = this.state;
+    const infos = this.refs.deckgl.queryObjects({x: 0, y: 0, width, height});
+    console.log(infos); // eslint-disable-line
+  }
+
   _renderExampleLayer(example, settings, index) {
     const {layer: Layer, props, getData} = example;
     const layerProps = Object.assign({}, props, settings);
@@ -185,7 +191,7 @@ class App extends PureComponent {
         { ...mapViewState }
         onChangeViewport={this._onViewportChanged}>
 
-        <DeckGL
+        <DeckGL ref="deckgl"
           debug
           id="default-deckgl-overlay"
           width={width} height={height}
@@ -222,6 +228,7 @@ class App extends PureComponent {
         { this._renderMap() }
         { !MAPBOX_ACCESS_TOKEN && this._renderNoTokenWarning() }
         <div id="control-panel">
+          <button onClick={this._onQueryObjects}>Query Rendered Objects</button>
           <LayerControls
             title="Composite Settings"
             settings={settings}

--- a/examples/layer-browser/src/components/layer-info.js
+++ b/examples/layer-browser/src/components/layer-info.js
@@ -12,7 +12,7 @@ export default class LayerInfo extends PureComponent {
   }
 
   render() {
-    const {hovered, clicked} = this.props;
+    const {hovered, clicked, queried} = this.props;
 
     return (
       <div id="layer-info">
@@ -23,6 +23,10 @@ export default class LayerInfo extends PureComponent {
         { clicked && (<div>
           <h4>Click</h4>
           <span>Layer: { clicked.layer.id } Object: { this._infoToString(clicked) }</span>
+        </div>) }
+        { queried && (<div>
+          <h4>Query</h4>
+          <span>{ queried.length } Objects found</span>
         </div>) }
       </div>
     );

--- a/src/lib/draw-and-pick.js
+++ b/src/lib/draw-and-pick.js
@@ -55,6 +55,57 @@ export function drawLayers({layers, pass}) {
     ${visibleCount} visible, ${layers.length} total`);
 }
 
+export function queryLayers(gl, {
+  layers,
+  pickingFBO,
+  x,
+  y,
+  width,
+  height,
+  viewport,
+  mode
+}) {
+
+  // Convert from canvas top-left to WebGL bottom-left coordinates
+  // And compensate for pixelRatio
+  const pixelRatio = typeof window !== 'undefined' ?
+    window.devicePixelRatio : 1;
+  const deviceLeft = Math.round(x * pixelRatio);
+  const deviceBottom = Math.round(gl.canvas.height - y * pixelRatio);
+  const deviceRight = Math.round((x + width) * pixelRatio);
+  const deviceTop = Math.round(gl.canvas.height - (y + height) * pixelRatio);
+
+  const pickInfos = queryFromBuffer(gl, {
+    layers,
+    pickingFBO,
+    deviceRect: {
+      x: deviceLeft,
+      y: deviceTop,
+      width: deviceRight - deviceLeft,
+      height: deviceBottom - deviceTop
+    }
+  });
+
+  // Only return unique infos, identified by info.object
+  const uniqueInfos = new Map();
+
+  pickInfos.forEach(pickInfo => {
+    let info = createInfo([pickInfo.x / pixelRatio, pickInfo.y / pixelRatio], viewport);
+    info.devicePixel = [pickInfo.x, pickInfo.y];
+    info.pixelRatio = pixelRatio;
+    info.color = pickInfo.pickedColor;
+    info.index = pickInfo.pickedObjectIndex;
+    info.picked = true;
+
+    info = getLayerPickingInfo({layer: pickInfo.pickedLayer, info, mode});
+    if (!uniqueInfos.has(info.object)) {
+      uniqueInfos.set(info.object, info);
+    }
+  });
+
+  return Array.from(uniqueInfos.values());
+}
+
 /* eslint-disable max-depth, max-statements */
 export function pickLayers(gl, {
   layers,
@@ -212,6 +263,93 @@ function pickFromBuffer(gl, {
   const width = Math.min(pickingFBO.width, deviceX + deviceRadius) - x + 1;
   const height = Math.min(pickingFBO.height, deviceY + deviceRadius) - y + 1;
 
+  const pickedColors = getPickedColors(gl, {layers, pickingFBO, deviceRect: {x, y, width, height}});
+
+  // Traverse all pixels in picking results and find the one closest to the supplied
+  // [deviceX, deviceY]
+  let minSquareDistanceToCenter = deviceRadius * deviceRadius;
+  let closestResultToCenter = null;
+  let i = 0;
+
+  for (let row = 0; row < height; row++) {
+    for (let col = 0; col < width; col++) {
+      // Decode picked layer from color
+      const pickedLayerIndex = pickedColors[i + 3] - 1;
+
+      if (pickedLayerIndex >= 0) {
+        const dx = col + x - deviceX;
+        const dy = row + y - deviceY;
+        const d2 = dx * dx + dy * dy;
+
+        if (d2 <= minSquareDistanceToCenter) {
+          minSquareDistanceToCenter = d2;
+
+          // Decode picked object index from color
+          const pickedColor = pickedColors.slice(i, i + 4);
+          const pickedLayer = layers[pickedLayerIndex];
+          const pickedObjectIndex = pickedLayer.decodePickingColor(pickedColor);
+          closestResultToCenter = {pickedColor, pickedLayer, pickedObjectIndex};
+        }
+      }
+      i += 4;
+    }
+  }
+
+  return closestResultToCenter || {
+    pickedColor: EMPTY_PIXEL,
+    pickedLayer: null,
+    pickedObjectIndex: -1
+  };
+}
+
+/**
+ * Query within a specified rectangle
+ * Returns array of unique objects in shape `{x, y, pickedColor, pickedLayer, pickedObjectIndex}`
+ */
+function queryFromBuffer(gl, {
+  layers,
+  pickingFBO,
+  deviceRect: {x, y, width, height}
+}) {
+  const pickedColors = getPickedColors(gl, {layers, pickingFBO, deviceRect: {x, y, width, height}});
+  const uniqueColors = new Map();
+
+  // Traverse all pixels in picking results and get unique colors
+  let i = 0;
+
+  for (let row = 0; row < height; row++) {
+    for (let col = 0; col < width; col++) {
+      // Decode picked layer from color
+      const pickedLayerIndex = pickedColors[i + 3] - 1;
+
+      if (pickedLayerIndex >= 0) {
+        const pickedColor = pickedColors.slice(i, i + 4);
+        const colorKey = pickedColor.join(',');
+        if (!uniqueColors.has(colorKey)) {
+          const pickedLayer = layers[pickedLayerIndex];
+          uniqueColors.set(colorKey, {
+            x: col + x,
+            y: row + y,
+            pickedColor,
+            pickedLayer,
+            pickedObjectIndex: pickedLayer.decodePickingColor(pickedColor)
+          });
+        }
+      }
+      i += 4;
+    }
+  }
+
+  return Array.from(uniqueColors.values());
+}
+/* eslint-enable max-depth, max-statements */
+
+// Returns an Uint8ClampedArray of picked pixels
+function getPickedColors(gl, {
+  layers,
+  pickingFBO,
+  deviceRect: {x, y, width, height}
+}) {
   // TODO - just return glContextWithState once luma updates
   // Make sure we clear scissor test and fbo bindings in case of exceptions
   // We are only interested in one pixel, no need to render anything else
@@ -257,44 +395,9 @@ function pickFromBuffer(gl, {
     // restore blend mode
     setBlendMode(gl, oldBlendMode);
 
-    // Traverse all pixels in picking results and find the one closest to the supplied
-    // [deviceX, deviceY]
-    let minSquareDistanceToCenter = deviceRadius * deviceRadius;
-    let closestResultToCenter = null;
-    let i = 0;
-
-    for (let row = 0; row < height; row++) {
-      for (let col = 0; col < width; col++) {
-        // Decode picked layer from color
-        const pickedLayerIndex = pickedColors[i + 3] - 1;
-
-        if (pickedLayerIndex >= 0) {
-          const dx = col + x - deviceX;
-          const dy = row + y - deviceY;
-          const d2 = dx * dx + dy * dy;
-
-          if (d2 <= minSquareDistanceToCenter) {
-            minSquareDistanceToCenter = d2;
-
-            // Decode picked object index from color
-            const pickedColor = pickedColors.slice(i, i + 4);
-            const pickedLayer = layers[pickedLayerIndex];
-            const pickedObjectIndex = pickedLayer.decodePickingColor(pickedColor);
-            closestResultToCenter = {pickedColor, pickedLayer, pickedObjectIndex};
-          }
-        }
-        i += 4;
-      }
-    }
-
-    return closestResultToCenter || {
-      pickedColor: EMPTY_PIXEL,
-      pickedLayer: null,
-      pickedObjectIndex: -1
-    };
+    return pickedColors;
   });
 }
-/* eslint-enable max-depth, max-statements */
 
 function createInfo(pixel, viewport) {
   // Assign a number of potentially useful props to the "info" object

--- a/src/react/deckgl.js
+++ b/src/react/deckgl.js
@@ -82,6 +82,11 @@ export default class DeckGL extends React.Component {
     this._updateLayers(nextProps);
   }
 
+  /* Public API */
+  queryObjects(boundingBox, layerIds) {
+    return this.layerManager.queryLayer(boundingBox, layerIds);
+  }
+
   _updateLayers(nextProps) {
     const {width, height, latitude, longitude, zoom, pitch, bearing, altitude} = nextProps;
     let {viewport} = nextProps;

--- a/src/react/deckgl.js
+++ b/src/react/deckgl.js
@@ -83,8 +83,13 @@ export default class DeckGL extends React.Component {
   }
 
   /* Public API */
-  queryObjects(boundingBox, layerIds) {
-    return this.layerManager.queryLayer(boundingBox, layerIds);
+  queryObject({x, y, radius = 0, layerIds = null}) {
+    const selectedInfos = this.layerManager.pickLayer({x, y, radius, layerIds, mode: 'query'});
+    return selectedInfos.length ? selectedInfos[0] : null;
+  }
+
+  queryObjects({x, y, width = 1, height = 1, layerIds = null}) {
+    return this.layerManager.queryLayer({x, y, width, height, layerIds});
   }
 
   _updateLayers(nextProps) {


### PR DESCRIPTION
Given a bounding box and a list of layer ids (optional), returns an array of unique picking info objects.

As discussed before, the limitation of this API is that it doesn't return occluded objects.