### PR TITLE
Reducing distribution size RFC

### DIFF
--- a/dev-docs/RFCs/README.md
+++ b/dev-docs/RFCs/README.md
@@ -6,7 +6,7 @@ Implementation of non-trivial new deck.gl features should typically be started o
 | ---          | --- |
 | Proposed     | Call for an RFC to be written |
 | Draft        | WIP version available, not ready for formal review |
-| In Review    | In formal review |
+| **Review**   | In formal review |
 | **Approved** | Approved, ready for implementation |
 | **Deferred** | Review uncovered reasons not to proceed at this time |
 | **Rejected** | Review uncovered reasons not to proceed at this time |
@@ -50,13 +50,12 @@ These RFCs implement features that are considered to be supporting or complemeti
 | [**PropTypes RFC**](drafts/prop-types-rfc.md) | ? | Draft | Validate e.g ranges for numeric attributes, support animation/auto-interpolation. |
 
 
-### Ease-of-Use RFCs
-
-These RFCs represent features that are not listed as part of focus areas for next generation but can help the ease-of-use of deck.gl which is a constant background priority for all deck.gl releases.
+### General RFCs
 
 | RFC | Author | Status | Description |
 | --- | --- | --- | --- |
-| [**dataUrl RFC**](drafts/data-url-rfc.md) | @pessimistress & @ibgreen | Draft | Allow deck.gl layers to specify a URL and asynchronously download the resulting data |
+| [**dataUrl RFC**](drafts/data-url-rfc.md) | @pessimistress & @ibgreen | Draft | **Ease-of-Use** Allow deck.gl layers to specify a URL and asynchronously download the resulting data |
+| [**Reduce Distribution Size RFC**](drafts/reduce-distribution-size-rfc.md) | @ibgreen | **Review** | **Hygiene** Reduce size of distribution and the bundle size of apps consuming deck.gl |
 
 
 ## Deferred RFCs

--- a/dev-docs/RFCs/drafts/reduce-distribution-size.md
+++ b/dev-docs/RFCs/drafts/reduce-distribution-size.md
@@ -4,6 +4,8 @@
 * **Date**: Aug 2017
 * **Status**: Early draft, not ready for formal review.
 
+Notes:
+* Add comments as reviews in [PR 859](https://github.com/uber/deck.gl/pull/859)
 
 ## Motivation
 

--- a/dev-docs/RFCs/drafts/reducing-distribution-size.md
+++ b/dev-docs/RFCs/drafts/reducing-distribution-size.md
@@ -5,13 +5,13 @@
 * **Status**: Early draft, not ready for formal review.
 
 
-## Problem
+## Motivation
 
 * deck.gl + luma.gl keeps growing > 1MB
 * react-map-gl pulls in mapbox which is already big
-* Users are complaining
+* Users are starting to show concern
 
-While one might be tempted to focus on prod sizes, many users look at the debug sizes (which affects build/load/debug cycle speeds) so optimizing both are important.
+It is the premise of this RFC that there is no single bullet to help us solve the distribution size issue. While we'd love to be proven wrong, it is expected that we will have to apply a combination of continued efforts in multiple areas and be thoughtful about how we organize code going forward.
 
 
 ## Critera
@@ -19,6 +19,8 @@ While one might be tempted to focus on prod sizes, many users look at the debug 
 * Size of bundle after application minification (prod)
 * Size of bundle before application minification (debug)
 * Easy of debugging
+
+While one might be tempted to focus on prod sizes, many users look at the debug sizes (which affects build/load/debug cycle speeds) so optimizing both are important.
 
 
 ## Proposed Techniques
@@ -45,6 +47,10 @@ WORK ITEMS:
 * Measure size (dev and prod)
 * ...
 
+
+### Dependency Management
+
+We have already made sure that luma.gl and deck.gl have a minimal number of dependencies.
 
 
 ### gl-matrix is a huge dependency

--- a/dev-docs/RFCs/drafts/reducing-distribution-size.md
+++ b/dev-docs/RFCs/drafts/reducing-distribution-size.md
@@ -33,7 +33,7 @@ Ordered loosely after expected size savings
 STATUS: PROMISING - 20% REDUCTION?
 EFFORT: FAIRLY BIG (depends on ambition level)
 
-We don't run any serious minification on our code before we . At a minimum, we should strip comments from our published code, but we could do a lot more.
+We currently don't run any serious minification on our code before we publish it to npm. At a minimum, we should strip comments from our published code, but we could do a lot more.
 
 Stripping transpiled code and es6 code has different challenges. Each minifier has its own set of problems.
 

--- a/dev-docs/RFCs/drafts/reducing-distribution-size.md
+++ b/dev-docs/RFCs/drafts/reducing-distribution-size.md
@@ -1,0 +1,149 @@
+# RFC: Reducing Distribution Size
+
+* **Authors**: Ib Green, ...
+* **Date**: Aug 2017
+* **Status**: Early draft, not ready for formal review.
+
+
+## Problem
+
+* deck.gl + luma.gl keeps growing > 1MB
+* react-map-gl pulls in mapbox which is already big
+* Users are complaining
+
+While one might be tempted to focus on prod sizes, many users look at the debug sizes (which affects build/load/debug cycle speeds) so optimizing both are important.
+
+
+## Critera
+
+* Size of bundle after application minification (prod)
+* Size of bundle before application minification (debug)
+* Easy of debugging
+
+
+## Proposed Techniques
+
+Ordered loosely after expected size savings
+
+
+### Proper Minification Techniques
+
+STATUS: PROMISING - 20% REDUCTION?
+EFFORT: FAIRLY BIG (depends on ambition level)
+
+We don't run any serious minification on our code before we . At a minimum, we should strip comments from our published code, but we could do a lot more.
+
+Stripping transpiled code and es6 code has different challenges. Each minifier has its own set of problems.
+
+Have experimented with Babili which seems like an attractive solution, but a number of small issues kept popping up.
+
+Note: Pre-minification is expected to have a bigger impact on debug builds, but can also impact prod builds (especially if we organize source code carefully like using local GL constants in luma.gl).
+
+WORK ITEMS:
+* Experiment with minification tools and settle on tool chain
+* Adjust code to work well with minifiers
+* Measure size (dev and prod)
+* ...
+
+
+
+### gl-matrix is a huge dependency
+
+STATUS: IN-PROGRESS, ABOUT 10% SIZE REDUCTION
+EFFORT: MEDIUM
+
+gl-matrix takes about 200KB it includes every function many that are never used. Since functions are imported as objects tree-shaking is defeated.
+
+Creating our own math library that handpicks the most common functions from the stack-gl versions of these libraries brings the size down to about 60KB and can make this code more amenable to tree-shaking.
+
+
+
+
+### Remove Deprecated Code
+
+STATUS: OBVIOUS - POTENTIAL 5%? SIZE REDUCTION
+EFFORT: SMALL, but can only happen in major release
+
+While the amount of backwards compatible code is generally modest deck.gl contains a number of big layers (the Choropleths) that are completely duplicated by newer layers, still all apps
+
+WORK ITEMS:
+* ChoroplethLayers should be removed in next big release.
+
+
+### Remove Duplicated Code
+
+STATUS: OBVIOUS - 1-2% PERCENT REDUCTION?
+EFFORT: MODEST
+
+deck.gl and luma.gl contain duplicated code, in particular AnimationLoop/WebGLRenderer.
+
+deck.gl and viewport-mercator-project contains some duplicate code.
+
+WORK ITEMS:
+* ChoroplethLayers should be removed in next big release.
+
+
+
+## Proposal: Avoid Bundling Unused Classes/Function
+
+There are three known techniques to achieve this in JavaScript:
+* Subdirectory Imports
+* Publishing Separate Packages
+* Tree Shaking
+
+
+### Subdirectory Imports
+
+STATUS: HAS SEVERE ISSUES, NOT PURSUED
+
+This technique (offering subdirectory imports `import ScatterplotLayer from `deck.gl/scatterplot-layer`) has serious complications when combined with tree shaking. Unless we can solve these this technique can not be used in deck.gl.
+
+
+### Publishing Separate Packages
+
+STATUS: PROMISING, BEING CONSIDERED
+EFFORT: MEDIUM-LARGE (setting up monorepo/new repos)
+
+Idea:
+`import {ScatterplotLayer} from '@deck.gl/core-layers';`
+
+This is mostly helpful when we have parts of the library that are clearly optional - e.g. special-purpose extra layer packages (such as s2-layers).
+
+WORK ITEMS:
+* We'd need to define a meaningful separation into sub-packages - if most apps end up importing all the modules.
+
+
+### Tree-Shaking
+
+STATUS: PARTIALLY SUPPORTED, NEEDS MORE WORK
+EFFORT: MODEST (doing some improvements on current state)
+
+Requires a separate distribution that does not transpile ES6 module statement.
+
+We have added tree-shaking examples to our repos. We can build a minimal app that uses almost no symbols from the lib and inspect what actually gets bundled (a lot is still bundled, but some things do get "shaken out").
+
+* Only supported by Webpack2 and Rollup (but most of our users are likely on webpack 2)
+* Webpack2 only gets three-shaking during minification through UglifyJs, so has no effect on debug builds.
+* Tree shaking of functions works fairly well
+* Tree shaking of classes has lots of problems, due to transpiled class declarations looking like "side effects", requires build tricks to (partially) work around
+* UglifyJS support for ES6 is not strong, tree shaking must be done on transpiled code
+
+WORK ITEMS:
+* Continue to refine our libraries to work with tree-shaking, combat tree-shaking-defeating "side effects" so that less unused symbols are included.
+* Get rollup working for deck (only works for luma today) so we have two points of reference
+
+
+## Additional Ideas
+
+### Remove asserts in production
+
+STATUS: PROMISING, NEEDS EXPERIMENTATION
+EFFORT: MODEST
+
+There are npm packages that strip out asserts in production builds.
+
+WORK ITEM:
+* Experiment with assert-stripping packages for production builds
+* If good results, include example/recipe in our webpage
+* Use in our own apps
+


### PR DESCRIPTION
Since we are in RFC creation mode for deck.gl, did a write-up on current thoughts around reducing distribution size.

#621

@georgios-uber  @romaxa