### PR TITLE
Rename coordinateSystem props

### DIFF
--- a/docs/advanced/composite-layers.md
+++ b/docs/advanced/composite-layers.md
@@ -1,48 +1,30 @@
 # Composite Layers
 
-Composite layer is a special kind of layers that creates other layers.
-It is often convenient to change the behavior of an existing layer using
+Composite layer is a special kind of layers that creates other layers. It is often convenient to change the behavior of an existing layer using
 an composite (or "adaptor") layer instead of modifying the layer itself.
 
 ## Use Cases
 
 ### Adaptor Layers
 
-Sometimes an existing layer renders the right thing, but it would be desirable
-that it accepts another data format, had another interface (different accessors),
-or performed aggregation on its data.
+Sometimes an existing layer renders the right thing, but it would be desirable that it accepts another data format, had another interface (different accessors), or performed aggregation on its data.
 
 Examples could be:
-* Creating a `LASPointCloudLayer` that accepts `data` as an ArrayBuffer object
-  that is loaded directly from a
-  [LAS](https://www.asprs.org/committee-general/laser-las-file-format-exchange-activities.html)
-  file, and convert it to the format that `PointCloudLayer` consumes. 
-* Creating an `S2Layer` with an accessor that takes
-  [S2](https://code.google.com/archive/p/s2-geometry-library/)
-  tokens, uses the S2 library to calculates the polygons corresponding
-  to that cell, and renders it using e.g. the PolygonLayer.
-* Adding aggregation to an existing layer.
-  By default, deck.gl layers render one graphical element for each element in
-  the `data` prop. But in some cases, e.g. heatmaps, the data needs to be
-  aggregated (or "binned") into cells before rendering. An adaptor in
-  the form of a composite layer is a great way of organizing this.
+* Creating a `LASPointCloudLayer` that accepts `data` as an ArrayBuffer object that is loaded directly from a [LAS](https://www.asprs.org/committee-general/laser-las-file-format-exchange-activities.html)
+  file, and convert it to the format that `PointCloudLayer` consumes.
+* Creating an `S2Layer` with an accessor that takes [S2](https://code.google.com/archive/p/s2-geometry-library/) tokens, uses the S2 library to calculates the polygons corresponding to that cell, and renders it using e.g. the PolygonLayer.
+* Adding aggregation to an existing layer. By default, deck.gl layers render one graphical element for each element in the `data` prop. But in some cases, e.g. heatmaps, the data needs to be aggregated (or "binned") into cells before rendering. An adaptor in the form of a composite layer is one way to add this functionality.
 
-In fact several core deck.gl layers, like the GeoJsonLayer and the GridLayer
-are written as composite "adapter" layers.
+In fact several core deck.gl layers, like the GeoJsonLayer and the GridLayer are written as composite "adapter" layers.
 
 ### Collection Layers
 
-Often a more complex visualization consists of a number of layers that are
-rendered after breaking down a common set of props. It can be helpful
-to collect the code that does this breakdown into a single composite layer.
+Often a more complex visualization consists of a number of layers that are rendered after breaking down a common set of props. It can be helpful to collect the code that does this breakdown into a single composite layer.
 
 
 ## Implementing Composite Layers
 
-A common use case of composite layers is to augment the interface of existing
-layers. Consider the following example: the
-[ScatterplotLayer](/docs/layers/scatterplot-layer.md) either fills or outlines
-its circles. We need a layer that does both.
+A common use case of composite layers is to augment the interface of existing layers. Consider the following example: the [ScatterplotLayer](/docs/layers/scatterplot-layer.md) either fills or outlines its circles. We need a layer that does both.
 
 A composite layer can be created by extending the `CompositeLayer` class:
 
@@ -57,10 +39,7 @@ NiceScatterplotLayer.layerName = 'NiceScatterplotLayer';
 
 ### Defining Layer Properties
 
-We will need to define the layer-specific properties of the new layer.
-In this example, the new layer's interface is almost identical to that of the
-ScatterplotLayer, except instead of one `getColor` accessor, you need two
-accessors `getStrokeColor` and `getFillColor`:
+We will need to define the layer-specific properties of the new layer. In this example, the new layer's interface is almost identical to that of the ScatterplotLayer, except instead of one `getColor` accessor, you need two accessors `getStrokeColor` and `getFillColor`:
 
 ```
 NiceScatterplotLayer.defaultProps = {
@@ -72,9 +51,7 @@ NiceScatterplotLayer.defaultProps = {
 
 ### Rendering Sublayers
 
-A composite layer should implement the `renderLayers()` method and return
-an array of layers. In this example, the idea is to draw two ScatterplotLayers,
-one for fill and one for the outline:
+A composite layer should implement the `renderLayers()` method and return an array of layers. In this example, the idea is to draw two ScatterplotLayers, one for fill and one for the outline:
 
 ```
 class NiceScatterplotLayer extends CompositeLayer {
@@ -96,21 +73,13 @@ class NiceScatterplotLayer extends CompositeLayer {
 
 ### Mapping Vs. Forwarding Properties
 
-Because the composite layer doesn't draw directly to the canvas, it
-controls the rendering result by setting props of its sublayers.
+Because the composite layer doesn't draw directly to the canvas, it controls the rendering result by setting props of its sublayers.
 
-In our example, we want the sublayers to share the same ScatterplotLayer
-properties such as `radiusScale`, `getPosition` and `getRadius`. It is
-also desirable to pass many of the base layer props to the sublayers,
-e.g. `opacity`, `fp64`, `pickable`, `visible`, `projectionMode` etc.
+In our example, we want the sublayers to share the same ScatterplotLayer properties such as `radiusScale`, `getPosition` and `getRadius`. It is also desirable to pass many of the base layer props to the sublayers, e.g. `opacity`, `fp64`, `pickable`, `visible` etc.
 
-We then want to map the user defined `getFillColor` and `getStrokeColor`
-accessors to each `getColor` prop of the fill layer and the outline layer.
+We then want to map the user defined `getFillColor` and `getStrokeColor` accessors to each `getColor` prop of the fill layer and the outline layer.
 
-Finally, to make
-[`updateTrigger`](/docs/api-reference/base-layer.md#-updatetriggers-object-optional-)
-work when colors need to be recalculated, we will map respective accessor
-names to `getColor`.
+Finally, to make [`updateTrigger`](/docs/api-reference/base-layer.md#-updatetriggers-object-optional-) work when colors need to be recalculated, we will map respective accessor names to `getColor`.
 
 ```
 class NiceScatterplotLayer extends CompositeLayer {
@@ -149,13 +118,9 @@ class NiceScatterplotLayer extends CompositeLayer {
 
 ### Picking
 
-By default, the composite layer passes the picking info from its sublayers
-as-is to the callbacks. However, when we implement an adaptor layer that
-performs data conversion or aggregation, the data that the sublayer sees
-may not be the same data that the user passed in.
+By default, the composite layer passes the picking info from its sublayers as-is to the callbacks. However, when we implement an adaptor layer that performs data conversion or aggregation, the data that the sublayer sees may not be the same data that the user passed in.
 
-In this case, The composite layer may intercept the event info and modify
-it by implementing the `getPickingInfo()` method:
+In this case, The composite layer may intercept the event info and modify it by implementing the `getPickingInfo()` method:
 
 ```
 class AwesomeCompositeLayer extends CompositeLayer {
@@ -169,5 +134,4 @@ class AwesomeCompositeLayer extends CompositeLayer {
 
 }
 ```
-For more details, read about
-[how picking works](/docs/advanced/picking.md).
+For more details, read about [how picking works](/docs/advanced/picking.md).

--- a/docs/api-reference/base-layer.md
+++ b/docs/api-reference/base-layer.md
@@ -162,19 +162,19 @@ Requires `pickable` to be true.
 Normally only used when the application wants to work with coordinates
 that are not Web Mercator projected longitudes/latitudes.
 
-##### `projectionMode` (Number, optional)
+##### `coordinateSystem` (Number, optional)
 
 Specifies how layer positions and offsets should be geographically interpreted.
 
 The default is to interpret positions as latitude and longitude, however it
 is also possible to interpret positions as meter offsets added to projection
-center specified by the `positionOrigin` prop.
+center specified by the `coordinateOrigin` prop.
 
 See the article on Coordinate Systems for details.
 
-##### `positionOrigin` ([Number, Number], optional)
+##### `coordinateOrigin` ([Number, Number], optional)
 
-Required when the `projectionMode` is set to `COORDINATE_SYSTEM.METER_OFFSETS`.
+Required when the `coordinateSystem` is set to `COORDINATE_SYSTEM.METER_OFFSETS`.
 
 Specifies a longitude and a latitude from which meter offsets are calculated.
 
@@ -428,7 +428,7 @@ Parameters:
     + `x` (Number) - Mouse position x relative to the viewport.
     + `y` (Number) - Mouse position y relative to the viewport.
     + `lngLat` ([Number, Number]) - Mouse position in world coordinates. Only applies if
-      [`projectionMode`](/docs/api-reference/base-layer.md#-projectionmode-number-optional-)
+      [`coordinateSystem`](/docs/api-reference/base-layer.md#-projectionmode-number-optional-)
       is `COORDINATE_SYSTEM.LNGLAT`.
     + `color` (Number[4]) - The color of the pixel that is being picked. It represents a
       "picking color" that is encoded by

--- a/docs/api-reference/composite-layer.md
+++ b/docs/api-reference/composite-layer.md
@@ -52,15 +52,15 @@ Parameters:
   following fields:
     + `x` (Number) - Mouse position x relative to the viewport.
     + `y` (Number) - Mouse position y relative to the viewport.
-    + `lngLat` ([Number, Number]) - Mouse position in world coordinates. Only applies if
-      [`projectionMode`](/docs/api-reference/base-layer.md#-projectionmode-number-optional-)
-      is `COORDINATE_SYSTEM.LNGLAT`.
+    + `lngLat` ([Number, Number]) - Mouse position in world coordinates. Only applies if the
+      [`coordinateSystem`](/docs/api-reference/base-layer.md#-projectionmode-number-optional-)
+      prop is set to `COORDINATE_SYSTEM.LNGLAT`.
     + `color` (Number[4]) - The color of the pixel that is being picked. It represents a
       "picking color" that is encoded by
       [`layer.encodePickingColor()`](/docs/api-reference/base-layer.md#-encodepickingcolor-).
     + `index` (Number) - The index of the object that is being picked. It is the returned
       value of
-      [`layer.dncodePickingColor()`](/docs/api-reference/base-layer.md#-decodepickingcolor-).
+      [`layer.decodePickingColor()`](/docs/api-reference/base-layer.md#-decodepickingcolor-).
     + `picked` (Boolean) - `true` if `index` is not `-1`.
   * `pickParams.mode` (String) - One of `hover` and `click`
   * `pickParams.sourceLayer` (Layer) - the sublayer instance where this event originates from.

--- a/docs/get-started/interactivity.md
+++ b/docs/get-started/interactivity.md
@@ -23,7 +23,7 @@ The picking engine returns "picking info" objects which contains a variety of fi
 | `object` | The object that was picked. This is typically an entry in the layer's `props.data` array, but can vary from layer to layer. |
 | `x`      | Mouse position x relative to the viewport. |
 | `y`      | Mouse position y relative to the viewport. |
-| `lngLat` | Mouse position in geospatial coordinates. Only applies if `layer.props.projectionMode` is a geospatial mode such as `COORDINATE_SYSTEM.LNGLAT`. |
+| `lngLat` | Mouse position in geospatial coordinates. Only applies if `layer.props.coordinateSystem` is a geospatial mode such as `COORDINATE_SYSTEM.LNGLAT`. |
 
 > Specific deck.gl Layers may add additional fields to the picking `info` object. Check the documentation of each layer.
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -1,5 +1,17 @@
 # Upgrade Guide
 
+## Upgrading from deck.gl v4.1 to v4.2
+
+### Layer Props
+
+* Coordinate system related props have been renamed for clarity
+
+| Layer            | Old Prop           | New Prop             | Comment |
+| ---              | ---                | ---                  | ---     |
+| Layer            | `projectionMode`   | `coordinateSystem`   | Any constant from `COORDINATE_SYSTEM`  |
+| Layer            | `projectionOrigin` | `coordinateOrigin`   | |
+
+
 ## Upgrading from deck.gl v4 to v4.1
 
 deck.gl v4.1 is a backward-compatible release. Most of the functionality and APIs remain unchanged but there are smaller changes that might requires developers' attention if they **develop custom layers**. Note that applications that are only using the provided layers should not need to make any changes issues.

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -1,7 +1,11 @@
-# deck.gl v4.2
+# deck.gl v.Next
+
+Interesting in what is coming down the road? The deck.gl roadmap is now public. RFCs (Requests For Comments) for features in upcoming releases are available in the [developer documents](https://github.com/uber/deck.gl/tree/master/dev-docs/RFCs) section of the github repo.
+
+
+# deck.gl v4.2 (Under development)
 
 Release date: TBD, late 2017
-
 
 ## Control over DevicePixelRatio
 
@@ -20,7 +24,7 @@ Added new props (`getDashArray` and `justified`) to render paths as dashed lines
 
 ## Shader Modules
 
-* Shader module documenation is much improved, both in deck.gl and luma.gl. Shader Modules are listed under the "API Reference" heading after the JavaScript classes.
+* Shader module documenation is much improved, both in deck.gl and luma.gl. In the deck.gl docs, shader modules are listed under the "API Reference" heading, after the JavaScript classes.
 * The `project` module provides a new function `project_pixel_to_clipspace` for screen space calculations that takes variable `useDevicePixelRatio` and focal distance into account, making such calculation simpler and less prone to fail when parameters change.
 * The core deck.gl shader modules (`project` etc) now conform to the luma.gl shadertools conventions.
 

--- a/examples/graph/graph-layer/graph-layer.js
+++ b/examples/graph/graph-layer/graph-layer.js
@@ -28,7 +28,7 @@ import {
 
 const defaultProps = {
   offset: {x: 0, y: 0},
-  projectionMode: COORDINATE_SYSTEM.IDENTITY,
+  coordinateSystem: COORDINATE_SYSTEM.IDENTITY,
 
   getLinkPosition: link => ({
     sourcePosition: [link.source.x, link.source.y],
@@ -89,7 +89,7 @@ export default class GraphLayer extends CompositeLayer {
     const {opacity, pickable, visible} = this.props;
 
     // viewport props
-    const {projectionMode} = this.props;
+    const {coordinateSystem} = this.props;
 
     const drawLinks = links && links.length > 0;
     const drawNodes = nodes && nodes.length > 0;
@@ -106,7 +106,7 @@ export default class GraphLayer extends CompositeLayer {
       strokeWidth: getLinkWidth(),
       opacity,
       pickable,
-      projectionMode,
+      coordinateSystem,
       updateTriggers: {
         getSourcePosition: layoutTime,
         getTargetPosition: layoutTime,
@@ -122,7 +122,7 @@ export default class GraphLayer extends CompositeLayer {
       getColor: n => n.highlighting ? [255, 255, 0, 255] : getNodeColor(n),
       opacity,
       pickable,
-      projectionMode,
+      coordinateSystem,
       updateTriggers: {
         getPosition: layoutTime,
         getColor: layoutTime
@@ -141,7 +141,7 @@ export default class GraphLayer extends CompositeLayer {
       iconMapping,
       opacity,
       pickable,
-      projectionMode,
+      coordinateSystem,
       sizeScale,
       updateTriggers: {
         getPosition: layoutTime

--- a/examples/graph/graph-layer/graph-layout-layer.js
+++ b/examples/graph/graph-layer/graph-layout-layer.js
@@ -9,7 +9,7 @@ const defaultProps = {
   data: null,
   opacity: 1.0,
   layout: LayoutD3,
-  projectionMode: COORDINATE_SYSTEM.IDENTITY,
+  coordinateSystem: COORDINATE_SYSTEM.IDENTITY,
   nodeIconAccessors: {}
 };
 
@@ -112,7 +112,7 @@ export default class GraphLayoutLayer extends CompositeLayer {
     const pickable = Boolean(this.props.onHover || this.props.onClick);
 
     // viewport props
-    const {projectionMode} = this.props;
+    const {coordinateSystem} = this.props;
 
     // base layer accessors
     const {linkAccessors, nodeAccessors, nodeIconAccessors} = this.props;
@@ -129,7 +129,7 @@ export default class GraphLayoutLayer extends CompositeLayer {
         opacity,
         pickable,
         visible,
-        projectionMode,
+        coordinateSystem,
 
         onHover,
         onClick

--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -129,8 +129,9 @@ class App extends PureComponent {
       Object.assign(layerProps, {data: getData()});
     }
 
+    const useModelMatrix = layerProps.coordinateSystem === COORDINATE_SYSTEM.METER_OFFSETS;
     Object.assign(layerProps, {
-      modelMatrix: this._getModelMatrix(index, layerProps.coordinateSystem === COORDINATE_SYSTEM.METER_OFFSETS)
+      modelMatrix: this._getModelMatrix(index, useModelMatrix)
     });
 
     return new Layer(layerProps);

--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -1,5 +1,5 @@
 /* global window, document */
-import DeckGL, {experimental} from 'deck.gl';
+import DeckGL, {COORDINATE_SYSTEM, experimental} from 'deck.gl';
 const {ReflectionEffect} = experimental;
 
 import React, {PureComponent} from 'react';
@@ -130,7 +130,7 @@ class App extends PureComponent {
     }
 
     Object.assign(layerProps, {
-      modelMatrix: this._getModelMatrix(index, layerProps.projectionMode === 2)
+      modelMatrix: this._getModelMatrix(index, layerProps.coordinateSystem === COORDINATE_SYSTEM.METER_OFFSETS)
     });
 
     return new Layer(layerProps);

--- a/examples/layer-browser/src/examples/core-layers.js
+++ b/examples/layer-browser/src/examples/core-layers.js
@@ -1,4 +1,6 @@
 import {
+  COORDINATE_SYSTEM,
+
   ScatterplotLayer,
   ArcLayer,
   LineLayer,
@@ -181,8 +183,8 @@ const PointCloudLayerExample = {
   props: {
     id: 'pointCloudLayer',
     outline: true,
-    projectionMode: 2,
-    positionOrigin: dataSamples.positionOrigin,
+    coordinateSystem: COORDINATE_SYSTEM.METER_OFFSETS,
+    coordinateOrigin: dataSamples.positionOrigin,
     getPosition: d => get(d, 'position'),
     getNormal: d => get(d, 'normal'),
     getColor: d => get(d, 'color'),

--- a/examples/point-cloud-laz/app.js
+++ b/examples/point-cloud-laz/app.js
@@ -150,7 +150,7 @@ class Example extends PureComponent {
     return new PointCloudLayer({
       id: 'laz-point-cloud-layer',
       data: points,
-      projectionMode: COORDINATE_SYSTEM.IDENTITY,
+      coordinateSystem: COORDINATE_SYSTEM.IDENTITY,
       getPosition: d => d.position,
       getNormal: d => [0, 0.5, 0.2],
       getColor: d => [255, 255, 255, 128],

--- a/examples/point-cloud-ply/app.js
+++ b/examples/point-cloud-ply/app.js
@@ -101,7 +101,7 @@ class Example extends PureComponent {
     return new PointCloudLayer({
       id: 'point-cloud-layer',
       data: points,
-      projectionMode: COORDINATE_SYSTEM.IDENTITY,
+      coordinateSystem: COORDINATE_SYSTEM.IDENTITY,
       getPosition: d => d.position,
       getNormal: d => d.normal,
       radiusPixels: 2

--- a/examples/svg-interoperability/app.js
+++ b/examples/svg-interoperability/app.js
@@ -115,7 +115,7 @@ class Root extends PureComponent {
       updateTriggers: {
         getPosition: this.points._lastUpdate
       },
-      projectionMode: COORDINATE_SYSTEM.IDENTITY,
+      coordinateSystem: COORDINATE_SYSTEM.IDENTITY,
       // there's a bug that the radius calculated with project_scale
       radiusMinPixels: 2
     });

--- a/examples/tagmap/tagmap-layer/text-layer/multi-icon-layer/multi-icon-layer.js
+++ b/examples/tagmap/tagmap-layer/text-layer/multi-icon-layer/multi-icon-layer.js
@@ -14,7 +14,7 @@ export default class MultiIconLayer extends IconLayer {
   // copied from src/lib/utils/fp64.js for now as it is not visible outside the deck.gl repo
   enable64bitSupport(props) {
     if (props.fp64) {
-      if (props.projectionMode === COORDINATE_SYSTEM.LNGLAT) {
+      if (props.coordinateSystem === COORDINATE_SYSTEM.LNGLAT) {
         return true;
       }
     }

--- a/examples/text-layer/text-layer/multi-icon-layer/multi-icon-layer.js
+++ b/examples/text-layer/text-layer/multi-icon-layer/multi-icon-layer.js
@@ -14,7 +14,7 @@ export default class MultiIconLayer extends IconLayer {
   // copied from src/lib/utils/fp64.js for now as it is not visible outside the deck.gl repo
   enable64bitSupport(props) {
     if (props.fp64) {
-      if (props.projectionMode === COORDINATE_SYSTEM.LNGLAT) {
+      if (props.coordinateSystem === COORDINATE_SYSTEM.LNGLAT) {
         return true;
       }
     }

--- a/src/layers/core/arc-layer/arc-layer.js
+++ b/src/layers/core/arc-layer/arc-layer.js
@@ -66,7 +66,7 @@ export default class ArcLayer extends Layer {
       const {attributeManager} = this.state;
       attributeManager.invalidateAll();
 
-      if (props.fp64 && props.projectionMode === COORDINATE_SYSTEM.LNGLAT) {
+      if (props.fp64 && props.coordinateSystem === COORDINATE_SYSTEM.LNGLAT) {
         attributeManager.addInstanced({
           instancePositions64Low: {
             size: 4,

--- a/src/layers/core/geojson-layer/geojson-layer.js
+++ b/src/layers/core/geojson-layer/geojson-layer.js
@@ -119,14 +119,14 @@ export default class GeoJsonLayer extends CompositeLayer {
     const {opacity, pickable, visible, parameters, getPolygonOffset,
       highlightedObjectIndex, autoHighlight, highlightColor} = this.props;
     // viewport props
-    const {positionOrigin, projectionMode, modelMatrix} = this.props;
+    const {coordinateSystem, coordinateOrigin, modelMatrix} = this.props;
 
     const forwardProps = {
       // Forward layer props
       opacity, pickable, visible, parameters, getPolygonOffset,
       highlightedObjectIndex, autoHighlight, highlightColor,
       // Forward viewport props
-      projectionMode, positionOrigin, modelMatrix,
+      coordinateSystem, coordinateOrigin, modelMatrix,
       // Forward common props
       fp64
     };

--- a/src/layers/core/grid-cell-layer/grid-cell-layer.js
+++ b/src/layers/core/grid-cell-layer/grid-cell-layer.js
@@ -89,7 +89,7 @@ export default class GridCellLayer extends Layer {
       const {attributeManager} = this.state;
       attributeManager.invalidateAll();
 
-      if (props.fp64 && props.projectionMode === COORDINATE_SYSTEM.LNGLAT) {
+      if (props.fp64 && props.coordinateSystem === COORDINATE_SYSTEM.LNGLAT) {
         attributeManager.addInstanced({
           instancePositions64xyLow: {
             size: 2,

--- a/src/layers/core/grid-layer/grid-layer.js
+++ b/src/layers/core/grid-layer/grid-layer.js
@@ -176,7 +176,7 @@ export default class GridLayer extends CompositeLayer {
     highlightedObjectIndex, autoHighlight, highlightColor} = this.props;
 
     // viewport props
-    const {positionOrigin, projectionMode, modelMatrix} = this.props;
+    const {coordinateSystem, coordinateOrigin, modelMatrix} = this.props;
 
     // return props to the sublayer constructor
     return {
@@ -192,8 +192,8 @@ export default class GridLayer extends CompositeLayer {
       pickable,
       visible,
       getPolygonOffset,
-      projectionMode,
-      positionOrigin,
+      coordinateSystem,
+      coordinateOrigin,
       modelMatrix,
       highlightedObjectIndex,
       autoHighlight,

--- a/src/layers/core/hexagon-cell-layer/hexagon-cell-layer.js
+++ b/src/layers/core/hexagon-cell-layer/hexagon-cell-layer.js
@@ -107,7 +107,7 @@ export default class HexagonCellLayer extends Layer {
       const {attributeManager} = this.state;
       attributeManager.invalidateAll();
 
-      if (props.fp64 && props.projectionMode === COORDINATE_SYSTEM.LNGLAT) {
+      if (props.fp64 && props.coordinateSystem === COORDINATE_SYSTEM.LNGLAT) {
         attributeManager.addInstanced({
           instancePositions64xyLow: {
             size: 2,

--- a/src/layers/core/hexagon-layer/hexagon-layer.js
+++ b/src/layers/core/hexagon-layer/hexagon-layer.js
@@ -219,7 +219,7 @@ export default class HexagonLayer extends CompositeLayer {
     highlightedObjectIndex, autoHighlight, highlightColor} = this.props;
 
     // viewport props
-    const {positionOrigin, projectionMode, modelMatrix} = this.props;
+    const {coordinateSystem, coordinateOrigin, modelMatrix} = this.props;
 
     // return props to the sublayer constructor
     return {
@@ -237,8 +237,8 @@ export default class HexagonLayer extends CompositeLayer {
       pickable,
       visible,
       getPolygonOffset,
-      projectionMode,
-      positionOrigin,
+      coordinateSystem,
+      coordinateOrigin,
       modelMatrix,
       highlightedObjectIndex,
       autoHighlight,

--- a/src/layers/core/icon-layer/icon-layer.js
+++ b/src/layers/core/icon-layer/icon-layer.js
@@ -98,7 +98,7 @@ export default class IconLayer extends Layer {
       const {attributeManager} = this.state;
       attributeManager.invalidateAll();
 
-      if (props.fp64 && props.projectionMode === COORDINATE_SYSTEM.LNGLAT) {
+      if (props.fp64 && props.coordinateSystem === COORDINATE_SYSTEM.LNGLAT) {
         attributeManager.addInstanced({
           instancePositions64xyLow: {
             size: 2,

--- a/src/layers/core/line-layer/line-layer.js
+++ b/src/layers/core/line-layer/line-layer.js
@@ -65,7 +65,7 @@ export default class LineLayer extends Layer {
       const {attributeManager} = this.state;
       attributeManager.invalidateAll();
 
-      if (props.fp64 && props.projectionMode === COORDINATE_SYSTEM.LNGLAT) {
+      if (props.fp64 && props.coordinateSystem === COORDINATE_SYSTEM.LNGLAT) {
         attributeManager.addInstanced({
           instanceSourceTargetPositions64xyLow: {
             size: 4,

--- a/src/layers/core/path-layer/path-layer.js
+++ b/src/layers/core/path-layer/path-layer.js
@@ -82,7 +82,7 @@ export default class PathLayer extends Layer {
       const {attributeManager} = this.state;
       attributeManager.invalidateAll();
 
-      if (props.fp64 && props.projectionMode === COORDINATE_SYSTEM.LNGLAT) {
+      if (props.fp64 && props.coordinateSystem === COORDINATE_SYSTEM.LNGLAT) {
         attributeManager.addInstanced({
           instanceStartEndPositions64xyLow: {
             size: 4,

--- a/src/layers/core/point-cloud-layer/point-cloud-layer.js
+++ b/src/layers/core/point-cloud-layer/point-cloud-layer.js
@@ -73,7 +73,7 @@ export default class PointCloudLayer extends Layer {
       const {attributeManager} = this.state;
       attributeManager.invalidateAll();
 
-      if (props.fp64 && props.projectionMode === COORDINATE_SYSTEM.LNGLAT) {
+      if (props.fp64 && props.coordinateSystem === COORDINATE_SYSTEM.LNGLAT) {
         attributeManager.addInstanced({
           instancePositions64xyLow: {
             size: 2,

--- a/src/layers/core/polygon-layer/polygon-layer.js
+++ b/src/layers/core/polygon-layer/polygon-layer.js
@@ -105,7 +105,7 @@ export default class PolygonLayer extends CompositeLayer {
     highlightedObjectIndex, autoHighlight, highlightColor} = this.props;
 
     // viewport props
-    const {positionOrigin, projectionMode, modelMatrix} = this.props;
+    const {coordinateSystem, coordinateOrigin, modelMatrix} = this.props;
 
     const {paths} = this.state;
 
@@ -122,8 +122,8 @@ export default class PolygonLayer extends CompositeLayer {
       pickable,
       visible,
       getPolygonOffset,
-      projectionMode,
-      positionOrigin,
+      coordinateSystem,
+      coordinateOrigin,
       modelMatrix,
       getPolygon,
       getElevation,
@@ -151,8 +151,8 @@ export default class PolygonLayer extends CompositeLayer {
         pickable,
         visible,
         getPolygonOffset,
-        projectionMode,
-        positionOrigin,
+        coordinateSystem,
+        coordinateOrigin,
         modelMatrix,
         getPolygon,
         getElevation,
@@ -180,8 +180,8 @@ export default class PolygonLayer extends CompositeLayer {
         pickable,
         visible,
         getPolygonOffset,
-        projectionMode,
-        positionOrigin,
+        coordinateSystem,
+        coordinateOrigin,
         modelMatrix,
         getPath: x => x.path,
         getColor: getLineColor,

--- a/src/layers/core/scatterplot-layer/scatterplot-layer.js
+++ b/src/layers/core/scatterplot-layer/scatterplot-layer.js
@@ -73,7 +73,7 @@ export default class ScatterplotLayer extends Layer {
       const {attributeManager} = this.state;
       attributeManager.invalidateAll();
 
-      if (props.fp64 && props.projectionMode === COORDINATE_SYSTEM.LNGLAT) {
+      if (props.fp64 && props.coordinateSystem === COORDINATE_SYSTEM.LNGLAT) {
         attributeManager.addInstanced({
           instancePositions64xyLow: {
             size: 2,

--- a/src/layers/core/solid-polygon-layer/solid-polygon-layer.js
+++ b/src/layers/core/solid-polygon-layer/solid-polygon-layer.js
@@ -90,7 +90,7 @@ export default class SolidPolygonLayer extends Layer {
       const {attributeManager} = this.state;
       attributeManager.invalidateAll();
 
-      if (props.fp64 && props.projectionMode === COORDINATE_SYSTEM.LNGLAT) {
+      if (props.fp64 && props.coordinateSystem === COORDINATE_SYSTEM.LNGLAT) {
         attributeManager.add({
           positions64xyLow: {size: 2, update: this.calculatePositionsLow}
         });

--- a/src/lib/layer.js
+++ b/src/lib/layer.js
@@ -51,7 +51,8 @@ const defaultProps = {
   onHover: noop,
   onClick: noop,
 
-  projectionMode: COORDINATE_SYSTEM.LNGLAT,
+  coordinateSystem: COORDINATE_SYSTEM.LNGLAT,
+  coordinateOrigin: [0, 0, 0],
 
   parameters: {},
   uniforms: {},

--- a/src/lib/utils/fp64.js
+++ b/src/lib/utils/fp64.js
@@ -30,10 +30,10 @@ export function fp64ify(a) {
 
 export function enable64bitSupport(props) {
   if (props.fp64) {
-    if (props.projectionMode === COORDINATE_SYSTEM.LNGLAT) {
+    if (props.coordinateSystem === COORDINATE_SYSTEM.LNGLAT) {
       return true;
     }
-    log.once(0, `64-bit mode only works with projectionMode set to
+    log.once(0, `64-bit mode only works with coordinateSystem set to
       COORDINATE_SYSTEM.LNGLAT. Rendering in 32-bit mode instead`);
   }
 

--- a/src/shaderlib/project/viewport-uniforms.js
+++ b/src/shaderlib/project/viewport-uniforms.js
@@ -78,10 +78,14 @@ function calculateMatrixAndOffset({
   // NEW PARAMS
   coordinateSystem,
   coordinateOrigin,
+<<<<<<< HEAD
   coordinateZoom,
   // DEPRECATED PARAMS
   projectionMode,
   positionOrigin = [0, 0]
+=======
+  coordinateZoom
+>>>>>>> Rename coordinateSystem props
 }) {
   const {viewMatrixUncentered} = viewport;
   let {viewMatrix} = viewport;
@@ -139,7 +143,6 @@ export function getUniformsFromViewport({
   modelMatrix = null,
   coordinateSystem = COORDINATE_SYSTEM.LNGLAT,
   coordinateOrigin = [0, 0],
-  coordinateZoom,
   // Deprecated
   projectionMode,
   positionOrigin
@@ -155,7 +158,7 @@ export function getUniformsFromViewport({
     log.deprecated('positionOrigin', 'coordinateOrigin');
   }
 
-  coordinateZoom = coordinateZoom || viewport.zoom;
+  const coordinateZoom = viewport.zoom;
   assert(coordinateZoom >= 0);
 
   const {projectionCenter, viewProjectionMatrix, cameraPos} =
@@ -180,7 +183,7 @@ export function getUniformsFromViewport({
 
   return {
     // Projection mode values
-    project_uCoordinateSystem: projectionMode,
+    project_uCoordinateSystem: coordinateSystem,
     project_uCenter: projectionCenter,
 
     // Screen size
@@ -207,7 +210,10 @@ export function getUniformsFromViewport({
     //
     // DEPRECATED UNIFORMS - For backwards compatibility with old custom layers
     //
+    projectionMode: coordinateSystem,
+    projectionOrigin: coordinateOrigin,
     modelMatrix: glModelMatrix,
+
     projectionMatrix: glViewProjectionMatrix,
     projectionPixelsPerUnit: distanceScales.pixelsPerMeter,
     projectionScale: viewport.scale, // This is the mercator scale (2 ** zoom)

--- a/src/shaderlib/project/viewport-uniforms.js
+++ b/src/shaderlib/project/viewport-uniforms.js
@@ -78,14 +78,7 @@ function calculateMatrixAndOffset({
   // NEW PARAMS
   coordinateSystem,
   coordinateOrigin,
-<<<<<<< HEAD
-  coordinateZoom,
-  // DEPRECATED PARAMS
-  projectionMode,
-  positionOrigin = [0, 0]
-=======
   coordinateZoom
->>>>>>> Rename coordinateSystem props
 }) {
   const {viewMatrixUncentered} = viewport;
   let {viewMatrix} = viewport;

--- a/test/bench/index.js
+++ b/test/bench/index.js
@@ -55,13 +55,13 @@ suite
 .add('getUniformsFromViewport#LNGLAT', () => {
   return getUniformsFromViewport(data.sampleViewport, {
     modelMatrix: data.sampleModelMatrix,
-    projectionMode: COORDINATE_SYSTEM.LNGLAT
+    coordinateSystem: COORDINATE_SYSTEM.LNGLAT
   });
 })
 .add('getUniformsFromViewport#METER_OFFSETS', () => {
   return getUniformsFromViewport(data.sampleViewport, {
     modelMatrix: data.sampleModelMatrix,
-    projectionMode: COORDINATE_SYSTEM.METER_OFFSETS
+    coordinateSystem: COORDINATE_SYSTEM.METER_OFFSETS
   });
 })
 .add('WebMercatorViewport', () => {

--- a/test/lib/viewport-uniforms.spec.js
+++ b/test/lib/viewport-uniforms.spec.js
@@ -56,7 +56,7 @@ test('getUniformsFromViewport', t => {
     (uniforms.modelViewMatrix instanceof Matrix4), 'Returned modelViewMatrix');
 
   uniforms = getUniformsFromViewport(viewport, {
-    projectionMode: COORDINATE_SYSTEM.METER_OFFSETS
+    coordinateSystem: COORDINATE_SYSTEM.METER_OFFSETS
   });
   t.ok(uniforms.projectionCenter.some(x => x), 'Returned non-trivial projection center');
 

--- a/test/rendering-test/test-config.js
+++ b/test/rendering-test/test-config.js
@@ -1,4 +1,4 @@
-import {getPoints100K, getPoints100KMeters, positionOrigin} from './data-generator';
+import {getPoints100K, getPoints100KMeters, coordinateOrigin} from './data-generator';
 
 import {
   COORDINATE_SYSTEM,
@@ -98,8 +98,8 @@ export const TEST_CASES = [
       props: {
         id: 'scatterplot-1-meters',
         data: getPoints100KMeters(),
-        projectionMode: COORDINATE_SYSTEM.METERS,
-        positionOrigin,
+        coordinateSystem: COORDINATE_SYSTEM.METERS,
+        coordinateOrigin,
         getPosition: d => d,
         getColor: d => [255, 128, 0],
         getRadius: d => 5.0,

--- a/test/shaderlib/project/viewport-uniforms.spec.js
+++ b/test/shaderlib/project/viewport-uniforms.spec.js
@@ -56,7 +56,7 @@ test('getUniformsFromViewport', t => {
     (uniforms.modelViewMatrix instanceof Matrix4), 'Returned modelViewMatrix');
 
   uniforms = getUniformsFromViewport(viewport, {
-    projectionMode: COORDINATE_SYSTEM.METER_OFFSETS
+    coordinateSystem: COORDINATE_SYSTEM.METER_OFFSETS
   });
   t.ok(uniforms.projectionCenter.some(x => x), 'Returned non-trivial projection center');
 

--- a/website/src/components/demos/layer-demos.js
+++ b/website/src/components/demos/layer-demos.js
@@ -2,6 +2,7 @@ import createLayerDemoClass from './layer-demo-base';
 import {DATA_URI} from '../../constants/defaults';
 
 import {
+  COORDINATE_SYSTEM,
   ScatterplotLayer,
   LineLayer,
   ArcLayer,
@@ -183,8 +184,8 @@ export const PointCloudLayerDemo = createLayerDemoClass({
   formatTooltip: d => d.position.join(', '),
   props: {
     pickable: false,
-    projectionMode: 2,
-    positionOrigin: [-122.4, 37.74],
+    coordinateSystem: COORDINATE_SYSTEM.METER_OFFSETS,
+    coordinateOrigin: [-122.4, 37.74],
     radiusPixels: 4,
     getPosition: d => d.position,
     getNormal: d => d.normal,

--- a/website/src/utils/layer-params.js
+++ b/website/src/utils/layer-params.js
@@ -1,5 +1,5 @@
 const blackList = [
-  'projectionMode',
+  'coordinateSystem',
   'modelMatrix'
 ];
 


### PR DESCRIPTION
This is a follow up to the recent extensive rewrite of the "Coordinate Systems" article. 

One small but important step towards making these thing simpler to explain and use, is to have the prop names match the type (i.e. `COORDINATE_SYSTEM`) and the concepts used in the docs.

* `projectionMode` => `coordinateSystem`
* `projectionOrigin` => `coordinateOrigin`

Now when the docs talk about coordinate systems it will be much easier for the user to make the right associations.

* Backwards compatibility is supported.
* What's New and Upgrade Guide are updated
* All layers and examples are updated
* All tests pass
