### PR TITLE
Remove UTM_OFFSETS mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Ref: http://keepachangelog.com/en/0.3.0/
 - Move react controllers to react directory, export from index.js
 - Move viewports and some utils out of `lib` folder.
 - Add `start-es6` script to layer-browser
-
+- Remove UTM_OFFSETS projection mode
 
 #### [4.2.0-alpha.2]
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   "dependencies": {
     "d3-hexbin": "^0.2.1",
     "earcut": "^2.0.6",
-    "gl-mat2": "^1.0.0",
     "gl-mat4": "^1.1.4",
     "gl-vec2": "^1.0.0",
     "gl-vec3": "^1.0.3",
@@ -52,8 +51,7 @@
     "hammerjs": "^2.0.8",
     "lodash.flattendeep": "^4.4.0",
     "prop-types": "^15.5.8",
-    "seer": "^0.2.3",
-    "utm": "^1.1.1"
+    "seer": "^0.2.3"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -38,10 +38,6 @@ export const COORDINATE_SYSTEM = {
   // distances as meters.
   LNGLAT_OFFSETS: 3.0,
 
-  // Positions are interpreted as UTM offsets: [deltaX, deltaY, elevation]
-  // distances in meters
-  UTM_OFFSETS: 4.0,
-
   // Positions and distances are not transformed: [x, y, z] in unit coordinates
   IDENTITY: 0.0
 };

--- a/src/shaderlib/project/project.glsl.js
+++ b/src/shaderlib/project/project.glsl.js
@@ -27,7 +27,6 @@ const float WORLD_SCALE = TILE_SIZE / (PI * 2.0);
 const float PROJECT_IDENTITY = 0.;
 const float PROJECT_MERCATOR = 1.;
 const float PROJECT_MERCATOR_OFFSETS = 2.;
-const float PROJECT_UTM_OFFSETS = 4.;
 
 uniform float projectionMode;
 uniform float projectionScale;
@@ -48,11 +47,6 @@ float project_scale(float meters) {
 }
 
 vec2 project_scale(vec2 meters) {
-  if (projectionMode == PROJECT_UTM_OFFSETS) {
-    // In UTM projection mode, latitude and longitude are no longer independent
-    // in the scaling transformation. The scaler is therefore a mat2.
-    return meters * projectionPixelsPerUnitUTM;
-  }
   return meters * projectionPixelsPerUnit.xy;
 }
 
@@ -108,7 +102,7 @@ vec2 project_position(vec2 position) {
 }
 
 vec4 project_to_clipspace(vec4 position) {
-  if (projectionMode == PROJECT_MERCATOR_OFFSETS || projectionMode == PROJECT_UTM_OFFSETS) {
+  if (projectionMode == PROJECT_MERCATOR_OFFSETS) {
     position.w *= projectionPixelsPerUnit.z;
   }
   return projectionMatrix * position + projectionCenter;

--- a/src/shaderlib/project/viewport-uniforms.js
+++ b/src/shaderlib/project/viewport-uniforms.js
@@ -59,7 +59,6 @@ function calculateMatrixAndOffset({
 
   // TODO: make lighitng work for meter offset mode
   case COORDINATE_SYSTEM.METER_OFFSETS:
-  case COORDINATE_SYSTEM.UTM_OFFSETS:
     // Calculate transformed projectionCenter (in 64 bit precision)
     // This is the key to offset mode precision (avoids doing this
     // addition in 32 bit precision)
@@ -118,19 +117,8 @@ export function getUniformsFromViewport({
     calculateMatrixAndOffset({projectionMode, positionOrigin, viewport});
 
   // Calculate projection pixels per unit
-  const {pixelsPerMeter, pixelsPerDegree, degreesPerMeter} =
-    viewport.getDistanceScales({positionOrigin});
+  const {pixelsPerMeter} = viewport.getDistanceScales();
   assert(pixelsPerMeter, 'Viewport missing pixelsPerMeter');
-
-  let pixelsPerMeterUTM = ZERO_VECTOR;
-  if (projectionMode === COORDINATE_SYSTEM.UTM_OFFSETS) {
-    pixelsPerMeterUTM = [
-      degreesPerMeter[0] * pixelsPerDegree[0],
-      degreesPerMeter[1] * pixelsPerDegree[1],
-      degreesPerMeter[2] * pixelsPerDegree[0],
-      degreesPerMeter[3] * pixelsPerDegree[1]
-    ];
-  }
 
   // "Float64Array"
   // Transpose the projection matrix to column major for GLSL.
@@ -162,7 +150,6 @@ export function getUniformsFromViewport({
     projectionFP64: glProjectionMatrixFP64,
 
     projectionPixelsPerUnit: pixelsPerMeter,
-    projectionPixelsPerUnitUTM: pixelsPerMeterUTM,
     projectionScale: viewport.scale, // This is the mercator scale (2 ** zoom)
     projectionScaleFP64: fp64ify(viewport.scale), // Deprecated?
 

--- a/src/viewport-mercator-project/web-mercator-utils.js
+++ b/src/viewport-mercator-project/web-mercator-utils.js
@@ -5,9 +5,7 @@ import mat4_translate from 'gl-mat4/translate';
 import mat4_rotateX from 'gl-mat4/rotateX';
 import mat4_rotateZ from 'gl-mat4/rotateZ';
 import vec2_distance from 'gl-vec2/distance';
-import mat2_invert from 'gl-mat2/invert';
 import assert from 'assert';
-import * as utm from 'utm';
 
 // CONSTANTS
 const PI = Math.PI;
@@ -103,36 +101,6 @@ export function calculateDistanceScales({latitude, longitude, zoom, scale}) {
     metersPerPixel,
     pixelsPerDegree,
     degreesPerPixel
-  };
-}
-
-/**
- * Calculate distance scales in meters around the given lat/lon
- * In UTM projection mode, latitude and longitude are no longer independent
- * in the scaling transformation. The scaler is therefore a mat2.
- */
-export function calculateDistanceScalesUTM(positionOrigin) {
-  const [longitude, latitude] = positionOrigin;
-
-  // Calculate easting/northing difference per degree change in longitude/latitude
-  // Reference points
-  const center = utm.fromLatLon(latitude, longitude);
-  const east = utm.fromLatLon(latitude, longitude + 0.005, center.zoneNum);
-  const west = utm.fromLatLon(latitude, longitude - 0.005, center.zoneNum);
-  const north = utm.fromLatLon(latitude + 0.005, longitude, center.zoneNum);
-  const south = utm.fromLatLon(latitude - 0.005, longitude, center.zoneNum);
-
-  // UTM northing/easting is not aligned with longitude/latitude
-  const metersPerDegree = [
-    (east.easting - west.easting) * 100,
-    (east.northing - west.northing) * 100,
-    (north.easting - south.easting) * 100,
-    (north.northing - south.northing) * 100
-  ];
-
-  return {
-    metersPerDegree,
-    degreesPerMeter: mat2_invert([], metersPerDegree)
   };
 }
 


### PR DESCRIPTION
Reverts most of https://github.com/uber/deck.gl/pull/806

As discussed, the plan is to provide a more generic solution for alternative projections, as opposed to including arbitrary modes and dependencies in deck.gl.
