### PR TITLE
Add depthTest:false to ScreenGridLayer

### DIFF
--- a/examples/layer-browser/src/examples/core-layers.js
+++ b/examples/layer-browser/src/examples/core-layers.js
@@ -142,11 +142,7 @@ const ScreenGridLayerExample = {
     cellSizePixels: 40,
     minColor: [0, 0, 80, 0],
     maxColor: [100, 255, 0, 128],
-    pickable: false,
-    // TODO - should this be set by default by ScreenGridLayer
-    parameters: {
-      depthTest: false
-    }
+    pickable: false
   }
 };
 

--- a/examples/layer-browser/src/examples/core-layers.js
+++ b/examples/layer-browser/src/examples/core-layers.js
@@ -142,7 +142,11 @@ const ScreenGridLayerExample = {
     cellSizePixels: 40,
     minColor: [0, 0, 80, 0],
     maxColor: [100, 255, 0, 128],
-    pickable: false
+    pickable: false,
+    // TODO - should this be set by default by ScreenGridLayer
+    parameters: {
+      depthTest: false
+    }
   }
 };
 

--- a/src/layers/core/screen-grid-layer/screen-grid-layer.js
+++ b/src/layers/core/screen-grid-layer/screen-grid-layer.js
@@ -75,14 +75,15 @@ export default class ScreenGridLayer extends Layer {
   }
 
   draw({uniforms}) {
-    const {minColor, maxColor} = this.props;
+    const {minColor, maxColor, parameters = {}} = this.props;
     const {model, cellScale, maxCount} = this.state;
     uniforms = Object.assign({}, uniforms, {minColor, maxColor, cellScale, maxCount});
     model.draw({
       uniforms,
-      parameters: {
-        depthMask: true
-      }
+      parameters: Object.assign({
+        depthTest: false,
+        depthMask: false
+      }, parameters)
     });
   }
 


### PR DESCRIPTION
Fixes #602 - removes the artifacts in layer-browser. We can discuss if this should be the default parameter setting in `ScreenGridLayer`.