### PR TITLE
Update canvas size to match with device framebuffer size.

### DIFF
--- a/src/react/deckgl.js
+++ b/src/react/deckgl.js
@@ -164,9 +164,11 @@ export default class DeckGL extends React.Component {
     return createElement(WebGLRenderer, Object.assign({}, this.props, {
       width,
       height,
+      // NOTE: Add 'useDevicePixelRatio' to 'this.props' and also pass it down to
+      // to modules where window.devicePixelRatio is used.
+      useDevicePixelRatio: true,
       gl,
       debug,
-      viewport: {x: 0, y: 0, width, height},
       onRendererInitialized: this._onRendererInitialized,
       onNeedRedraw: this._onNeedRedraw,
       onRenderFrame: this._onRenderFrame


### PR DESCRIPTION
- Fixes #747 
- Update canvas size to match with device framebuffer for each frame, considering logical size and `devicePixelRation`
- Use canvas size to set viewport.

@ibgreen @Pessimistress  : not ready to merge, have some open questions 

