### PR TITLE
Hex grid layer methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Ref: http://keepachangelog.com/en/0.3.0/
 ## Beta Releases
 
 - Fix `GridCellLayer` cellSize changing on zooming (#782)
+- Add `getSubLayerClass`, `getSubLayerProps` methods to `GridLayer` and `HexagonLayer` for easy subclassing
 
 ### deck.gl v4.1.0-beta.4
 - Picking clean up (#774)

--- a/src/layers/core/grid-cell-layer/grid-cell-layer.js
+++ b/src/layers/core/grid-cell-layer/grid-cell-layer.js
@@ -127,16 +127,12 @@ export default class GridCellLayer extends Layer {
   }
 
   updateUniforms() {
-    const {opacity, extruded, elevationScale, cellSize, coverage, lightSettings} = this.props;
-    const {viewport} = this.context;
-    // TODO - this should be a standard uniform in project package
-    const {pixelsPerMeter} = viewport.getDistanceScales();
+    const {opacity, extruded, elevationScale, coverage, lightSettings} = this.props;
 
     this.setUniforms(Object.assign({}, {
       extruded,
       elevationScale,
       opacity,
-      cellSize: cellSize * pixelsPerMeter[0],
       coverage
     },
     lightSettings));

--- a/src/layers/core/grid-cell-layer/grid-cell-layer.js
+++ b/src/layers/core/grid-cell-layer/grid-cell-layer.js
@@ -127,12 +127,16 @@ export default class GridCellLayer extends Layer {
   }
 
   updateUniforms() {
-    const {opacity, extruded, elevationScale, coverage, lightSettings} = this.props;
+    const {opacity, extruded, elevationScale, cellSize, coverage, lightSettings} = this.props;
+    const {viewport} = this.context;
+    // TODO - this should be a standard uniform in project package
+    const {pixelsPerMeter} = viewport.getDistanceScales();
 
     this.setUniforms(Object.assign({}, {
       extruded,
       elevationScale,
       opacity,
+      cellSize: cellSize * pixelsPerMeter[0],
       coverage
     },
     lightSettings));

--- a/src/layers/core/grid-layer/grid-layer.js
+++ b/src/layers/core/grid-layer/grid-layer.js
@@ -167,6 +167,8 @@ export default class GridLayer extends CompositeLayer {
   }
 
   getSubLayerProps() {
+    // for subclassing, override this method to return
+    // customized sub layer props
     const {id, elevationScale, fp64, extruded, cellSize, coverage, lightSettings} = this.props;
 
     // base layer props
@@ -175,6 +177,7 @@ export default class GridLayer extends CompositeLayer {
     // viewport props
     const {positionOrigin, projectionMode, modelMatrix} = this.props;
 
+    // return props to the sublayer constructor
     return {
       id: `${id}-grid-cell`,
       data: this.state.layerData,
@@ -198,14 +201,16 @@ export default class GridLayer extends CompositeLayer {
     };
   }
 
-  getSubLayer() {
+  getSubLayerClass() {
+    // for subclassing, override this method to return
+    // customized sub layer class
     return GridCellLayer;
   }
 
   renderLayers() {
-    const SubLayerComp = this.getSubLayer();
+    const SubLayerClass = this.getSubLayerClass();
 
-    return new SubLayerComp(
+    return new SubLayerClass(
       this.getSubLayerProps()
     );
   }

--- a/src/layers/core/grid-layer/grid-layer.js
+++ b/src/layers/core/grid-layer/grid-layer.js
@@ -52,19 +52,6 @@ const defaultProps = {
   }
 };
 
-function _needsReProjectPoints(oldProps, props) {
-  return oldProps.cellSize !== props.cellSize;
-}
-
-function _percentileChanged(oldProps, props) {
-  return oldProps.lowerPercentile !== props.lowerPercentile ||
-    oldProps.upperPercentile !== props.upperPercentile;
-}
-
-function _needsReSortBins(oldProps, props) {
-  return oldProps.getColorValue !== props.getColorValue;
-}
-
 export default class GridLayer extends CompositeLayer {
   initializeState() {
     this.state = {
@@ -75,22 +62,35 @@ export default class GridLayer extends CompositeLayer {
   }
 
   updateState({oldProps, props, changeFlags}) {
-    if (changeFlags.dataChanged || _needsReProjectPoints(oldProps, props)) {
+    if (changeFlags.dataChanged || this.needsReProjectPoints(oldProps, props)) {
       // project data into hexagons, and get sortedBins
       this.getLayerData();
       this.getSortedBins();
 
       // this needs sortedBins to be set
       this.getValueDomain();
-    } else if (_needsReSortBins(oldProps, props)) {
+    } else if (this.needsReSortBins(oldProps, props)) {
 
       this.getSortedBins();
       this.getValueDomain();
 
-    } else if (_percentileChanged(oldProps, props)) {
+    } else if (this.needsRecalculateColorDomain(oldProps, props)) {
 
       this.getValueDomain();
     }
+  }
+
+  needsReProjectPoints(oldProps, props) {
+    return oldProps.cellSize !== props.cellSize;
+  }
+
+  needsRecalculateColorDomain(oldProps, props) {
+    return oldProps.lowerPercentile !== props.lowerPercentile ||
+      oldProps.upperPercentile !== props.upperPercentile;
+  }
+
+  needsReSortBins(oldProps, props) {
+    return oldProps.getColorValue !== props.getColorValue;
   }
 
   getLayerData() {
@@ -166,7 +166,7 @@ export default class GridLayer extends CompositeLayer {
     return linearScale(domain, elevationRange, cell.points.length);
   }
 
-  renderLayers() {
+  getSubLayerProps() {
     const {id, elevationScale, fp64, extruded, cellSize, coverage, lightSettings} = this.props;
 
     // base layer props
@@ -175,7 +175,7 @@ export default class GridLayer extends CompositeLayer {
     // viewport props
     const {positionOrigin, projectionMode, modelMatrix} = this.props;
 
-    return new GridCellLayer({
+    return {
       id: `${id}-grid-cell`,
       data: this.state.layerData,
       cellSize,
@@ -195,7 +195,19 @@ export default class GridLayer extends CompositeLayer {
       getElevation: this._onGetSublayerElevation.bind(this),
       getPosition: d => d.position,
       updateTriggers: this.getUpdateTriggers()
-    });
+    };
+  }
+
+  getSubLayer() {
+    return GridCellLayer;
+  }
+
+  renderLayers() {
+    const SubLayerComp = this.getSubLayer();
+
+    return new SubLayerComp(
+      this.getSubLayerProps()
+    );
   }
 }
 

--- a/src/layers/core/hexagon-layer/hexagon-layer.js
+++ b/src/layers/core/hexagon-layer/hexagon-layer.js
@@ -210,6 +210,8 @@ export default class HexagonLayer extends CompositeLayer {
   }
 
   getSubLayerProps() {
+    // for subclassing, override this method to return
+    // customized sub layer props
     const {id, radius, elevationScale, extruded, coverage, lightSettings, fp64} = this.props;
 
     // base layer props
@@ -218,6 +220,7 @@ export default class HexagonLayer extends CompositeLayer {
     // viewport props
     const {positionOrigin, projectionMode, modelMatrix} = this.props;
 
+    // return props to the sublayer constructor
     return {
       id: `${id}-hexagon-cell`,
       data: this.state.hexagons,
@@ -242,14 +245,16 @@ export default class HexagonLayer extends CompositeLayer {
     };
   }
 
-  getSubLayer() {
+  getSubLayerClass() {
+    // for subclassing, override this method to return
+    // customized sub layer class
     return HexagonCellLayer;
   }
 
   renderLayers() {
-    const SubLayerComp = this.getSubLayer();
+    const SubLayerClass = this.getSubLayerClass();
 
-    return new SubLayerComp(
+    return new SubLayerClass(
       this.getSubLayerProps()
     );
   }

--- a/src/layers/core/hexagon-layer/hexagon-layer.js
+++ b/src/layers/core/hexagon-layer/hexagon-layer.js
@@ -209,7 +209,7 @@ export default class HexagonLayer extends CompositeLayer {
     return linearScale(domain, elevationRange, cell.points.length);
   }
 
-  renderLayers() {
+  getSubLayerProps() {
     const {id, radius, elevationScale, extruded, coverage, lightSettings, fp64} = this.props;
 
     // base layer props
@@ -218,7 +218,7 @@ export default class HexagonLayer extends CompositeLayer {
     // viewport props
     const {positionOrigin, projectionMode, modelMatrix} = this.props;
 
-    return new HexagonCellLayer({
+    return {
       id: `${id}-hexagon-cell`,
       data: this.state.hexagons,
       hexagonVertices: this.state.hexagonVertices,
@@ -239,7 +239,19 @@ export default class HexagonLayer extends CompositeLayer {
       getColor: this._onGetSublayerColor.bind(this),
       getElevation: this._onGetSublayerElevation.bind(this),
       updateTriggers: this.getUpdateTriggers()
-    });
+    };
+  }
+
+  getSubLayer() {
+    return HexagonCellLayer;
+  }
+
+  renderLayers() {
+    const SubLayerComp = this.getSubLayer();
+
+    return new SubLayerComp(
+      this.getSubLayerProps()
+    );
   }
 }
 

--- a/src/layers/core/hexagon-layer/hexagon-layer.js
+++ b/src/layers/core/hexagon-layer/hexagon-layer.js
@@ -54,19 +54,6 @@ const defaultProps = {
   }
 };
 
-function _needsReProjectPoints(oldProps, props) {
-  return oldProps.radius !== props.radius || oldProps.hexagonAggregator !== props.hexagonAggregator;
-}
-
-function _percentileChanged(oldProps, props) {
-  return oldProps.lowerPercentile !== props.lowerPercentile ||
-    oldProps.upperPercentile !== props.upperPercentile;
-}
-
-function _needsReSortBins(oldProps, props) {
-  return oldProps.getColorValue !== props.getColorValue;
-}
-
 export default class HexagonLayer extends CompositeLayer {
   constructor(props) {
     if (!props.hexagonAggregator && !props.radius) {
@@ -116,7 +103,7 @@ export default class HexagonLayer extends CompositeLayer {
   }
 
   updateState({oldProps, props, changeFlags}) {
-    if (changeFlags.dataChanged || _needsReProjectPoints(oldProps, props)) {
+    if (changeFlags.dataChanged || this.needsReProjectPoints(oldProps, props)) {
       // project data into hexagons, and get sortedBins
       this.getHexagons();
       this.getSortedBins();
@@ -124,15 +111,29 @@ export default class HexagonLayer extends CompositeLayer {
       // this needs sortedBins to be set
       this.getValueDomain();
 
-    } else if (_needsReSortBins(oldProps, props)) {
+    } else if (this.needsReSortBins(oldProps, props)) {
 
       this.getSortedBins();
       this.getValueDomain();
 
-    } else if (_percentileChanged(oldProps, props)) {
+    } else if (this.needsRecalculateColorDomain(oldProps, props)) {
 
       this.getValueDomain();
     }
+  }
+
+  needsReProjectPoints(oldProps, props) {
+    return oldProps.radius !== props.radius ||
+      oldProps.hexagonAggregator !== props.hexagonAggregator;
+  }
+
+  needsRecalculateColorDomain(oldProps, props) {
+    return oldProps.lowerPercentile !== props.lowerPercentile ||
+      oldProps.upperPercentile !== props.upperPercentile;
+  }
+
+  needsReSortBins(oldProps, props) {
+    return oldProps.getColorValue !== props.getColorValue;
   }
 
   getHexagons() {


### PR DESCRIPTION
For easier subclassing:
- Add static methods to layer class
- Add method `getSubLayer ` to get SubLayer class
- Add method `getSubLayerProps` to get SubLayer props