### PR TITLE
V4.1 doc update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,55 +43,54 @@ Ref: http://keepachangelog.com/en/0.3.0/
 ### deck.gl v4.1.0-beta.2
 - NEW: `getUniformsFromViewport` refactored into `project` shader module's `getUniforms`.
 - NEW: Replaced explicit calls to `assembleShaders` with `Model` parameters.
-- SIZE: Remove gl-matrix (#759)
 - FIX: Update canvas size to match with device framebuffer size.
+- WEBSITE: Links to other frameworks (#753)
+- FIX: Avoid deep comparison error in compareProps when oldProp is empty (#754)
 - FIX: Fix the fluctuation of the end cap for path layer 64bit (#755)
-- FIX: Avoid deep comparison error in compareProps when oldProp is empty
-- WEBSITE: Links to other frameworks
-- EXAMPLE: Fix updateState issue: add shouldUpdateState function
-
 - MapController clean up (#757)
+- SIZE: Remove gl-matrix (#759
 - OrbitController clean up (#761)
+- EXAMPLE: Fix updateState issue in TagMap: add shouldUpdateState function (#762)
 
 ### deck.gl v4.1.0-beta.1
-- Import luma.gl v4.0.0-beta.1
 - webpack configuration cleanup
-- SEER integration upgrades
-- EXAMPLES: Experimental TagMap Layer @zhan1486
+- EXAMPLES: Experimental TagMap Layer (#735, @zhan1486)
 - FIX: Use external buffers for layer attributes
+- SEER integration upgrades (#744)
+- Import luma.gl v4.0.0-beta.1 (#752)
 
 ### deck.gl v4.1.0-alpha.15
 
-- Graph Layer example refactor
-- Event Management Refactor
-- queryVisibleObjects (renamed from queryObject)
+- FIX: Tween.js import (#730, #734)
+- Example config files cleaned up (#731, #732)
+- queryVisibleObjects (renamed from queryObject) (#736)
+- Event Management Refactor (#738)
+- SEER integration upgrades (#740)
+- Graph Layer example refactor (#742)
 - New luma state management API
-- Example config files cleaned up
 - WEBSITE: demo renamed to website
-
 
 ### deck.gl v4.1.0-alpha.14
 
-- Lifecycle performance tuning
-- SEER performance badges
-- "Stateless" picking
+- "Stateless" picking (#717)
+- Lifecycle performance tuning (#721)
+- SEER performance badges (#720, #722)
 - Custom "spy" class to fix test-browser
 - FIX: Using external buffers for layer attributes
-
+- FIX: Shadercache import (#727)
 
 ### deck.gl v4.1.0-alpha.13
-- FIX external buffers for layer attributes
-- Event Manager API Audit fixes
-- Travis CI fixes
-- Custom spy for tests
-- Stateless picking (uses new luma.gl features)
-- Seer performance badges
-- Examples now on react-map-gl v3
-- Lifecycle tuning
-- Shadercache import
+- Lifecycle tuning (#708)
+- Seer performance badges (#709)
+- Event Manager API Audit fixes (#710)
+- FIX external buffers for layer attributes (#711)
+- Travis CI fixes (#713)
+- Examples now on react-map-gl v3 (#714)
+- Stateless picking (uses new luma.gl features) (#715)
+- Custom spy for tests (#716)
 
-### deck.gl v4.1.0-alpha.11
-- Seer fix
+### deck.gl v4.1.0-alpha.12
+- Seer fix (#706)
 
 ### deck.gl v4.1.0-alpha.11
 - EXAMPLE: PlotLayer example improvement (#689)
@@ -103,7 +102,6 @@ Ref: http://keepachangelog.com/en/0.3.0/
 - FIX: fix modelMatrix in meter offset mode (#678)
 - NEW: Add queryObjects api to DeckGL component (#673)
 - Flatten CompositeLayer.renderLayer() output (#676)
-
 
 ### deck.gl v4.1.0-alpha.9
 - EXAMPLES: update the PlotLayer example with axis labels (#671)
@@ -141,7 +139,7 @@ Versions 4.1.0 alpha 1, 2 and 3 have been unpublished due to a wrong tagging.
 - FEAT: Seer integration and performace improvements
 - PERFORMANCE: Compiled are now cached for reuse so that same shaders are not recompiled for the same type of layers (#613)
 - PERFORMANCE: getViewportUniforms optimization (#586)
-- BREAKING: Only composite layers have `renderLayer` methods (#585)
+- BREAKING: Only composite layers have `renderLayers` methods (#585)
 - BREAKING: Only primitive layers' `draw` methods are called during render (#585)
 - `GridLayer` add `coverage`, `lowerPercentile`, `upperPercentile` and `getColorValue` to layer prop (#614)
 - `IconLayer` add `getAngle` for rotating each icon with a specific angles (in degrees) (#625)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,12 +37,13 @@ Ref: http://keepachangelog.com/en/0.3.0/
 - Rename `settings` prop to `parameters`
 
 ### deck.gl v4.1.0-beta.3
-- Use luma.gl shader modules
-- FIX: polygonOffset
+- WEBSITE update (#768)
+- FIX: polygonOffset (#770)
+- Use luma.gl shader modules (#772)
+- DOC: Vis suite blog posts (#773)
 
 ### deck.gl v4.1.0-beta.2
 - NEW: `getUniformsFromViewport` refactored into `project` shader module's `getUniforms`.
-- NEW: Replaced explicit calls to `assembleShaders` with `Model` parameters.
 - FIX: Update canvas size to match with device framebuffer size.
 - WEBSITE: Links to other frameworks (#753)
 - FIX: Avoid deep comparison error in compareProps when oldProp is empty (#754)
@@ -51,6 +52,7 @@ Ref: http://keepachangelog.com/en/0.3.0/
 - SIZE: Remove gl-matrix (#759
 - OrbitController clean up (#761)
 - EXAMPLE: Fix updateState issue in TagMap: add shouldUpdateState function (#762)
+- NEW: Replaced explicit calls to `assembleShaders` with `Model` parameters. (#764, #765, #767)
 
 ### deck.gl v4.1.0-beta.1
 - webpack configuration cleanup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,7 +148,7 @@ Versions 4.1.0 alpha 1, 2 and 3 have been unpublished due to a wrong tagging.
 - `HexagonLayer` add interval `getHexagons`, `getSortedCounts` `getUpdateTriggers` methods, make it easier to create layer subclass
 - `HexagonLayer` add `getColorValue` (optional) prop, returns a value to base bin color on.
 - `HexagonLayer` change default `hexagonAggregator` output to `{hexagons: [], hexagonVertices: []}`
-- `HexagonLayer` add `getValue` to `BiinSorter` to support color / elevation by value
+- `HexagonLayer` add `getValue` to `BinSorter` to support color / elevation by value
 - TEST: Implement code coverage with nyc and coverall report (#596)
 - HOTFIX: fix `HexagonLayer` hex color calculation, use `bin.value` instead of `bin.points.count` to calculate color
 - HOTFIX: Fix the bug that layer is finalized at every cycle due to an incorrect if check(#552)

--- a/docs/advanced/layer-lifecycle.md
+++ b/docs/advanced/layer-lifecycle.md
@@ -27,7 +27,7 @@ Layers can use the state object to store persistent information cross rendering 
 
 ### Initialization
 
-This happens only once for each layer that is being added, i.e. a layer from the
+Initialization happens only once for each layer that is being added, i.e. a layer from the
 current rendering cycle whose `id` does not get matched with any layer in the previous
 cycle.
 [`layer.initializeState()`](/docs/api-reference/base-layer.md#-initializestate-) is called at
@@ -39,7 +39,7 @@ before the first render.
 
 ### Updating
 
-Happens when a new layer has been matched with a layer from the previous
+Updating happens when a new layer has been matched with a layer from the previous
 rendering cycle (resulting in new props being passed to that layer),
 or when context has changed and layers are about to be drawn.
 
@@ -55,9 +55,8 @@ If the layer does need to be updated,
 is called to perform any necessary operation before the layer is rendered.
 This usually involves recalculating an attribute by calling
 [`state.attributeManager.invalidate`](/docs/api-reference/attribute-manager.md#-invalidate-)
-and updating unforms by calling
-`model.setUniforms`.
-By default, when `props.data` changes, all attributes are recalculated.
+and updating uniforms by calling `model.setUniforms`.
+By default, when `props.data` changes, all attributes are invalidated and recalculated.
 
 A composite layer may use
 [`compositeLayer.renderLayers()`](/docs/api-reference/composite-layer.md#-renderlayers-)
@@ -68,10 +67,11 @@ into "primitive" layers.
 
 ### Rendering
 
-Happens during each rendering cycle to draw the layer to the WebGL context.
+Rendering happens during each rendering cycle to draw the layer to the WebGL context.
 
-[`layer.draw()`](/docs/api-reference/base-layer.md#-draw-)
-is called at this stage.
+For primitive layers, [`layer.draw()`](/docs/api-reference/base-layer.md#-draw-)
+is called at this stage, which invokes the layers' `model.render` calls.
+For composite layers, `layer.renderLayers` is called to genrate sublayers.
 
 ### Picking
 

--- a/docs/layers/hexagon-layer.md
+++ b/docs/layers/hexagon-layer.md
@@ -9,10 +9,9 @@
 
 The Hexagon Layer renders a hexagon heatmap based on an array of points.
 It takes the radius of hexagon bin, projects points into hexagon bins. The color
-and height of the hexagon is scaled by number of points it contains. HexagonLayer
-at the moment only works with COORDINATE_SYSTEM.LNGLAT.
+and height of the hexagon is scaled by number of points it contains.
 
-HexagonLayer is a `CompositeLayer`
+HexagonLayer is a `CompositeLayer` and at the moment only works with COORDINATE_SYSTEM.LNGLAT.
 
 ```js
 import DeckGL, {HexagonLayer} from 'deck.gl';
@@ -54,9 +53,9 @@ Radius of hexagon bin in meters. The hexagons are pointy-topped (rather than fla
 
 `hexagonAggregator` is a function to aggregate data into hexagonal bins.
 The `hexagonAggregator` takes props of the layer and current viewport as arguments.
-The output should be `{hexagons: [], hexagonVertices: []}`. `hexagons` is 
-an array of `{centroid: [], points: []}`, where `centroid` is the 
-center of the hexagon, and `points` is an array of points that contained by it.  `hexagonVertices` 
+The output should be `{hexagons: [], hexagonVertices: []}`. `hexagons` is
+an array of `{centroid: [], points: []}`, where `centroid` is the
+center of the hexagon, and `points` is an array of points that contained by it.  `hexagonVertices`
 (optional) is an array of points define the primitive hexagon geometry.
 
 By default, the `HexagonLayer` uses
@@ -83,22 +82,22 @@ Hexagon color ranges as an array of colors formatted as `[[255, 255, 255, 255]]`
 
 - Default: `points => points.length`
 
-`getColorValue` is the accessor function to get the value that bin color is based on. 
-It takes an array of points inside each bin as arguments, returns a number. For example, 
+`getColorValue` is the accessor function to get the value that bin color is based on.
+It takes an array of points inside each bin as arguments, returns a number. For example,
 You can pass in `getColorValue` to color the bins by avg/mean/max of a specific attributes of each point.
 By default `getColorValue` returns the length of the points array.
 
 Note: hexagon layer compares whether `getColorValue` has changed to
 recalculate the value for each bin that its color based on. You should
-pass in the function defined outside the render function so it doesn't create a 
-new function on every rendering pass. 
+pass in the function defined outside the render function so it doesn't create a
+new function on every rendering pass.
 
 ```
  class MyHexagonLayer {
     getColorValue (points) {
         return points.length;
     }
-    
+
     renderLayers() {
       return new HexagonLayer({
         id: 'hexagon-layer',
@@ -184,4 +183,3 @@ Method called to retrieve the position of each point.
 ## Source
 
 [src/layers/core/hexagon-layer](https://github.com/uber/deck.gl/tree/4.0-release/src/layers/core/hexagon-layer)
-

--- a/docs/layers/icon-layer.md
+++ b/docs/layers/icon-layer.md
@@ -99,6 +99,12 @@ Method called to retrieve the height of each icon, returns a number. Unit is pix
 Method called to retrieve the color of each object, returns `[r, g, b, a]`.
 If the alpha component is not supplied, it is set to `255`.
 
+##### `getAngle` (Function, optional)
+
+- Default: `d => d.angle || 0`
+
+Method called to retrieve the rotating angle (in degree) of each object, returns a number.
+
 ## Source
 
 [src/layers/core/icon-layer](https://github.com/uber/deck.gl/tree/4.0-release/src/layers/core/icon-layer)

--- a/src/layers/core/icon-layer/icon-layer.js
+++ b/src/layers/core/icon-layer/icon-layer.js
@@ -49,6 +49,7 @@ const DEFAULT_COLOR = [0, 0, 0, 255];
  * @param {func} props.getSize - returns icon size multiplier as a number
  * @param {func} props.getColor - returns color of the icon in [r, g, b, a]. Only works on icons
  *   with mask: true.
+ * @param {func} props.getAngle - returns rotating angle (in degree) of the icon.
  */
 const defaultProps = {
   iconAtlas: null,


### PR DESCRIPTION
did a sweep on the docs and update logs for the post-v4.0.0 PRs (#548-#787).
most changes are documented (if we were not to document internal methods changes like in #783).
also, we don't have any docs on how shaderCache works, consider it as implicit from the users for now?