### PR TITLE
Multi viewport support

### DIFF
--- a/dev-docs/RFCs/README.md
+++ b/dev-docs/RFCs/README.md
@@ -20,20 +20,25 @@ Current direction for deck.gl v5 (v.Next) is to focus on effects and animation, 
 
 | RFC | Author | Status | Description |
 | --- | --- | --- | --- |
-| **Effect Management** | | | |
-| **[EffectsManager](v5.0/effects-manager-rfc.md)** | @1chandu @ibgreen | Draft | Official support for effects (shadows, reflections, better lighting, postprocessing, framebuffer composition etc).  |
-| | | | |
 | **Animation** | | | |
 | [**Auto Highlighting**](v5.0/auto-highlighting-rfc.md) | @ibgreen @1chandu | **Approved** | Auto highlight hovered object via `picking` module |
 | [**Viewport interpolation**](v5.0/viewport-animation-rfc.md) | @1chandu | Proposed | This should build on the new Viewport system in the First Person RFC. Also needs to consider react-map-gl. |
-| [**Uniform and Parameter Animation**](v5.0/property-animation-rfc.md) | @ibgreen | Draft | Allow Layer props and GL parameters to accept functions in addition to values and call these on every render to update values |
+| [**Property Animation**](v5.0/property-animation-rfc.md) | @ibgreen | Draft | Allow Layer props and GL parameters to accept functions in addition to values and call these on every render to update values |
 | [**Attribute Animation**](v5.0/attribute-animation-rfc.md) | @pessimistress | Proposed | Automatically interpolate between two copies of a vertex attributes |
 | [**Expose Layer AttributeManager**](v5.0/expose-attribute-manager.md) | @ibgreen | Draft | simplifies pregenerating attributes in apps for fast animation. |
-| [**First Person Viewport**](v5.0/first-person-mercator-viewport-rfc.md) | @ibgreen | **Approved** | Geospatially enable all viewports |
 | [**PropTypes**](v5.0/prop-types-rfc.md) | ? | Draft | Validate e.g ranges for numeric attributes, support animation/auto-interpolation. |
 | | | | |
-| **General** | | | |
+| **Effects** | | | |
+| **[Effects Manager](v5.0/effects-manager-rfc.md)** | @1chandu @ibgreen | Draft | Official support for effects (shadows, reflections, better lighting, postprocessing, framebuffer composition etc).  |
+| | | | |
+| **Viewports** | | | |
+| [**Multiple Viewports**](v5.0/multi-viewport-rfc.md) | @ibgreen | Review | Supoort for multiple, synchronized or unsynchronized viewports |
+| [**First Person Viewport**](v5.0/first-person-mercator-viewport-rfc.md) | @ibgreen | **Approved** | Geospatially enable all viewports |
+| | | | |
+| **Ease-of-Use** | | | |
 | [**dataUrl**](v5.0/data-url-rfc.md) | @pessimistress & @ibgreen | Draft | **Ease-of-Use** Allow deck.gl layers to specify a URL and asynchronously download the resulting data |
+| | | | |
+| **Internals** | | | |
 | [**Reduce Distribution Size**](v5.0/reduce-distribution-size-rfc.md) | @ibgreen | **Review** | **Hygiene** Reduce size of distribution and the bundle size of apps consuming deck.gl |
 | [**Reduce Repository Size**](v5.0/reduce-repo-size-rfc.md) | @ibgreen | **Draft** | **Hygiene** Reduce size of deck.gl github repository |
 | [**Break out Math Module**](v5.0/break-out-math-module-rfc.md) | @ibgreen | **Draft** | **Hygiene** Break out luma.gl math module |

--- a/dev-docs/RFCs/v5.0/multi-viewport-rfc.md
+++ b/dev-docs/RFCs/v5.0/multi-viewport-rfc.md
@@ -1,0 +1,201 @@
+ RFC - Multi Viewports
+
+* **Author**: Ib Green
+* **Date**: August 10, 2017
+* **Status**: **Draft**
+
+Notes:
+* This RFC started out as an extension of an initial left/right viewport prototype for WebVR integration made by Xiaoji Chen.
+
+
+## Motivation
+
+It is common in 3D applications to render a 3D scene multiple times, with different cameras:
+* To show views from multiple viewpoints (cameras), e.g. in a split screen setup.
+* To show a detail view (e.g, first person), and an overlaid, smaller "map" view (e.g. third person or top down, zoomed out to show where the primary viewpoint is).
+* To support stereoscopic rendering, where left and right views are needed, providing the necessary parallax between left and right eye.
+* For rendering into offscreen framebuffers, which can then be used for e.g. advanced visual effects, screen shot solutions, overlays onto DOM elements outside of the primary deck.gl canvas (e.g. a video).
+
+
+# Problem Statement
+
+* In v4.1, deck.gl creates a canvas and allows only a single viewport that always renders in the top-left corner of that canvas.
+* deck.gl is also limited to rendering into a single canvas, due to the one-to-one relation between a canvas and a `WebGLRenderingContext` (that said it is possible to render into framebuffers that can be extracted).
+In addition
+
+
+## Proposal 1: New `DeckGL.viewports` property
+
+Allows the main `DeckGL` component to accept a list of Viewports (and/or viewport descriptors). This will be in addition to, or preferably instead of, the current `viewport` prop.
+
+Viewports can be side-by-side (top and bottom in this first example). Note how the application controls both the height and the y position of the two viewports.
+```js
+  <DeckGL viewports=[
+    new FirstPersonViewport({...viewprops, height: viewprops.height / 2}),
+    new WebMercatorViewport({...viewprops, y: viewprops.height / 2, height: viewprops.height / 2}),
+    ...
+  ]/>
+```
+
+Side-by-side is of course essential for stereoscopic rendering (and conveniently, the base deck.gl viewport can directly accept view and projection matrices from the WebVR API):
+```js
+  <DeckGL viewports=[
+    // left eye viewport
+    new Viewport({
+      width: viewprops.width / 2,
+      viewMatrix: leftViewMatrix, projectionMatrix: leftProjectionMatrix
+    }),
+    // right eye
+    new Viewport({
+      width: viewprops.width / 2, x: viewprops.width / 2
+      viewMatrix: rightViewMatrix, projectionMatrix: rightProjectionMatrix
+    }),
+    ...
+  ]/>
+```
+
+Or they can overlap, (e.g. having a small overview map in the bottom middle of the screen overlaid over the main view)
+```js
+  const {width, height} = viewportProps;
+  ...
+  <DeckGL viewports=[
+    new FirstPersonViewport({...viewprops}),
+
+    // Render a small map viewport over the main first person viewport
+    new WebMercatorViewport({
+      ...viewprops,
+      height: height / 8,
+      width: width / 8,
+      x: width * 7 / 16,
+      y: height * 13 / 16
+    })
+  ]/>
+```
+
+### Viewport x,y coordinates
+
+Specifying x,y coordinates in the viewport is a small addition to the current set of parameters which already includes width and height. Even though it will only be used for positioning (and not for calculation of intrinsic viewport parameters) it seems to make sense to include these parameters in the viewport (as opposed to the Viewport Descriptor, see below).
+
+A downside of putting x,y in the Viewport is that it becomes tricky to use the same viewport several times in the list. One could get around this by letting x,y in the viewport descriptor override the viewport but this risks making the system too complicated, and the use case is very limited.
+
+This means that viewport without backing components or other special features will not need a descriptor.
+
+The biggest question is which coordinate system to use for x,y. gl.viewport uses bottom-left and normal CSS layout uses top left. Translating between the two is surprisingly fiddly since both y coordinates and heights need to be stacked (and there could be a DPR issue as well).
+
+The proposal here is to use top left (CSS) coordinates and document it carefully. It is likely to be more natural as the rest of the UI layout with other HTML overlays is done in this coordinate system.
+
+### Viewport Descriptors
+
+## Proposal (Phase 2a): `DeckGL.viewport` prop can take "Viewport Descriptors"
+
+By allowing the `viewport` prop to take "viewport descriptor" objects (in addition) we can address use cases beyond simply rendering multiple views:
+* Multiple render passes over the same viewport - avoid clearing background
+* Rendering to offscreen framebuffers
+
+<DeckGL viewports=[
+  {viewport: new Viewport(...), framebuffer: ...,  clear: ..., parameters: {blendMode, ...}},
+  ...
+]/>
+
+* Alternative: Of course all these options could also be jammed into the base `Viewport` class, but that would add a lot of complexity to an already quite complex class, so allowing separate Viewport descriptors is preferred.
+
+
+### Performance Concerns Around Layer.updateState
+
+updateState({changeFlags: viewportChanged})
+
+The Layer life cycle supports updateState being called when a viewport changes (in addition to when props or data change), so that a layer can do JavaScript calculations using the updated viewport.
+
+When rendering with many viewports there is a concern that updateState gets called many times per frame (potentially recalculating other things that have nothing to do with viewport updates, in less strictly coded layers).  It feels like a perf hit for an edge scenario (though of course still cheaper than maintaining two deck.gl instances in this case).
+
+An important but little known mitigation is that since viewports change very frequently, but few layers actually need to handle this, shouldUpdateState was subtly changed in deck.gl 4.1. It now only returns true when props or data changed, but not when viewports change. So layers that want updateState to be called when viewports change (like ScreenGridLayer) now need to redefine shouldUpdateState. This will mean that even though all layer’s will have shouldUpdateState called every viewport every frame, at least only a few will get calls to updateState.
+
+ACTION: The shouldUpdateState semantics are poorly documented, it would be good to have a comprehensive article about **Updates** that included this information.
+
+### Open Questions
+
+**Picking**
+Picking - should picking also render all viewports? Probably yes.
+Should the pickInfo object contain a viewport reference? Probably not.
+Push multi viewport rendering into LayerManager / draw-and-pick.js
+
+* Since our goal is to continuously reduce React dependencies it is suggested the multi-viewport rendering loop is placed outside of the `DeckGL` React component. Perhaps in an `AnimationLoop` instantiation?
+
+
+MINOR
+* Deprecate the current `viewport` prop? If we support `flattenArray`, it will allow a single viewport to be passed to `viewports`.
+* Currently the `DeckGL` component creates a default viewport from props if none were supplied. Presumably we want to keep this for backwards compatibility, and to let basic users avoid dealing with Viewports.
+* Should we call our `flattenArray` on the viewports prop, just like we do on the `layers` prop, and presumably the `effects` prop? This means the user can supply `null`s and nested arrays in the viewport list, potentilayy simplifying the generation of the list in application code.
+
+
+
+
+# Proposal 2: Support for positioning background maps
+
+For map backed viewports, some assistance in positioning maps correctly under the viewports would be nice. It requires some fiddling with CSS properties, a method that read the viewport descriptors and rendered map components?
+
+react-map-gl provides a `StaticMap` that is a perfect backdrop for `WebMercatorViewports`. In deck.gl v4.1 the maps and the main viewport take up a 100% of the viewport, so aligning the two are trivial.
+
+In fact, the DeckGL component is usually set to a child of the MapGL component. When using multiple base maps, this obviously won't work.
+
+The suggestion is to supply a new React component `<ViewportBaseComponents>` that walks the viewport descriptor list and looks for some attributes and renders base map components (absolutely positioned in CSS) in the same place as the deck.gl viewport will appear in the overlay.
+
+```js
+const viewports = [
+  // Non geospatial viewport
+  new Viewport({...}),
+  {viewport: new WebMercatorViewport({}), baseComponent: ReactMapGL, ...},
+  ...
+];
+
+render() {
+  return (
+    <*Controller ...>
+      <ViewportBaseComponents width={} height={} viewports={viewports}/>
+      <DeckGL width={} height={} viewports={viewports} layers={...} .../>
+    </Controller>
+  )
+}
+
+```
+
+Questions
+
+
+# Appendices
+
+These sections supply contextual information and ideas. They should not be considered a formal part of this RFC (for review / approval). That said comments are always welcome!
+
+
+## Ideas
+
+* Could we autocalculate deck.gl canvas width/height props from the viewports list? a bounding box?
+
+
+## Appendix: Advanced Render Parameters
+
+Note: This describes a possible extension to the functionality described in this proposal. It would need be detailed in a separate RFC before implemntation.
+
+A viewport descriptor could specify additional information like:
+* a list of layer ids, causing the rendering into that viewport to only cover the listed layers.
+* a named renderbuffer from a previous stage (viewport descriptor) to be used as input for effects, stencil buffering etc.
+* a `context object` with parameters that get passed to property animation functions.
+
+More ambitous extensions:
+* Each descriptor can provide its own layer and effects lists...
+
+
+### Appendix: Controller support for Multiple Viewports
+
+
+**Restrict Event Handling to match Viewport Size** - Controllers need to be able to be restricted to a certain area (in terms of event handling). Some controllers are completely general (just general drag up/down):
+* When working with a map controller, especially panning and zooming, the point under the mouse represents a grab point or a reference for the operation and mapping event coordinates correctly is imporant for the experience.
+* Controllers might not be designed to receive coordinates from outside their viewports.
+* Basically, if the map backing one WebMercator viewport doesn't fill the entire canvas, and the application wants to use a MapControls
+
+Controllers will also benefit from be able to feed multiple viewports of different types. There are limits to this of course, in particular it would be nice if for instance a geospatially neabled FirstPerson controller can feed both a `FirstPersonViewport` and a `WebMercatorViewport`. Various different viewports must be created from one set of parameters.
+
+Contrast this to deck.gl v4.1, where the idea was that each the of Viewport was associated with a specific controller (WebMercatorViewport has a MapController, etc).
+
+* **Using Multiple Controllers** An application having multiple viewports might want to use different interaction in each viewport - this has multiple complications...
+* **Switching Controllers** - An application that wants to switch between Viewports might want to switch between controllers, ideally this should not require too much coding effort.

--- a/src/experimental/react/deckgl-multiview.js
+++ b/src/experimental/react/deckgl-multiview.js
@@ -1,0 +1,101 @@
+// Copyright (c) 2015 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import DeckGL, {Viewport} from 'deck.gl';
+import {GL, withParameters} from 'luma.gl';
+import {flatten} from '../../lib/utils/flatten';
+
+/* A flavor of the DeckGL component that renders using multiple viewports */
+export default class DeckGLMultiView extends DeckGL {
+
+  _onRendererInitialized(params) {
+    super._onRendererInitialized(params);
+  }
+
+  _getViewports() {
+    const {viewports, viewport} = this.props;
+    if (viewports) {
+      return flatten(viewports);
+    }
+    if (viewport) {
+      return [viewport];
+    }
+    const {width, height} = this.props;
+    return new Viewport({width, height});
+  }
+
+  _getViewportFromDescriptor(viewportOrDescriptor) {
+    return viewportOrDescriptor.viewport ?
+      viewportOrDescriptor.viewport :
+      viewportOrDescriptor;
+  }
+
+  _updateLayers(nextProps) {
+    // HACK: UpdateLayers need the viewport prop set
+    const viewports = this._getViewports();
+    if (!nextProps.viewport) {
+      nextProps = Object.assign({}, {
+        viewport: this._getViewportFromDescriptor(viewports[0])
+      }, nextProps);
+    }
+    super._updateLayers(nextProps);
+  }
+
+  _onRenderFrame({gl}) {
+    const {height} = this.props;
+
+    // UpdateLayers
+    const viewports = this._getViewports();
+
+    // clear depth and color buffers
+    gl.clear(GL.COLOR_BUFFER_BIT | GL.DEPTH_BUFFER_BIT);
+
+    this.effectManager.preDraw();
+
+    viewports.forEach((viewportOrDescriptor, i) => {
+      const viewport = this._getViewportFromDescriptor(viewportOrDescriptor);
+
+      // this._updateLayers(Object.assign({}, this.props, {viewport}));
+
+      // Convert viewport top-left CSS coordinates to bottom up WebGL coordinates
+      const glViewport = [
+        viewport.x, height - viewport.y - viewport.height, viewport.width, viewport.height
+      ];
+
+      // render this viewport
+      withParameters(gl, {viewport: glViewport}, () => {
+        this.layerManager.setViewport(viewport).drawLayers({pass: `viewport ${i}`});
+      });
+    });
+
+    this.effectManager.draw();
+
+    // Picking
+    // if (this.props.onLayerHover) {
+    //   // Arbitrary gaze location
+    //   const x = this.props.width * 2 / 3;
+    //   const y = this.props.height / 2;
+
+    //   const info = this.queryObject({x, y, radius: this.props.pickingRadius});
+    //   this.props.onLayerHover(info);
+    // }
+  }
+
+}

--- a/src/experimental/react/deckgl-multiview.md
+++ b/src/experimental/react/deckgl-multiview.md
@@ -1,0 +1,18 @@
+## DeckGL
+
+## Properties
+
+### viewports
+
+* A singe viewport, or an array of `Viewports` or "Viewport Descriptors".
+
+deck.gl will render all the viewports in order.
+
+Default: If not supplied, deck.gl will try to create a `WebMercatorViewport` from other props (longitude, latitude, ...).
+
+
+### viewport
+
+* Deprecated
+
+use `viewports` property instead, it can accept a single `Viewport`.

--- a/src/experimental/react/viewport-layout.js
+++ b/src/experimental/react/viewport-layout.js
@@ -1,0 +1,60 @@
+import React, {createElement, cloneElement} from 'react';
+
+export default class ViewportLayout extends React.Component {
+
+  constructor(props) {
+    super(props);
+  }
+
+  // Iterate over viewport descriptors and render viewports at specified positions
+  _renderViewportComponents() {
+    const {viewports} = this.props;
+
+    const children = [];
+
+    viewports.forEach((viewportOrDescriptor, i) => {
+      const {viewport, component, Component, props = {}} = viewportOrDescriptor;
+
+      // Check if this is a descriptor with a component, otherwise ignore
+      if (viewport && (component || Component)) {
+
+        // TODO - this is too react-map-gl specific
+        const newProps = Object.assign({}, props, {
+          visible: viewport.isMapSynched(),
+          width: viewport.width,
+          height: viewport.height
+        });
+
+        // Check if we should create or just modify a supplied React component
+        const newComponent = component ?
+          cloneElement(component, newProps) :
+          createElement(Component, newProps);
+
+        const style = {
+          position: 'absolute',
+          left: viewport.x,
+          top: viewport.y,
+          width: viewport.width,
+          height: viewport.height
+        };
+
+        children.push(createElement('div', {key: `viewport-component-${i}`, style}, newComponent));
+      }
+    });
+
+    return children;
+  }
+
+  render() {
+    // Render the background elements (typically react-map-gl instances)
+    // using the viewport descriptors
+    const elements = this._renderViewportComponents();
+
+    // Render the foreground elements, after (i.e. on top of) the background elements
+    // This will typically be the DeckGL component
+    const style = {position: 'absolute', left: 0, top: 0};
+    elements.push(createElement('div', {key: 'children', style}, this.props.children));
+
+    return createElement('div', {}, elements);
+  }
+}

--- a/src/experimental/react/viewport-layout.md
+++ b/src/experimental/react/viewport-layout.md
@@ -1,0 +1,57 @@
+## ViewportLayout
+
+`ViewportLayout` is a react helper component that is intended to render base maps (or other base React components underneath DeckGL viewports.
+
+Since deck.gl is WebGL based, all its viewports need to be in the same canvas (unless you use multiple DeckGL instances, but that can have significant resource and performance impact)
+
+`ViewportLayout` takes a `viewport` prop that contains a mixed array of `Viewports` and "viewport descriptors" (intended to be the same array passed to the `DeckGL` component, and renders any base components specified by viewport descriptors.
+
+
+
+
+## Usage
+
+```js
+  const viewports = [
+    // viewport
+    new FirstPersonViewport({...}),
+    // viewport descriptor
+    {
+      viewport: new WebMercatorViewport({...}),
+      component: <StaticMap {...viewportProps}/>
+    }
+  ];
+
+  render() {
+	  <ViewportLayout viewports={viewports}>
+
+	    <DeckGL
+	      id="first-person"
+	      width={viewportProps.width}
+	      height={viewportProps.height}
+	      viewports={viewports}
+	      useDevicePixelRatio={false}
+	      layers={this._renderLayers()}
+	      onWebGLInitialized={this._initialize} />
+
+	  </ViewportLayout>
+  }
+```
+
+## Properties
+
+
+### viewports
+
+* A singe viewport, or an array of `Viewport`s or "Viewport Descriptors".
+
+Will walk the list looking for viewport descriptors with `component` fields, rendering those components in the position and size specified by that viewport.
+
+Positioning is done with CSS styling on a wrapper div, and sizing by injecting width and height properties.
+
+Also injects the `visible: viewport.isMapSynched()` prop.
+
+
+### children
+
+Normally the DeckGL component, any children are rendered last, in inteionally on top.

--- a/src/index.js
+++ b/src/index.js
@@ -58,13 +58,17 @@ import {get} from './lib/utils/get';
 import {count} from './lib/utils/count';
 import {EffectManager, Effect} from './experimental/lib';
 import {default as ReflectionEffect} from './experimental/effects/reflection-effect';
+import DeckGLMultiView from './experimental/react/deckgl-multiview';
+import ViewportLayout from './experimental/react/viewport-layout';
 
 export const experimental = {
   get,
   count,
   EffectManager,
   Effect,
-  ReflectionEffect
+  ReflectionEffect,
+  DeckGLMultiView,
+  ViewportLayout
 };
 
 // Deprecated Layers


### PR DESCRIPTION
This adds two new React components in the `experimental` folder: `DeckGLMultiView` and `ViewportLayouts`. The RFC text is included, as are documentation fragments for the new components.
