### PR TITLE
Example fixes.

### DIFF
--- a/docs/layers/hexagon-cell-layer.md
+++ b/docs/layers/hexagon-cell-layer.md
@@ -67,7 +67,7 @@ they will be used to calculate primitive hexagon instead of `hexagonVertices`
 - Default: `1`
 
 Hexagon radius multiplier, between 0 - 1. The radius of hexagon is calculated by
-`coverage * getRadius(d)`
+`coverage * radius`
 
 ##### `elevationScale` (Number, optional)
 

--- a/examples/brushing/deckgl-overlay.js
+++ b/examples/brushing/deckgl-overlay.js
@@ -160,7 +160,8 @@ export default class DeckGLOverlay extends Component {
         pickable: false,
         // only show source points when brushing
         radiusScale: startBrushing ? 3000 : 0,
-        getColor: d => (d.gain > 0 ? targetColor : sourceColor)
+        getColor: d => (d.gain > 0 ? targetColor : sourceColor),
+        getTargetPosition: d => [d[0], d[1], 0]
       }),
       new ScatterplotBrushingLayer({
         id: 'targets-ring',

--- a/examples/layer-browser/src/examples/core-layers.js
+++ b/examples/layer-browser/src/examples/core-layers.js
@@ -87,7 +87,8 @@ const GeoJsonLayerExample = {
     getElevation: f => 500,
     lineWidthScale: 10,
     lineWidthMinPixels: 1,
-    pickable: true
+    pickable: true,
+    fp64: true
   }
 };
 


### PR DESCRIPTION
Brushing : data source only contains vec2, use '0' for z component. Fixes #882 
Layer-browser:GeoJson : enable fp64 by default to avoid z-fighting between layers. Fixes #411 
Minor documentation changes. Fixes #840 