### PR TITLE
test(travis): use pinned latest lts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,7 @@
 language: node_js
-os: linux
-sudo: required
-dist: trusty
-addons:
-  apt:
-    packages:
-    - mesa-utils
-    - xvfb
-    - libgl1-mesa-dri
-    - libglapi-mesa
-    - libosmesa6
-    - libxi-dev
 node_js:
   - 6.9.1
-before_script:
-  - export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start
-  - ulimit -c unlimited -S       # enable core dumps
+  - 7
 script:
   - npm run lint
   - npm run cover

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ addons:
     - libosmesa6
     - libxi-dev
 node_js:
-  - 6
-  - 7
+  - 6.9.1
 before_script:
   - export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start
   - ulimit -c unlimited -S       # enable core dumps

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
+dist: precise
+os: linux
+group: stable
 node_js:
   - 6.9.1
   - 7


### PR DESCRIPTION
Use only latest LTS `6.9.1` for travis, as other versions are having too many issues lately and creating false negative build results

WIP