### PR TITLE
ShaderModule: Remove supplying 'project' module, fix 'lighting' module dependency.

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -6,14 +6,6 @@ A highly compatible release, the biggest change is that deck.gl v4.1 brings in l
 
 ## Shader Assembly
 
-A notable change if you are writing your own layers is that the `project` shader module is no longer included by default.
-```js
-new Model(gl, {
-  vs: ...,
-  fs: ...,
-  modules: ['project']
-});
-```
 Note that instead of calling `assembleShaders` directly (as was required in the v4.0), you can now just pass a `modules` parameter to the luma.gl `Model`.
 
 

--- a/examples/plot/package.json
+++ b/examples/plot/package.json
@@ -5,8 +5,8 @@
   },
   "dependencies": {
     "d3-scale": "^1.0.6",
-    "deck.gl": ">=4.1.0-beta.1",
-    "luma.gl": ">=4.0.0-beta.1",
+    "deck.gl": ">=4.1.0-beta.5",
+    "luma.gl": ">=4.0.0-beta.6",
     "prop-types": "^15.5.8",
     "react": "^15.4.1",
     "react-dom": "^15.4.1"

--- a/examples/trips/package.json
+++ b/examples/trips/package.json
@@ -5,8 +5,8 @@
   },
   "dependencies": {
     "d3-request": "^1.0.5",
-    "deck.gl": ">=4.1.0-beta.1",
-    "luma.gl": ">=4.0.0-beta.1",
+    "deck.gl": ">=4.1.0-beta.5",
+    "luma.gl": ">=4.0.0-beta.6",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
     "react-map-gl": ">=3.0.0-beta.1"

--- a/src/layers/core/arc-layer/arc-layer.js
+++ b/src/layers/core/arc-layer/arc-layer.js
@@ -43,7 +43,7 @@ export default class ArcLayer extends Layer {
   getShaders() {
     return enable64bitSupport(this.props) ?
       {vs: vs64, fs, modules: ['project64']} :
-      {vs, fs, modules: ['project']};
+      {vs, fs}; // 'project' module added by default.
   }
 
   initializeState() {

--- a/src/layers/core/grid-cell-layer/grid-cell-layer.js
+++ b/src/layers/core/grid-cell-layer/grid-cell-layer.js
@@ -68,7 +68,7 @@ export default class GridCellLayer extends Layer {
     const {shaderCache} = this.context;
     return enable64bitSupport(this.props) ?
       {vs: vs64, fs, modules: ['project64', 'lighting'], shaderCache} :
-      {vs, fs, modules: ['project', 'lighting'], shaderCache};
+      {vs, fs, modules: ['lighting'], shaderCache};  // 'project' module added by default.
   }
 
   initializeState() {

--- a/src/layers/core/hexagon-cell-layer/hexagon-cell-layer.js
+++ b/src/layers/core/hexagon-cell-layer/hexagon-cell-layer.js
@@ -81,7 +81,7 @@ export default class HexagonCellLayer extends Layer {
   getShaders() {
     return enable64bitSupport(this.props) ?
       {vs: vs64, fs, modules: ['project64', 'lighting']} :
-      {vs, fs, modules: ['project', 'lighting']};
+      {vs, fs, modules: ['lighting']}; // 'project' module added by default.
   }
 
   /**

--- a/src/layers/core/icon-layer/icon-layer.js
+++ b/src/layers/core/icon-layer/icon-layer.js
@@ -67,7 +67,7 @@ export default class IconLayer extends Layer {
   getShaders() {
     return enable64bitSupport(this.props) ?
       {vs: vs64, fs, modules: ['project64']} :
-      {vs, fs, modules: ['project']};
+      {vs, fs};  // 'project' module added by default.
   }
 
   initializeState() {

--- a/src/layers/core/line-layer/line-layer.js
+++ b/src/layers/core/line-layer/line-layer.js
@@ -42,7 +42,7 @@ export default class LineLayer extends Layer {
   getShaders() {
     return enable64bitSupport(this.props) ?
       {vs: vs64, fs, modules: ['project64']} :
-      {vs, fs, modules: ['project']};
+      {vs, fs}; // 'project' module added by default.
   }
 
   initializeState() {

--- a/src/layers/core/path-layer/path-layer.js
+++ b/src/layers/core/path-layer/path-layer.js
@@ -53,7 +53,7 @@ export default class PathLayer extends Layer {
   getShaders() {
     return enable64bitSupport(this.props) ?
       {vs: vs64, fs, modules: ['project64']} :
-      {vs, fs, modules: ['project']};
+      {vs, fs}; // 'project' module added by default.
   }
 
   initializeState() {

--- a/src/layers/core/point-cloud-layer/point-cloud-layer.js
+++ b/src/layers/core/point-cloud-layer/point-cloud-layer.js
@@ -52,7 +52,7 @@ export default class PointCloudLayer extends Layer {
     const {shaderCache} = this.context;
     return enable64bitSupport(this.props) ?
       {vs: vs64, fs, modules: ['project64', 'lighting'], shaderCache} :
-      {vs, fs, modules: ['project', 'lighting'], shaderCache};
+      {vs, fs, modules: ['lighting'], shaderCache}; // 'project' module added by default.
   }
 
   initializeState() {

--- a/src/layers/core/scatterplot-layer/scatterplot-layer.js
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer.js
@@ -48,7 +48,7 @@ export default class ScatterplotLayer extends Layer {
     const {shaderCache} = this.context;
     return enable64bitSupport(this.props) ?
       {vs: vs64, fs, modules: ['project64'], shaderCache} :
-      {vs, fs, modules: ['project'], shaderCache};
+      {vs, fs, shaderCache}; // 'project' module added by default.
   }
 
   initializeState() {

--- a/src/layers/core/screen-grid-layer/screen-grid-layer.js
+++ b/src/layers/core/screen-grid-layer/screen-grid-layer.js
@@ -37,7 +37,7 @@ const defaultProps = {
 
 export default class ScreenGridLayer extends Layer {
   getShaders() {
-    return {vs, fs, modules: ['project']};
+    return {vs, fs}; // 'project' module added by default.
   }
 
   constructor(props) {

--- a/src/layers/core/solid-polygon-layer/solid-polygon-layer.js
+++ b/src/layers/core/solid-polygon-layer/solid-polygon-layer.js
@@ -61,7 +61,7 @@ export default class SolidPolygonLayer extends Layer {
   getShaders() {
     return enable64bitSupport(this.props) ?
       {vs: vs64, fs, modules: ['project64', 'lighting']} :
-      {vs, fs, modules: ['project', 'lighting']};
+      {vs, fs, modules: ['lighting']}; // 'project' module added by default.
   }
 
   initializeState() {

--- a/src/shaderlib/lighting/lighting.js
+++ b/src/shaderlib/lighting/lighting.js
@@ -19,8 +19,10 @@
 // THE SOFTWARE.
 
 import lightingShader from './lighting.glsl';
+import project from '../project/project';
 
 export default {
   name: 'lighting',
+  dependencies: [project],
   vs: lightingShader
 };


### PR DESCRIPTION
* Now that 'project' module is added by default, remove code supplying to `model` object.
* Add dependency `lighting` -> `project`, so modules are inserted in right order.
* Tested with : test-browser, layer-browser, examples.
NOTE: not ready to merge, requires luma.gl change (https://github.com/uber/luma.gl/pull/270)