### PR TITLE
TagMap: add shouldUpdateState function

### DIFF
--- a/examples/tagmap/tagmap-layer/tagmap-layer.js
+++ b/examples/tagmap/tagmap-layer/tagmap-layer.js
@@ -25,8 +25,12 @@ export default class TagmapLayer extends CompositeLayer {
     this.state = {canvas};
   }
 
+  shouldUpdateState({changeFlags}) {
+    return changeFlags.somethingChanged;
+  }
+
   updateState({props, oldProps, changeFlags}) {
-    // super.updateState({props, oldProps, changeFlags});
+    super.updateState({props, oldProps, changeFlags});
 
     if (changeFlags.dataChanged) {
       this.updateLabelAtlas();


### PR DESCRIPTION
This worked well in the previous deck.gl version. But in the recently released beta version, the `tagMap` example doesn't call the `updateState` function when the viewport changes. Adding the `shouldUpdateState` function fixed the issue though.