### PR TITLE
_animation typo fix

### DIFF
--- a/examples/trips/app.js
+++ b/examples/trips/app.js
@@ -44,7 +44,7 @@ class Root extends Component {
   }
 
   componentWillUnmount() {
-    if (this._animation) {
+    if (this._animationFrame) {
       window.cancelAnimationFrame(this._animationFrame);
     }
   }


### PR DESCRIPTION
There was a mismatch as ._animation must be replaced with ._animationFrame to successfully stop listing to animation frames.