### PR TITLE
fix point cloud examples bug

### DIFF
--- a/examples/point-cloud-laz/app.js
+++ b/examples/point-cloud-laz/app.js
@@ -139,9 +139,14 @@ class Example extends PureComponent {
   }
 
   _renderLazPointCloudLayer() {
-    return this.state.points.length && new PointCloudLayer({
+    const {points} = this.state;
+    if (!points || points.length === 0) {
+      return null;
+    }
+
+    return new PointCloudLayer({
       id: 'laz-point-cloud-layer',
-      data: this.state.points,
+      data: points,
       projectionMode: COORDINATE_SYSTEM.IDENTITY,
       getPosition: d => d.position,
       getNormal: d => [0, 0.5, 0.2],

--- a/examples/point-cloud-laz/package.json
+++ b/examples/point-cloud-laz/package.json
@@ -7,7 +7,7 @@
     "start-local": "webpack-dev-server --env.local --progress --hot --open"
   },
   "dependencies": {
-    "deck.gl": "^4.0.0-rc.4",
+    "deck.gl": "^4.0.6",
     "is-little-endian": "0.0.0",
     "luma.gl": "^3.0.1",
     "react": "^15.5.4",

--- a/examples/point-cloud-laz/package.json
+++ b/examples/point-cloud-laz/package.json
@@ -3,19 +3,19 @@
   "version": "0.0.1",
   "license": "MIT",
   "scripts": {
-    "start": "webpack-dev-server --progress --hot --port 3000 --open",
+    "start": "webpack-dev-server --progress --hot --open",
     "start-local": "webpack-dev-server --env.local --progress --hot --open"
   },
   "dependencies": {
-    "deck.gl": "4.0.0-rc.4",
-    "is-little-endian": "^0.0.0",
-    "luma.gl": "3.0.1",
-    "react": "^15.4.1",
-    "react-dom": "^15.4.1"
+    "deck.gl": "^4.0.0-rc.4",
+    "is-little-endian": "0.0.0",
+    "luma.gl": "^3.0.1",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4"
   },
   "devDependencies": {
-    "buble-loader": "^0.4.0",
-    "webpack": "^2.2.1",
-    "webpack-dev-server": "^2.3.0"
+    "buble-loader": "^0.4.1",
+    "webpack": "^2.6.1",
+    "webpack-dev-server": "^2.4.5"
   }
 }

--- a/examples/point-cloud-ply/app.js
+++ b/examples/point-cloud-ply/app.js
@@ -90,9 +90,14 @@ class Example extends PureComponent {
   }
 
   _renderPointCloudLayer() {
-    return this.state.points.length && new PointCloudLayer({
+    const {points} = this.state;
+    if (!points || points.length === 0) {
+      return null;
+    }
+
+    return new PointCloudLayer({
       id: 'point-cloud-layer',
-      data: this.state.points,
+      data: points,
       projectionMode: COORDINATE_SYSTEM.IDENTITY,
       getPosition: d => d.position,
       getNormal: d => d.normal,

--- a/examples/point-cloud-ply/package.json
+++ b/examples/point-cloud-ply/package.json
@@ -3,19 +3,19 @@
   "version": "0.0.1",
   "license": "MIT",
   "scripts": {
-    "start": "webpack-dev-server --progress --hot --port 3000 --open",
+    "start": "webpack-dev-server --progress --hot --open",
     "start-local": "webpack-dev-server --env.local --progress --hot --open"
   },
   "dependencies": {
-    "deck.gl": "4.0.0-rc.4",
-    "is-little-endian": "^0.0.0",
-    "luma.gl": "3.0.1",
-    "react": "^15.4.1",
-    "react-dom": "^15.4.1"
+    "deck.gl": "^4.0.6",
+    "is-little-endian": "0.0.0",
+    "luma.gl": "^3.0.1",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4"
   },
   "devDependencies": {
-    "buble-loader": "^0.4.0",
-    "webpack": "^2.2.1",
-    "webpack-dev-server": "^2.3.0"
+    "buble-loader": "^0.4.1",
+    "webpack": "^2.6.1",
+    "webpack-dev-server": "^2.4.5"
   }
 }


### PR DESCRIPTION
changed how the empty data is checked.

the filtering logics was moved to post-renderLayers() in https://github.com/uber/deck.gl/pull/676,
causing 0, generated by previous check logics, being used as a 'layer' that leads to the error.