### PR TITLE
New controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,21 @@ Each version should:
 Ref: http://keepachangelog.com/en/0.3.0/
 -->
 
-## Pre Releases
+## Latest Beta Releases
 
-### deck.gl v4.2
+For Earlier Beta Releases see below
+
+## Beta Releases
+
+### deck.gl v4.2 Beta Releases
+
+#### [4.2.0-alpha.6] -
+- First person view merged to master
+
+#### [4.2.0-alpha.5] -
+- FIXES for First Person View
 
 #### [4.2.0-alpha.4] -
-
 - NEW: Automatic/custom highlighting using picking shader module.
 - FIX: ScreenGridLayer `depthTest`
 - FIX: CompositeLayer `parameters` forwarding
@@ -48,9 +57,24 @@ Ref: http://keepachangelog.com/en/0.3.0/
 
 - Add: UTM_OFFSETS projection mode
 
+
 ## Official Releases
 
 ### deck.gl v4.1
+
+#### [4.1.2] - Patch Release
+- FIX: IconLayer texture filter and rotation:
+
+#### [4.1.1] - Patch Release
+- NEW: Automatic/custom highlighting using picking shader module.
+- FIX: ScreenGridLayer `depthTest`
+- FIX: CompositeLayer `parameters` forwarding
+- FIX: S2Layer prop forwarding
+- FIX: GridLayer crash: max call stack size
+- NEW: Add `devicePixelRatio` prop
+- NEW: RFCs
+- DOCS: picking/event handling refresh
+- DEMO: Wind demo fixes
 
 #### [4.1.0] - 2017-7-27 Minor deck.gl Release
 
@@ -206,6 +230,7 @@ For details see [What's New](docs/whats-new.md)
 
 #### [1.0.0] - 2016-01-06
 - Initial commit of the open-source version of deck.gl
+
 
 ## Beta Releases
 

--- a/src/controllers/first-person-state.js
+++ b/src/controllers/first-person-state.js
@@ -1,0 +1,361 @@
+import {Vector3, experimental} from 'math.gl';
+const {SphericalCoordinates} = experimental;
+import assert from 'assert';
+
+const MOVEMENT_SPEED = 1;  // 1 meter per keyboard click
+// const ROTATION_STEP_RADIANS = 0.03;
+const ROTATION_STEP_DEGREES = 2;
+
+const defaultState = {
+  position: [0, 0, 0],
+  lookAt: [0, 0, 0],
+  up: [0, 0, 1],
+
+  rotationX: 0,
+  rotationY: 0,
+
+  fov: 50,
+  near: 1,
+  far: 100
+};
+
+/* Helpers */
+
+// Constrain number between bounds
+function clamp(x, min, max) {
+  return x < min ? min : (x > max ? max : x);
+}
+
+function ensureFinite(value, fallbackValue) {
+  return Number.isFinite(value) ? value : fallbackValue;
+}
+
+export default class FirstPersonState {
+
+  constructor({
+    /* Viewport arguments */
+    width, // Width of viewport
+    height, // Height of viewport
+
+    // Position and orientation
+    position, // typically in meters from anchor point
+    direction,
+
+    bearing, // Rotation around y axis
+    pitch, // Rotation around x axis
+    zoom,
+
+    syncBearing = true, // Whether to lock bearing to direction
+
+    // Constraints - simple movement limit
+    // Bounding box of the world, in the shape of {minX, maxX, minY, maxY, minZ, maxZ}
+    bounds,
+
+    /** Interaction states, required to calculate change during transform */
+    // Model state when the pan operation first started
+    startPanEventPosition,
+    startPanPosition,
+
+    // Model state when the rotate operation first started
+    startRotateCenter,
+    startRotateViewport,
+
+    // Model state when the zoom operation first started
+    startZoomPos,
+    startZoom
+  }) {
+    assert(Number.isFinite(width), '`width` must be supplied');
+    assert(Number.isFinite(height), '`height` must be supplied');
+    // assert(Number.isFinite(distance), '`distance` must be supplied');
+
+    bearing = ensureFinite(bearing, defaultState.bearing);
+
+    this._viewportProps = this._applyConstraints({
+      width,
+      height,
+      position: new Vector3(
+        ensureFinite(position[0], defaultState.position[0]),
+        ensureFinite(position[1], defaultState.position[1]),
+        ensureFinite(position[2], defaultState.position[2])
+      ),
+      direction: this._getDirectionFromBearing(bearing),
+      bearing,
+      pitch: ensureFinite(pitch, defaultState.pitch),
+      zoom,
+      bounds
+    });
+
+    this._interactiveState = {
+      startPanEventPosition,
+      startPanPosition,
+      startRotateCenter,
+      startRotateViewport,
+      startZoomPos,
+      startZoom
+    };
+  }
+
+  /* Public API */
+
+  getViewportProps() {
+    return this._viewportProps;
+  }
+
+  getInteractiveState() {
+    return this._interactiveState;
+  }
+
+  getLookAt() {
+    return [];
+  }
+
+  /**
+   * Start panning
+   * @param {[Number, Number]} pos - position on screen where the pointer grabs
+   */
+  panStart({pos}) {
+    const {translationX, translationY} = this._viewportProps;
+
+    return this._getUpdatedState({
+      startPanPosition: [translationX, translationY],
+      startPanEventPosition: pos
+    });
+  }
+
+  /**
+   * Pan
+   * @param {[Number, Number]} pos - position on screen where the pointer is
+   */
+  pan({pos, startPos}) {
+    const startPanEventPosition = this._interactiveState.startPanEventPosition || startPos;
+    assert(startPanEventPosition, '`startPanEventPosition` props is required');
+
+    let [translationX, translationY] = this._interactiveState.startPanPosition || [];
+    translationX = ensureFinite(translationX, this._viewportProps.translationX);
+    translationY = ensureFinite(translationY, this._viewportProps.translationY);
+
+    const deltaX = pos[0] - startPanEventPosition[0];
+    const deltaY = pos[1] - startPanEventPosition[1];
+
+    return this._getUpdatedState({
+      translationX: translationX + deltaX,
+      translationY: translationY - deltaY
+    });
+  }
+
+  /**
+   * End panning
+   * Must call if `panStart()` was called
+   */
+  panEnd() {
+    return this._getUpdatedState({
+      startPanPosition: null,
+      startPanPos: null
+    });
+  }
+
+  /**
+   * Start rotating
+   * @param {[Number, Number]} pos - position on screen where the pointer grabs
+   */
+  rotateStart({pos}) {
+    return this._getUpdatedState({
+      startRotateCenter: this._viewportProps.position,
+      startRotateViewport: this._viewportProps
+    });
+  }
+
+  /**
+   * Rotate
+   * @param {[Number, Number]} pos - position on screen where the pointer is
+   */
+  rotate({deltaScaleX, deltaScaleY}) {
+    const {direction} = this._viewportProps;
+
+    return this._getUpdatedState({
+      direction: new Vector3(direction).rotateZ({radians: deltaScaleX / 50}),
+    });
+  }
+
+  /**
+   * End rotating
+   * Must call if `rotateStart()` was called
+   */
+  rotateEnd() {
+    return this._getUpdatedState({
+      startRotateCenter: null,
+      startRotateViewport: null
+    });
+  }
+
+  /**
+   * Start zooming
+   * @param {[Number, Number]} pos - position on screen where the pointer grabs
+   */
+  zoomStart({pos}) {
+    return this._getUpdatedState({
+      startZoomPos: pos,
+      startZoom: this._viewportProps.zoom
+    });
+  }
+
+  /**
+   * Zoom
+   * @param {[Number, Number]} pos - position on screen where the current center is
+   * @param {[Number, Number]} startPos - the center position at
+   *   the start of the operation. Must be supplied of `zoomStart()` was not called
+   * @param {Number} scale - a number between [0, 1] specifying the accumulated
+   *   relative scale.
+   */
+  zoom({pos, startPos, scale}) {
+    const {zoom, minZoom, maxZoom, width, height, translationX, translationY} = this._viewportProps;
+
+    const startZoomPos = this._interactiveState.startZoomPos || startPos || pos;
+
+    const newZoom = clamp(zoom * scale, minZoom, maxZoom);
+    const deltaX = pos[0] - startZoomPos[0];
+    const deltaY = pos[1] - startZoomPos[1];
+
+    // Zoom around the center position
+    const cx = startZoomPos[0] - width / 2;
+    const cy = height / 2 - startZoomPos[1];
+    /* eslint-disable no-unused-vars */
+    const newTranslationX = cx - (cx - translationX) * newZoom / zoom + deltaX;
+    const newTranslationY = cy - (cy - translationY) * newZoom / zoom - deltaY;
+    /* eslint-enable no-unused-vars */
+
+    // return this._getUpdatedState({
+    //   position
+    //   translationX: newTranslationX,
+    //   translationY: newTranslationY
+    // });
+
+    // TODO HACK
+    return newZoom / zoom < 1 ? this.moveBackward() : this.moveForward();
+  }
+
+  /**
+   * End zooming
+   * Must call if `zoomStart()` was called
+   */
+  zoomEnd() {
+    return this._getUpdatedState({
+      startZoomPos: null,
+      startZoom: null
+    });
+  }
+
+  _getDirectionFromBearing(bearing) {
+    const spherical = new SphericalCoordinates({
+      bearing,
+      pitch: 90
+    });
+    const direction = spherical.toVector3().normalize();
+    return direction;
+  }
+
+  moveLeft() {
+    // const {position, direction} = this._viewportProps;
+    // const newDirection = new Vector3(direction).rotateZ({radians: ROTATION_STEP_RADIANS});
+    // return this._getUpdatedState({
+    //   direction: newDirection,
+    //   lookAt: new Vector3(position).add(newDirection.normalize()),
+    //   bearing: this._viewportProps.bearing - ROTATION_STEP_DEGREES
+    // });
+
+    const {position, bearing} = this._viewportProps;
+    const newBearing = bearing - ROTATION_STEP_DEGREES;
+    const newDirection = this._getDirectionFromBearing(newBearing);
+    return this._getUpdatedState({
+      direction: newDirection,
+      lookAt: new Vector3(position).add(newDirection),
+      bearing: newBearing
+    });
+  }
+
+  moveRight() {
+    // const {position, direction} = this._viewportProps;
+    // const newDirection = new Vector3(direction).rotateZ({radians: -ROTATION_STEP_RADIANS});
+    // return this._getUpdatedState({
+    //   direction: newDirection,
+    //   lookAt: new Vector3(position).add(newDirection.normalize()),
+    //   bearing: this._viewportProps.bearing + ROTATION_STEP_DEGREES
+    // });
+
+    const {position, bearing} = this._viewportProps;
+    const newBearing = bearing + ROTATION_STEP_DEGREES;
+    const newDirection = this._getDirectionFromBearing(newBearing);
+    return this._getUpdatedState({
+      direction: newDirection,
+      lookAt: new Vector3(position).add(newDirection),
+      bearing: newBearing
+    });
+  }
+
+  moveForward() {
+    const {position, direction} = this._viewportProps;
+    const delta = new Vector3(direction).normalize().scale(MOVEMENT_SPEED);
+    return this._getUpdatedState({
+      // pitch: this._viewportProps.pitch + 3
+      position: new Vector3(position).add(delta),
+      lookAt: new Vector3(position).add(direction)
+    });
+  }
+
+  moveBackward() {
+    const {position, direction} = this._viewportProps;
+    const delta = new Vector3(direction).normalize().scale(-MOVEMENT_SPEED);
+    return this._getUpdatedState({
+      // pitch: this._viewportProps.pitch - 3
+      position: new Vector3(position).add(delta),
+      lookAt: new Vector3(position).add(direction)
+    });
+  }
+
+  moveUp() {
+    const {position, direction} = this._viewportProps;
+    const delta = [0, 0, 1];
+    return this._getUpdatedState({
+      // pitch: this._viewportProps.pitch + 3
+      position: new Vector3(position).add(delta),
+      lookAt: new Vector3(position).add(direction)
+    });
+  }
+
+  moveDown() {
+    const {position, direction} = this._viewportProps;
+    const delta = position[2] >= 1 ? [0, 0, -1] : [0, 0, 0];
+    return this._getUpdatedState({
+      // pitch: this._viewportProps.pitch + 3
+      position: new Vector3(position).add(delta),
+      lookAt: new Vector3(position).add(direction)
+    });
+  }
+
+  zoomIn() {
+    return this._getUpdatedState({
+      zoom: this._viewportProps.zoom + 0.2
+    });
+  }
+
+  zoomOut() {
+    return this._getUpdatedState({
+      zoom: this._viewportProps.zoom - 0.2
+    });
+  }
+
+  /* Private methods */
+
+  _getUpdatedState(newProps) {
+    // Update _viewportProps
+    return new FirstPersonState(
+      Object.assign({}, this._viewportProps, this._interactiveState, newProps)
+    );
+  }
+
+  // Apply any constraints (mathematical or defined by _viewportProps) to map state
+  _applyConstraints(props) {
+    // TODO/ib - Ensure position is within bounds
+    return props;
+  }
+}

--- a/src/controllers/first-person-state.js
+++ b/src/controllers/first-person-state.js
@@ -173,7 +173,7 @@ export default class FirstPersonState {
     const {direction} = this._viewportProps;
 
     return this._getUpdatedState({
-      direction: new Vector3(direction).rotateZ({radians: deltaScaleX / 50}),
+      direction: new Vector3(direction).rotateZ({radians: deltaScaleX / 50})
     });
   }
 

--- a/src/controllers/map-state.js
+++ b/src/controllers/map-state.js
@@ -113,7 +113,7 @@ export default class MapState {
    * @param {[Number, Number]} pos - position on screen where the pointer grabs
    */
   panStart({pos}) {
-    return this._getUpdatedMapState({
+    return this._getUpdatedState({
       startPanLngLat: this._unproject(pos)
     });
   }
@@ -133,7 +133,7 @@ export default class MapState {
 
     const [longitude, latitude] = this._calculateNewLngLat({startPanLngLat, pos});
 
-    return this._getUpdatedMapState({
+    return this._getUpdatedState({
       longitude,
       latitude
     });
@@ -144,7 +144,7 @@ export default class MapState {
    * Must call if `panStart()` was called
    */
   panEnd() {
-    return this._getUpdatedMapState({
+    return this._getUpdatedState({
       startPanLngLat: null
     });
   }
@@ -154,7 +154,7 @@ export default class MapState {
    * @param {[Number, Number]} pos - position on screen where the center is
    */
   rotateStart({pos}) {
-    return this._getUpdatedMapState({
+    return this._getUpdatedState({
       startBearing: this._viewportProps.bearing,
       startPitch: this._viewportProps.pitch
     });
@@ -189,7 +189,7 @@ export default class MapState {
       startPitch
     });
 
-    return this._getUpdatedMapState({
+    return this._getUpdatedState({
       bearing,
       pitch
     });
@@ -200,7 +200,7 @@ export default class MapState {
    * Must call if `rotateStart()` was called
    */
   rotateEnd() {
-    return this._getUpdatedMapState({
+    return this._getUpdatedState({
       startBearing: null,
       startPitch: null
     });
@@ -211,7 +211,7 @@ export default class MapState {
    * @param {[Number, Number]} pos - position on screen where the center is
    */
   zoomStart({pos}) {
-    return this._getUpdatedMapState({
+    return this._getUpdatedState({
       startZoomLngLat: this._unproject(pos),
       startZoom: this._viewportProps.zoom
     });
@@ -248,7 +248,7 @@ export default class MapState {
     );
     const [longitude, latitude] = zoomedViewport.getLocationAtPoint({lngLat: startZoomLngLat, pos});
 
-    return this._getUpdatedMapState({
+    return this._getUpdatedState({
       zoom,
       longitude,
       latitude
@@ -260,15 +260,51 @@ export default class MapState {
    * Must call if `zoomStart()` was called
    */
   zoomEnd() {
-    return this._getUpdatedMapState({
+    return this._getUpdatedState({
       startZoomLngLat: null,
       startZoom: null
     });
   }
 
+  moveLeft() {
+    return this._getUpdatedState({
+      bearing: this._viewportProps.bearing - 3
+    });
+  }
+
+  moveRight() {
+    return this._getUpdatedState({
+      bearing: this._viewportProps.bearing + 3
+    });
+  }
+
+  moveForward() {
+    return this._getUpdatedState({
+      pitch: this._viewportProps.pitch + 3
+    });
+  }
+
+  moveBackward() {
+    return this._getUpdatedState({
+      pitch: this._viewportProps.pitch - 3
+    });
+  }
+
+  zoomIn() {
+    return this._getUpdatedState({
+      zoom: this._viewportProps.zoom + 0.2
+    });
+  }
+
+  zoomOut() {
+    return this._getUpdatedState({
+      zoom: this._viewportProps.zoom - 0.2
+    });
+  }
+
   /* Private methods */
 
-  _getUpdatedMapState(newProps) {
+  _getUpdatedState(newProps) {
     // Update _viewportProps
     return new MapState(Object.assign({}, this._viewportProps, this._interactiveState, newProps));
   }
@@ -332,5 +368,4 @@ export default class MapState {
       bearing
     };
   }
-
 }

--- a/src/index.js
+++ b/src/index.js
@@ -28,9 +28,12 @@ export {default as CompositeLayer} from './lib/composite-layer';
 
 // Viewports
 export {default as Viewport} from './viewports/viewport';
-export {default as FirstPersonViewport} from './viewports/first-person-viewport';
-export {default as ThirdPersonViewport} from './viewports/third-person-viewport';
 export {default as WebMercatorViewport} from './viewports/web-mercator-viewport';
+
+// TODO - Do we need to export? Move to experimental?
+export {default as FirstPersonState} from './controllers/first-person-state';
+export {default as MapState} from './controllers/map-state';
+export {default as OrbitState} from './controllers/orbit-state';
 
 // Core Layers
 export {default as ArcLayer} from './layers/core/arc-layer/arc-layer';
@@ -54,6 +57,7 @@ export {default as GeoJsonLayer} from './layers/core/geojson-layer/geojson-layer
 export {default as DeckGL} from './react/deckgl';
 export {default as default} from './react/deckgl';
 
+export {default as ViewportController} from './react/controllers/viewport-controller';
 export {default as MapController} from './react/controllers/map-controller';
 
 // Experimental Features (May change in minor version bumps, use at your own risk)

--- a/src/react/controllers/viewport-controller.js
+++ b/src/react/controllers/viewport-controller.js
@@ -1,0 +1,132 @@
+import {PureComponent, createElement} from 'react';
+import PropTypes from 'prop-types';
+
+import EventManager from '../../controllers/events/event-manager';
+import Controls from '../../controllers/controls';
+import CURSOR from './cursors';
+
+const propTypes = {
+  StateClass: PropTypes.func,
+  state: PropTypes.object,
+
+  /** Viewport constraints */
+  // Max zoom level
+  maxZoom: PropTypes.number,
+  // Min zoom level
+  minZoom: PropTypes.number,
+  // Max pitch in degrees
+  maxPitch: PropTypes.number,
+  // Min pitch in degrees
+  minPitch: PropTypes.number,
+
+  /**
+   * `onViewportChange` callback is fired when the user interacted with the
+   * map. The object passed to the callback contains viewport properties
+   * such as `longitude`, `latitude`, `zoom` etc.
+   */
+  onViewportChange: PropTypes.func,
+
+  /** Enables control event handling */
+  // Scroll to zoom
+  scrollZoom: PropTypes.bool,
+  // Drag to pan
+  dragPan: PropTypes.bool,
+  // Drag to rotate
+  dragRotate: PropTypes.bool,
+  // Double click to zoom
+  doubleClickZoom: PropTypes.bool,
+  // Pinch to zoom / rotate
+  touchZoomRotate: PropTypes.bool,
+
+  /** Accessor that returns a cursor style to show interactive state */
+  getCursor: PropTypes.func,
+
+  // A map control instance to replace the default map controls
+  // The object must expose one property: `events` as an array of subscribed
+  // event names; and two methods: `setState(state)` and `handle(event)`
+  controls: PropTypes.shape({
+    events: PropTypes.arrayOf(PropTypes.string),
+    handleEvent: PropTypes.func
+  })
+};
+
+const getDefaultCursor = ({isDragging}) => isDragging ? CURSOR.GRABBING : CURSOR.GRAB;
+
+const defaultProps = {
+  onViewportChange: null,
+
+  scrollZoom: true,
+  dragPan: true,
+  dragRotate: true,
+  doubleClickZoom: true,
+  touchZoomRotate: true,
+
+  getCursor: getDefaultCursor
+};
+
+export default class Controller extends PureComponent {
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isDragging: false      // Whether the cursor is down
+    };
+  }
+
+  componentDidMount() {
+    const {eventCanvas} = this.refs;
+
+    this._eventManager = new EventManager(eventCanvas);
+
+    // If props.controls is not provided, fallback to default MapControls instance
+    // Cannot use defaultProps here because it needs to be per map instance
+    this._controls = this.props.controls || new Controls(this.props.StateClass);
+
+    this._controls.setOptions(Object.assign({}, this.props, {
+      onStateChange: this._onInteractiveStateChange.bind(this),
+      eventManager: this._eventManager
+    }));
+  }
+
+  componentWillUpdate(nextProps) {
+    if (this._controls) {
+      this._controls.setOptions(nextProps);
+    }
+  }
+
+  componentWillUnmount() {
+    this._eventManager.destroy();
+  }
+
+  _onInteractiveStateChange({isDragging = false}) {
+    if (isDragging !== this.state.isDragging) {
+      this.setState({isDragging});
+    }
+  }
+
+  render() {
+    const {width, height, getCursor} = this.props;
+
+    const eventCanvasStyle = {
+      width,
+      height,
+      position: 'relative',
+      cursor: getCursor(this.state)
+    };
+
+    return (
+      createElement('div', {
+        key: 'map-controls',
+        ref: 'eventCanvas',
+        style: eventCanvasStyle
+      },
+        this.props.children
+      )
+    );
+  }
+}
+
+Controller.displayName = 'Controller';
+Controller.propTypes = propTypes;
+Controller.defaultProps = defaultProps;

--- a/src/viewports/viewport.js
+++ b/src/viewports/viewport.js
@@ -115,6 +115,7 @@ export default class Viewport {
       distanceScales || DEFAULT_DISTANCE_SCALES;
 
     this.focalDistance = opts.focalDistance || 1;
+
     this.distanceScales.metersPerPixel = new Vector3(this.distanceScales.metersPerPixel);
     this.distanceScales.pixelsPerMeter = new Vector3(this.distanceScales.pixelsPerMeter);
 
@@ -157,9 +158,6 @@ export default class Viewport {
       const aspect = this.width / this.height;
       this.projectionMatrix = mat4_perspective([], fovyRadians, aspect, near, far);
     }
-
-    // console.log(this.constructor.name,
-    //   this.viewMatrixUncentered, this.viewMatrix, this.projectionMatrix);
 
     // Init pixel matrices
     this._initMatrices();


### PR DESCRIPTION
This PR continues the generalization of controllers.

The vision is that there should be only one react component: 
```
<ViewportController >
```
that can take a state class and do the right thing

This PR is a partial step, it leaves things in a "half finished" state:
- temporarily breaking `npm run start-local` in some non-geospatial examples.
- more work is needed on `FirstPersonState` to handle mouse events.
- `OrbitState` should be updated to work better with `ThirdPersonViewport`.
- All `Viewports` should be able to extract at least some information from each `State` class
