### PR TITLE
wind demo: fix particle/elevation rendering

### DIFF
--- a/examples/wind/src/layers/delaunay-cover-layer/delaunay-cover-layer.js
+++ b/examples/wind/src/layers/delaunay-cover-layer/delaunay-cover-layer.js
@@ -92,9 +92,10 @@ export default class DelaunayCoverLayer extends Layer {
         setParameters(gl, {
           blend: true,
           blendFunc: [gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA],
-          blendEquation: gl.FUNC_ADD
+          blendEquation: gl.FUNC_ADD,
+          depthTest: true,
+          depthFunc: gl.LEQUAL
         });
-
       },
       onAfterRender: () => {
         // gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);

--- a/examples/wind/src/layers/particle-layer/particle-layer.js
+++ b/examples/wind/src/layers/particle-layer/particle-layer.js
@@ -129,7 +129,9 @@ export default class ParticleLayer extends Layer {
 
     setParameters(gl, {
       blend: true,
-      blendFunc: [gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA]
+      blendFunc: [gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA],
+      depthTest: true,
+      depthFunc: gl.LEQUAL
     });
     const pixelStoreParameters = {
       [GL.UNPACK_FLIP_Y_WEBGL]: true

--- a/examples/wind/src/layers/wind-layer/wind-layer.js
+++ b/examples/wind/src/layers/wind-layer/wind-layer.js
@@ -37,7 +37,7 @@ export default class WindLayer extends Layer {
       this.setState({elevationTexture: textures[0]});
     });
 
-    const model = this.getModel({gl, bbox, nx: 80, ny: 30});
+    const model = this.getModel({gl, bbox, nx: 100, ny: 30});
 
     const {width, height} = dataTextureSize;
     const textureFrom = this.createTexture(gl, {});


### PR DESCRIPTION
- Port depth behavior from demo version. This matches rendering of particles/elevations with the demo.
- Increase field layer sample count, to show high wind speeds at `mount washington`.