### PR TITLE
A pass on refreshing picking and event handling docs

### DIFF
--- a/docs/advanced/performance.md
+++ b/docs/advanced/performance.md
@@ -4,31 +4,15 @@
 ## General Expectations
 
 There are mainly two aspects that developers usually consider regarding the
-performance of any computer programs: the time and the memory consumption, both
-of which obviously depends on the specs of the hardware deck.gl is ultimately
-running on.
+performance of any computer programs: the time and the memory consumption, both of which obviously depends on the specs of the hardware deck.gl is ultimately running on.
 
 On 2015 MacBook Pros with dual graphics cards, most basic layers
 (like `ScatterplotLayer`) renders fluidly at 60 FPS during pan and zoom
-operations up to about 1M (one million) data items, with framerates dropping
-into low double digits (10-20FPS) when the data sets approach 10M items.
+operations up to about 1M (one million) data items, with framerates dropping into low double digits (10-20FPS) when the data sets approach 10M items.
 
-Even if interactivity is not an issue, browser limitations on how
-big chunks of contiguous memory can be allocated (e.g. Chrome caps
-individual allocations at 1GB) will cause most layers to crash
-during WebGL buffer generation somewhere between 10M and 100M items.
-You would need to break up your data into chunks and use multiple
-deck.gl layers to get past this limit.
+Even if interactivity is not an issue, browser limitations on how big chunks of contiguous memory can be allocated (e.g. Chrome caps individual allocations at 1GB) will cause most layers to crash during WebGL buffer generation somewhere between 10M and 100M items. You would need to break up your data into chunks and use multiple deck.gl layers to get past this limit.
 
-Modern phones (recent iPhones and higher-end Android phones) are
-surprisingly capable in terms of rendering performance, but are considerably
-more sensitive to memory pressure than laptops, resulting in browser restarts
-or page reloads.
-
-Remarks:
-* The layer browser example has a couple of performance tests that you can use
-  to get FPS readings for 1M and 10M data sets on your hardware.
-
+Modern phones (recent iPhones and higher-end Android phones) are surprisingly capable in terms of rendering performance, but are considerably more sensitive to memory pressure than laptops, resulting in browser restarts or page reloads. They also tend to load data significantly slower than desktop computers, so some tuning is usually needed to ensure a good overall user experience on mobile.
 
 ## Layer Update Performance
 
@@ -68,26 +52,40 @@ Thus it is possible to render a scatterplot layer with 10M items with reasonable
 frame rates on recent GPUs, provided that the radius (number of pixels) of each
 point is small.
 
-It is good to be aware that excessive overdraw can generate very high fragment
-counts and thus hurt performance.
-As an example, a `Scatterplot` radius of 5 pixels generates ~ 100 pixels per point,
-times 10M points, which can result in up to 1 billion fragment shader invocations
-per frame. While dependent on zoom levels (clipping will improve performance
-to some extent) this will certainly strain even a recent MacBook Pro GPU.
-
-
-## Layer Picking Performance
-
-Recommendation: Enabling picking has a small performance penalty so make sure
-the `pickable` property is `false` in layers that do not need picking (this
-is the default value).
-
-deck.gl performs picking by drawing the layer into an off screen
-picking buffer. This essentially means that every layer that supports picking
-will be drawn off screen when panning and hovering.
+It is good to be aware that excessive overdraw (drawing many objects/pixels on top of each other) can generate very high fragment counts and thus hurt performance. As an example, a `Scatterplot` radius of 5 pixels generates ~ 100 pixels per point. If you have a `Scatterplot` layer with 10 million points, this can result in up to 1 billion fragment shader invocations per frame. While dependent on zoom levels (clipping will improve performance to some extent) this many fragments will certainly strain even a recent MacBook Pro GPU.
 
 
 ## Layer Precision
 
-32 bit precision in many layers means that there is a limit to precision
-at high zoom levels, unless using an offset mode around a local center.
+* 32 bit precision is the default in most layers which means that there is a limit to precision that usually becomes evident at high zoom levels (objects start to "wobble" at around mercator zoom 18). These precision can be worked around by setting the `fp64` prop to true, or by using an offset mode based coordinate system (assumes data is clusted around a local center). Flipping on 64 bit precision affects performance as described above and in the separate chapter about the 64-bit GPU solution in deck.gl.
+
+
+## Layer Picking Performance
+
+deck.gl performs picking by drawing the layer into an off screen picking buffer. This essentially means that every layer that supports picking will be drawn off screen when panning and hovering. The picking is performed using the same GPU code that does the visual rendering, so the performance should be easy to predict.
+
+Picking limitations:
+* The picking system can only distinguish between 16M items per layer.
+* The picking system can only handle 256 layers with the pickable flag set to true.
+
+
+## Number of Layers
+
+The layer count of an advanced deck.gl application tends to gradually increase, especially when using composite layers. We have built and optimized a highly complex application using close to 100 deck.gl layers (this includes hierarchies of sublayers rendered by custom composite layers rendering other composite layers) without seeing any performance issues related to the number of layers. If you really need to, it is probably possible to go a little higher (a few hundred layers). Just keep in mind that deck.gl was not designed to be used with thousands of layers.
+
+
+## Profiling Ideas
+
+Some profiling techniques:
+* Using the `seer` chrome extension you can also get GPU timings for your layers.
+* The `layer-browser` example (in the `examples` folder has a couple of performance tests that you can use to get FPS readings on your hardware for Scatterplot layers with 1M and 10M points.
+
+## Common Issues
+
+A couple of particular things to watch out for that tend to have a big impact on performance:
+* Be careful when enabling Retina/High DPI rendering. It generetes 4x the number of pixels (fragments) and can have a big performance impact that depends on which computer or monitor is being used.
+* Avoid using luma.gl debug mode in production. It queries the GPU error status after each operation which has a big impact on performance.
+
+Smaller considerations:
+* Enabling picking can have a small performance penalty so make sure the `pickable` property is `false` in layers that do not need picking (this is the default value).
+

--- a/docs/advanced/picking.md
+++ b/docs/advanced/picking.md
@@ -1,20 +1,15 @@
 # Picking
 
+Make sure you have read [Interactivity](/docs/get-started/interactivity.md) before reading this section.
+
 ## How It Works
 
-When the user moves or clicks the pointer over the deck.gl canvas, all pickable
-layers are rendered into an off-screen buffer with the uniform:
-[`renderPickingBuffer`](/docs/writing-shaders.md#-float-renderpickingbuffer-)
-set to `1`. In this mode, the default implementation of the core layers
-render using `pickingColor` or `instancePickingColor` attributes instead of
-their normal color calculation.
+Rather than doing traditional ray-casting or building octrees etc in JavaScript, deck.gl implements picking on the GPU using a technique we refer to as "color picking". When deck.gl needs to determine what is under the mouse (e.g. when the user moves or clicks the pointer over the deck.gl canvas), all pickable layers are rendered into an off-screen buffer, but in a special mode activated by a GLSL uniform. In this mode, the shaders of the core layers render picking colors instead of their normal visual colors.
 
-The `pickingColor` is a special encoding that converts the index of a object
-of a given layer into a 3-byte color array. When the picking buffer is rendered,
-deck.gl looks at the color of the pixel under the pointer, and decodes it back
-to the index number using
-[`layer.decodePickingColor()`](/docs/api-reference/base-layer.md#-decodepickingcolor-)
-to determine which object of the layer has been picked.
+Each object in each layer gets its own picking color assigned. The picking color is determined using a special encoding that converts the index of a object of a given layer into a 3-byte color array (the color buffer allows us to distinguish between 16M unique colors per layer, and between 256 different layers).
+
+After the picking buffer is rendered, deck.gl looks at the color of the pixel under the pointer, and decodes it back to the index number using
+[`layer.decodePickingColor()`](/docs/api-reference/base-layer.md#-decodepickingcolor-) to determine which object of the layer has been picked.
 
 A `hover` event is triggered on a layer if:
 - The layer is picked, and the picked object is different from the last frame
@@ -22,24 +17,16 @@ A `hover` event is triggered on a layer if:
 
 A `click` event is triggered on a layer only if it's picked.
 
-When an event is triggered,
-[`layer.getPickingInfo()`](/docs/api-reference/base-layer.md#-getpickinginfo-)
-is called on the affected layers to populate the `info` object of the event.
-This object is then passed to the `onHover` and `onClick` callbacks.
+When an event is triggered, [`layer.getPickingInfo()`](/docs/api-reference/base-layer.md#-getpickinginfo-) is called on the affected layers to populate the `info` object of the event. This object is then passed to the `onHover` and `onClick` callbacks.
 
 
 ## Event Propagation In Composite Layers
 
-When a picking event is triggered, `getPickingInfo()` of the layer that rendered the
-object is called first. The event then gets propagate to its parent layer, and so on.
+When a picking event is triggered, `getPickingInfo()` of the layer that rendered the object is called first. The event then gets propagate to its parent layer, and so on.
 
-Composite layers can further augment the `info` object after it is processed by
-the picked sublayer. This allows the composite layer to hide implementation details
-and expose only user-friendly information.
+Composite layers can further augment the `info` object after it is processed by the picked sublayer. This allows the composite layer to hide implementation details and expose only user-friendly information.
 
-Only the `onHover` and `onClick` callbacks of the top-level layer is called. The idea
-is that the user should only interface with the layer that they created, and not having
-to know the underlying implementation.
+Only the `onHover` and `onClick` callbacks of the top-level layer is called. The idea is that the user should only interface with the layer that they created, and not having to know the underlying implementation.
 
 
 ## Implementing Custom Picking
@@ -51,42 +38,34 @@ system, which most layers use.
 To take full control of picking, a layer need to take the following steps:
 
 1. Add a picking color attribute during initialization:
-  ```js
-  initializeState() {
+```js
+initializeState() {
 
-    ...
+  ...
 
-    this.state.attributeManager.add({
-      pickingColors: {size: 3, type: GL.UNSIGNED_BYTE, update: this.calculatePickingColors}
-    });
-  }
-  ```
+  this.state.attributeManager.add({
+    pickingColors: {size: 3, type: GL.UNSIGNED_BYTE, update: this.calculatePickingColors}
+  });
+}
+```
 - Calculate the attribute by providing a different picking color for every object that
 you need to differentiate, such as:
-  ```js
-  calculatePickingColors(attribute) {
-    const {data} = this.props;
-    const {value, size} = attribute;
-    
-    let i = 0;
-    for (const object of data) {
-      const pickingColor = this.encodePickingColor(i);
-      value[i++] = pickingColor[0];
-      value[i++] = pickingColor[1];
-      value[i++] = pickingColor[2];
-    }
-  }
-  ```
-- The default implementation of
-[`layer.encodePickingColor()`](/docs/api-reference/base-layer.md#-encodepickingcolor-) and
-[`layer.decodePickingColor()`](/docs/api-reference/base-layer.md#-decodepickingcolor-)
-is likely sufficient, but you may need to implement your own pair.
-- Support picking in shaders by rendering picking colors when `renderPickingBuffer`
-is `1`, like [this example](/docs/advanced/writing-shaders.md#-float-renderpickingbuffer-).
-- By default, the `object` field of the picking `info` object is indexed from
-the layer's `data` prop. Custom layers often need to define on their own terms what 
-constitutes meaningful information to the user's callbacks. A layer can achieve this 
-by overriding
-[`layer.getPickingInfo()`](/docs/api-reference/base-layer.md#-getpickinginfo-)
-to add or modify fields to the `info` object.
+```js
+calculatePickingColors(attribute) {
+  const {data} = this.props;
+  const {value, size} = attribute;
 
+  let i = 0;
+  for (const object of data) {
+    const pickingColor = this.encodePickingColor(i);
+    value[i++] = pickingColor[0];
+    value[i++] = pickingColor[1];
+    value[i++] = pickingColor[2];
+  }
+}
+```
+
+- The default implementation of [`layer.encodePickingColor()`](/docs/api-reference/base-layer.md#-encodepickingcolor-) and
+[`layer.decodePickingColor()`](/docs/api-reference/base-layer.md#-decodepickingcolor-) is likely sufficient, but you may need to implement your own pair.
+- By default, the `object` field of the picking `info` object is indexed from the layer's `data` prop. Custom layers often need to define on their own terms what  constitutes meaningful information to the user's callbacks. A layer can achieve this  by overriding [`layer.getPickingInfo()`](/docs/api-reference/base-layer.md#-getpickinginfo-) to add or modify fields to the `info` object.
+- For more information about how to implement picking in shaders see: [`renderPickingBuffer`](/docswriting-shaders.md#-float-renderpickingbuffer-)

--- a/docs/api-reference/deckgl.md
+++ b/docs/api-reference/deckgl.md
@@ -121,9 +121,11 @@ are affected.
 
 ### Methods
 
-##### `queryObject(options)`
+##### queryObject
 
 Get the closest pickable and visible object at screen coordinate.
+
+`queryObject({x, y, radius, layerIds})`
 
 Parameters:
 - `options` (Object)
@@ -135,9 +137,11 @@ Parameters:
 
 Returns: a single [`info`](/docs/get-started/interactivity.md#the-picking-info-object) object, or `null` if nothing is found.
 
-##### `queryVisibleObjects(options)`
+##### queryVisibleObjects
 
 Get all pickable and visible objects within a bounding box.
+
+`queryVisibleObjects({x, y, width, height, layerIds})`
 
 Parameters:
 - `options` (Object)

--- a/docs/get-started/interactivity.md
+++ b/docs/get-started/interactivity.md
@@ -2,18 +2,30 @@
 
 ## Overview
 
-deck.gl layers support two mouse events: `hover` and `click` in a process
-called *picking*. Picking can be enabled or disabled on a layer-by-layer basis.
+deck.gl provides a powerful picking engine that enables the application to determine what object is rendered on a certain pixel on the screen. This picking engine can either be called directly by an application (which is then typically implementing its own event handling), or it can be called automatically by the basic built-in event handling in deck.gl
 
-To enable picking on a layer, set
-its [`pickable`](/docs/api-reference/base-layer.md#-pickable-boolean-optional-) prop to `true`.
-This value is `false` by default.
 
-There are two ways to subscribe to picking events:
+### Enabling Picking
 
-- Set callback for each pickable layer by
-setting [`onHover`](/docs/api-reference/base-layer.md#-onhover-function-optional-)
-and [`onClick`](/docs/api-reference/base-layer.md#-onclick-function-optional-) props:
+To enable picking on a layer, set its [`pickable`](/docs/api-reference/base-layer.md#-pickable-boolean-optional-) prop to `true`. This value is `false` by default.
+
+
+### Calling the Picking Engine Directly
+
+The picking engine is exposed through the [`DeckGL.queryObject`]((/docs/api-reference/deckgl.md) and [`DeckGL.queryVisibleObject`]((/docs/api-reference/deckgl.md) methods. These methods allow you to query what layers and objects within those layers are under a specific point or within a specified rectangle.
+
+`queryObject` allows an application to define its own event handling. hen it comes to how to actually do event handling in a browser, there are many options, perhaps the simplest is to just use react's event handling together with queryObject.
+
+Also note that by directly calling `queryObject`, integrating deck.gl into an existing application typically becomes easier since you don't have to port the application's existing event handling to deck.gl.
+
+
+### Using the Built-in Event-Handling
+
+For applications that have basic event handling needs, deck.gl layers have built-in support for two mouse events: `hover` and `click` in a process called *picking*. Picking can be enabled or disabled on a layer-by-layer basis.
+
+There are two ways to subscribe to this built-in picking event handling:
+
+- Set callback for each pickable layer by setting [`onHover`](/docs/api-reference/base-layer.md#-onhover-function-optional-) and [`onClick`](/docs/api-reference/base-layer.md#-onclick-function-optional-) props:
 ```js
 const layer = new ScatterplotLayer({
     ...
@@ -22,10 +34,7 @@ const layer = new ScatterplotLayer({
     onClick: info => console.log('Clicked:', info)
 });
 ```
-- Set callback for all pickable layers by
-setting [`onLayerHover`](/docs/api-reference/deckgl.md#-onlayerhover-function-optional-)
-and [`onLayerClick`](/docs/api-reference/deckgl.md#-onlayerclick-function-optional-)
-props of the `DeckGL` canvas:
+- Set callback for all pickable layers by setting [`onLayerHover`](/docs/api-reference/deckgl.md#-onlayerhover-function-optional-) and [`onLayerClick`](/docs/api-reference/deckgl.md#-onlayerclick-function-optional-) props of the `DeckGL` canvas:
 ```js
 <DeckGL
     ...
@@ -37,36 +46,24 @@ props of the `DeckGL` canvas:
 ## Notes On Behavior
 
 Picking events are triggered based on *pickable objects*:
-- A `click` event is triggered every time the pointer clicked on an object in
-a pickable layer.
+- A `click` event is triggered every time the pointer clicked on an object in a pickable layer.
 - A `hover` event is triggered every time the hovered object of a pickable
 layer changes.
 
-What constitutes an object is defined by each layer.
-Usually, it is one of the data entries that is passed in via `prop.data`.
-For example, in
-[Scatterplot Layer](/docs/layers/scatterplot-layer.md), an object is an element
-in the `props.data` array that is used to render one circle. In
-[GeoJson Layer](/docs/layers/geojson-layer.md), an object is a GeoJSON feature
-in the `props.data` feature collection that is used to render one
-point, path or polygon.
+What constitutes an object is defined by each layer. Usually, it is one of the data entries that is passed in via `prop.data`.
+For example, in [Scatterplot Layer](/docs/layers/scatterplot-layer.md), an object is an element in the `props.data` array that is used to render one circle. In [GeoJson Layer](/docs/layers/geojson-layer.md), an object is a GeoJSON feature in the `props.data` feature collection that is used to render one point, path or polygon.
 
 When an event is fired, the `onHover` or `onClick` callback of the affected
 layer is called first. If the callback returns a truthy value, the event is
-marked as handled. Otherwise, the event will bubble up to the `DeckGL` canvas
-and be visible to its `onLayerHover` and `onLayerClick` callbacks.
+marked as handled. Otherwise, the event will bubble up to the `DeckGL` canvas and be visible to its `onLayerHover` and `onLayerClick` callbacks.
 
 
 ## The Picking Info Object
 
-The callbacks for `hover` and `click` events are called with a single parameter
-`info` which contains a variety of fields describing the mouse or touch event
-and what was hovered.
-
+The callbacks for `hover` and `click` events are called with a single parameter `info` which contains a variety of fields describing the mouse or touch event and what was hovered.
 - `info.layer`: the layer that this event originates from.
 - `info.index`: the index of the object that is being picked.
-- `info.object`: the object that is being picked. This may vary from layer to
-layer.
+- `info.object`: the object that is being picked. This may vary from layer to layer.
 - `info.x`: mouse position x relative to the viewport.
 - `info.y`: mouse position y relative to the viewport.
 - `info.lngLat`: mouse position in world coordinates. Only applies if

--- a/docs/get-started/interactivity.md
+++ b/docs/get-started/interactivity.md
@@ -2,28 +2,62 @@
 
 ## Overview
 
-deck.gl provides a powerful picking engine that enables the application to determine what object is rendered on a certain pixel on the screen. This picking engine can either be called directly by an application (which is then typically implementing its own event handling), or it can be called automatically by the basic built-in event handling in deck.gl
+deck.gl includes a powerful picking engine that enables the application to precisely determine what object and layer is rendered on a certain pixel on the screen. This picking engine can either be called directly by an application (which is then typically implementing its own event handling), or it can be called automatically by the basic built-in event handling in deck.gl
 
+### What can be Picked?
+
+The "picking engine" identifies which object in which layer is at the given coordinates. While usually intuitive, what constitutes a pickable "object" is defined by each layer. Typically, it corresponds to one of the data entries that is passed in via `prop.data`. For example, in [Scatterplot Layer](/docs/layers/scatterplot-layer.md), an object is an element in the `props.data` array that is used to render one circle. In [GeoJson Layer](/docs/layers/geojson-layer.md), an object is a GeoJSON feature in the `props.data` feature collection that is used to render one point, path or polygon.
 
 ### Enabling Picking
 
-To enable picking on a layer, set its [`pickable`](/docs/api-reference/base-layer.md#-pickable-boolean-optional-) prop to `true`. This value is `false` by default.
+Picking can be enabled or disabled on a layer-by-layer basis. To enable picking on a layer, set its [`pickable`](/docs/api-reference/base-layer.md#-pickable-boolean-optional-) prop to `true`. This value is `false` by default.
 
+### The Picking Info Object
 
-### Calling the Picking Engine Directly
+The picking engine returns "picking info" objects which contains a variety of fields describing what layer and object was picked.
 
-The picking engine is exposed through the [`DeckGL.queryObject`]((/docs/api-reference/deckgl.md) and [`DeckGL.queryVisibleObject`]((/docs/api-reference/deckgl.md) methods. These methods allow you to query what layers and objects within those layers are under a specific point or within a specified rectangle.
+| Key      | Value |
+| ---      | --- |
+| `layer`  | The layer that the picked object belongs to. Only layers with the `pickable` prop set to true can be picked. |
+| `index`  | The index of the object in the layer that was picked. |
+| `object` | The object that was picked. This is typically an entry in the layer's `props.data` array, but can vary from layer to layer. |
+| `x`      | Mouse position x relative to the viewport. |
+| `y`      | Mouse position y relative to the viewport. |
+| `lngLat` | Mouse position in geospatial coordinates. Only applies if `layer.props.projectionMode` is a geospatial mode such as `COORDINATE_SYSTEM.LNGLAT`. |
 
-`queryObject` allows an application to define its own event handling. hen it comes to how to actually do event handling in a browser, there are many options, perhaps the simplest is to just use react's event handling together with queryObject.
+> Specific deck.gl Layers may add additional fields to the picking `info` object. Check the documentation of each layer.
 
-Also note that by directly calling `queryObject`, integrating deck.gl into an existing application typically becomes easier since you don't have to port the application's existing event handling to deck.gl.
+## Calling the Picking Engine Directly
 
+The picking engine is exposed through the [`DeckGL.queryObject`]((/docs/api-reference/deckgl.md) and [`DeckGL.queryVisibleObject`]((/docs/api-reference/deckgl.md) methods. These methods allow you to query what layers and objects within those layers are under a specific point or within a specified rectangle. They return `Picking Info` objects as described below.
 
-### Using the Built-in Event-Handling
+`queryObject` allows an application to define its own event handling. When it comes to how to actually do event handling in a browser, there are many options. In a React application, perhaps the simplest is to just use React's "synthetic" event handling together with `queryObject`:
 
-For applications that have basic event handling needs, deck.gl layers have built-in support for two mouse events: `hover` and `click` in a process called *picking*. Picking can be enabled or disabled on a layer-by-layer basis.
+```js
+class MyComponent extends React.Component {
+  ...
+  onClickHandler = (event) => {
+    const pickInfo = this.deckGL.queryObject({x: event.clientX, y: event.clientY, ...});
+    console.log(pickInfo.lngLat);
+  }
 
-There are two ways to subscribe to this built-in picking event handling:
+  render() {
+    return (
+      <div onClick={this.onClickHandler}>
+        <DeckGL ref={deck => { this.deckGL = deck; }} .../>
+      </div>
+    );
+  }
+}
+```
+
+Also note that by directly calling `queryObject`, integrating deck.gl into an existing application often becomes easier since you don't have to change the application's existing approach to event handling.
+
+## Using the Built-in Event-Handling
+
+For applications that have basic event handling needs, deck.gl has built-in support for handling the two most basic mouse events: `hover` and `click`. When the application registers callbacks, deck.gl automatically tracks these events, runs the picking engine and calls application callbacks with a single parameter `info` which contains the resulting picking info object.
+
+There are two ways to subscribe to the built-in picking event handling:
 
 - Set callback for each pickable layer by setting [`onHover`](/docs/api-reference/base-layer.md#-onhover-function-optional-) and [`onClick`](/docs/api-reference/base-layer.md#-onclick-function-optional-) props:
 ```js
@@ -43,35 +77,15 @@ const layer = new ScatterplotLayer({
 />
 ```
 
-## Notes On Behavior
+The callbacks for `hover` and `click` events are called with a single parameter `info` that contains the mouse or touch event and what was hovered, including which layer was selected. Thus event handlers registered directly on the `DeckGL` compionents are also able to distinguish between clicks in different layers.
+
+### Behavior of Built-in Event Handling
 
 Picking events are triggered based on *pickable objects*:
 - A `click` event is triggered every time the pointer clicked on an object in a pickable layer.
-- A `hover` event is triggered every time the hovered object of a pickable
-layer changes.
+- A `hover` event is triggered every time the hovered object of a pickable layer changes.
 
-What constitutes an object is defined by each layer. Usually, it is one of the data entries that is passed in via `prop.data`.
-For example, in [Scatterplot Layer](/docs/layers/scatterplot-layer.md), an object is an element in the `props.data` array that is used to render one circle. In [GeoJson Layer](/docs/layers/geojson-layer.md), an object is a GeoJSON feature in the `props.data` feature collection that is used to render one point, path or polygon.
-
-When an event is fired, the `onHover` or `onClick` callback of the affected
-layer is called first. If the callback returns a truthy value, the event is
-marked as handled. Otherwise, the event will bubble up to the `DeckGL` canvas and be visible to its `onLayerHover` and `onLayerClick` callbacks.
-
-
-## The Picking Info Object
-
-The callbacks for `hover` and `click` events are called with a single parameter `info` which contains a variety of fields describing the mouse or touch event and what was hovered.
-- `info.layer`: the layer that this event originates from.
-- `info.index`: the index of the object that is being picked.
-- `info.object`: the object that is being picked. This may vary from layer to layer.
-- `info.x`: mouse position x relative to the viewport.
-- `info.y`: mouse position y relative to the viewport.
-- `info.lngLat`: mouse position in world coordinates. Only applies if
-`layer.props.projectionMode` is `COORDINATE_SYSTEM.LNGLAT`.
-
-
-> Layers can add additional fields to the picking `info` object. Check the
-  documentation of each layer.
+When an event is fired, the `onHover` or `onClick` callback of the affected layer is called first. If the callback returns a truthy value, the event is marked as handled. Otherwise, the event will bubble up to the `DeckGL` canvas and be visible to its `onLayerHover` and `onLayerClick` callbacks.
 
 
 ## Under The Hood


### PR DESCRIPTION
Some cleanup of the overall picking/interactivity/event-handling documentation complex.

- I tried to keep new features out of this pass so that it could be merged to current 4.1-release and website.
- We should discuss how to add documentation for in-progress features such as auto highlighting, use of new picking module, and a presumably public EventManager class.