### PR TITLE
Automatic/custom highlighting using picking shader module.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Ref: http://keepachangelog.com/en/0.3.0/
 
 ### deck.gl v4.2
 
+- Automatic/custom highlighting using picking shader module.
+
 #### [4.2.0-alpha.X]
 
 - Move react controllers to react directory, export from index.js

--- a/docs/api-reference/base-layer.md
+++ b/docs/api-reference/base-layer.md
@@ -135,6 +135,26 @@ callback of the `DeckGL` canvas.
 
 Requires `pickable` to be true.
 
+##### `highlightColor` (Array, optional)
+
+- Default: `[0, 0, 128, 128]`
+
+RGBA color to be used to render highlighted object.
+
+##### `highlightedObjectIndex` (Integer, optional)
+
+- Default: `-1`
+
+When provided a valid value corresponding object (one instance in instanced rendering or group of primitives with same picking color) will be highlighted with `highlightColor`.
+
+##### `autoHighlight` (Boolean, optional)
+
+- Default: `false`
+
+When true, current object pointed by mouse pointer (when hovered over) is highlighted with `highlightColor`.
+
+Requires `pickable` to be true.
+
 ---
 
 ### Coordinate System Properties

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -1,3 +1,9 @@
+# deck.gl v4.2
+
+## Automatic and custom highlighting
+
+Three new props (`highlightColor`, `highlightedObjectIndex` and `autoHighlight`) are added to `Layer` class to support object highlighting.
+
 # deck.gl v4.1
 
 Release date: July 27th, 2017

--- a/src/layers/core/path-layer/path-layer-fragment.glsl.js
+++ b/src/layers/core/path-layer/path-layer-fragment.glsl.js
@@ -41,5 +41,11 @@ void main(void) {
     discard;
   }
   gl_FragColor = vColor;
+
+  // use highlight color if this fragment belongs to the selected object.
+  gl_FragColor = picking_filterHighlightColor(gl_FragColor);
+
+  // use picking color if rendering to picking FBO.
+  gl_FragColor = picking_filterPickingColor(gl_FragColor);
 }
 `;

--- a/src/layers/core/path-layer/path-layer-vertex.glsl.js
+++ b/src/layers/core/path-layer/path-layer-vertex.glsl.js
@@ -175,5 +175,8 @@ void main() {
   pos = lineJoin(prevPosition, currPosition, nextPosition);
 
   gl_Position = project_to_clipspace(vec4(pos, 1.0));
+
+  // Set color to be rendered to picking fbo (also used to check for selection highlight).
+  picking_setPickingColor(instancePickingColors);
 }
 `;

--- a/src/layers/core/path-layer/path-layer.js
+++ b/src/layers/core/path-layer/path-layer.js
@@ -52,8 +52,8 @@ const isClosed = path => {
 export default class PathLayer extends Layer {
   getShaders() {
     return enable64bitSupport(this.props) ?
-      {vs: vs64, fs, modules: ['project64']} :
-      {vs, fs}; // 'project' module added by default.
+      {vs: vs64, fs, modules: ['project64', 'picking']} :
+      {vs, fs, modules: ['picking']}; // 'project' module added by default.
   }
 
   initializeState() {

--- a/src/layers/core/scatterplot-layer/scatterplot-layer-fragment.glsl.js
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer-fragment.glsl.js
@@ -33,10 +33,15 @@ void main(void) {
 
   float distToCenter = length(unitPosition);
 
-  if (distToCenter <= 1.0 && distToCenter >= innerUnitRadius) {
-    gl_FragColor = vColor;
-  } else {
+  if (distToCenter > 1.0 || distToCenter < innerUnitRadius) {
     discard;
   }
+  gl_FragColor = vColor;
+
+  // use highlight color if this fragment belongs to the selected object.
+  gl_FragColor = picking_filterHighlightColor(gl_FragColor);
+
+  // use picking color if rendering to picking FBO.
+  gl_FragColor = picking_filterPickingColor(gl_FragColor);
 }
 `;

--- a/src/layers/core/scatterplot-layer/scatterplot-layer-vertex.glsl.js
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer-vertex.glsl.js
@@ -60,9 +60,10 @@ void main(void) {
   vec3 vertex = positions * outerRadiusPixels;
   gl_Position = project_to_clipspace(vec4(center + vertex, 1.0));
 
+  // Set color to be rendered to picking fbo (also used to check for selection highlight).
+  picking_setPickingColor(instancePickingColors);
+
   // Apply opacity to instance color, or return instance picking color
-  vec4 color = vec4(instanceColors.rgb, instanceColors.a * opacity) / 255.;
-  vec4 pickingColor = vec4(instancePickingColors / 255., 1.);
-  vColor = mix(color, pickingColor, renderPickingBuffer);
+  vColor = vec4(instanceColors.rgb, instanceColors.a * opacity) / 255.;
 }
 `;

--- a/src/layers/core/scatterplot-layer/scatterplot-layer.js
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer.js
@@ -47,8 +47,8 @@ export default class ScatterplotLayer extends Layer {
   getShaders(id) {
     const {shaderCache} = this.context;
     return enable64bitSupport(this.props) ?
-      {vs: vs64, fs, modules: ['project64'], shaderCache} :
-      {vs, fs, shaderCache}; // 'project' module added by default.
+      {vs: vs64, fs, modules: ['project64', 'picking'], shaderCache} :
+      {vs, fs, modules: ['picking'], shaderCache}; // 'project' module added by default.
   }
 
   initializeState() {

--- a/src/lib/draw-and-pick.js
+++ b/src/lib/draw-and-pick.js
@@ -35,12 +35,26 @@ export function drawLayers({layers, pass}) {
       compositeCount++;
     } else if (layer.props.visible) {
 
+      const pickingSelectedColor = _selectedObjectPickingColor(layer);
+      if (pickingSelectedColor) {
+        layer.state.model.updateModuleSettings({
+          pickingSelectedColor,
+          pickingSelectedColorValid: true
+        });
+      }
+
       layer.drawLayer({
         moduleParameters: Object.assign({}, layer.props, {
           viewport: layer.context.viewport
         }),
         uniforms: Object.assign(
-          {renderPickingBuffer: 0, pickingEnabled: 0},
+          // TODO: Update all layers to use 'picking_uActive' (picking shader module)
+          // and then remove 'renderPickingBuffer' and 'pickingEnabled'.
+          {
+            renderPickingBuffer: 0,
+            pickingEnabled: 0,
+            picking_uActive: 0
+          },
           layer.context.uniforms,
           {layerIndex}
         ),
@@ -196,6 +210,17 @@ export function pickLayers(gl, {
     if (info) {
       infos.set(info.layer.id, info);
     }
+
+    const pickingSelectedColor = pickedColor;
+    const pickingSelectedColorValid = Boolean(
+      layer.props.autoHighlight &&
+      pickedLayer === layer &&
+      pickingSelectedColor !== EMPTY_PIXEL
+    );
+    layer.state.model.updateModuleSettings({
+      pickingSelectedColor,
+      pickingSelectedColorValid
+    });
   });
 
   infos.forEach(info => {
@@ -333,8 +358,8 @@ function getPickedColors(gl, {
     scissor: [x, y, width, height],
     blend: true,
     blendFunc: [gl.ONE, gl.ZERO, gl.CONSTANT_ALPHA, gl.ZERO],
-    blendEquation: gl.FUNC_ADD
-    // TODO - Set clear color
+    blendEquation: gl.FUNC_ADD,
+    clearColor: [0, 0, 0, 0]
   }, () => {
 
     // Clear the frame buffer
@@ -351,7 +376,13 @@ function getPickedColors(gl, {
             viewport: layer.context.viewport
           }),
           uniforms: Object.assign(
-            {renderPickingBuffer: 1, pickingEnabled: 1},
+            // TODO: Update all layers to use 'picking_uActive' (picking shader module)
+            // and then remove 'renderPickingBuffer' and 'pickingEnabled'.
+            {
+              renderPickingBuffer: 1,
+              pickingEnabled: 1,
+              picking_uActive: 1
+            },
             layer.context.uniforms,
             {layerIndex}
           ),
@@ -398,4 +429,16 @@ function getLayerPickingInfo({layer, info, mode}) {
     layer = layer.parentLayer;
   }
   return info;
+}
+
+/**
+ * Returns the picking color of currenlty selected object of the given 'layer'.
+ * @return {Array} - the picking color or null if layers selected object is invalid.
+ */
+function _selectedObjectPickingColor(layer) {
+  if (layer.props.highlightedObjectIndex < 0) {
+    return null;
+  }
+  // TODO: Add warning if 'highlightedObjectIndex' is > numberOfInstances of the model.
+  return layer.encodePickingColor(layer.props.highlightedObjectIndex);
 }

--- a/src/lib/layer.js
+++ b/src/lib/layer.js
@@ -62,7 +62,12 @@ const defaultProps = {
   // Offset depth based on layer index to avoid z-fighting.
   // Negative values pull layer towards the camera
   // https://www.opengl.org/archives/resources/faq/technical/polygonoffset.htm
-  getPolygonOffset: ({layerIndex}) => [0, -layerIndex * 100]
+  getPolygonOffset: ({layerIndex}) => [0, -layerIndex * 100],
+
+  // Selection/Highlighting
+  highlightedObjectIndex: -1,
+  autoHighlight: false,
+  highlightColor: [0, 0, 128, 128]
 };
 
 let counter = 0;
@@ -276,6 +281,7 @@ export default class Layer {
    * @return {Array} - the decoded color
    */
   encodePickingColor(i) {
+    assert(((((i + 1) >> 24) & 255) === 0), 'index out of picking color range');
     return [
       (i + 1) & 255,
       ((i + 1) >> 8) & 255,
@@ -385,6 +391,7 @@ export default class Layer {
     // Add any subclass attributes
     this.updateAttributes(this.props);
     this._updateBaseUniforms();
+    this._updateModuleSettings();
 
     const {model} = this.state;
     if (model) {
@@ -415,6 +422,7 @@ export default class Layer {
       // Run the attribute updaters
       this.updateAttributes(updateParams.props);
       this._updateBaseUniforms();
+      this._updateModuleSettings();
 
       if (this.state.model) {
         this.state.model.setInstanceCount(this.getNumInstances());
@@ -610,6 +618,14 @@ export default class Layer {
       opacity: Math.pow(this.props.opacity, 1 / 2.2),
       ONE: 1.0
     });
+  }
+
+  _updateModuleSettings() {
+    if (this.state.model) {
+      this.state.model.updateModuleSettings({
+        pickingHighlightColor: this.props.highlightColor
+      });
+    }
   }
 
   // DEPRECATED METHODS

--- a/src/shaderlib/index.js
+++ b/src/shaderlib/index.js
@@ -23,13 +23,15 @@ import {fp32, fp64} from 'luma.gl';
 import project from '../shaderlib/project/project';
 import project64 from '../shaderlib/project64/project64';
 import lighting from '../shaderlib/lighting/lighting';
+import picking from '../shaderlib/picking/picking';
 
 import {registerShaderModules, setDefaultShaderModules} from 'luma.gl';
 
 registerShaderModules([
   fp32, fp64,
   project, project64,
-  lighting
+  lighting,
+  picking
 ]);
 
 setDefaultShaderModules([project]);

--- a/src/shaderlib/picking/picking.js
+++ b/src/shaderlib/picking/picking.js
@@ -1,0 +1,97 @@
+const DEFAULT_HIGHLIGHT_COLOR = new Uint8Array([0, 64, 128, 64]);
+
+const DEFAULT_MODULE_OPTIONS = {
+  pickingSelectedColor: null, //  Set to a picking color to visually highlight that item
+  pickingHighlightColor: DEFAULT_HIGHLIGHT_COLOR, // Color of visual highlight of "selected" item
+  pickingThreshold: 1.0,
+  pickingActive: false, // Set to true when rendering to off-screen "picking" buffer
+  pickingValid: false
+};
+
+/* eslint-disable camelcase */
+function getUniforms(opts = DEFAULT_MODULE_OPTIONS) {
+  const uniforms = {};
+  uniforms.picking_uValid = opts.pickingValid ? 1 : 0;
+  if (opts.pickingSelectedColor !== undefined) {
+    if (opts.pickingSelectedColor) {
+      const selectedColor = [
+        opts.pickingSelectedColor[0],
+        opts.pickingSelectedColor[1],
+        opts.pickingSelectedColor[2]
+      ];
+      // console.log('selected picking color', selectedColor);
+      uniforms.picking_uSelectedPickingColor = selectedColor;
+    }
+  }
+  if (opts.pickingHighlightColor !== undefined) {
+    uniforms.picking_uHighlightColor = opts.pickingHighlightColor;
+  }
+  // TODO - major hack - decide on normalization and remove
+  if (opts.pickingThreshold !== undefined) {
+    uniforms.picking_uThreshold = opts.pickingThreshold;
+  }
+  if (opts.pickingActive !== undefined) {
+    uniforms.picking_uActive = opts.pickingActive ? 1 : 0;
+  }
+  return uniforms;
+}
+
+const vs = `\
+uniform vec3 picking_uSelectedPickingColor;
+uniform float picking_uThreshold;
+uniform bool picking_uValid;
+
+varying vec4 picking_vRGBcolor_Aselected;
+
+const float COLOR_SCALE = 1. / 256.;
+
+bool isVertexPicked(vec3 vertexColor, vec3 pickedColor, bool pickingValid) {
+  return
+    pickingValid &&
+    abs(vertexColor.r - pickedColor.r) < picking_uThreshold &&
+    abs(vertexColor.g - pickedColor.g) < picking_uThreshold &&
+    abs(vertexColor.b - pickedColor.b) < picking_uThreshold;
+}
+
+void picking_setPickingColor(vec3 pickingColor) {
+  // Do the comparison with selected item color in vertex shader as it should mean fewer compares
+  picking_vRGBcolor_Aselected.a =
+    float(isVertexPicked(pickingColor, picking_uSelectedPickingColor, picking_uValid));
+
+  // Stores the picking color so that the fragment shader can render it during picking
+  picking_vRGBcolor_Aselected.rgb = pickingColor * COLOR_SCALE;
+}
+`;
+
+const fs = `\
+uniform bool picking_uActive; // true during rendering to offscreen picking buffer
+uniform vec3 picking_uSelectedPickingColor;
+uniform vec4 picking_uHighlightColor;
+
+varying vec4 picking_vRGBcolor_Aselected;
+
+const float COLOR_SCALE = 1. / 256.;
+
+/*
+ * Returns highlight color if this item is selected.
+ */
+vec4 picking_filterHighlightColor(vec4 color) {
+  bool selected = bool(picking_vRGBcolor_Aselected.a);
+  return selected ? picking_uHighlightColor : color;
+}
+
+/*
+ * Returns picking color if picking enabled else unmodified argument.
+ */
+vec4 picking_filterPickingColor(vec4 color) {
+  vec3 pickingColor = picking_vRGBcolor_Aselected.rgb;
+  return picking_uActive ? vec4(pickingColor, 1.0) : color;
+}
+`;
+
+export default {
+  name: 'picking',
+  vs,
+  fs,
+  getUniforms
+};

--- a/src/shaderlib/picking/shadertools-picking.md
+++ b/src/shaderlib/picking/shadertools-picking.md
@@ -1,0 +1,75 @@
+# picking (Shader Module)
+
+Provides support for color-coding-based picking. In particular, supports picking a specific instance in an instanced draw call.
+
+Color based picking lets the application draw a primitive with a color that can later be used to index this specific primitive.
+
+## Usage
+
+In your vertex shader, your inform the picking module what object we are currently rendering by supplying a picking color, perhaps from an attribute.
+```
+attribute vec3 aPickingColor;
+main() {
+  picking_setColor(aPickingColor);
+  ...
+}
+```
+
+In your fragment shader, you simply apply (call) the `picking_filterPickingColor` filter function at the very end of the shader. This will return the normal color, or the highlight color, or the picking color, as appropriate.
+```
+main() {
+  gl_FragColor = ...
+  gl_FragColor = picking_filterPickingColor(gl_FragColor);
+}
+```
+If you would like to apply the highlight color to the currently selected element call `picking_filterHighlightColor` before calling `picking_filterPickingColor`. You can also apply other filters on the non-picking color (vertex or highlight color) by placing those instruction between these two function calls.
+
+ ```
+main() {
+   gl_FragColor = picking_filterHighlightColor(color);
+    ... apply any filters on gl_FragColor ...
+  gl_FragColor = picking_filterPickingColor(gl_FragColor);
+}
+
+```
+
+## JavaScript Functions
+
+### getUniforms
+
+`getUniforms` returns an object with key/value pairs representing the uniforms that the `picking` module shaders need.
+
+`getUniforms({enabled, })`
+
+* `enabled`=`true` (*boolean*) - Activates picking
+* `selectedIndex`=-1 (*number*) - The index of the selected item, or -1 if no selection.
+* `highlightColor`= (*array*)- Color used to highlight the currently selected
+* `active`=`false` (*boolean*) - Renders the picking colors instead of the normal colors. Normally only used with an off-screen framebuffer during picking.
+
+Note that the selected item will be rendered using `highlightColor`.
+
+
+## Vertex Shader Functions
+
+### `void picking_setPickingColor(vec3)`
+
+Sets the color that will be returned by the fragment shader if color based picking is enabled. Typically set from a `pickingColor` uniform or a `pickingColors` attribute (e.g. when using instanced rendering, to identify the actual instance that was picked).
+
+
+## Fragment Shader Functions
+
+### picking_filterPickingColor
+
+If picking active, returns the current vertex's picking color set by `picking_setPickingColor`, otherwise returns its argument unmodified.
+
+`vec4 picking_filterPickingColor(vec4 color)`
+
+### picking_filterHighlightColor
+
+Returns picking highlight color if the pixel belongs to currently selected model, otherwise returns its argument unmodified.
+
+`vec4 picking_filterHighlightColor(vec4 color)`
+
+## Remarks
+
+* It is strongly recommended that `picking_filterPickingColor` is called last in a fragment shader, as the picking color (returned when picking is enabled) must not be modified in any way (and alpha must remain 1) or picking results will not be correct.

--- a/src/shaderlib/picking/shadertools-picking.md
+++ b/src/shaderlib/picking/shadertools-picking.md
@@ -1,8 +1,10 @@
 # picking (Shader Module)
 
-Provides support for color-coding-based picking. In particular, supports picking a specific instance in an instanced draw call.
+Provides support for color-coding-based picking and highlighting. In particular, supports picking a specific instance in an instanced draw call and highlighting an instance based on its picking color, and correspondingly, supports picking and highlighting groups of primitives with the same picking color in non-instanced draw-calls
 
 Color based picking lets the application draw a primitive with a color that can later be used to index this specific primitive.
+
+Highlighting allows application to specify a picking color corresponding to an object that need to be highlighted and the highlight color to be used.
 
 ## Usage
 
@@ -37,16 +39,16 @@ main() {
 
 ### getUniforms
 
-`getUniforms` returns an object with key/value pairs representing the uniforms that the `picking` module shaders need.
+`getUniforms` takes an object takes a set of key/value pairs, returns an object with key/value pairs representing the uniforms that the `picking` module shaders need.
 
-`getUniforms({enabled, })`
+`getUniforms(opts)`
+opts can contain following keys:
+* `pickingValid` (*boolean*) - When true current instance picking color is ignored, hence no instance is highlighted.
+* `pickingSelectedColor` (*array*) - Picking color of the currently selected instance.
+* `pickingHighlightColor` (*array*)- Color used to highlight the currently selected instance.
+* `pickingActive`=`false` (*boolean*) - When true, renders the picking colors instead of the normal colors. Normally only used with an off-screen framebuffer during picking. Default value is `false`.
 
-* `enabled`=`true` (*boolean*) - Activates picking
-* `selectedIndex`=-1 (*number*) - The index of the selected item, or -1 if no selection.
-* `highlightColor`= (*array*)- Color used to highlight the currently selected
-* `active`=`false` (*boolean*) - Renders the picking colors instead of the normal colors. Normally only used with an off-screen framebuffer during picking.
-
-Note that the selected item will be rendered using `highlightColor`.
+Note that the selected item will be rendered using `pickingHighlightColor`, if blending is enabled for the draw, alpha channel can be used to control the blending result.
 
 
 ## Vertex Shader Functions


### PR DESCRIPTION
- Copy picking module from luma.gl, this is temporary and avoids dependencies as I make changes to this module, once all layers are modified to use picking module, I will update luma version and remove it from deck.gl.
- Add new props required for highlighting as described in RFC : https://github.com/uber/deck.gl/pull/839
- Update Scatterplot and Path layer shaders to use picking module.
- Verified rendering/performance using layer-browser example.
- Found one issue related to mouse leave event : #847