### PR TITLE
Fix the icon rotation issue

### DIFF
--- a/src/layers/core/icon-layer/icon-layer-vertex-64.glsl.js
+++ b/src/layers/core/icon-layer/icon-layer-vertex-64.glsl.js
@@ -36,6 +36,7 @@ attribute vec2 instanceOffsets;
 uniform vec2 viewportSize;
 uniform float sizeScale;
 uniform vec2 iconsTextureDim;
+uniform float devicePixelRatio;
 
 varying float vColorMode;
 varying vec4 vColor;
@@ -51,15 +52,13 @@ vec2 rotate_by_angle(vec2 vertex, float angle) {
 
 void main(void) {
   vec2 iconSize = instanceIconFrames.zw;
-  vec2 iconSize_clipspace = iconSize / viewportSize * 2.0;
   // scale icon height to match instanceSize
   float instanceScale = iconSize.y == 0.0 ? 0.0 : instanceSizes / iconSize.y;
 
-  // The vertex variable is in clip space and should not go through project_to_clipspace call
-  vec2 vertex = (positions / 2.0 + instanceOffsets);
-  vertex = rotate_by_angle(vertex, instanceAngles) * iconSize_clipspace *
-    sizeScale * instanceScale;
-
+  // scale and rotate vertex in "pixel" value and convert back to fraction in clipspace
+  vec2 vertex = positions / 2.0 * iconSize + instanceOffsets;
+  vertex = rotate_by_angle(vertex, instanceAngles) / viewportSize * sizeScale *
+    instanceScale * devicePixelRatio;
   vertex.y *= -1.0;
 
   vec4 instancePositions64xy = vec4(

--- a/src/layers/core/icon-layer/icon-layer-vertex-64.glsl.js
+++ b/src/layers/core/icon-layer/icon-layer-vertex-64.glsl.js
@@ -36,6 +36,7 @@ attribute vec2 instanceOffsets;
 uniform vec2 viewportSize;
 uniform float sizeScale;
 uniform vec2 iconsTextureDim;
+// devicePixelRatio is set up as uniform but not declared in the shader function
 uniform float devicePixelRatio;
 
 varying float vColorMode;
@@ -56,10 +57,10 @@ void main(void) {
   float instanceScale = iconSize.y == 0.0 ? 0.0 : instanceSizes / iconSize.y;
 
   // scale and rotate vertex in "pixel" value and convert back to fraction in clipspace
-  vec2 vertex = positions / 2.0 * iconSize + instanceOffsets;
-  vertex = rotate_by_angle(vertex, instanceAngles) / viewportSize * sizeScale *
+  vec2 pixelOffset = positions / 2.0 * iconSize + instanceOffsets;
+  pixelOffset = rotate_by_angle(pixelOffset, instanceAngles) / viewportSize * sizeScale *
     instanceScale * devicePixelRatio;
-  vertex.y *= -1.0;
+  pixelOffset.y *= -1.0;
 
   vec4 instancePositions64xy = vec4(
     instancePositions.x, instancePositions64xyLow.x,
@@ -74,7 +75,7 @@ void main(void) {
   vertex_pos_modelspace[2] = vec2(project_scale(instancePositions.z), 0.0);
   vertex_pos_modelspace[3] = vec2(1.0, 0.0);
 
-  gl_Position = project_to_clipspace_fp64(vertex_pos_modelspace) + vec4(vertex, 0.0, 0.0);
+  gl_Position = project_to_clipspace_fp64(vertex_pos_modelspace) + vec4(pixelOffset, 0.0, 0.0);
 
   vTextureCoords = mix(
     instanceIconFrames.xy,

--- a/src/layers/core/icon-layer/icon-layer-vertex.glsl.js
+++ b/src/layers/core/icon-layer/icon-layer-vertex.glsl.js
@@ -35,6 +35,7 @@ attribute vec2 instanceOffsets;
 uniform vec2 viewportSize;
 uniform float sizeScale;
 uniform vec2 iconsTextureDim;
+uniform float devicePixelRatio;
 
 varying float vColorMode;
 varying vec4 vColor;
@@ -50,15 +51,16 @@ vec2 rotate_by_angle(vec2 vertex, float angle) {
 
 void main(void) {
   vec2 iconSize = instanceIconFrames.zw;
-  vec2 iconSize_clipspace = iconSize / viewportSize * 2.0;
   // scale icon height to match instanceSize
   float instanceScale = iconSize.y == 0.0 ? 0.0 : instanceSizes / iconSize.y;
-  vec3 center = project_position(instancePositions);
-  vec2 vertex = (positions / 2.0 + instanceOffsets);
-  vertex = rotate_by_angle(vertex, instanceAngles) * iconSize_clipspace *
-    sizeScale * instanceScale;
+
+  // scale and rotate vertex in "pixel" value and convert back to fraction in clipspace
+  vec2 vertex = positions / 2.0 * iconSize + instanceOffsets;
+  vertex = rotate_by_angle(vertex, instanceAngles) / viewportSize * sizeScale *
+    instanceScale * devicePixelRatio;
   vertex.y *= -1.0;
 
+  vec3 center = project_position(instancePositions);
   gl_Position = project_to_clipspace(vec4(center, 1.0)) + vec4(vertex, 0.0, 0.0);
 
   vTextureCoords = mix(

--- a/src/layers/core/icon-layer/icon-layer-vertex.glsl.js
+++ b/src/layers/core/icon-layer/icon-layer-vertex.glsl.js
@@ -35,6 +35,7 @@ attribute vec2 instanceOffsets;
 uniform vec2 viewportSize;
 uniform float sizeScale;
 uniform vec2 iconsTextureDim;
+// devicePixelRatio is set up as uniform but not declared in the shader function
 uniform float devicePixelRatio;
 
 varying float vColorMode;
@@ -55,13 +56,13 @@ void main(void) {
   float instanceScale = iconSize.y == 0.0 ? 0.0 : instanceSizes / iconSize.y;
 
   // scale and rotate vertex in "pixel" value and convert back to fraction in clipspace
-  vec2 vertex = positions / 2.0 * iconSize + instanceOffsets;
-  vertex = rotate_by_angle(vertex, instanceAngles) / viewportSize * sizeScale *
+  vec2 pixelOffset = positions / 2.0 * iconSize + instanceOffsets;
+  pixelOffset = rotate_by_angle(pixelOffset, instanceAngles) / viewportSize * sizeScale *
     instanceScale * devicePixelRatio;
-  vertex.y *= -1.0;
+  pixelOffset.y *= -1.0;
 
   vec3 center = project_position(instancePositions);
-  gl_Position = project_to_clipspace(vec4(center, 1.0)) + vec4(vertex, 0.0, 0.0);
+  gl_Position = project_to_clipspace(vec4(center, 1.0)) + vec4(pixelOffset, 0.0, 0.0);
 
   vTextureCoords = mix(
     instanceIconFrames.xy,

--- a/src/layers/core/icon-layer/icon-layer.js
+++ b/src/layers/core/icon-layer/icon-layer.js
@@ -236,8 +236,8 @@ export default class IconLayer extends Layer {
     for (const object of data) {
       const icon = getIcon(object);
       const rect = iconMapping[icon] || {};
-      value[i++] = (1 / 2 - rect.anchorX / rect.width) || 0;
-      value[i++] = (1 / 2 - rect.anchorY / rect.height) || 0;
+      value[i++] = (rect.width / 2 - rect.anchorX) || 0;
+      value[i++] = (rect.height / 2 - rect.anchorY) || 0;
     }
   }
 

--- a/src/layers/core/icon-layer/icon-layer.js
+++ b/src/layers/core/icon-layer/icon-layer.js
@@ -28,6 +28,8 @@ import fs from './icon-layer-fragment.glsl';
 
 const DEFAULT_COLOR = [0, 0, 0, 255];
 const DEFAULT_TEXTURE_MIN_FILTER = GL.LINEAR_MIPMAP_LINEAR;
+// GL.LINEAR is the default value but explicitly set it here
+const DEFAULT_TEXTURE_MAG_FILTER = GL.LINEAR;
 
 /*
  * @param {object} props
@@ -129,7 +131,8 @@ export default class IconLayer extends Layer {
 
       if (iconAtlas instanceof Texture2D) {
         iconAtlas.setParameters({
-          [GL.TEXTURE_MIN_FILTER]: DEFAULT_TEXTURE_MIN_FILTER
+          [GL.TEXTURE_MIN_FILTER]: DEFAULT_TEXTURE_MIN_FILTER,
+          [GL.TEXTURE_MAG_FILTER]: DEFAULT_TEXTURE_MAG_FILTER
         });
         this.setState({iconsTexture: iconAtlas});
       } else if (typeof iconAtlas === 'string') {
@@ -138,7 +141,8 @@ export default class IconLayer extends Layer {
         })
         .then(([texture]) => {
           texture.setParameters({
-            [GL.TEXTURE_MIN_FILTER]: DEFAULT_TEXTURE_MIN_FILTER
+            [GL.TEXTURE_MIN_FILTER]: DEFAULT_TEXTURE_MIN_FILTER,
+            [GL.TEXTURE_MAG_FILTER]: DEFAULT_TEXTURE_MAG_FILTER
           });
           this.setState({iconsTexture: texture});
         });

--- a/src/layers/core/icon-layer/icon-layer.js
+++ b/src/layers/core/icon-layer/icon-layer.js
@@ -27,6 +27,7 @@ import vs64 from './icon-layer-vertex-64.glsl';
 import fs from './icon-layer-fragment.glsl';
 
 const DEFAULT_COLOR = [0, 0, 0, 255];
+const DEFAULT_TEXTURE_MIN_FILTER = GL.LINEAR_MIPMAP_LINEAR;
 
 /*
  * @param {object} props
@@ -127,12 +128,18 @@ export default class IconLayer extends Layer {
     if (oldProps.iconAtlas !== iconAtlas) {
 
       if (iconAtlas instanceof Texture2D) {
+        iconAtlas.setParameters({
+          [GL.TEXTURE_MIN_FILTER]: DEFAULT_TEXTURE_MIN_FILTER
+        });
         this.setState({iconsTexture: iconAtlas});
       } else if (typeof iconAtlas === 'string') {
         loadTextures(this.context.gl, {
           urls: [iconAtlas]
         })
         .then(([texture]) => {
+          texture.setParameters({
+            [GL.TEXTURE_MIN_FILTER]: DEFAULT_TEXTURE_MIN_FILTER
+          });
           this.setState({iconsTexture: texture});
         });
       }


### PR DESCRIPTION
A different (and better) fix for #834 as opposed to the way originally proposed. Manipulate the vertex scaling and rotation in "pixel" values before converting back to "fraction" in the screen space.  No need to calculate the aspect ratio and factor it in the rotation function. To do this, it is better to pass the anchor position into the shader as pixel values instead of normalizing it (see the change in `icon-layer.js`). The `devicePixelRatio` is used to avoid hardcoding in the previous implementation.