### PR TITLE
Use luma picking module in scatterplot layer.

### DIFF
--- a/examples/layer-browser/src/examples/core-layers.js
+++ b/examples/layer-browser/src/examples/core-layers.js
@@ -168,6 +168,7 @@ const ScatterplotLayerExample = {
     getRadius: d => get(d, 'SPACES'),
     opacity: 0.5,
     pickable: true,
+    pickingHighlightColor: [1, 0, 0, 1],
     radiusScale: 30,
     radiusMinPixels: 1,
     radiusMaxPixels: 30

--- a/src/layers/core/scatterplot-layer/scatterplot-layer-fragment.glsl.js
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer-fragment.glsl.js
@@ -35,6 +35,8 @@ void main(void) {
 
   if (distToCenter <= 1.0 && distToCenter >= innerUnitRadius) {
     gl_FragColor = vColor;
+    gl_FragColor = picking_filterHighlightColor(gl_FragColor);
+    gl_FragColor = picking_filterPickingColor(gl_FragColor);
   } else {
     discard;
   }

--- a/src/layers/core/scatterplot-layer/scatterplot-layer-vertex.glsl.js
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer-vertex.glsl.js
@@ -60,9 +60,10 @@ void main(void) {
   vec3 vertex = positions * outerRadiusPixels;
   gl_Position = project_to_clipspace(vec4(center + vertex, 1.0));
 
+  // Set color to be rendered to picking fbo.
+  picking_setPickingColor(instancePickingColors);
+
   // Apply opacity to instance color, or return instance picking color
-  vec4 color = vec4(instanceColors.rgb, instanceColors.a * opacity) / 255.;
-  vec4 pickingColor = vec4(instancePickingColors / 255., 1.);
-  vColor = mix(color, pickingColor, renderPickingBuffer);
+  vColor = vec4(instanceColors.rgb, instanceColors.a * opacity) / 255.;
 }
 `;

--- a/src/layers/core/scatterplot-layer/scatterplot-layer.js
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer.js
@@ -47,8 +47,8 @@ export default class ScatterplotLayer extends Layer {
   getShaders(id) {
     const {shaderCache} = this.context;
     return enable64bitSupport(this.props) ?
-      {vs: vs64, fs, modules: ['project64'], shaderCache} :
-      {vs, fs, shaderCache}; // 'project' module added by default.
+      {vs: vs64, fs, modules: ['project64', 'picking'], shaderCache} :
+      {vs, fs, modules: ['picking'], shaderCache}; // 'project' module added by default.
   }
 
   initializeState() {

--- a/src/lib/draw-and-pick.js
+++ b/src/lib/draw-and-pick.js
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 /* global window */
-import {GL, withParameters, setParameters} from 'luma.gl';
+import {GL, withParameters, setParameters, NULL_PICKING_COLOR} from 'luma.gl';
 import {log} from './utils';
 
 const EMPTY_PIXEL = new Uint8Array(4);
@@ -40,7 +40,7 @@ export function drawLayers({layers, pass}) {
           viewport: layer.context.viewport
         }),
         uniforms: Object.assign(
-          {renderPickingBuffer: 0, pickingEnabled: 0},
+          {renderPickingBuffer: 0, pickingEnabled: 0, picking_uActive: 0},
           layer.context.uniforms,
           {layerIndex}
         ),
@@ -196,6 +196,15 @@ export function pickLayers(gl, {
     if (info) {
       infos.set(info.layer.id, info);
     }
+
+    // update pickingSelectedColor so picked model is highlighted.
+    if (layer.props.pickingHighlightColor !== NULL_PICKING_COLOR) {
+      layer.state.model.updateModuleSettings({
+        pickingSelectedColor: pickedColor,
+        pickingValid: pickedLayer === layer
+      });
+    }
+
   });
 
   infos.forEach(info => {
@@ -333,8 +342,8 @@ function getPickedColors(gl, {
     scissor: [x, y, width, height],
     blend: true,
     blendFunc: [gl.ONE, gl.ZERO, gl.CONSTANT_ALPHA, gl.ZERO],
-    blendEquation: gl.FUNC_ADD
-    // TODO - Set clear color
+    blendEquation: gl.FUNC_ADD,
+    clearColor: NULL_PICKING_COLOR
   }, () => {
 
     // Clear the frame buffer
@@ -351,7 +360,9 @@ function getPickedColors(gl, {
             viewport: layer.context.viewport
           }),
           uniforms: Object.assign(
-            {renderPickingBuffer: 1, pickingEnabled: 1},
+            // TODO: Update all layers to use 'picking_uActive' and then
+            // remove 'renderPickingBuffer' and 'pickingEnabled'.
+            {renderPickingBuffer: 1, pickingEnabled: 1, picking_uActive: 1},
             layer.context.uniforms,
             {layerIndex}
           ),

--- a/src/lib/layer.js
+++ b/src/lib/layer.js
@@ -25,7 +25,7 @@ import Stats from './stats';
 import {getDefaultProps, compareProps} from './props';
 import {log, count} from './utils';
 import {applyPropOverrides, removeLayerInSeer} from '../debug/seer-integration';
-import {GL, withParameters} from 'luma.gl';
+import {GL, withParameters, NULL_PICKING_COLOR} from 'luma.gl';
 import assert from 'assert';
 
 const LOG_PRIORITY_UPDATE = 1;
@@ -62,7 +62,10 @@ const defaultProps = {
   // Offset depth based on layer index to avoid z-fighting.
   // Negative values pull layer towards the camera
   // https://www.opengl.org/archives/resources/faq/technical/polygonoffset.htm
-  getPolygonOffset: ({layerIndex}) => [0, -layerIndex * 100]
+  getPolygonOffset: ({layerIndex}) => [0, -layerIndex * 100],
+
+  // Picking
+  pickingHighlightColor: NULL_PICKING_COLOR
 };
 
 let counter = 0;
@@ -608,7 +611,10 @@ export default class Layer {
     this.setUniforms({
       // apply gamma to opacity to make it visually "linear"
       opacity: Math.pow(this.props.opacity, 1 / 2.2),
-      ONE: 1.0
+      ONE: 1.0,
+      // Picking
+      pickingSelectedColor: NULL_PICKING_COLOR,
+      pickingHighlightColor: this.props.pickingHighlightColor
     });
   }
 

--- a/src/shaderlib/index.js
+++ b/src/shaderlib/index.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {fp32, fp64} from 'luma.gl';
+import {fp32, fp64, picking} from 'luma.gl';
 
 import project from '../shaderlib/project/project';
 import project64 from '../shaderlib/project64/project64';
@@ -29,7 +29,8 @@ import {registerShaderModules, setDefaultShaderModules} from 'luma.gl';
 registerShaderModules([
   fp32, fp64,
   project, project64,
-  lighting
+  lighting,
+  picking
 ]);
 
 setDefaultShaderModules([project]);


### PR DESCRIPTION
- Add a new prop to Layer class to specify picking highlight color, by default its value is set to 'NULL_PICKING_COLOR' which will disable highlighting.
- Set highlighting for scatterplot layer of layer-browser example.
NOTE: Not ready to merge, also requires luma changes.

