### PR TITLE
Doc paragraph reformatting. Bump code links to 4.1-release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,9 +44,7 @@ For details see [What's New](https://github.com/uber/deck.gl/blob/4.1-release/do
 
 #### [4.0.0] - 2017-4-6 Major deck.gl Release
 
-For details see [What's New](https://github.com/uber/deck.gl/blob/4.0-release/docs/whats-new.md)
-
-
+For details see What's New
 ### deck.gl v3.0
 
 #### [3.1.3] - 2017-1-25

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,19 +9,13 @@
 
 # Introduction
 
-deck.gl is designed to make visualization of large data sets simple.
-It enables users to quickly get impressive visual results with limited effort
-through composition of existing layers, while offering a complete architecture
-for packaging advanced WebGL based visualizations as reusable JavaScript
-layers.
+deck.gl is designed to make visualization of large data sets simple. It enables users to quickly get impressive visual results with limited effort through composition of existing layers, while offering a complete architecture for packaging advanced WebGL based visualizations as reusable JavaScript layers.
 
 ## Brief Overview
 
-The basic idea of using deck.gl is to render a stack of visual overlays,
-usually (but not always) over maps.
+The basic idea of using deck.gl is to render a stack of visual overlays, usually (but not always) over maps.
 
 To make this simple concept work, deck.gl handles a number of challenges:
-
 * Handling of large data sets and performant updates
 * Interactive event handling such as picking
 * Cartographic projections and integration with underlying map
@@ -32,51 +26,29 @@ To make this simple concept work, deck.gl handles a number of challenges:
 
 deck.gl has been developed in parallel with a number of companion modules:
 
-* [luma.gl](https://uber.github.io/luma.gl/#/) -
-  A general purpose WebGL library designed to be interoperable both with the
-  raw WebGL API and (as far as possible) with other WebGL libraries.
-  In particular, luma.gl does not claim ownership of the WebGL context, and can
-  work with any supplied context, including contexts created by the application
-  or other WebGL libraries.
-* [react-map-gl](https://uber.github.io/react-map-gl/#/) - A React wrapper
-  around Mapbox GL which works seamlessly with deck.gl.
+* [luma.gl](https://uber.github.io/luma.gl/#/) - A general purpose WebGL library designed to be interoperable both with the raw WebGL API and (as far as possible) with other WebGL libraries. In particular, luma.gl does not claim ownership of the WebGL context, and can work with any supplied context, including contexts created by the application or other WebGL libraries.
+* [react-map-gl](https://uber.github.io/react-map-gl/#/) - A React wrapper around Mapbox GL which works seamlessly with deck.gl.
 
-In addition, in the future we plan to publish additional deck.gl layers and
-layer packages as separate modules.
+In addition, in the future we plan to publish additional deck.gl layers and layer packages as separate modules.
 
 ## Learning deck.gl
 
-How you approach learning deck.gl will depend on your previous
-knowledge and how you want to use it.
+How you approach learning deck.gl will depend on your previous knowledge and how you want to use it.
 
-Learning the layer props, and reading the basic articles in the deck.gl
-documentation should of course be the first step. But where to go
-after that?
+Learning the layer props, and reading the basic articles in the deck.gl documentation should of course be the first step. But where to go after that?
 
 ### Understanding the Reactive Programming Model
 
-deck.gl is designed according to the principles of the
-[Reactive Programming Model](https://en.wikipedia.org/wiki/Reactive_programming).
+deck.gl is designed according to the principles of the [Reactive Programming Model](https://en.wikipedia.org/wiki/Reactive_programming).
 
-The key to writing good, performant deck.gl applications and layers
-lies in understanding how to minimize updates and redundant calculations.
+The key to writing good, performant deck.gl applications and layers lies in understanding how to minimize updates and redundant calculations.
 
-It is important to understand the implications of the shallow equality
-comparisons deck.gl performs on layer properties, and how this implies that
-new data and property objects must only be created when the underlying
-data actually changes in order to prevent unnecessary updates.
+It is important to understand the implications of the shallow equality comparisons deck.gl performs on layer properties, and how this implies that new data and property objects must only be created when the underlying data actually changes in order to prevent unnecessary updates.
 
-There is an impressive amount of information (documentation, blog posts,
-educational videos, etc.) on the reactive programming paradigm in relation to
-modern web frameworks such as React, Flux and Redux. Where to start depends
-mostly on your application architecture choices.
+There is an impressive amount of information (documentation, blog posts, educational videos, etc.) on the reactive programming paradigm in relation to modern web frameworks such as React, Flux and Redux. Where to start depends mostly on your application architecture choices.
 
 ### Understanding WebGL
 
-This is only needed if you want to create custom layers in deck.gl.
-Note that while trying out a new ambitious rendering approach for a
-new layer will likely require deeper knowledge, it is often possible to modify
-or extend existing deck.gl layers (including modifying the shader code) with
-a surprisingly limited amount of WebGL knowledge.
+This is only needed if you want to create custom layers in deck.gl. Note that while trying out a new ambitious rendering approach for a new layer will likely require deeper knowledge, it is often possible to modify or extend existing deck.gl layers (including modifying the shader code) with a surprisingly limited amount of WebGL knowledge.
 
-There are many web resources for learning WebGL.
+There are many web resources for learning WebGL. [luma.gl](https://uber.github.io/luma.gl/#/)can be a good start.

--- a/docs/advanced/performance.md
+++ b/docs/advanced/performance.md
@@ -4,31 +4,15 @@
 ## General Expectations
 
 There are mainly two aspects that developers usually consider regarding the
-performance of any computer programs: the time and the memory consumption, both
-of which obviously depends on the specs of the hardware deck.gl is ultimately
-running on.
+performance of any computer programs: the time and the memory consumption, both of which obviously depends on the specs of the hardware deck.gl is ultimately running on.
 
 On 2015 MacBook Pros with dual graphics cards, most basic layers
 (like `ScatterplotLayer`) renders fluidly at 60 FPS during pan and zoom
-operations up to about 1M (one million) data items, with framerates dropping
-into low double digits (10-20FPS) when the data sets approach 10M items.
+operations up to about 1M (one million) data items, with framerates dropping into low double digits (10-20FPS) when the data sets approach 10M items.
 
-Even if interactivity is not an issue, browser limitations on how
-big chunks of contiguous memory can be allocated (e.g. Chrome caps
-individual allocations at 1GB) will cause most layers to crash
-during WebGL buffer generation somewhere between 10M and 100M items.
-You would need to break up your data into chunks and use multiple
-deck.gl layers to get past this limit.
+Even if interactivity is not an issue, browser limitations on how big chunks of contiguous memory can be allocated (e.g. Chrome caps individual allocations at 1GB) will cause most layers to crash during WebGL buffer generation somewhere between 10M and 100M items. You would need to break up your data into chunks and use multiple deck.gl layers to get past this limit.
 
-Modern phones (recent iPhones and higher-end Android phones) are
-surprisingly capable in terms of rendering performance, but are considerably
-more sensitive to memory pressure than laptops, resulting in browser restarts
-or page reloads.
-
-Remarks:
-* The layer browser example has a couple of performance tests that you can use
-  to get FPS readings for 1M and 10M data sets on your hardware.
-
+Modern phones (recent iPhones and higher-end Android phones) are surprisingly capable in terms of rendering performance, but are considerably more sensitive to memory pressure than laptops, resulting in browser restarts or page reloads. They also tend to load data significantly slower than desktop computers, so some tuning is usually needed to ensure a good overall user experience on mobile.
 
 ## Layer Update Performance
 
@@ -68,26 +52,40 @@ Thus it is possible to render a scatterplot layer with 10M items with reasonable
 frame rates on recent GPUs, provided that the radius (number of pixels) of each
 point is small.
 
-It is good to be aware that excessive overdraw can generate very high fragment
-counts and thus hurt performance.
-As an example, a `Scatterplot` radius of 5 pixels generates ~ 100 pixels per point,
-times 10M points, which can result in up to 1 billion fragment shader invocations
-per frame. While dependent on zoom levels (clipping will improve performance
-to some extent) this will certainly strain even a recent MacBook Pro GPU.
-
-
-## Layer Picking Performance
-
-Recommendation: Enabling picking has a small performance penalty so make sure
-the `pickable` property is `false` in layers that do not need picking (this
-is the default value).
-
-deck.gl performs picking by drawing the layer into an off screen
-picking buffer. This essentially means that every layer that supports picking
-will be drawn off screen when panning and hovering.
+It is good to be aware that excessive overdraw (drawing many objects/pixels on top of each other) can generate very high fragment counts and thus hurt performance. As an example, a `Scatterplot` radius of 5 pixels generates ~ 100 pixels per point. If you have a `Scatterplot` layer with 10 million points, this can result in up to 1 billion fragment shader invocations per frame. While dependent on zoom levels (clipping will improve performance to some extent) this many fragments will certainly strain even a recent MacBook Pro GPU.
 
 
 ## Layer Precision
 
-32 bit precision in many layers means that there is a limit to precision
-at high zoom levels, unless using an offset mode around a local center.
+* 32 bit precision is the default in most layers which means that there is a limit to precision that usually becomes evident at high zoom levels (objects start to "wobble" at around mercator zoom 18). These precision can be worked around by setting the `fp64` prop to true, or by using an offset mode based coordinate system (assumes data is clusted around a local center). Flipping on 64 bit precision affects performance as described above and in the separate chapter about the 64-bit GPU solution in deck.gl.
+
+
+## Layer Picking Performance
+
+deck.gl performs picking by drawing the layer into an off screen picking buffer. This essentially means that every layer that supports picking will be drawn off screen when panning and hovering. The picking is performed using the same GPU code that does the visual rendering, so the performance should be easy to predict.
+
+Picking limitations:
+* The picking system can only distinguish between 16M items per layer.
+* The picking system can only handle 256 layers with the pickable flag set to true.
+
+
+## Number of Layers
+
+The layer count of an advanced deck.gl application tends to gradually increase, especially when using composite layers. We have built and optimized a highly complex application using close to 100 deck.gl layers (this includes hierarchies of sublayers rendered by custom composite layers rendering other composite layers) without seeing any performance issues related to the number of layers. If you really need to, it is probably possible to go a little higher (a few hundred layers). Just keep in mind that deck.gl was not designed to be used with thousands of layers.
+
+
+## Profiling Ideas
+
+Some profiling techniques:
+* Using the `seer` chrome extension you can also get GPU timings for your layers.
+* The `layer-browser` example (in the `examples` folder has a couple of performance tests that you can use to get FPS readings on your hardware for Scatterplot layers with 1M and 10M points.
+
+## Common Issues
+
+A couple of particular things to watch out for that tend to have a big impact on performance:
+* Be careful when enabling Retina/High DPI rendering. It generetes 4x the number of pixels (fragments) and can have a big performance impact that depends on which computer or monitor is being used.
+* Avoid using luma.gl debug mode in production. It queries the GPU error status after each operation which has a big impact on performance.
+
+Smaller considerations:
+* Enabling picking can have a small performance penalty so make sure the `pickable` property is `false` in layers that do not need picking (this is the default value).
+

--- a/docs/get-started/getting-started.md
+++ b/docs/get-started/getting-started.md
@@ -1,6 +1,8 @@
-# Installation
+# Installing, Building and Running Examples
 
-## The deck.gl Framework
+## Installation
+
+First, you need to install the deck.gl and luma.gl frameworks
 ```bash
 npm install --save deck.gl luma.gl
 ```
@@ -9,20 +11,9 @@ or
 yarn add deck.gl luma.gl
 ```
 
-Remarks:
-* `luma.gl` will not be automatically installed with deck.gl.
-  The reason is that an application must only include one copy of luma.gl.
-  Please explicitly install `luma.gl` with your app (`npm install )
-  This is similar to React components which typically only have "peer dependencies"
-  on React, and it is the application's responsibility to actually
-  select and install a specific React version.
+## Running the Examples
 
-## Examples
-
-The deck.gl repository contains an
-[examples folder](https://github.com/uber/deck.gl/tree/4.0-release/examples)
-with a selection of small, standalone examples that could be good starting
-points for your application.
+The deck.gl repository contains an [examples folder](https://github.com/uber/deck.gl/tree/4.1-release/examples) with a selection of small, standalone examples that could be good starting points for your application.
 
 You should be able to copy these folders to your preferred locations, and get them running simply by installing dependencies using:
 
@@ -33,12 +24,10 @@ npm install  # or yarn
 and then running using:
 
 ```bash
-export MAPBOX_ACCESS_TOKEN={Your Token Here} && npm start
+export MapboxAccessToken={Your Token Here} && npm start
 ```
 
-Remarks:
+## Remarks:
 
-`MAPBOX_ACCESS_TOKEN` is the Mapbox token. For most examples shipped with deck.gl, geospatial data is rendered on top of Mapbox-powered basemap. Mapbox requires users to provide an access token before
-they serve map tiles to user's browsers.
-
-For more information about map token read the sections about [Using with Mapbox GL](/docs/get-started/using-with-mapbox-gl.md).
+* `luma.gl` will not be automatically installed with deck.gl. The reason is that an application must only include one copy of luma.gl. Please explicitly install `luma.gl` with your app (`npm install luma.gl`). This is similar to React components which typically only have "peer dependencies" on React, and it is the application's responsibility to actually select and install a specific React version.
+* `MapboxAccessToken` is the Mapbox token. For most examples shipped with deck.gl, geospatial data is rendered on top of Mapbox-powered basemap. Mapbox requires users to provide an access token before they serve map tiles to the user's browser. For more information about map token read the sections about [Using with Mapbox GL](/docs/get-started/using-with-mapbox-gl.md).

--- a/docs/get-started/using-layers.md
+++ b/docs/get-started/using-layers.md
@@ -1,15 +1,14 @@
-# Using Layers
+# Visualizing Data through Layers
 
 ## Rendering a Single Layer
 
-deck.gl is designed to allow you to take any data with which you can associate
-positions, and easily render that data on a map using a deck.gl `Layer`. By
-simply instantiating that layer's class, and passing in a set of `properties`
-that would include the `data` itself, together with some `accessors` and `properties`
-that the layer uses to build the visualization.
+deck.gl is designed to allow you to take any data with which you can associate positions, and easily render that data on a map using a deck.gl `Layer`. By simply instantiating that layer's class, and passing in a set of `properties` that would include the `data` itself, together with some `accessors` and `properties` that the layer uses to build the visualization.
+
+The `properties` are values that allow you to control how the layer
+should render your data.
 
 The `accessors` are functions that you supply to describe how the layer
-should extract various values
+should extract various values.
 
 The data would typically be a list (e.g. Array) of objects, often parsed
 from a JSON or CSV formatted data.
@@ -20,16 +19,12 @@ from a JSON or CSV formatted data.
 ]} />
 ```
 
-When the layer is about to be drawn on screen for the first time,
-the layer will traverse the `data` array and build up WebGL buffers that
-allow the GPU to render a visualization of your data very quickly.
-These WebGL buffers are saved and matched with any future changes.
+When the layer is about to be drawn on screen for the first time, the layer will traverse the `data` array and build up WebGL buffers that
+allow the GPU to render a visualization of your data very quickly. These WebGL buffers are saved and matched with any future changes.
 
 ## Rendering Multiple Layers
 
-deck.gl allows you to render multiple layers using the same or different data
-sets. You simply provide an array of layer instances and deck.gl will render
-them in order (and handle interactivity when hovering clicking etc).
+deck.gl allows you to render multiple layers using the same or different data sets. You simply provide an array of layer instances and deck.gl will render them in order (and handle interactivity when hovering clicking etc).
 
 This allows you to compose visualizations using several primitive layers.
 
@@ -41,9 +36,7 @@ This allows you to compose visualizations using several primitive layers.
 ]} />
 ```
 
-The main concern when rendering more than one instance of a specific layer (say
-two `ScatterplotLayer`s) is that their `id` props must be unique for each layer
-or deck.gl will fail to match layers between render cycles.
+The main concern when rendering more than one instance of a specific layer (say two `ScatterplotLayer`s) is that their `id` props must be unique for each layer or deck.gl will fail to match layers between render cycles.
 
 ```js
 <DeckGL layers={[
@@ -52,50 +45,30 @@ or deck.gl will fail to match layers between render cycles.
 ]} />
 ```
 
-The `id` property is similar (but not identicaly) to the `key` property on
-React components.
+The `id` property works similarly (but not identically) to the `key` property on React components.
 
 ## Available Layers
 
-All deck.gl layers inherit from either the
-[`Layer`](/docs/api-reference/base-layer.md) or the
-[`CompositeLayer`](/docs/api-reference/composite-layer.md) base classes and the props of
-those layers are available to all layers unless otherwise documented.
+All deck.gl layers inherit from either the [`Layer`](/docs/api-reference/base-layer.md) or the [`CompositeLayer`](/docs/api-reference/composite-layer.md) base classes and the props of those layers are available to all layers unless otherwise documented.
 
 ### Core Layers
 
 [Browse deck.gl's layer catalog](/docs/layers/arc-layer.md)
 
-The "core layers" are a group of geospatial visualization focused layers,
-intended to represent a small set of widely applicable data visualization building
-blocks. The core layers are the most stable and supported deck.gl layers.
+The "core layers" are a group of geospatial visualization focused layers, intended to represent a small set of widely applicable data visualization building blocks. The core layers are the most stable and supported deck.gl layers.
 
 ### Sample Layers
 
-deck.gl provides a number of sample layers in the
-[examples directory](https://github.com/uber/deck.gl/tree/4.0-release/examples/sample-layers)
-intended to illustrate various ideas and approaches to how layers can be designed.
-These layers have documentation in their respective folders, but they are not
-listed here in the official documentation.
+deck.gl provides a number of sample layers in the [examples directory](https://github.com/uber/deck.gl/tree/4.1-release/examples/sample-layers) intended to illustrate various ideas and approaches to how layers can be designed. These layers have documentation in their respective folders, but they are not listed here in the official documentation.
 
 ## Layer Creation, Update and Destruction
 
-Every time some state in your application that affects visualization changes,
-you simply create new layer instances with updated properties and pass them to
-deck.gl for rendering.
+Every time some state in your application that affects visualization changes, you simply create new layer instances with updated properties and pass them to deck.gl for rendering.
 
-After matching your newly supplied layers with the layers you provided
-in your previous call to deck.gl, the state of any old layers is copied to
-the new layers, and the old layers are discarded by deck.gl.
+After matching your newly supplied layers with the layers you provided in your previous call to deck.gl, the state of any old layers is copied to the new layers, and the old layers are discarded by deck.gl.
 
-The application does not have to be aware about this, as long as it keeps
-rendering new layers with the same `id` they will be matched and the existing
-state of that layer will be updated accordingly
+The application does not have to be aware about this, as long as it keeps rendering new layers with the same `id` they will be matched and the existing state of that layer will be updated accordingly
 
-The constant creation and disposal of layer instances may seem wasteful,
-however the creation and recycling of JavaScript objects is quite efficient
-in modern JavaScript environments, and this is very similar to how React
-works where every render cycle generates a new tree of ReactElement instances,
-so the model is proven.
+The constant creation and disposal of layer instances may seem wasteful, however the creation and recycling of JavaScript objects is quite efficient in modern JavaScript environments, and this is very similar to how React works where every render cycle generates a new tree of ReactElement instances, so the model is proven.
 
 For more details, read about [Layer Lifecycle](/docs/advanced/layer-lifecycle.md).

--- a/docs/get-started/using-with-mapbox-gl.md
+++ b/docs/get-started/using-with-mapbox-gl.md
@@ -1,35 +1,18 @@
 # Using deck.gl with Mapbox GL
 
-While a deck.gl application could choose to render on top of any JavaScript
-Map component (or even render without an underlying map),
-deck.gl has been developed in parallel with
-the [react-map-gl](https://github.com/uber/react-map-gl) component,
-which is a React wrapper around mapbox-gl, and is the recommended companion
-to use deck.gl for most applications.
+While a deck.gl application could choose to render on top of any JavaScript Map component (or even render without an underlying map), deck.gl has been developed in parallel with the [react-map-gl](https://github.com/uber/react-map-gl) component, which is a React wrapper around mapbox-gl, and is the recommended companion to use deck.gl for most applications.
 
 ## About react-map-gl
 
-As shown in the [examples](https://github.com/uber/deck.gl/tree/4.0-release/examples/), the `DeckGL` React component works especially
-well as the child of a React component such as react-map-gl that displays
-a map using parameters similar to the deck.gl Viewport (i.e. latitude,
-longitude, zoom etc). In this configuration your deck.gl layers will
-render as a perfectly synchronized geospatial overlay over the underlying map.
+As shown in the [examples](https://github.com/uber/deck.gl/tree/4.1-release/examples/), the `DeckGL` React component works especially well as the child of a React component such as react-map-gl that displays a map using parameters similar to the deck.gl Viewport (i.e. latitude, longitude, zoom etc). In this configuration your deck.gl layers will render as a perfectly synchronized geospatial overlay over the underlying map.
 
 ## About Mapbox Tokens
 
-To show maps from a service such as Mapbox you will need to register with
-Mapbox and get a "token" that you need to provide to your map component.
-The map component will use the token to identify itself to the mapbox service
-which then will start serving up map tiles.
+To show maps from a service such as Mapbox you will need to register with Mapbox and get a "token" that you need to provide to your map component. The map component will use the token to identify itself to the mapbox service which then will start serving up map tiles.
 
-To get a token, you typically need to register (create an account)
-with the map data provider (mapbox), and apply for a token.
-The token will usually be free until a certain level of traffic is exceeded.
+To get a token, you typically need to register (create an account) with the map data provider (mapbox), and apply for a token. The token will usually be free until a certain level of traffic is exceeded.
 
-While the token will need to be hard-coded into your application in
-production, there are several ways to provide a token during development:
+While the token will need to be hard-coded into your application in production, there are several ways to provide a token during development:
 * Modify file to specify your Mapbox token,
-* Set an environment variable (MapboxAccessToken) - through the use of a
-  webpack loader or browserify transform, see the hello-world examples
-  for details.
+* Set an environment variable (MapboxAccessToken) - through the use of a webpack loader or browserify transform, see the hello-world examples for details.
 * Provide a token in the URL. See documentation of react-map-gl.

--- a/docs/layers/README.md
+++ b/docs/layers/README.md
@@ -4,46 +4,25 @@ The deck.gl layer catalog is organized into a couple of sections.
 
 ## Base Layer
 
-All deck.gl layers inherit from the
-[`Layer`](/docs/api-reference/base-layer.md) base class
-and its props are available to all layers unless otherwise documented.
+All deck.gl layers inherit from the [`Layer`](/docs/api-reference/base-layer.md) base class and its props are available to all layers unless otherwise documented.
 
 ## Core Layers
 
-The [Core Layers](/docs/layers/scatterplot-layer.md)
-are a group of geospatial visualization focused layers,
-intended to represent a small set of widely applicable data visualization
-building blocks.
+The [Core Layers](/docs/layers/scatterplot-layer.md) are a group of geospatial visualization focused layers, intended to represent a small set of widely applicable data visualization building blocks.
 
 The core layers are the most stable and supported deck.gl layers.
 
 Some notable features of the core deck.gl layers
 
-* **64-bit Mode**
-Most core Layers support a 64 bit mode that can be used
-to achieve higher precision, particularly under high zoom levels (> 1.000.000x)
-at the cost of sacrificing some performance and memory.
-Layers that have a 64 bit counterpart are marked with a "64-bit" tag.
-* **Extrusions**
-Some of the Core layers support extrusions and heights (aka "elevations")
-enabling applications to show a "2.5D" view of their data when using the map
-in perspective mode.
-The layers that support extrusions are marked with an "Extrusion" tag.
+* **64-bit Mode** Most core Layers support a 64 bit mode that can be used to achieve higher precision, particularly under high zoom levels (> 1.000.000x) at the cost of sacrificing some performance and memory. Layers that have a 64 bit counterpart are marked with a "64-bit" tag.
+* **Extrusions** Some of the Core layers support extrusions and heights (aka "elevations") enabling applications to show a "2.5D" view of their data when using the map in perspective mode. The layers that support extrusions are marked with an "Extrusion" tag.
 
 ## Deprecated Layers
 
-These are layers from an older releases that now have better counterparts.
-They should not be used in new applications as they may be removed in future
-deck.gl releases.
+These are layers from an older releases that now have better counterparts. They should not be used in new applications as they may be removed in future deck.gl releases.
 
 ## Sample Layers
 
-deck.gl provides a number of sample layers in the
-[examples folders](https://github.com/uber/deck.gl/tree/4.0-release/examples/sample-layers)
-intended to illustrate various ideas and approaches to how layers
-can be designed. These layers sometimes have documentation in the example
-code, but they are not listed here in the official documentation.
+deck.gl provides a number of sample layers in the [examples folders](https://github.com/uber/deck.gl/tree/4.1-release/examples/sample-layers) intended to illustrate various ideas and approaches to how layers can be designed. These layers sometimes have documentation in the example code, but they are not listed here in the official documentation.
 
-To use one of the sample layers an application simply needs to copy it into
-its own source tree. This is necessary because these layers are not
-included in the deck.gl distribution (i.e. they are not `export`ed by deck.gl).
+To use one of the sample layers an application simply needs to copy it into its own source tree. This is necessary because these layers are not included in the deck.gl distribution (i.e. they are not `export`ed by deck.gl).

--- a/docs/layers/arc-layer.md
+++ b/docs/layers/arc-layer.md
@@ -81,8 +81,8 @@ Method called to determine the rgba color of the source.
 * If the method does not return a value for the given object, fallback to `[0, 0, 255, 255]`.
 
 ## Source
-[src/layers/core/arc-layer](https://github.com/uber/deck.gl/tree/4.0-release/src/layers/core/arc-layer)
+[src/layers/core/arc-layer](https://github.com/uber/deck.gl/tree/4.1-release/src/layers/core/arc-layer)
 
-<a href="https://github.com/uber/deck.gl/tree/4.0-release/src/layers/core/arc-layer">
+<a href="https://github.com/uber/deck.gl/tree/4.1-release/src/layers/core/arc-layer">
 </a>
 

--- a/docs/layers/geojson-layer.md
+++ b/docs/layers/geojson-layer.md
@@ -196,5 +196,5 @@ Note: This accessor is only called for `Polygon` and `MultiPolygon` features.
   the color of that `Feature`.
 
 ## Source
-[src/layers/core/geojson-layer](https://github.com/uber/deck.gl/tree/4.0-release/src/layers/core/geojson-layer)
+[src/layers/core/geojson-layer](https://github.com/uber/deck.gl/tree/4.1-release/src/layers/core/geojson-layer)
 

--- a/docs/layers/grid-cell-layer.md
+++ b/docs/layers/grid-cell-layer.md
@@ -97,5 +97,5 @@ If the alpha is not provided, it will be set to `255`.
 
 ## Source
 
-[/src/layers/core/grid-cell-layer](https://github.com/uber/deck.gl/tree/4.0-release/src/layers/core/grid-cell-layer)
+[/src/layers/core/grid-cell-layer](https://github.com/uber/deck.gl/tree/4.1-release/src/layers/core/grid-cell-layer)
 

--- a/docs/layers/grid-layer.md
+++ b/docs/layers/grid-layer.md
@@ -163,6 +163,6 @@ Be aware that this prop will likely be changed in a future version of deck.gl.
 Method called to retrieve the position of each point.
 
 ## Source
-[src/layers/core/grid-layer](https://github.com/uber/deck.gl/tree/4.0-release/src/layers/core/grid-layer)
+[src/layers/core/grid-layer](https://github.com/uber/deck.gl/tree/4.1-release/src/layers/core/grid-layer)
 
 

--- a/docs/layers/hexagon-cell-layer.md
+++ b/docs/layers/hexagon-cell-layer.md
@@ -122,5 +122,5 @@ Method called to retrieve the elevation of each object. 1 unit approximate to 10
 
 ## Source
 
-[src/layers/core/hexagon-cell-layer](https://github.com/uber/deck.gl/tree/4.0-release/src/layers/core/hexagon-cell-layer)
+[src/layers/core/hexagon-cell-layer](https://github.com/uber/deck.gl/tree/4.1-release/src/layers/core/hexagon-cell-layer)
 

--- a/docs/layers/hexagon-layer.md
+++ b/docs/layers/hexagon-layer.md
@@ -182,4 +182,4 @@ Method called to retrieve the position of each point.
 
 ## Source
 
-[src/layers/core/hexagon-layer](https://github.com/uber/deck.gl/tree/4.0-release/src/layers/core/hexagon-layer)
+[src/layers/core/hexagon-layer](https://github.com/uber/deck.gl/tree/4.1-release/src/layers/core/hexagon-layer)

--- a/docs/layers/icon-layer.md
+++ b/docs/layers/icon-layer.md
@@ -107,5 +107,5 @@ Method called to retrieve the rotating angle (in degree) of each object, returns
 
 ## Source
 
-[src/layers/core/icon-layer](https://github.com/uber/deck.gl/tree/4.0-release/src/layers/core/icon-layer)
+[src/layers/core/icon-layer](https://github.com/uber/deck.gl/tree/4.1-release/src/layers/core/icon-layer)
 

--- a/docs/layers/line-layer.md
+++ b/docs/layers/line-layer.md
@@ -74,5 +74,5 @@ Method called to determine the rgba color of the source.
 
 ## Source
 
-[src/layers/core/line-layer](https://github.com/uber/deck.gl/tree/4.0-release/src/layers/core/line-layer)
+[src/layers/core/line-layer](https://github.com/uber/deck.gl/tree/4.1-release/src/layers/core/line-layer)
 

--- a/docs/layers/path-layer.md
+++ b/docs/layers/path-layer.md
@@ -108,5 +108,5 @@ Unit is meters.
 
 ## Source
 
-[src/layers/core/path-layer](https://github.com/uber/deck.gl/tree/4.0-release/src/layers/core/path-layer)
+[src/layers/core/path-layer](https://github.com/uber/deck.gl/tree/4.1-release/src/layers/core/path-layer)
 

--- a/docs/layers/point-cloud-layer.md
+++ b/docs/layers/point-cloud-layer.md
@@ -77,5 +77,5 @@ Method called to retrieve the rgba color of each object.
 `[0, 0, 0, 255]`.
 
 ## Source
-[src/layers/core/point-cloud-layer](https://github.com/uber/deck.gl/tree/4.0-release/src/layers/core/point-cloud-layer)
+[src/layers/core/point-cloud-layer](https://github.com/uber/deck.gl/tree/4.1-release/src/layers/core/point-cloud-layer)
 

--- a/docs/layers/polygon-layer.md
+++ b/docs/layers/polygon-layer.md
@@ -184,5 +184,5 @@ The width of the outline of the polygon, in meters
 
 ## Source
 
-[src/layers/core/polygon-layer](https://github.com/uber/deck.gl/tree/4.0-release/src/layers/core/polygon-layer)
+[src/layers/core/polygon-layer](https://github.com/uber/deck.gl/tree/4.1-release/src/layers/core/polygon-layer)
 

--- a/docs/layers/scatterplot-layer.md
+++ b/docs/layers/scatterplot-layer.md
@@ -93,5 +93,5 @@ Method called to retrieve the rgba color of each object.
 
 ## Source
 
-[src/layers/core/scatterplot-layer](https://github.com/uber/deck.gl/tree/4.0-release/src/layers/core/scatterplot-layer)
+[src/layers/core/scatterplot-layer](https://github.com/uber/deck.gl/tree/4.1-release/src/layers/core/scatterplot-layer)
 

--- a/docs/layers/screen-grid-layer.md
+++ b/docs/layers/screen-grid-layer.md
@@ -73,5 +73,5 @@ Method called to retrieve the weight of each object.
 
 ## Source
 
-[src/layers/core/screen-grid-layer](https://github.com/uber/deck.gl/tree/4.0-release/src/layers/core/screen-grid-layer)
+[src/layers/core/screen-grid-layer](https://github.com/uber/deck.gl/tree/4.1-release/src/layers/core/screen-grid-layer)
 

--- a/docs/layers/solid-polygon-layer.md
+++ b/docs/layers/solid-polygon-layer.md
@@ -99,5 +99,5 @@ otherwise will be in unit coordinates.
 
 ## Source
 
-[src/layers/core/primitive-polygon-layer](https://github.com/uber/deck.gl/tree/4.0-release/src/layers/core/primitive-polygon-layer)
+[src/layers/core/primitive-polygon-layer](https://github.com/uber/deck.gl/tree/4.1-release/src/layers/core/primitive-polygon-layer)
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -46,18 +46,14 @@ const model = new Model(gl, {
 
 ### Changed Import: The `DeckGL` React component
 
-A small but breaking change that will affect all applications is that the
-'deck.gl/react' import is no longer available. As of v4.0, the app is required
-to import deck.gl as follows:
+A small but breaking change that will affect all applications is that the 'deck.gl/react' import is no longer available. As of v4.0, the app is required to import deck.gl as follows:
 ```
 // V4
 import DeckGL from 'deck.gl';
 // V3
 import DeckGL from 'deck.gl/react';
 ```
-While it would have been preferable to avoid this change, a significant
-modernization of the deck.gl build process and preparations for "tree-shaking"
-support combined to make it impractical to keep supporting the old import style.
+While it would have been preferable to avoid this change, a significant modernization of the deck.gl build process and preparations for "tree-shaking" support combined to make it impractical to keep supporting the old import style.
 
 
 ### Deprecated/Removed Layers
@@ -71,23 +67,16 @@ support combined to make it impractical to keep supporting the old import style.
 
 * ChoroplethLayer, ChoroplethLayer64, ExtrudedChoroplethLayer
 
-These set of layers are deprecated in deck.gl v4, with their functionality
-completely substituted by more unified, flexible and performant new layers:
+These set of layers are deprecated in deck.gl v4, with their functionality completely substituted by more unified, flexible and performant new layers:
  `GeoJsonLayer`, `PolygonLayer` and `PathLayer`.
 
-Developers should be able to just supply the same geojson data that are used with
-`ChoroplethLayer`s to the new `GeoJsonLayer`. The props of the `GeoJsonLayer` are
-a bit different from the old `ChoroplethLayer`, so proper testing is recommended
-to achieve satisfactory result.
+Developers should be able to just supply the same geojson data that are used with `ChoroplethLayer`s to the new `GeoJsonLayer`. The props of the `GeoJsonLayer` are a bit different from the old `ChoroplethLayer`, so proper testing is recommended to achieve satisfactory result.
 
 * EnhancedChoroplethLayer
 
-This was a a sample layer in deck.gl v3 and has now been moved to a
-stand-alone example and is no longer exported from the deck.gl npm module.
+This was a a sample layer in deck.gl v3 and has now been moved to a stand-alone example and is no longer exported from the deck.gl npm module.
 
-Developers can either copy this layer from the example folder into their
-application's source tree, or consider using the new `PathLayer` which also
-handles wide lines albeit in a slightly different way.
+Developers can either copy this layer from the example folder into their application's source tree, or consider using the new `PathLayer` which also handles wide lines albeit in a slightly different way.
 
 
 ### Removed, Changed and Deprecated Layer Properties
@@ -103,56 +92,38 @@ handles wide lines albeit in a slightly different way.
 
 #### Note about `strokeWidth` props
 
-All line based layers (`LineLayer and `ArcLayer` and the `ScatterplotLayer`
-in outline mode) now use use shaders to render an exact pixel thickness
-on lines, instead of using the `GL.LINE` drawing mode.
+All line based layers (`LineLayer and `ArcLayer` and the `ScatterplotLayer` in outline mode) now use use shaders to render an exact pixel thickness on lines, instead of using the `GL.LINE` drawing mode.
 
-This particular change was caused by browsers dropping support for this feature
-([Chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=60124)
-and [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=634506)).
+This particular change was caused by browsers dropping support for this feature ([Chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=60124) and [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=634506)).
 
-Also `GL.LINE` mode rendering always had signficant limitations in terms of
-lack of support for mitering, unreliable support for anti-aliasing and
-platform dependent line width limits so this should represent an improvement
-in visual quality and consistency for these layers.
+Also `GL.LINE` mode rendering always had signficant limitations in terms of lack of support for mitering, unreliable support for anti-aliasing and platform dependent line width limits so this should represent an improvement in visual quality and consistency for these layers.
 
 #### Removed prop: `Layer.dataIterator`
 
-This prop has been removed in deck.gl v4. Note that it was not functioning
-as documented in deck.gl v3.
+This prop has been removed in deck.gl v4. Note that it was not functioning as documented in deck.gl v3.
 
 #### Renamed Props: The `...Scale` suffix
 
-Props that have their name end of `Scale` is a set of props that
-multiply some existing value for all objects in the layers.
-These props usually correspond to WebGL shader uniforms that "scaling" all
-values of specific attributes simultaneously.
+Props that have their name end of `Scale` is a set of props that multiply some existing value for all objects in the layers. These props usually correspond to WebGL shader uniforms that "scaling" all values of specific attributes simultaneously.
 
-For API consistency reasons these have all been renamed with the suffix `..Scale`.
-See the property table above.
+For API consistency reasons these have all been renamed with the suffix `..Scale`. See the property table above.
 
 #### Removed lifecycle method: `Layer.willReceiveProps`
 
-This lifecycle was deprecated in v3 and is now removed in v4.
-Use `Layer.updateState` instead.
+This lifecycle was deprecated in v3 and is now removed in v4. Use `Layer.updateState` instead.
 
 #### Changes to `updateTriggers`
 
-Update triggers can now be specified by referring to the name of the accessor,
-instead of the name of the actual WebGL attribute.
+Update triggers can now be specified by referring to the name of the accessor, instead of the name of the actual WebGL attribute.
 
-Note that this is supported on all layers supplied by deck.gl v4, but if you
-are using older layers, they need a small addition to their attribute
-definitions to specify the name of the accessor.
+Note that this is supported on all layers supplied by deck.gl v4, but if you are using older layers, they need a small addition to their attribute definitions to specify the name of the accessor.
 
 ### AttributeManager changes
 
 #### Removed method: `AttributeManager.setLogFunctions`
 
-Use the new static function `AttributeManager.setDefaultLogFunctions` to set
-loggers for all AttributeManagers (i.e. for all layers).
+Use the new static function `AttributeManager.setDefaultLogFunctions` to set loggers for all AttributeManagers (i.e. for all layers).
 
 #### Removed method: `AttributeManager.addDynamic`
 
-This method has been deprecated since version 2.5 and is now removed in v4.
-Use `AttributeManager.add()` instead.
+This method has been deprecated since version 2.5 and is now removed in v4. Use `AttributeManager.add()` instead.

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -2,30 +2,28 @@
 
 Release date: July 27th, 2017
 
-## WebGL2 support provided by luma.gl v4
+## WebGL2 Support provided by luma.gl v4
 
-While deck.gl v4.1 is not a backward-compatible minor release, its rendering functionality is backed by luma.gl v4, a WebGL2-enabled rendering framework. On all browsers that supports WebGL2, deck.gl will obtain WebGL2 context and utilize WebGL2 functionalities. To know more about WebGL2, please check [here](https://www.khronos.org/registry/webgl/specs/latest/2.0/).
+While the deck.gl v4.1 release is highly backward-compatible with 4.0, its rendering functionality is now backed by luma.gl v4, a WebGL2-enabled rendering framework. On all browsers that supports WebGL2 (e.g. recent Chrome and Firefox browsers), deck.gl will obtain WebGL2 context and utilize WebGL2 functionalities. To know more about WebGL2, please check [here](https://www.khronos.org/registry/webgl/specs/latest/2.0/).
 
 ## Query Methods
 
-Two new functions - `DeckGL.queryObject` and `DeckGL.queryVisibleObjects` allow developers to directly query the picking results, in addition to handling picking via built-in click and hover callbacks.
-
+Two new functions - `DeckGL.queryObject` and `DeckGL.queryVisibleObjects` allow developers to directly query the picking results, in addition to handling picking via built-in click and hover callbacks. This allows applications to build more advanced event handling and makes deck.gl easier to integrate with existing applications that have already implemented their own event handling.
 
 ## Shader Assembly
 
-For developers that write their own custome layers, the `shadertools` shader assembly system is now in place to replace the existing `assembleShaders` function in deck.gl. The new shader assemble system is integrated with luma.gl's [`Model`]() so users no longer need to call `assembleShaders` before creating the `Model` for the layer.
+For developers that write their own custome layers, the `shadertools` shader assembly system is now in place to replace the existing `assembleShaders` function in deck.gl. The new shader assembler system supports organizing shader codes into modules and is integrated with luma.gl's [`Model`]() so users no longer need to call `assembleShaders` before creating the `Model` for the layer.
 
 ## CompositeLayer
 
-Composite layers, which was introduced in v4.0, receive some polish and performance improvement. `CompositeLayer.renderLayers` function now returns a nested array that could contain `null` values and deck.gl will automatically flatten, filter and render all layers in the array. This is a small convenience that makes the `renderLayers methods in complex composite layers a little more readable.
+Composite layers, which were introduced in v4.0, have received some polish and performance improvements. `CompositeLayer.renderLayers` function now returns a nested array that could contain `null` values, and deck.gl will automatically flatten, filter and render all layers in the array. This is a small convenience that makes using the `renderLayers` methods in complex composite layers a little more readable. deck.gl now also avoids rerendering sublayers of `CompositeLayer` whose props haven't changed.
 
-## New examples
+## New Examples
 
-Several new examples are added to illustrate the wide applicability of deck.gl. To name a few:
-
+Several new examples have been added to illustrate the wide applicability of deck.gl. To name a few:
 * Wind visualization in US. This example is featured on [OpenVIS 2017 by @philogb](https://www.youtube.com/watch?v=KPiONdmNOuI). This example shows how new features in WebGL2 can be used to accelerate compute intensive tasks through GPU computing right in the browsers
 * Tagmap. This example by @rivulet-zhang shows some novel approching in placing and rendering text symbols in deck.gl
-* Point cloud example. The point cloud example shows how deck.gl could be used to render large amount of 3D point cloud data without any basemap context.
+* Point cloud example" The point cloud example shows how deck.gl could be used to render large amount of 3D point cloud data without any basemap context.
 * Node-link Graph. This is another example showing how deck.gl could be extended to the info-vis domain.
 
 
@@ -35,58 +33,38 @@ Release date: March 31, 2017
 
 ## Highlights
 
-- **New Geospatial Layers** GeoJsonLayer, PathLayer, PolygonLayer, IconLayer,
-  GridCellLayer, HexagonCellLayer, PointCloudLayer.
-- **New Aggregating Layers** GridLayer and HexagonLayer now join the ScreenGridLayer
-  in a growing family of layers that automatically "bin" your point data, in this
-  case into grid cells or hexagons.
-- **New Examples** deck.gl now provides multiple stand-alone examples, with minimal
-  configuration files (`package.json`, `webpack.config.js` etc) intended to make it
-  easy to just copy an example folder and get an app up and running in minutes.
+- **New Geospatial Layers** GeoJsonLayer, PathLayer, PolygonLayer, IconLayer, GridCellLayer, HexagonCellLayer, PointCloudLayer.
+- **New Aggregating Layers** GridLayer and HexagonLayer now join the ScreenGridLayer in a growing family of layers that automatically "bin" your point data, in this case into grid cells or hexagons.
+- **New Examples** deck.gl now provides multiple stand-alone examples, with minimal configuration files (`package.json`, `webpack.config.js` etc) intended to make it easy to just copy an example folder and get an app up and running in minutes.
 - **Unified 64-bit Layers** - 64-bit Layers are now unified with 32-bit layers, controlled via a new `fp64` prop.
-- **Library Size Reduction** - A number of npm package dependencies have been
-  trimmed from deck.gl, and the distribution has initial support for "tree-shaking"
-  bundlers like webpack2 and rollup.
-- **Performance** A number of improvements across the core library and layers
-   improves rendering and picking performance.
-- **Model Matrix Support** - Model matrix support for the `METER_OFFSET` projection mode
-  enables arbitrary coordinate transforms (translations, rotations, scaling etc)
-  to be applied on individual layer enabling scene graph like layer composition and animation.
+- **Library Size Reduction** - A number of npm package dependencies have been trimmed from deck.gl, and the distribution has initial support for "tree-shaking" bundlers like webpack2 and rollup.
+- **Performance** A number of improvements across the core library and layers improves rendering and picking performance.
+- **Model Matrix Support** - Model matrix support for the `METER_OFFSET` projection mode enables arbitrary coordinate transforms (translations, rotations, scaling etc) to be applied on individual layer enabling scene graph like layer composition and animation.
 - **Documentation** Improved and reorganized in response to user feedback.
-- **Experimental Features** Experimental support for non-Mercator projections and
-  rendering effects (e.g. Reflections)
+- **Experimental Features** Experimental support for non-Mercator projections and rendering effects (e.g. Reflections)
 
 ## New Layers
 
 ### GeoJsonLayer
 
-A layer that parses and renders GeoJson. Supports all GeoJson primitives
-(polygons, lines and points).
-The GeoJsonLayer is an example of a composite layer that instantiates other layers
-(in this case `PathLayer`, `PolygonLayer` and `ScatterplotLayer`) to do the actual
-rendering. This layer replaces the now deprecated family of `ChoroplethLayer`s.
+A layer that parses and renders GeoJson. Supports all GeoJson primitives (polygons, lines and points).
+The GeoJsonLayer is an example of a composite layer that instantiates other layers (in this case `PathLayer`, `PolygonLayer` and `ScatterplotLayer`) to do the actual rendering. This layer replaces the now deprecated family of `ChoroplethLayer`s.
 
 ### PathLayer
 
-Takes a sequence of coordinates and renders them as a thick line with
-mitered or rounded end caps.
+Takes a sequence of coordinates and renders them as a thick line with mitered or rounded end caps.
 
 ### PolygonLayer
 
-Each object in data is expected to provide a "closed" sequence of coordinates
-and renders them as a polygon, optionally extruded or in wireframe mode.
-Supports polygons with holes.
+Each object in data is expected to provide a "closed" sequence of coordinates and renders them as a polygon, optionally extruded or in wireframe mode. Supports polygons with holes.
 
 ### IconLayer
 
-Allows the user to provide a texture atlas and a JSON configuration specifying
-where icons are located in the atlas.
+Allows the user to provide a texture atlas and a JSON configuration specifying where icons are located in the atlas.
 
 ### GridLayer
 
-A layer that draws rectangular, optionally elevated cells. A typical grid based
-heatmap layer. Differs from the `ScreenGridLayer` in that the cells are in world
-coordinates and pre aggregated.
+A layer that draws rectangular, optionally elevated cells. A typical grid based heatmap layer. Differs from the `ScreenGridLayer` in that the cells are in world coordinates and pre aggregated.
 
 ### HexagonLayer
 
@@ -100,24 +78,17 @@ Draws a LiDAR point cloud. Supports point position/normal/color.
 
 ### Support for Per-Layer Model Matrix
 
-Each layer now supports a `modelMatrix` property that can be used to
-specify a local coordinate system for the data in that layer:
+Each layer now supports a `modelMatrix` property that can be used to specify a local coordinate system for the data in that layer:
 
-* Model matrices can dramatically simplify working with data in different
-  coordinate systems, as the data does not need to be pre-transformed into
-  a common coordinate system.
+* Model matrices can dramatically simplify working with data in different coordinate systems, as the data does not need to be pre-transformed into a common coordinate system.
 
-* Model matrices also enable interesting layer animation and composition
-  possibilities as individual layers can be scaled, rotated, translated etc
-  with very low computational cost (i.e. without modifying the data).
+* Model matrices also enable interesting layer animation and composition possibilities as individual layers can be scaled, rotated, translated etc with very low computational cost (i.e. without modifying the data).
 
 ### UpdateTriggers now accept Accessor Names
 
 `updateTriggers` now accept Accessor Names.
 
-The `updateTriggers` mechanism in deck.gl v3 required the user to know the
-name of the vertex attribute controlled by an accessor. It is now possible
-to supply names of `accessors`.
+The `updateTriggers` mechanism in deck.gl v3 required the user to know the name of the vertex attribute controlled by an accessor. It is now possible to supply names of `accessors`.
 
 ### More intuitive mouse events
 
@@ -128,103 +99,55 @@ to supply names of `accessors`.
 
 ### Overridable Shaders
 
-All layers now have a `getShaders` method that can
-be overriden by subclasses, enables reuse of all layer code while just
-replacing one or both shaders, often dramatically reducing the amount of
-code needed to add a small feature or change to en existing layers.
+All layers now have a `getShaders` method that can be overriden by subclasses, enables reuse of all layer code while just replacing one or both shaders, often dramatically reducing the amount of code needed to add a small feature or change to en existing layers.
 
 ## New Features for Layer Writers
 
 ### `defaultProps`
 
-Layers are now encouraged to define a `defaultProps`
-static member listing their props and default values, rather than programmatically
-declaring the props in constructor parameters etc. Using `defaultProps` means
-that many layer classes no longer need a constructor.
+Layers are now encouraged to define a `defaultProps` static member listing their props and default values, rather than programmatically declaring the props in constructor parameters etc. Using `defaultProps` means that many layer classes no longer need a constructor.
 
 ### AttributeManager now accepts new `accessor` field
 
-Can be a string or a an array of strings. Will be used to match
-`updateTriggers` accessor names with instance attributes.
+Can be a string or a an array of strings. Will be used to match `updateTriggers` accessor names with instance attributes.
 
 ### `getPickingInfo()`
 
-This method replaces the old `pick()` method and is expected to return an info
-object. Layers can block the execution of callback functions by returning `null`.
+This method replaces the old `pick()` method and is expected to return an info object. Layers can block the execution of callback functions by returning `null`.
 
 ## Performance
 
-A number of performance improvements and fixes have been gradually introduced
-since deck.gl v3.0 was launched. While many are not new in v4.0, cumulatively
-they enable noticeably better framerates and a lighter footprint when big data
-sets are loaded, compared to the initial v3.0.0 version.
+A number of performance improvements and fixes have been gradually introduced since deck.gl v3.0 was launched. While many are not new in v4.0, cumulatively they enable noticeably better framerates and a lighter footprint when big data sets are loaded, compared to the initial v3.0.0 version.
 
-The `AttributeManager` class now supports default logging of timings for attribute
-updates. This logging can be activated by simply setting `deck.log.priority=2`
-in the console (levels 1 and 2 provide different amounts of detail).
-This can be very helpful in verifying that your application is not triggering
-unnecessary attribute updates.
+The `AttributeManager` class now supports default logging of timings for attribute updates. This logging can be activated by simply setting `deck.log.priority=2` in the console (levels 1 and 2 provide different amounts of detail). This can be very helpful in verifying that your application is not triggering unnecessary attribute updates.
 
-In addition, the new function `AttributeManager.setDefaultLogFunctions` allows
-the app to install its own custom logging functions to take even more control
-over logging of attribute updates.
+In addition, the new function `AttributeManager.setDefaultLogFunctions` allows the app to install its own custom logging functions to take even more control over logging of attribute updates.
 
 ## Library Improvements
 
-JavaScript build tooling continues to evolve and efforts have
-been made to ensure deck.gl supports several popular new tooling setups:
+JavaScript build tooling continues to evolve and efforts have been made to ensure deck.gl supports several popular new tooling setups:
 
-* **Dependency Reduction** The number of npm dependencies (both in `deck.gl`,
-  `luma.gl` and `react-map-gl`) have been reduced considerably, meaning that
-  installing deck.gl and related modules will bring in less additional
-  JavaScript code into your app, and your app will build and run faster.
-* **Tree-shaking support**: deck.gl and related libraries now publish a "module"
-  entry point in package.json which points to a parallel distribution (`deck.gl/dist-es6`)
-  that preserves the `import` and `export` statements. This should allow tree
-  shaking bundlers such as webpack 2 and rollup to further reduce bundle size.
-* **Pure ES6 source code**: With few exceptions (e.g some JSX usage in examples),
-  the source code of deck.gl and related modules are now all restricted to
-  conformant ES6 (i.e. no ES2016 or ES2017, flow or similar syntax is used).
-  This means that the source code can run directly (ie. without transpilation)
-  in Node.js and modern browsers.
-  You could potentially import code directly from `deck.gl/src` to experiment with
-  this.
-* **Buble support** in examples. [Buble](https://buble.surge.sh/guide/) is a nice
-  alternative to babel if you have a simple app and don't need all the power of babel.
-  Many of the examples now use buble for faster and smaller builds.
+* **Dependency Reduction** The number of npm dependencies (both in `deck.gl`, `luma.gl` and `react-map-gl`) have been reduced considerably, meaning that installing deck.gl and related modules will bring in less additional JavaScript code into your app, and your app will build and run faster.
+* **Tree-shaking support**: deck.gl and related libraries now publish a "module" entry point in package.json which points to a parallel distribution (`deck.gl/dist-es6`) that preserves the `import` and `export` statements. This should allow tree shaking bundlers such as webpack 2 and rollup to further reduce bundle size.
+* **Pure ES6 source code**: With few exceptions (e.g some JSX usage in examples), the source code of deck.gl and related modules are now all restricted to conformant ES6 (i.e. no ES2016 or ES2017, flow or similar syntax is used). This means that the source code can run directly (ie. without transpilation) in Node.js and modern browsers. You could potentially import code directly from `deck.gl/src` to experiment with this.
+* **Buble support** in examples. [Buble](https://buble.surge.sh/guide/) is a nice alternative to babel if you have a simple app and don't need all the power of babel. Many of the examples now use buble for faster and smaller builds.
 
 ## Examples
 
 Code examples have been improved in several ways:
-* **Multiple Examples** deck.gl now provides multiple different examples in an
-  [examples folder](https://github.com/uber/deck.gl/tree/4.0-release/examples),
-  showing various interesting uses of deck.gl.
-* **Stand Alone Examples** Examples are now stand alone, each with its own
-  minimal `package.json` and configuration files, enabling them to be easily
-  copied and modified.
-* **Hello World Examples** Minimal examples for building with webpack 2
-  and browserify (previously called "exhibits") are still provided,
-  and have been further simplified.
-* **Layer Browser** The main `layer-browser` example has been expanded
-  into a full "layer and property browser" allowing for easy testing of layers.
+* **Multiple Examples** deck.gl now provides multiple different examples in an `examples` folder, showing various interesting uses of deck.gl.
+* **Stand Alone Examples** Examples are now stand alone, each with its own minimal `package.json` and configuration files, enabling them to be easily copied and modified.
+* **Hello World Examples** Minimal examples for building with webpack 2 and browserify (previously called "exhibits") are still provided, and have been further simplified.
+* **Layer Browser** The main `layer-browser` example has been expanded into a full "layer and property browser" allowing for easy testing of layers.
 
 ## Deprecations
 
-The various Choropleth layers have been deprecated since deck.gl has new and
-better layers (`GeoJsonLayer`, `PathLayer`, `PolygonLayer`) that fill the same
-roles. The choropleth layers are still available but will not be maintained
-beyond critical bug fixes and will likely be removed in the next major version
-of deck.gl.
+The various Choropleth layers have been deprecated since deck.gl has new and better layers (`GeoJsonLayer`, `PathLayer`, `PolygonLayer`) that fill the same roles. The choropleth layers are still available but will not be maintained beyond critical bug fixes and will likely be removed in the next major version of deck.gl.
 
 A careful API audit has also been done to align property names between old and
-new layers.
-While this will makes the layers more consistent and the combined API easier
-to learn and work with, it does mean that some properties have been renamed,
-with the old name being deprecated, and in some very few cases,
-default values have changed.
+new layers. While this will makes the layers more consistent and the combined API easier to learn and work with, it does mean that some properties have been renamed, with the old name being deprecated, and in some very few cases, default values have changed.
 
-For more information on deprecations and how to update your code in response
-to these changes, please consult the deck.gl [Upgrade Guide](/docs/get-started/upgrade-guide.md).
+For more information on deprecations and how to update your code in response to these changes, please consult the deck.gl [Upgrade Guide](/docs/get-started/upgrade-guide.md).
 
 # deck.gl v3.0
 
@@ -242,32 +165,18 @@ Release date: November, 2016
 
 ## React Integration
 
-- `DeckGL` (`DeckGLOverlay` in v2) component now requires a separate
-  import (`import DeckGL from 'deck.gl/react'`). This allows the core
-  deck.gl library to be imported by non-React applications without
-  pulling in React.
-- Adds `onLayerClick` and `onLayerHover` props to the `DeckGL` React
-  component.
-- The `DeckGL` component now cancels animation loop on unmount,
-  important when repeatedly creating/destroying deck.gl components.
-- The `DeckGL` component no longer manages WebGL blending modes,
-  as this is better done directly by layers.
+- `DeckGL` (`DeckGLOverlay` in v2) component now requires a separate import (`import DeckGL from 'deck.gl/react'`). This allows the core deck.gl library to be imported by non-React applications without pulling in React.
+- Adds `onLayerClick` and `onLayerHover` props to the `DeckGL` React component.
+- The `DeckGL` component now cancels animation loop on unmount, important when repeatedly creating/destroying deck.gl components.
+- The `DeckGL` component no longer manages WebGL blending modes, as this is better done directly by layers.
 
 ## Layers
 
-- All layers now support accessors, removing the need for applications to
-  transform data before passing it to deck.gl.
-- Layer props and accessors now always expect arrays (e.g. colors
-  are expected as `[r,g,b,a]` instead of `{r,g,b,a}` etc).
-- line widths now takes device pixel ratio into account for more consistent
-  look between displays
-- METERS projection mode allows specifying positions in meter offsets in
-  addition to longitude/latitude.
-- Layers now receive viewport information from the `DeckGL` component.
-  This implies that apps no longer need to pass the `width`, `height`,
-  `longitude`, `latitude`, `zoom`, `pitch`, `bearing` and `bearing`
-  props to each layer.
-  These properties only need to be passed to the `DeckGL` react component.
+- All layers now support accessors, removing the need for applications to transform data before passing it to deck.gl.
+- Layer props and accessors now always expect arrays (e.g. colors are expected as `[r,g,b,a]` instead of `{r,g,b,a}` etc).
+- line widths now takes device pixel ratio into account for more consistent look between displays
+- METERS projection mode allows specifying positions in meter offsets in addition to longitude/latitude.
+- Layers now receive viewport information from the `DeckGL` component. This implies that apps no longer need to pass the `width`, `height`, `longitude`, `latitude`, `zoom`, `pitch`, `bearing` and `bearing` props to each layer. These properties only need to be passed to the `DeckGL` react component.
 
 #### Base Layer
 
@@ -324,15 +233,12 @@ Sample layers now available through `import 'deck.gl/samples';
 
 ### Streamlined life cycle methods
 
-- The Layer life cycle methods are now optimized for deck.gl's needs
-  and no longer try to mimic React.
-- Limited compatibility with deck.gl v2 is provided but it is strongly
-  recommended to update layers to the new methods
+- The Layer life cycle methods are now optimized for deck.gl's needs and no longer try to mimic React.
+- Limited compatibility with deck.gl v2 is provided but it is strongly recommended to update layers to the new methods
 
 ### Optimizations
 
-- `Uint8Array` encoding is now supported for color and picking color
-   attributes, which provides significant GPU memory savings.
+- `Uint8Array` encoding is now supported for color and picking color attributes, which provides significant GPU memory savings.
 
 ### GLSL package manager and modules
 

--- a/website/contents/pages.js
+++ b/website/contents/pages.js
@@ -2,7 +2,7 @@ function getDocUrl(filename) {
   return `docs/${filename}`;
 }
 function getCodeUrl(pathname) {
-  return `https://github.com/uber/deck.gl/tree/4.0-release/${pathname}`;
+  return `https://github.com/uber/deck.gl/tree/4.1-release/${pathname}`;
 }
 
 // mapping from file path in source to generated page url


### PR DESCRIPTION
There are not many textual changes here, mostly structural updates and some edits due to proof reading. I'll land this without review but will be happy to address any comments post-facto.

There are a few new sections in the performance doc, if anything you may want to look at those.