### PR TITLE
Graph layer drag refactor

### DIFF
--- a/examples/graph/app.js
+++ b/examples/graph/app.js
@@ -146,15 +146,15 @@ class Root extends Component {
     });
   }
 
-  _onHover(el) {
-    if (el) {
-      this.setState({hovered: el});
+  _onHover(info) {
+    if (info) {
+      this.setState({hovered: info});
     }
   }
 
-  _onClick(el) {
-    if (el) {
-      this.setState({clicked: el});
+  _onClick(info) {
+    if (info) {
+      this.setState({clicked: info});
     } else {
       const {clicked} = this.state;
       if (clicked) {
@@ -166,23 +166,21 @@ class Root extends Component {
   _onMouseDown(event) {
     // Use DeckGL.queryObject() to find the object under the mouse,
     // and store it for updating on mouse move.
-    const point = {x: event.clientX, y: event.clientY};
-    const el = this.deckGL.queryObject(point);
-    if (el) {
+    const info = this.deckGL.queryObject({x: event.clientX, y: event.clientY});
+    if (info) {
       this.setState({
-        clicked: el,
+        clicked: info,
         dragging: {
-          node: el.object
+          node: info.object
         }
       });
-      this._updateDraggedElement(point);
+      this._updateDraggedElement([event.clientX, event.clientY]);
     }
   }
 
   _onMouseMove(event) {
     if (this.state.dragging) {
-      const point = {x: event.clientX, y: event.clientY};
-      this._updateDraggedElement(point);
+      this._updateDraggedElement([event.clientX, event.clientY]);
     }
   }
 
@@ -195,15 +193,15 @@ class Root extends Component {
     });
   }
 
-  _updateDraggedElement({x, y}) {
+  _updateDraggedElement(point) {
     const {viewport: {width, height}} = this.state;
-    const dragX = x - width / 2;
-    const dragY = y - height / 2;
+    const x = point[0] - width / 2;
+    const y = point[1] - height / 2;
     this.setState({
       dragging: {
         node: this.state.dragging.node,
-        x: dragX,
-        y: dragY
+        x,
+        y
       }
     });
   }

--- a/examples/graph/deckgl-overlay.js
+++ b/examples/graph/deckgl-overlay.js
@@ -15,9 +15,9 @@ export default class DeckGLOverlay extends Component {
     }
 
     const {width, height} = viewport;
-    const {layoutProps} = this.props;
+    const {layoutProps, deckGLRef} = this.props;
     const {layoutAccessors, linkAccessors, nodeAccessors, nodeIconAccessors} = this.props;
-    const {onHover, onClick, onDragMove, onDragEnd} = this.props;
+    const {onHover, onClick} = this.props;
     const layer = new GraphLayoutLayer({
       id: 'graph-layout',
       data,
@@ -29,9 +29,7 @@ export default class DeckGLOverlay extends Component {
       nodeIconAccessors,
 
       onHover,
-      onClick,
-      onDragMove,
-      onDragEnd
+      onClick
     });
 
     // recalculate viewport on container size change.
@@ -42,6 +40,7 @@ export default class DeckGLOverlay extends Component {
     // TODO: clean up viewport / glViewport
     return (
       <DeckGL
+        ref={deckGLRef}
         width={width}
         height={height}
         viewport={glViewport}

--- a/examples/graph/graph-layer/graph-layout-layer.js
+++ b/examples/graph/graph-layer/graph-layout-layer.js
@@ -108,7 +108,7 @@ export default class GraphLayoutLayer extends CompositeLayer {
     const {opacity, visible} = this.props;
 
     // base layer handlers
-    const {onHover, onClick, onDragMove, onDragEnd} = this.props;
+    const {onHover, onClick} = this.props;
     const pickable = Boolean(this.props.onHover || this.props.onClick);
 
     // viewport props
@@ -132,9 +132,7 @@ export default class GraphLayoutLayer extends CompositeLayer {
         projectionMode,
 
         onHover,
-        onClick,
-        onDragMove,
-        onDragEnd
+        onClick
       },
 
       // deconstruct these

--- a/src/lib/layer.js
+++ b/src/lib/layer.js
@@ -50,10 +50,6 @@ const defaultProps = {
 
   onHover: noop,
   onClick: noop,
-  onDragStart: noop,
-  onDragMove: noop,
-  onDragEnd: noop,
-  onDragCancel: noop,
 
   projectionMode: COORDINATE_SYSTEM.LNGLAT,
 


### PR DESCRIPTION
Update graph example to maange drag state on its own, using mouse handlers and queryObject().

I branched off of #741, so once that's landed I'll just rebase this to remove the duplicate commit from #741.

(Also, looks like this is the first use of `queryLayers()` in our examples. Works like a charm, thx @Pessimistress 🙏 🙆 