### PR TITLE
Remove the last vestiges of drag event handling from the framework

### DIFF
--- a/src/lib/layer.js
+++ b/src/lib/layer.js
@@ -50,10 +50,6 @@ const defaultProps = {
 
   onHover: noop,
   onClick: noop,
-  onDragStart: noop,
-  onDragMove: noop,
-  onDragEnd: noop,
-  onDragCancel: noop,
 
   projectionMode: COORDINATE_SYSTEM.LNGLAT,
 


### PR DESCRIPTION
drag events in graph-layer example to follow in another PR.