### PR TITLE
Add useDevicePixelRatio prop to DeckGL component.

### DIFF
--- a/docs/advanced/performance.md
+++ b/docs/advanced/performance.md
@@ -83,7 +83,8 @@ Some profiling techniques:
 ## Common Issues
 
 A couple of particular things to watch out for that tend to have a big impact on performance:
-* Be careful when enabling Retina/High DPI rendering. It generetes 4x the number of pixels (fragments) and can have a big performance impact that depends on which computer or monitor is being used.
+* Be careful when enabling Retina/High DPI rendering. It generetes 4x the number of pixels (fragments) and can have a big performance impact that depends on which computer or monitor is being used. This feature can be controlled using `useDevicePixelRatio` prop of `DeckGL` component.
+
 * Avoid using luma.gl debug mode in production. It queries the GPU error status after each operation which has a big impact on performance.
 
 Smaller considerations:

--- a/docs/api-reference/deckgl.md
+++ b/docs/api-reference/deckgl.md
@@ -75,9 +75,13 @@ This is helpful when rendered objects are difficult to target, for example
 irregularly shaped icons, small moving circles or interaction by touch.
 Default `0`.
 
-##### `pixelRatio` (Number, optional)
+##### `useDevicePixelRatio` (Boolean, optional)
 
-Will use device ratio by default.
+Default value is true.
+
+When true, device's full resolution will be used for rendering, this value can change per frame, like when moving windows between screens or when changing zoom level of the browser.
+
+Note: Set it false unless it is required, as it affects your application performance.
 
 ##### `gl` (Object, optional)
 

--- a/docs/api-reference/layer-manager.md
+++ b/docs/api-reference/layer-manager.md
@@ -20,6 +20,13 @@ Parameters:
 
 - `viewport` ([Viewport](/docs/api-reference/viewport.md)) - The new viewport
 
+##### `setParameters`
+
+Parameters:
+
+- `parameters` (Object)
+  * `useDevicePixelRatio` (Boolean) - Whether to use retina/HD display or not.
+
 ##### `updateLayers`
 
 Parameters:

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -1,5 +1,9 @@
 # deck.gl v4.2
 
+## useDevicePixelRatio
+
+This new prop for DeckGL component can be used to toggle usage of full resolution of retina/HD displays.
+
 ## Automatic and custom highlighting
 
 Three new props (`highlightColor`, `highlightedObjectIndex` and `autoHighlight`) are added to `Layer` class to support object highlighting.

--- a/examples/wind/src/wind-demo.js
+++ b/examples/wind/src/wind-demo.js
@@ -110,7 +110,8 @@ export default class WindDemo extends Component {
       <DeckGL
         glOptions={{webgl2: true}}
         {...viewport}
-        layers={layers} />
+        layers={layers}
+        useDevicePixelRatio={true} />
     );
   }
 }

--- a/src/lib/draw-and-pick.js
+++ b/src/lib/draw-and-pick.js
@@ -83,12 +83,14 @@ export function queryLayers(gl, {
   width,
   height,
   viewport,
-  mode
+  mode,
+  useDevicePixelRatio
 }) {
 
   // Convert from canvas top-left to WebGL bottom-left coordinates
   // And compensate for pixelRatio
-  const pixelRatio = typeof window !== 'undefined' ? window.devicePixelRatio : 1;
+  const pixelRatio = useDevicePixelRatio && typeof window !== 'undefined' ?
+    window.devicePixelRatio : 1;
   const deviceLeft = Math.round(x * pixelRatio);
   const deviceBottom = Math.round(gl.canvas.height - y * pixelRatio);
   const deviceRight = Math.round((x + width) * pixelRatio);
@@ -135,12 +137,14 @@ export function pickLayers(gl, {
   radius,
   viewport,
   mode,
-  lastPickedInfo
+  lastPickedInfo,
+  useDevicePixelRatio
 }) {
 
   // Convert from canvas top-left to WebGL bottom-left coordinates
   // And compensate for pixelRatio
-  const pixelRatio = typeof window !== 'undefined' ? window.devicePixelRatio : 1;
+  const pixelRatio = useDevicePixelRatio && typeof window !== 'undefined' ?
+    window.devicePixelRatio : 1;
   const deviceX = Math.round(x * pixelRatio);
   const deviceY = Math.round(gl.canvas.height - y * pixelRatio);
   const deviceRadius = Math.round(radius * pixelRatio);

--- a/src/lib/layer-manager.js
+++ b/src/lib/layer-manager.js
@@ -75,6 +75,7 @@ export default class LayerManager {
       viewport: null,
       viewportChanged: true,
       pickingFBO: null,
+      useDevicePixelRatio: true,
       lastPickedInfo: {
         index: -1,
         layerId: null
@@ -189,6 +190,15 @@ export default class LayerManager {
     this._validateEventHandling();
   }
 
+  /**
+   * Set parameters needed for layer rendering and picking.
+   * Parameters are to be passed as a single object, with the following values:
+   * @param {Boolean} useDevicePixelRatio
+   */
+  setParameters(parameters) {
+    this.context = Object.assign({}, this.context, parameters);
+  }
+
   updateLayers({newLayers}) {
     // TODO - something is generating state updates that cause rerender of the same
     if (newLayers === this.lastRenderedLayers) {
@@ -230,7 +240,7 @@ export default class LayerManager {
 
   // Pick the closest info at given coordinate
   pickLayer({x, y, mode, radius = 0, layerIds}) {
-    const {gl} = this.context;
+    const {gl, useDevicePixelRatio} = this.context;
     const layers = layerIds ?
       this.layers.filter(layer => layerIds.indexOf(layer.id) >= 0) :
       this.layers;
@@ -243,13 +253,14 @@ export default class LayerManager {
       mode,
       viewport: this.context.viewport,
       pickingFBO: this._getPickingBuffer(),
-      lastPickedInfo: this.context.lastPickedInfo
+      lastPickedInfo: this.context.lastPickedInfo,
+      useDevicePixelRatio
     });
   }
 
   // Get all unique infos within a bounding box
   queryLayer({x, y, width, height, layerIds}) {
-    const {gl} = this.context;
+    const {gl, useDevicePixelRatio} = this.context;
     const layers = layerIds ?
       this.layers.filter(layer => layerIds.indexOf(layer.id) >= 0) :
       this.layers;
@@ -262,7 +273,8 @@ export default class LayerManager {
       layers,
       mode: 'query',
       viewport: this.context.viewport,
-      pickingFBO: this._getPickingBuffer()
+      pickingFBO: this._getPickingBuffer(),
+      useDevicePixelRatio
     });
   }
 

--- a/src/react/deckgl.js
+++ b/src/react/deckgl.js
@@ -43,7 +43,8 @@ const propTypes = {
   onWebGLInitialized: PropTypes.func,
   onAfterRender: PropTypes.func,
   onLayerClick: PropTypes.func,
-  onLayerHover: PropTypes.func
+  onLayerHover: PropTypes.func,
+  useDevicePixelRatio: PropTypes.bool
 };
 
 const defaultProps = {
@@ -55,7 +56,8 @@ const defaultProps = {
   onWebGLInitialized: noop,
   onAfterRender: noop,
   onLayerClick: null,
-  onLayerHover: null
+  onLayerHover: null,
+  useDevicePixelRatio: true
 };
 
 export default class DeckGL extends React.Component {
@@ -100,13 +102,19 @@ export default class DeckGL extends React.Component {
       altitude,
       pickingRadius,
       onLayerClick,
-      onLayerHover
+      onLayerHover,
+      useDevicePixelRatio
     } = nextProps;
 
     this.layerManager.setEventHandlingParameters({
       pickingRadius,
       onLayerClick,
       onLayerHover
+    });
+
+    // If more parameters need to be udpated on layerManager add them to this method.
+    this.layerManager.setParameters({
+      useDevicePixelRatio
     });
 
     // If Viewport is not supplied, create one from mercator props
@@ -164,9 +172,6 @@ export default class DeckGL extends React.Component {
     return createElement(WebGLRenderer, Object.assign({}, this.props, {
       width,
       height,
-      // NOTE: Add 'useDevicePixelRatio' to 'this.props' and also pass it down to
-      // to modules where window.devicePixelRatio is used.
-      useDevicePixelRatio: true,
       gl,
       debug,
       onRendererInitialized: this._onRendererInitialized,


### PR DESCRIPTION
- `useDevicePixelRatio` prop will be single point of truth to use retina resolution of the device or not, will affect picking and normal rendering.
- Verified using layer-browser example, by setting `useDevicePixelRatio` to true and false.