### PR TITLE
Fix picking buffer clear color.

### DIFF
--- a/src/lib/draw-and-pick.js
+++ b/src/lib/draw-and-pick.js
@@ -275,8 +275,14 @@ function getClosestFromPickingBuffer(gl, {
     pickedObjectIndex: -1
   };
 
-  if (deviceX < 0 || deviceY < 0 || deviceX > pickingFBO.width || deviceY > pickingFBO.height) {
-    // x, y out of bounds
+  if (
+    deviceX < 0 ||
+    deviceY < 0 ||
+    deviceX > pickingFBO.width ||
+    deviceY > pickingFBO.height ||
+    layers.length <= 0
+  ) {
+    // x, y out of bounds or no layers to pick.
     return closestResultToCenter;
   }
 
@@ -369,7 +375,8 @@ function getPickedColors(gl, {
   return withParameters(gl, {
     framebuffer: pickingFBO,
     scissorTest: true,
-    scissor: [x, y, width, height]
+    scissor: [x, y, width, height],
+    clearColor: [0, 0, 0, 0]
   }, () => {
 
     // Clear the frame buffer
@@ -400,8 +407,7 @@ function getPickedColors(gl, {
           parameters: Object.assign({}, layer.props.parameters || {}, {
             blend: true,
             blendFunc: [gl.ONE, gl.ZERO, gl.CONSTANT_ALPHA, gl.ZERO],
-            blendEquation: gl.FUNC_ADD,
-            clearColor: [0, 0, 0, 0]
+            blendEquation: gl.FUNC_ADD
           })
         });
       }


### PR DESCRIPTION
- Clear color should be set before drawing any layers for picking. When none of the layers are eligible for picking, we still get correct picking results (alpha channel will be 0).
- Return early from picking flow, when layer count is 0.
- Fixes an issue with `point-cloud-laz` example.
- Tested with `test-browser` and `layer-browser`.