### PR TITLE
Update core layers to use picking module

### DIFF
--- a/dev-docs/RFCs/auto-highlighting-rfc.md
+++ b/dev-docs/RFCs/auto-highlighting-rfc.md
@@ -32,18 +32,18 @@ Layer props:
 
 1. **pickable** {Boolean, default: false} : Indicates whether deck.gl performs picking [**Existing**]
 
-2. **selectedObjectIndex** {Int: default: -1} : [**Proposed**] - If set, the object (if any) at that index will be shown as selected. If the value doesn’t point to valid index, no object is selected.
+2. **highlightedObjectIndex** {Int: default: -1} : [**Proposed**] - If set, the object (if any) at that index will be shown as selected. If the value doesn’t point to valid index, no object is selected.
 
-3. **autoHighlight** {Boolean, default: false} : [**Proposed**] for now, this is a boolean value, indicating that deck.gl will automatically track the hovered over object. Note: This could be extended in future to specify ‘hover’ , ‘click’ etc events, for different types of tracking. **selectedObjectIndex** prop takes precedence when both **selectedObjectIndex**and **autoHighlight** are set to valid values.
+3. **autoHighlight** {Boolean, default: false} : [**Proposed**] for now, this is a boolean value, indicating that deck.gl will automatically track the hovered over object. Note: This could be extended in future to specify ‘hover’ , ‘click’ etc events, for different types of tracking. **highlightedObjectIndex** prop takes precedence when both **highlightedObjectIndex**and **autoHighlight** are set to valid values.
 
 4. **highlightColor **{vec4: default: transparent light-blue color [0, 0, 128, 128]} : [**Proposed**] - This indicates which color should be used to display the selected object, if any.
 
 
 This table describes what these prop values should be for above mentioned use cases:
-| Use case # | pickable | autoHighlight | selectedObjectIndex | highlightColor | Implementation notes |
+| Use case # | pickable | autoHighlight | highlightedObjectIndex | highlightColor | Implementation notes |
 |------------|----------|---------------|---------------------| -------------- |---------------------|
 |1           |true      |*              |*                    |*               |- Render to FBO and perform readPixels to obtain current object details.|
-|2           |*         |value ignored  |valid index value    |Vec4 or default color |- Retrieve objects picking color at ‘selectedObjectIndex’, pass it to picking shader module.|
+|2           |*         |value ignored  |valid index value    |Vec4 or default color |- Retrieve objects picking color at ‘highlightedObjectIndex’, pass it to picking shader module.|
 |3           |true      |true           |default (-1) or null |Vec4 or default color |- Render to FBO and perform readPixels to obtain current object details. Pass its picking color to picking shader module.|
 
 

--- a/docs/advanced/writing-shaders.md
+++ b/docs/advanced/writing-shaders.md
@@ -141,7 +141,10 @@ uniform.
 
 ### Picking uniforms
 
-##### `float renderPickingBuffer`
+##### `float renderPickingBuffer` (Deprecated)
+
+Note: This uniform is deprecated and will be removed in future releases.
+For picking functionality please refer to `picking` shader module.
 
 If you choose to implement picking through picking colors, make sure
 the `pickingColors` or `instancePickingColors` attribute is correctly set up,
@@ -161,11 +164,6 @@ gl_FragColor = mix(
 );
 ```
 
-##### `vec3 selectedPickingColor`
-
-This uniform is set if `props.pickable` is enabled on the layer and reflects the color
-of the last picked pixel. If no pixel is selected, the value will be `[0, 0, 0]`.
-
 ## Use With Other GLSL Code Assemblers
 
 Your code can be run through another GLSL code assembler like
@@ -174,4 +172,3 @@ before you pass it to `assembleShaders`. The `assembleShaders` function
 does **not** do any kind of syntax analysis so is not able to prevent naming conflicts
 when variable or function names from different modules. You can use multiple
 techniques to organize your shader code to fit your project needs.
-

--- a/docs/layers/hexagon-cell-layer.md
+++ b/docs/layers/hexagon-cell-layer.md
@@ -89,10 +89,6 @@ Whether to extrude hexagon. If se to false, all hexagons will be set to flat.
 
 Whether the layer should be rendered in high-precision 64-bit mode
 
-##### `selectedPickingColor` (Array, optional) **EXPERIMENTAL**
-
-Shader based highlighting of a selected object
-
 ##### `lightSettings` (Object, optional) **EXPERIMENTAL**
 
 This is an object that contains light settings for extruded polygons.

--- a/examples/sample-layers/enhanced-choropleth-layer/enhanced-choropleth-layer-vertex.glsl.js
+++ b/examples/sample-layers/enhanced-choropleth-layer/enhanced-choropleth-layer-vertex.glsl.js
@@ -27,7 +27,6 @@ attribute vec3 pickingColors;
 
 uniform float opacity;
 uniform float renderPickingBuffer;
-uniform vec3 selectedPickingColor;
 
 varying vec4 vColor;
 

--- a/src/layers/core/arc-layer/arc-layer-fragment.glsl.js
+++ b/src/layers/core/arc-layer/arc-layer-fragment.glsl.js
@@ -29,5 +29,11 @@ varying vec4 vColor;
 
 void main(void) {
   gl_FragColor = vColor;
+
+  // use highlight color if this fragment belongs to the selected object.
+  gl_FragColor = picking_filterHighlightColor(gl_FragColor);
+
+  // use picking color if rendering to picking FBO.
+  gl_FragColor = picking_filterPickingColor(gl_FragColor);
 }
 `;

--- a/src/layers/core/arc-layer/arc-layer-vertex-64.glsl.js
+++ b/src/layers/core/arc-layer/arc-layer-vertex-64.glsl.js
@@ -34,7 +34,6 @@ uniform float numSegments;
 uniform vec2 viewportSize;
 uniform float strokeWidth;
 uniform float opacity;
-uniform float renderPickingBuffer;
 
 varying vec4 vColor;
 
@@ -125,11 +124,9 @@ void main(void) {
   gl_Position = curr_pos_clipspace + vec4(offset, 0.0, 0.0);
 
   vec4 color = mix(instanceSourceColors, instanceTargetColors, segmentRatio) / 255.;
+  vColor = vec4(color.rgb, color.a * opacity);
 
-  vColor = mix(
-    vec4(color.rgb, color.a * opacity),
-    vec4(instancePickingColors / 255., 1.),
-    renderPickingBuffer
-  );
+  // Set color to be rendered to picking fbo (also used to check for selection highlight).
+  picking_setPickingColor(instancePickingColors);
 }
 `;

--- a/src/layers/core/arc-layer/arc-layer-vertex.glsl.js
+++ b/src/layers/core/arc-layer/arc-layer-vertex.glsl.js
@@ -31,7 +31,6 @@ uniform float numSegments;
 uniform vec2 viewportSize;
 uniform float strokeWidth;
 uniform float opacity;
-uniform float renderPickingBuffer;
 
 varying vec4 vColor;
 
@@ -93,11 +92,9 @@ void main(void) {
   gl_Position = curr + vec4(offset, 0.0, 0.0);
 
   vec4 color = mix(instanceSourceColors, instanceTargetColors, segmentRatio) / 255.;
+  vColor = vec4(color.rgb, color.a * opacity);
 
-  vColor = mix(
-    vec4(color.rgb, color.a * opacity),
-    vec4(instancePickingColors / 255., 1.),
-    renderPickingBuffer
-  );
+  // Set color to be rendered to picking fbo (also used to check for selection highlight).
+  picking_setPickingColor(instancePickingColors);
 }
 `;

--- a/src/layers/core/arc-layer/arc-layer.js
+++ b/src/layers/core/arc-layer/arc-layer.js
@@ -42,8 +42,8 @@ const defaultProps = {
 export default class ArcLayer extends Layer {
   getShaders() {
     return enable64bitSupport(this.props) ?
-      {vs: vs64, fs, modules: ['project64']} :
-      {vs, fs}; // 'project' module added by default.
+      {vs: vs64, fs, modules: ['project64', 'picking']} :
+      {vs, fs, modules: ['picking']}; // 'project' module added by default.
   }
 
   initializeState() {

--- a/src/layers/core/geojson-layer/geojson-layer.js
+++ b/src/layers/core/geojson-layer/geojson-layer.js
@@ -111,7 +111,8 @@ export default class GeoJsonLayer extends CompositeLayer {
       getLineWidth, getElevation, updateTriggers} = this.props;
 
     // base layer props
-    const {opacity, pickable, visible, getPolygonOffset} = this.props;
+    const {opacity, pickable, visible, getPolygonOffset,
+    highlightedObjectIndex, autoHighlight, highlightColor} = this.props;
 
     // viewport props
     const {positionOrigin, projectionMode, modelMatrix} = this.props;
@@ -141,6 +142,9 @@ export default class GeoJsonLayer extends CompositeLayer {
         getPolygon: getCoordinates,
         getElevation,
         getColor: getFillColor,
+        highlightedObjectIndex,
+        autoHighlight,
+        highlightColor,
         updateTriggers: {
           getElevation: updateTriggers.getElevation,
           getColor: updateTriggers.getFillColor
@@ -219,6 +223,9 @@ export default class GeoJsonLayer extends CompositeLayer {
       getPath: getCoordinates,
       getColor: getLineColor,
       getWidth: getLineWidth,
+      highlightedObjectIndex,
+      autoHighlight,
+      highlightColor,
       updateTriggers: {
         getColor: updateTriggers.getLineColor,
         getWidth: updateTriggers.getLineWidth
@@ -242,6 +249,9 @@ export default class GeoJsonLayer extends CompositeLayer {
       getPosition: getCoordinates,
       getColor: getFillColor,
       getRadius,
+      highlightedObjectIndex,
+      autoHighlight,
+      highlightColor,
       updateTriggers: {
         getColor: updateTriggers.getFillColor,
         getRadius: updateTriggers.getRadius

--- a/src/layers/core/grid-cell-layer/grid-cell-layer-fragment.glsl.js
+++ b/src/layers/core/grid-cell-layer/grid-cell-layer-fragment.glsl.js
@@ -29,5 +29,11 @@ varying vec4 vColor;
 
 void main(void) {
   gl_FragColor = vColor;
+
+  // use highlight color if this fragment belongs to the selected object.
+  gl_FragColor = picking_filterHighlightColor(gl_FragColor);
+
+  // use picking color if rendering to picking FBO.
+  gl_FragColor = picking_filterPickingColor(gl_FragColor);
 }
 `;

--- a/src/layers/core/grid-cell-layer/grid-cell-layer.js
+++ b/src/layers/core/grid-cell-layer/grid-cell-layer.js
@@ -67,8 +67,8 @@ export default class GridCellLayer extends Layer {
   getShaders() {
     const {shaderCache} = this.context;
     return enable64bitSupport(this.props) ?
-      {vs: vs64, fs, modules: ['project64', 'lighting'], shaderCache} :
-      {vs, fs, modules: ['lighting'], shaderCache};  // 'project' module added by default.
+      {vs: vs64, fs, modules: ['project64', 'lighting', 'picking'], shaderCache} :
+      {vs, fs, modules: ['lighting', 'picking'], shaderCache}; // 'project' module added by default.
   }
 
   initializeState() {

--- a/src/layers/core/grid-layer/grid-layer.js
+++ b/src/layers/core/grid-layer/grid-layer.js
@@ -172,7 +172,8 @@ export default class GridLayer extends CompositeLayer {
     const {id, elevationScale, fp64, extruded, cellSize, coverage, lightSettings} = this.props;
 
     // base layer props
-    const {opacity, pickable, visible, getPolygonOffset} = this.props;
+    const {opacity, pickable, visible, getPolygonOffset,
+    highlightedObjectIndex, autoHighlight, highlightColor} = this.props;
 
     // viewport props
     const {positionOrigin, projectionMode, modelMatrix} = this.props;
@@ -194,6 +195,9 @@ export default class GridLayer extends CompositeLayer {
       projectionMode,
       positionOrigin,
       modelMatrix,
+      highlightedObjectIndex,
+      autoHighlight,
+      highlightColor,
       getColor: this._onGetSublayerColor.bind(this),
       getElevation: this._onGetSublayerElevation.bind(this),
       getPosition: d => d.position,

--- a/src/layers/core/hexagon-cell-layer/hexagon-cell-layer-fragment.glsl.js
+++ b/src/layers/core/hexagon-cell-layer/hexagon-cell-layer-fragment.glsl.js
@@ -29,5 +29,11 @@ varying vec4 vColor;
 
 void main(void) {
   gl_FragColor = vColor;
+
+  // use highlight color if this fragment belongs to the selected object.
+  gl_FragColor = picking_filterHighlightColor(gl_FragColor);
+
+  // use picking color if rendering to picking FBO.
+  gl_FragColor = picking_filterPickingColor(gl_FragColor);
 }
 `;

--- a/src/layers/core/hexagon-cell-layer/hexagon-cell-layer-vertex.glsl.js
+++ b/src/layers/core/hexagon-cell-layer/hexagon-cell-layer-vertex.glsl.js
@@ -29,11 +29,6 @@ attribute vec3 instancePositions;
 attribute vec4 instanceColors;
 attribute vec3 instancePickingColors;
 
-// Picking uniforms
-// Set to 1.0 if rendering picking buffer, 0.0 if rendering for display
-uniform float renderPickingBuffer;
-uniform vec3 selectedPickingColor;
-
 // Custom uniforms
 uniform float opacity;
 uniform float radius;
@@ -47,13 +42,6 @@ varying vec4 vColor;
 
 // A magic number to scale elevation so that 1 unit approximate to 1 meter.
 #define ELEVATION_SCALE 0.8
-
-// whether is point picked
-float isPicked(vec3 pickingColors, vec3 selectedColor) {
- return float(pickingColors.x == selectedColor.x
- && pickingColors.y == selectedColor.y
- && pickingColors.z == selectedColor.z);
-}
 
 void main(void) {
 
@@ -84,39 +72,26 @@ void main(void) {
 
   gl_Position = project_to_clipspace(position_worldspace);
 
-  // render display
-  if (renderPickingBuffer < 0.5) {
+  // Light calculations
+  // Worldspace is the linear space after Mercator projection
 
-    // TODO: we should allow the user to specify the color for "selected element"
-    // check whether hexagon is currently picked.
-    float selected = isPicked(instancePickingColors, selectedPickingColor);
+  vec3 normals_worldspace = rotatedNormals;
 
-    // Light calculations
-    // Worldspace is the linear space after Mercator projection
+  float lightWeight = 1.0;
 
-    vec3 normals_worldspace = rotatedNormals;
-
-    float lightWeight = 1.0;
-
-    if (extruded > 0.5) {
-      lightWeight = getLightWeight(
-        position_worldspace.xyz, // the w component is always 1.0
-        normals_worldspace
-      );
-    }
-
-    vec3 lightWeightedColor = lightWeight * instanceColors.rgb;
-
-    // Color: Either opacity-multiplied instance color, or picking color
-    vec4 color = vec4(lightWeightedColor, opacity * instanceColors.a) / 255.0;
-
-    vColor = color;
-
-  } else {
-
-    vec4 pickingColor = vec4(instancePickingColors / 255.0, 1.0);
-    vColor = pickingColor;
-
+  if (extruded > 0.5) {
+    lightWeight = getLightWeight(
+      position_worldspace.xyz, // the w component is always 1.0
+      normals_worldspace
+    );
   }
+
+  vec3 lightWeightedColor = lightWeight * instanceColors.rgb;
+
+  // opacity-multiplied instance color
+  vColor = vec4(lightWeightedColor, opacity * instanceColors.a) / 255.0;
+
+  // Set color to be rendered to picking fbo (also used to check for selection highlight).
+  picking_setPickingColor(instancePickingColors);
 }
 `;

--- a/src/layers/core/hexagon-cell-layer/hexagon-cell-layer.js
+++ b/src/layers/core/hexagon-cell-layer/hexagon-cell-layer.js
@@ -80,8 +80,8 @@ export default class HexagonCellLayer extends Layer {
 
   getShaders() {
     return enable64bitSupport(this.props) ?
-      {vs: vs64, fs, modules: ['project64', 'lighting']} :
-      {vs, fs, modules: ['lighting']}; // 'project' module added by default.
+      {vs: vs64, fs, modules: ['project64', 'lighting', 'picking']} :
+      {vs, fs, modules: ['lighting', 'picking']}; // 'project' module added by default.
   }
 
   /**

--- a/src/layers/core/hexagon-layer/hexagon-layer.js
+++ b/src/layers/core/hexagon-layer/hexagon-layer.js
@@ -215,7 +215,8 @@ export default class HexagonLayer extends CompositeLayer {
     const {id, radius, elevationScale, extruded, coverage, lightSettings, fp64} = this.props;
 
     // base layer props
-    const {opacity, pickable, visible, getPolygonOffset} = this.props;
+    const {opacity, pickable, visible, getPolygonOffset,
+    highlightedObjectIndex, autoHighlight, highlightColor} = this.props;
 
     // viewport props
     const {positionOrigin, projectionMode, modelMatrix} = this.props;
@@ -239,6 +240,9 @@ export default class HexagonLayer extends CompositeLayer {
       projectionMode,
       positionOrigin,
       modelMatrix,
+      highlightedObjectIndex,
+      autoHighlight,
+      highlightColor,
       getColor: this._onGetSublayerColor.bind(this),
       getElevation: this._onGetSublayerElevation.bind(this),
       updateTriggers: this.getUpdateTriggers()

--- a/src/layers/core/icon-layer/icon-layer-fragment.glsl.js
+++ b/src/layers/core/icon-layer/icon-layer-fragment.glsl.js
@@ -26,7 +26,6 @@ precision highp float;
 #endif
 
 uniform float opacity;
-uniform float renderPickingBuffer;
 uniform sampler2D iconsTexture;
 
 varying float vColorMode;
@@ -40,19 +39,19 @@ void main(void) {
 
   // if colorMode == 0, use pixel color from the texture
   // if colorMode == 1 or rendering picking buffer, use texture as transparency mask
-  vec3 color = mix(texColor.rgb, vColor.rgb,
-    max(vColorMode, renderPickingBuffer)
-  );
+  vec3 color = mix(texColor.rgb, vColor.rgb, vColorMode);
   float a = texColor.a * opacity * mix(1.0, vColor.a, vColorMode);
 
   if (a < MIN_ALPHA) {
     discard;
   }
 
-  // if rendering to screen, use mixed alpha
-  // if rendering picking buffer, use binary alpha
-  a = mix(a, 1.0, renderPickingBuffer);
-
   gl_FragColor = vec4(color, a);
+
+  // use highlight color if this fragment belongs to the selected object.
+  gl_FragColor = picking_filterHighlightColor(gl_FragColor);
+
+  // use picking color if rendering to picking FBO.
+  gl_FragColor = picking_filterPickingColor(gl_FragColor);
 }
 `;

--- a/src/layers/core/icon-layer/icon-layer-vertex-64.glsl.js
+++ b/src/layers/core/icon-layer/icon-layer-vertex-64.glsl.js
@@ -35,7 +35,6 @@ attribute vec2 instanceOffsets;
 
 uniform vec2 viewportSize;
 uniform float sizeScale;
-uniform float renderPickingBuffer;
 uniform vec2 iconsTextureDim;
 
 varying float vColorMode;
@@ -86,10 +85,11 @@ void main(void) {
 
   vTextureCoords.y = 1.0 - vTextureCoords.y;
 
-  vec4 color = instanceColors / 255.;
-  vec4 pickingColor = vec4(instancePickingColors / 255., 1.);
-  vColor = mix(color, pickingColor, renderPickingBuffer);
+  vColor = instanceColors / 255.;
 
   vColorMode = instanceColorModes;
+
+  // Set color to be rendered to picking fbo (also used to check for selection highlight).
+  picking_setPickingColor(instancePickingColors);
 }
 `;

--- a/src/layers/core/icon-layer/icon-layer-vertex.glsl.js
+++ b/src/layers/core/icon-layer/icon-layer-vertex.glsl.js
@@ -34,7 +34,6 @@ attribute vec2 instanceOffsets;
 
 uniform vec2 viewportSize;
 uniform float sizeScale;
-uniform float renderPickingBuffer;
 uniform vec2 iconsTextureDim;
 
 varying float vColorMode;
@@ -70,10 +69,11 @@ void main(void) {
 
   vTextureCoords.y = 1.0 - vTextureCoords.y;
 
-  vec4 color = instanceColors / 255.;
-  vec4 pickingColor = vec4(instancePickingColors / 255., 1.);
-  vColor = mix(color, pickingColor, renderPickingBuffer);
+  vColor = instanceColors / 255.;
 
   vColorMode = instanceColorModes;
+
+  // Set color to be rendered to picking fbo (also used to check for selection highlight).
+  picking_setPickingColor(instancePickingColors);
 }
 `;

--- a/src/layers/core/icon-layer/icon-layer.js
+++ b/src/layers/core/icon-layer/icon-layer.js
@@ -67,8 +67,8 @@ const defaultProps = {
 export default class IconLayer extends Layer {
   getShaders() {
     return enable64bitSupport(this.props) ?
-      {vs: vs64, fs, modules: ['project64']} :
-      {vs, fs};  // 'project' module added by default.
+      {vs: vs64, fs, modules: ['project64', 'picking']} :
+      {vs, fs, modules: ['picking']};  // 'project' module added by default.
   }
 
   initializeState() {

--- a/src/layers/core/line-layer/line-layer-fragment.glsl.js
+++ b/src/layers/core/line-layer/line-layer-fragment.glsl.js
@@ -29,5 +29,11 @@ varying vec4 vColor;
 
 void main(void) {
   gl_FragColor = vColor;
+
+  // use highlight color if this fragment belongs to the selected object.
+  gl_FragColor = picking_filterHighlightColor(gl_FragColor);
+
+  // use picking color if rendering to picking FBO.
+  gl_FragColor = picking_filterPickingColor(gl_FragColor);
 }
 `;

--- a/src/layers/core/line-layer/line-layer-vertex-64.glsl.js
+++ b/src/layers/core/line-layer/line-layer-vertex-64.glsl.js
@@ -31,7 +31,6 @@ attribute vec3 instancePickingColors;
 uniform vec2 viewportSize;
 uniform float strokeWidth;
 uniform float opacity;
-uniform float renderPickingBuffer;
 
 varying vec4 vColor;
 
@@ -89,13 +88,9 @@ void main(void) {
   gl_Position = p + vec4(offset, 0.0, 0.0);
 
   // Color
-  vec4 color = vec4(instanceColors.rgb, instanceColors.a * opacity) / 255.;
-  vec4 pickingColor = vec4(instancePickingColors / 255., 1.);
+  vColor = vec4(instanceColors.rgb, instanceColors.a * opacity) / 255.;
 
-  vColor = mix(
-    color,
-    pickingColor,
-    renderPickingBuffer
-  );
+  // Set color to be rendered to picking fbo (also used to check for selection highlight).
+  picking_setPickingColor(instancePickingColors);
 }
 `;

--- a/src/layers/core/line-layer/line-layer-vertex.glsl.js
+++ b/src/layers/core/line-layer/line-layer-vertex.glsl.js
@@ -30,7 +30,6 @@ attribute vec3 instancePickingColors;
 uniform vec2 viewportSize;
 uniform float strokeWidth;
 uniform float opacity;
-uniform float renderPickingBuffer;
 
 varying vec4 vColor;
 
@@ -64,12 +63,9 @@ void main(void) {
   gl_Position = p + vec4(offset, 0.0, 0.0);
 
   // Color
-  vec4 color = vec4(instanceColors.rgb, instanceColors.a * opacity) / 255.;
-  vec4 pickingColor = vec4(instancePickingColors / 255., 1.);
-  vColor = mix(
-    color,
-    pickingColor,
-    renderPickingBuffer
-  );
+  vColor = vec4(instanceColors.rgb, instanceColors.a * opacity) / 255.;
+
+  // Set color to be rendered to picking fbo (also used to check for selection highlight).
+  picking_setPickingColor(instancePickingColors);
 }
 `;

--- a/src/layers/core/line-layer/line-layer.js
+++ b/src/layers/core/line-layer/line-layer.js
@@ -41,8 +41,8 @@ const defaultProps = {
 export default class LineLayer extends Layer {
   getShaders() {
     return enable64bitSupport(this.props) ?
-      {vs: vs64, fs, modules: ['project64']} :
-      {vs, fs}; // 'project' module added by default.
+      {vs: vs64, fs, modules: ['project64', 'picking']} :
+      {vs, fs, modules: ['picking']}; // 'project' module added by default.
   }
 
   initializeState() {

--- a/src/layers/core/path-layer/path-layer-vertex-64.glsl.js
+++ b/src/layers/core/path-layer/path-layer-vertex-64.glsl.js
@@ -40,7 +40,6 @@ uniform float jointType;
 uniform float miterLimit;
 
 uniform float opacity;
-uniform float renderPickingBuffer;
 
 varying vec4 vColor;
 varying vec2 vCornerOffset;
@@ -168,9 +167,10 @@ vec3 lineJoin(vec2 prevPoint64[2], vec2 currPoint64[2], vec2 nextPoint64[2]) {
 }
 
 void main() {
-  vec4 color = vec4(instanceColors.rgb, instanceColors.a * opacity) / 255.;
-  vec4 pickingColor = vec4(instancePickingColors, 255.) / 255.;
-  vColor = mix(color, pickingColor, renderPickingBuffer);
+  vColor = vec4(instanceColors.rgb, instanceColors.a * opacity) / 255.;
+
+  // Set color to be rendered to picking fbo (also used to check for selection highlight).
+  picking_setPickingColor(instancePickingColors);
 
   float isEnd = positions.x;
 

--- a/src/layers/core/path-layer/path-layer-vertex.glsl.js
+++ b/src/layers/core/path-layer/path-layer-vertex.glsl.js
@@ -38,7 +38,6 @@ uniform float jointType;
 uniform float miterLimit;
 
 uniform float opacity;
-uniform float renderPickingBuffer;
 
 varying vec4 vColor;
 varying vec2 vCornerOffset;
@@ -155,9 +154,10 @@ vec3 lineJoin(vec3 prevPoint, vec3 currPoint, vec3 nextPoint) {
 }
 
 void main() {
-  vec4 color = vec4(instanceColors.rgb, instanceColors.a * opacity) / 255.;
-  vec4 pickingColor = vec4(instancePickingColors, 255.) / 255.;
-  vColor = mix(color, pickingColor, renderPickingBuffer);
+  vColor = vec4(instanceColors.rgb, instanceColors.a * opacity) / 255.;
+
+  // Set color to be rendered to picking fbo (also used to check for selection highlight).
+  picking_setPickingColor(instancePickingColors);
 
   float isEnd = positions.x;
 
@@ -175,8 +175,5 @@ void main() {
   pos = lineJoin(prevPosition, currPosition, nextPosition);
 
   gl_Position = project_to_clipspace(vec4(pos, 1.0));
-
-  // Set color to be rendered to picking fbo (also used to check for selection highlight).
-  picking_setPickingColor(instancePickingColors);
 }
 `;

--- a/src/layers/core/point-cloud-layer/point-cloud-layer-fragment.glsl.js
+++ b/src/layers/core/point-cloud-layer/point-cloud-layer-fragment.glsl.js
@@ -32,10 +32,16 @@ void main(void) {
 
   float distToCenter = length(unitPosition);
 
-  if (distToCenter <= 1.0) {
-    gl_FragColor = vColor;
-  } else {
+  if (distToCenter > 1.0) {
     discard;
   }
+
+  gl_FragColor = vColor;
+
+  // use highlight color if this fragment belongs to the selected object.
+  gl_FragColor = picking_filterHighlightColor(gl_FragColor);
+
+  // use picking color if rendering to picking FBO.
+  gl_FragColor = picking_filterPickingColor(gl_FragColor);
 }
 `;

--- a/src/layers/core/point-cloud-layer/point-cloud-layer-vertex-64.glsl.js
+++ b/src/layers/core/point-cloud-layer/point-cloud-layer-vertex-64.glsl.js
@@ -29,7 +29,6 @@ attribute vec3 instanceNormals;
 attribute vec4 instanceColors;
 attribute vec3 instancePickingColors;
 
-uniform float renderPickingBuffer;
 uniform float opacity;
 uniform float radiusPixels;
 uniform vec2 screenSize;
@@ -64,15 +63,14 @@ void main(void) {
     projected_coord_xy[0].x, projected_coord_xy[1].x,
     project_scale(instancePositions.z), 1.0);
 
-  if (renderPickingBuffer > 0.5) {
-    vColor = vec4(instancePickingColors / 255., 1.);
-  } else {
-    // Apply lighting
-    float lightWeight = getLightWeight(position_worldspace.xyz, // the w component is always 1.0
-      instanceNormals);
+  // Apply lighting
+  float lightWeight = getLightWeight(position_worldspace.xyz, // the w component is always 1.0
+    instanceNormals);
 
-    // Apply opacity to instance color, or return instance picking color
-    vColor = vec4(lightWeight * instanceColors.rgb, instanceColors.a * opacity) / 255.;
-  }
+  // Apply opacity to instance color, or return instance picking color
+  vColor = vec4(lightWeight * instanceColors.rgb, instanceColors.a * opacity) / 255.;
+
+  // Set color to be rendered to picking fbo (also used to check for selection highlight).
+  picking_setPickingColor(instancePickingColors);
 }
 `;

--- a/src/layers/core/point-cloud-layer/point-cloud-layer-vertex.glsl.js
+++ b/src/layers/core/point-cloud-layer/point-cloud-layer-vertex.glsl.js
@@ -28,7 +28,6 @@ attribute vec3 instanceNormals;
 attribute vec4 instanceColors;
 attribute vec3 instancePickingColors;
 
-uniform float renderPickingBuffer;
 uniform float opacity;
 uniform float radiusPixels;
 uniform vec2 viewportSize;
@@ -50,8 +49,9 @@ void main(void) {
     instanceNormals);
 
   // Apply opacity to instance color, or return instance picking color
-  vec4 color = vec4(lightWeight * instanceColors.rgb, instanceColors.a * opacity) / 255.;
-  vec4 pickingColor = vec4(instancePickingColors / 255., 1.);
-  vColor = mix(color, pickingColor, renderPickingBuffer);
+  vColor = vec4(lightWeight * instanceColors.rgb, instanceColors.a * opacity) / 255.;
+
+  // Set color to be rendered to picking fbo (also used to check for selection highlight).
+  picking_setPickingColor(instancePickingColors);
 }
 `;

--- a/src/layers/core/point-cloud-layer/point-cloud-layer.js
+++ b/src/layers/core/point-cloud-layer/point-cloud-layer.js
@@ -51,8 +51,8 @@ export default class PointCloudLayer extends Layer {
   getShaders(id) {
     const {shaderCache} = this.context;
     return enable64bitSupport(this.props) ?
-      {vs: vs64, fs, modules: ['project64', 'lighting'], shaderCache} :
-      {vs, fs, modules: ['lighting'], shaderCache}; // 'project' module added by default.
+      {vs: vs64, fs, modules: ['project64', 'lighting', 'picking'], shaderCache} :
+      {vs, fs, modules: ['lighting', 'picking'], shaderCache}; // 'project' module added by default.
   }
 
   initializeState() {

--- a/src/layers/core/polygon-layer/polygon-layer.js
+++ b/src/layers/core/polygon-layer/polygon-layer.js
@@ -101,7 +101,8 @@ export default class PolygonLayer extends CompositeLayer {
       getPolygon, updateTriggers, lightSettings} = this.props;
 
     // base layer props
-    const {opacity, pickable, visible, getPolygonOffset} = this.props;
+    const {opacity, pickable, visible, getPolygonOffset,
+    highlightedObjectIndex, autoHighlight, highlightColor} = this.props;
 
     // viewport props
     const {positionOrigin, projectionMode, modelMatrix} = this.props;
@@ -127,6 +128,9 @@ export default class PolygonLayer extends CompositeLayer {
       getPolygon,
       getElevation,
       getColor: getFillColor,
+      highlightedObjectIndex,
+      autoHighlight,
+      highlightColor,
       updateTriggers: {
         getElevation: updateTriggers.getElevation,
         getColor: updateTriggers.getFillColor

--- a/src/layers/core/scatterplot-layer/scatterplot-layer-vertex-64.glsl.js
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer-vertex-64.glsl.js
@@ -34,7 +34,6 @@ uniform float opacity;
 uniform float radiusScale;
 uniform float radiusMinPixels;
 uniform float radiusMaxPixels;
-uniform float renderPickingBuffer;
 uniform float outline;
 uniform float strokeWidth;
 
@@ -77,14 +76,9 @@ void main(void) {
 
   gl_Position = project_to_clipspace_fp64(vertex_pos_modelspace);
 
-  if (renderPickingBuffer > 0.5) {
-    vColor = vec4(instancePickingColors / 255., 1.);
-  } else {
-    vColor = vec4(instanceColors.rgb, instanceColors.a * opacity) / 255.;
-  }
-  // // Apply opacity to instance color, or return instance picking color
-  // vec4 color = vec4(instanceColors.rgb, instanceColors.a * opacity) / 255.;
-  // vec4 pickingColor = vec4(instancePickingColors / 255., 1.);
-  // vColor = mix(color, pickingColor, renderPickingBuffer);
+  vColor = vec4(instanceColors.rgb, instanceColors.a * opacity) / 255.;
+
+  // Set color to be rendered to picking fbo (also used to check for selection highlight).
+  picking_setPickingColor(instancePickingColors);
 }
 `;

--- a/src/layers/core/scatterplot-layer/scatterplot-layer-vertex.glsl.js
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer-vertex.glsl.js
@@ -32,7 +32,6 @@ uniform float opacity;
 uniform float radiusScale;
 uniform float radiusMinPixels;
 uniform float radiusMaxPixels;
-uniform float renderPickingBuffer;
 uniform float outline;
 uniform float strokeWidth;
 
@@ -60,10 +59,10 @@ void main(void) {
   vec3 vertex = positions * outerRadiusPixels;
   gl_Position = project_to_clipspace(vec4(center + vertex, 1.0));
 
-  // Set color to be rendered to picking fbo (also used to check for selection highlight).
-  picking_setPickingColor(instancePickingColors);
-
   // Apply opacity to instance color, or return instance picking color
   vColor = vec4(instanceColors.rgb, instanceColors.a * opacity) / 255.;
+
+  // Set color to be rendered to picking fbo (also used to check for selection highlight).
+  picking_setPickingColor(instancePickingColors);
 }
 `;

--- a/src/layers/core/screen-grid-layer/screen-grid-layer-fragment.glsl.js
+++ b/src/layers/core/screen-grid-layer/screen-grid-layer-fragment.glsl.js
@@ -30,5 +30,11 @@ varying vec4 vColor;
 
 void main(void) {
   gl_FragColor = vColor;
+
+  // use highlight color if this fragment belongs to the selected object.
+  gl_FragColor = picking_filterHighlightColor(gl_FragColor);
+
+  // use picking color if rendering to picking FBO.
+  gl_FragColor = picking_filterPickingColor(gl_FragColor);
 }
 `;

--- a/src/layers/core/screen-grid-layer/screen-grid-layer-vertex.glsl.js
+++ b/src/layers/core/screen-grid-layer/screen-grid-layer-vertex.glsl.js
@@ -30,20 +30,17 @@ uniform float maxCount;
 uniform float opacity;
 uniform vec4 minColor;
 uniform vec4 maxColor;
-uniform float renderPickingBuffer;
 uniform vec3 cellScale;
-uniform vec3 selectedPickingColor;
 
 varying vec4 vColor;
 
 void main(void) {
   vec4 color = mix(minColor, maxColor, instanceCount / maxCount) / 255.;
 
-  vColor = mix(
-    vec4(color.rgb, color.a * opacity),
-    vec4(instancePickingColors / 255., 1.),
-    renderPickingBuffer
-  );
+  vColor = vec4(color.rgb, color.a * opacity);
+
+  // Set color to be rendered to picking fbo (also used to check for selection highlight).
+  picking_setPickingColor(instancePickingColors);
 
   gl_Position = vec4(instancePositions + vertices * cellScale, 1.);
 }

--- a/src/layers/core/screen-grid-layer/screen-grid-layer.js
+++ b/src/layers/core/screen-grid-layer/screen-grid-layer.js
@@ -37,7 +37,7 @@ const defaultProps = {
 
 export default class ScreenGridLayer extends Layer {
   getShaders() {
-    return {vs, fs}; // 'project' module added by default.
+    return {vs, fs, modules: ['picking']}; // 'project' module added by default.
   }
 
   constructor(props) {

--- a/src/layers/core/solid-polygon-layer/solid-polygon-layer-fragment.glsl.js
+++ b/src/layers/core/solid-polygon-layer/solid-polygon-layer-fragment.glsl.js
@@ -27,13 +27,15 @@ precision highp float;
 
 // PICKING
 // uniform bool pickingEnabled;
-varying vec4 vPickingColor;
-vec4 picking_getColor() {
-  return vPickingColor;
-}
-// PICKING
+varying vec4 vColor;
 
 void main(void) {
-  gl_FragColor = picking_getColor();
+  gl_FragColor = vColor;
+
+  // use highlight color if this fragment belongs to the selected object.
+  gl_FragColor = picking_filterHighlightColor(gl_FragColor);
+
+  // use picking color if rendering to picking FBO.
+  gl_FragColor = picking_filterPickingColor(gl_FragColor);
 }
 `;

--- a/src/layers/core/solid-polygon-layer/solid-polygon-layer-vertex-64.glsl.js
+++ b/src/layers/core/solid-polygon-layer/solid-polygon-layer-vertex-64.glsl.js
@@ -30,12 +30,7 @@ attribute vec3 pickingColors;
 uniform float extruded;
 uniform float opacity;
 
-uniform float renderPickingBuffer;
-uniform vec3 selectedPickingColor;
-
-// PICKING
-uniform float pickingEnabled;
-varying vec4 vPickingColor;
+varying vec4 vColor;
 
 void main(void) {
   vec4 positions64xy = vec4(positions.x, positions64xyLow.x, positions.y, positions64xyLow.y);
@@ -55,23 +50,19 @@ void main(void) {
     vertex_pos_modelspace[0].x, vertex_pos_modelspace[1].x,
     vertex_pos_modelspace[2].x, vertex_pos_modelspace[3].x);
 
-  if (pickingEnabled < 0.5) {
-    float lightWeight = 1.0;
+  float lightWeight = 1.0;
 
-    if (extruded > 0.5) {
-      lightWeight = getLightWeight(
-        position_worldspace.xyz, // the w component is always 1.0
-        normals
-      );
-    }
-
-    vec3 lightWeightedColor = lightWeight * colors.rgb;
-    vec4 color = vec4(lightWeightedColor, colors.a * opacity) / 255.0;
-
-    vPickingColor = color;
-
-  } else {
-    vPickingColor = vec4(pickingColors.rgb / 255.0, 1.0);
+  if (extruded > 0.5) {
+    lightWeight = getLightWeight(
+      position_worldspace.xyz, // the w component is always 1.0
+      normals
+    );
   }
+
+  vec3 lightWeightedColor = lightWeight * colors.rgb;
+  vColor = vec4(lightWeightedColor, colors.a * opacity) / 255.0;
+
+  // Set color to be rendered to picking fbo (also used to check for selection highlight).
+  picking_setPickingColor(pickingColors);
 }
 `;

--- a/src/layers/core/solid-polygon-layer/solid-polygon-layer-vertex.glsl.js
+++ b/src/layers/core/solid-polygon-layer/solid-polygon-layer-vertex.glsl.js
@@ -29,42 +29,33 @@ attribute vec3 pickingColors;
 uniform float extruded;
 uniform float opacity;
 
-uniform float renderPickingBuffer;
-uniform vec3 selectedPickingColor;
-
-// PICKING
-uniform float pickingEnabled;
-varying vec4 vPickingColor;
+varying vec4 vColor;
 
 void main(void) {
   vec4 position_worldspace = vec4(project_position(positions), 1.0);
   gl_Position = project_to_clipspace(position_worldspace);
 
-  if (pickingEnabled < 0.5) {
-    float lightWeight = 1.0;
+  float lightWeight = 1.0;
 
-    if (extruded > 0.5) {
-      // Here, the input parameters should be
-      // position_worldspace.xyz / position_worldspace.w.
-      // However, this calculation generates all zeros on
-      // MacBook Pro with Intel Iris Pro GPUs for unclear reasons.
-      // (see https://github.com/uber/deck.gl/issues/559)
-      // Since the w component is always 1.0 in our shaders,
-      // we decided to just provide xyz component of position_worldspace
-      // to the getLightWeight() function
-      lightWeight = getLightWeight(
-        position_worldspace.xyz,
-        normals
-      );
-    }
-
-    vec3 lightWeightedColor = lightWeight * colors.rgb;
-    vec4 color = vec4(lightWeightedColor, colors.a * opacity) / 255.0;
-
-    vPickingColor = color;
-
-  } else {
-    vPickingColor = vec4(pickingColors.rgb / 255.0, 1.0);
+  if (extruded > 0.5) {
+    // Here, the input parameters should be
+    // position_worldspace.xyz / position_worldspace.w.
+    // However, this calculation generates all zeros on
+    // MacBook Pro with Intel Iris Pro GPUs for unclear reasons.
+    // (see https://github.com/uber/deck.gl/issues/559)
+    // Since the w component is always 1.0 in our shaders,
+    // we decided to just provide xyz component of position_worldspace
+    // to the getLightWeight() function
+    lightWeight = getLightWeight(
+      position_worldspace.xyz,
+      normals
+    );
   }
+
+  vec3 lightWeightedColor = lightWeight * colors.rgb;
+  vColor = vec4(lightWeightedColor, colors.a * opacity) / 255.0;
+
+  // Set color to be rendered to picking fbo (also used to check for selection highlight).
+  picking_setPickingColor(pickingColors);
 }
 `;

--- a/src/layers/core/solid-polygon-layer/solid-polygon-layer.js
+++ b/src/layers/core/solid-polygon-layer/solid-polygon-layer.js
@@ -60,8 +60,8 @@ const defaultProps = {
 export default class SolidPolygonLayer extends Layer {
   getShaders() {
     return enable64bitSupport(this.props) ?
-      {vs: vs64, fs, modules: ['project64', 'lighting']} :
-      {vs, fs, modules: ['lighting']}; // 'project' module added by default.
+      {vs: vs64, fs, modules: ['project64', 'lighting', 'picking']} :
+      {vs, fs, modules: ['lighting', 'picking']}; // 'project' module added by default.
   }
 
   initializeState() {

--- a/src/layers/deprecated/choropleth-layer-64/choropleth-layer-vertex-64.glsl.js
+++ b/src/layers/deprecated/choropleth-layer-64/choropleth-layer-vertex-64.glsl.js
@@ -27,8 +27,6 @@ attribute vec4 colors;
 attribute vec3 pickingColors;
 
 uniform float opacity;
-uniform float renderPickingBuffer;
-uniform vec3 selectedPickingColor;
 
 uniform float pickingEnabled;
 varying vec4 vPickingColor;

--- a/src/layers/deprecated/choropleth-layer/choropleth-layer-vertex.glsl.js
+++ b/src/layers/deprecated/choropleth-layer/choropleth-layer-vertex.glsl.js
@@ -27,7 +27,6 @@ attribute vec3 pickingColors;
 
 uniform float opacity;
 uniform float renderPickingBuffer;
-uniform vec3 selectedPickingColor;
 
 // PICKING
 uniform float pickingEnabled;

--- a/src/lib/layer.js
+++ b/src/lib/layer.js
@@ -152,22 +152,13 @@ export default class Layer {
   // called to populate the info object that is passed to the event handler
   // @return null to cancel event
   getPickingInfo({info, mode}) {
-    const {color, index} = info;
+    const {index} = info;
 
     if (index >= 0) {
       // If props.data is an indexable array, get the object
       if (Array.isArray(this.props.data)) {
         info.object = this.props.data[index];
       }
-    }
-
-    // TODO - move to the JS part of a shader picking shader package
-    if (mode === 'hover') {
-      const selectedPickingColor = new Float32Array(3);
-      selectedPickingColor[0] = color[0];
-      selectedPickingColor[1] = color[1];
-      selectedPickingColor[2] = color[2];
-      this.setUniforms({selectedPickingColor});
     }
 
     return info;


### PR DESCRIPTION
- Replace custom picking code and uniforms (`renderPickingBuffer`) in core layer shaders with `picking` shader module.

Diff looks big but change is pretty simple and same for all layers:
Old VS code:
```
if ( picking-not-enabled) {
	vColor = code-to-update-actual-color ...
} else {
	vColor = code-to-update-picking-color ...
}
```
New VS code:
```
	vColor = code-to-update-actual-color ...
	picking_setPickingColor(...);
```
For fragment shader add highlighting and picking filters.

- Also removed some unused code in shaders related to current selected object (given picking module + layer props can be used to enable highlighting).

- This is second PR for custom/automatic highlighting (initial support added in #848), remaining work related tot his feature
-- I see lot example layers use custom picking, need to investigate and remove if needed.
-- Add deprecated message when old picking related uniforms used (`pickingEnabled` and `renderPickingBuffer`)