### PR TITLE
Viewport Animation: Adding flyTo style animation support.

### DIFF
--- a/examples/wip/data/cities.json
+++ b/examples/wip/data/cities.json
@@ -1,0 +1,8 @@
+[
+  {"city":"New York","population":"8,175,133","image":"http://upload.wikimedia.org/wikipedia/commons/thumb/b/b9/Above_Gotham.jpg/240px-Above_Gotham.jpg","state":"New York","latitude":40.6643,"longitude":-73.9385},
+  {"city":"Los Angeles","population":"3,792,621","image":"http://upload.wikimedia.org/wikipedia/commons/thumb/5/57/LA_Skyline_Mountains2.jpg/240px-LA_Skyline_Mountains2.jpg","state":"California","latitude":34.0194,"longitude":-118.4108},
+  {"city":"San Jose","population":"945,942","image":"http://upload.wikimedia.org/wikipedia/commons/thumb/1/1e/Downtown_San_Jose_skyline.PNG/240px-Downtown_San_Jose_skyline.PNG","state":"California","latitude":37.337768,"longitude":-121.886548},
+  {"city":"San Francisco","population":"805,235","image":"http://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/San_Francisco_skyline_from_Coit_Tower.jpg/240px-San_Francisco_skyline_from_Coit_Tower.jpg","state":"California","latitude":37.7751,"longitude":-122.4193},
+  {"city":"London","population":"8,788,000","image":"http://upload.wikimedia.org/wikipedia/commons/thumb/6/6d/Downtown_El_Paso_at_sunset.jpeg/240px-Downtown_El_Paso_at_sunset.jpeg","state":"Texas","latitude":51.5074,"longitude":-0.1278},
+  {"city":"Hyderabad","population":"6,810,000","image":"http://upload.wikimedia.org/wikipedia/commons/thumb/6/6d/Downtown_El_Paso_at_sunset.jpeg/240px-Downtown_El_Paso_at_sunset.jpeg","state":"Telengana","latitude":17.3850,"longitude":78.4867}
+]

--- a/examples/wip/viewport-animation-3d-heatmap/README.md
+++ b/examples/wip/viewport-animation-3d-heatmap/README.md
@@ -1,36 +1,3 @@
-This is a minimal standalone version of the 3DHeatmap example
-on [deck.gl](http://deck.gl) website.
-
-### Usage
-- Copy the content of this folder to your project.
-
-- Install Package
-```
-npm install
-```
-
-- Delete last line in `webpack.config.js`
-```
-module.exports = require('../webpack.config.local')(module.exports);
-```
-
-- Add [Mapbox access token](https://www.mapbox.com/help/define-access-token/)
-by run this command in your terminal.
-
-```
-export MapboxAccessToken=<Your_Token>
-```
-
-or you can directly add it to `app.js`
-```
-// Set your mapbox token here
-const MAPBOX_TOKEN = <Your_Token>>;
-```
-- Start the app.
-```
-npm start
-```
-
-### Data format
-Sample data is stored in [deck.gl Example Data](https://github.com/uber-common/deck.gl-data/tree/master/examples/3d-heatmap). To use your own data, checkout
-the [documentation of HexagonLayer](../../docs/layers/hexagon-layer.md)
+<!--
+// TODO: This is copy of 3d-heatmap example to test viewport animations, add details here.
+-->

--- a/examples/wip/viewport-animation-3d-heatmap/app.js
+++ b/examples/wip/viewport-animation-3d-heatmap/app.js
@@ -40,7 +40,7 @@ class Root extends Component {
     this._resize();
 
     // TODO: this is to just simulate viwport prop change and test animation.
-    this._interval = setInterval(() => this._toggleViewport(), 5000);
+    this._interval = setInterval(() => this._toggleViewport(), 7000);
   }
 
   _resize() {
@@ -61,7 +61,7 @@ class Root extends Component {
   _toggleViewport() {
     const newViewport = {};
     newViewport.pitch = (this.state.viewport.pitch === 0) ? 60.0 : 0.0;
-    newViewport.bearing = (this.state.viewport.bearing === 0) ? -60.0 : 0.0;
+    newViewport.bearing = (this.state.viewport.bearing === 0) ? -90.0 : 0.0;
     this.setState({
       viewport: {...this.state.viewport, ...newViewport}
     });
@@ -73,7 +73,7 @@ class Root extends Component {
       <AnimationMapController
         {...viewport}
         onViewportChange={this._onViewportChange.bind(this)}
-        animateViewport={true}>
+        viewportAnimationDuration={2000}>
         <StaticMap
           {...viewport}
           mapStyle="mapbox://styles/mapbox/dark-v9"

--- a/examples/wip/viewport-animation-3d-heatmap/app.js
+++ b/examples/wip/viewport-animation-3d-heatmap/app.js
@@ -1,4 +1,4 @@
-/* global window,document, setInterval*/
+/* global window,document */
 import React, {Component} from 'react';
 import {render} from 'react-dom';
 import {StaticMap} from 'react-map-gl';
@@ -18,13 +18,18 @@ class Root extends Component {
 
   constructor(props) {
     super(props);
+    this.rotationStep = 0;
     this.state = {
       viewport: {
         ...DeckGLOverlay.defaultViewport,
         width: 500,
-        height: 500
+        height: 500,
+        bearing: 0
       },
-      data: null
+      data: null,
+      animaitonDuration: 0,
+      viewportToggled: false,
+      onAnimationStop: this.rotateCameara.bind(this)
     };
 
     requestCsv(DATA_URL, (error, response) => {
@@ -40,7 +45,8 @@ class Root extends Component {
     this._resize();
 
     // TODO: this is to just simulate viwport prop change and test animation.
-    this._interval = setInterval(() => this._toggleViewport(), 7000);
+    // this._interval = setInterval(() => this._toggleViewport(), 8000);
+    this.rotateCameara({t: 1.0});
   }
 
   _resize() {
@@ -52,7 +58,8 @@ class Root extends Component {
 
   _onViewportChange(viewport) {
     this.setState({
-      viewport: {...this.state.viewport, ...viewport}
+      viewport: {...this.state.viewport, ...viewport},
+      animaitonDuration: 0
     });
   }
 
@@ -60,20 +67,49 @@ class Root extends Component {
   // Add proper UI to change viewport.
   _toggleViewport() {
     const newViewport = {};
-    newViewport.pitch = (this.state.viewport.pitch === 0) ? 60.0 : 0.0;
-    newViewport.bearing = (this.state.viewport.bearing === 0) ? -90.0 : 0.0;
+    // newViewport.pitch = this.state.viewportToggled ? 60.0 : 0.0;
+    // newViewport.bearing = this.state.viewportToggled ? -90.0 : 0.0;
+    newViewport.bearing = (this.state.viewport.bearing + 120) % 360;
     this.setState({
-      viewport: {...this.state.viewport, ...newViewport}
+      viewport: {...this.state.viewport, ...newViewport},
+      animaitonDuration: 4000,
+      viewportToggled: !this.state.viewportToggled
+    });
+  }
+
+  rotateCameara(opts) {
+    if (opts && opts.t < 1.0) {
+      return;
+    }
+    const angleDelta = 120.0;
+    const bearing = (this.state.viewport.bearing + angleDelta);
+    const animaitonDuration = angleDelta * 35;
+    this.setState({
+      viewport: {
+        ...this.state.viewport,
+        bearing,
+        width: window.innerWidth,
+        height: window.innerHeight
+      },
+      animaitonDuration
     });
   }
 
   render() {
-    const {viewport, data} = this.state;
+    const {
+      viewport,
+      data,
+      animaitonDuration,
+      onAnimationInterruption,
+      onAnimationStop
+    } = this.state;
     return (
       <AnimationMapController
         {...viewport}
         onViewportChange={this._onViewportChange.bind(this)}
-        viewportAnimationDuration={2000}>
+        animaitonDuration={animaitonDuration}
+        onAnimationInterruption={onAnimationInterruption}
+        onAnimationStop={onAnimationStop}>
         <StaticMap
           {...viewport}
           mapStyle="mapbox://styles/mapbox/dark-v9"

--- a/examples/wip/viewport-animation-geojson/README.md
+++ b/examples/wip/viewport-animation-geojson/README.md
@@ -1,17 +1,3 @@
-This is a minimal standalone version of the GeoJsonLayer example
-on [deck.gl](http://deck.gl) website that demonstrates viewport animation using 'AnimatationMapController'.
-
-### Usage
-Copy the content of this folder to your project. Run
-```
-npm install
-npm start
-```
-
-### Data format
-Sample data is stored in [deck.gl Example Data](https://github.com/uber-common/deck.gl-data/tree/master/examples/geojson). To use your own data, checkout
-the [documentation of GeoJsonLayer](../../docs/layers/geojson-layer.md).
-
-### Viewport animation
-Viewports pitch and bearing are animated between two sets of values repeatedly.
-An easing function is provided to simulate elastic in and out animation.
+<!--
+// TODO: This is copy of geojson example to test viewport animations, add details here.
+-->

--- a/examples/wip/viewport-animation-geojson/app.js
+++ b/examples/wip/viewport-animation-geojson/app.js
@@ -83,7 +83,7 @@ class Root extends Component {
         {...viewport}
         onViewportChange={this._onViewportChange.bind(this)}
         animateViewport={true}
-        viewportAnimateDuration={4000}
+        viewportAnimationDuration={4000}
         viewportAnimationEasingFunc={easeInOutElastic}>
         <StaticMap
           {...viewport}

--- a/examples/wip/viewport-animation-geojson/app.js
+++ b/examples/wip/viewport-animation-geojson/app.js
@@ -30,10 +30,12 @@ class Root extends Component {
         ...DeckGLOverlay.defaultViewport,
         width: 500,
         height: 500,
-        pitch: 10,
-        bearing: 10
+        pitch: 0,
+        bearing: 0
       },
-      data: null
+      data: null,
+      animationDuration: 5000,
+      viewportToggled: false
     };
 
     requestJson(DATA_URL, (error, response) => {
@@ -47,7 +49,7 @@ class Root extends Component {
     window.addEventListener('resize', this._resize.bind(this));
     this._resize();
     // TODO: this is to just simulate viwport prop change and test animation.
-    this._interval = setInterval(() => this._toggleViewport(), 7000);
+    this._interval = setInterval(() => this._toggleViewport(), 4000);
   }
 
   _resize() {
@@ -67,24 +69,28 @@ class Root extends Component {
   // Add proper UI to change viewport.
   _toggleViewport() {
     const newViewport = {};
-    newViewport.pitch = (this.state.viewport.pitch === 10.0) ? 60.0 : 10.0;
-    newViewport.bearing = (this.state.viewport.bearing === 10.0) ? 90.0 : 10.0;
+    // newViewport.pitch = (this.state.viewport.pitch === 10.0) ? 60.0 : 10.0;
+    // newViewport.bearing = (this.state.viewport.bearing === 10.0) ? 90.0 : 10.0;
+    newViewport.pitch = this.state.viewportToggled ? 0.0 : 60.0;
+    newViewport.bearing = this.state.viewportToggled ? 0.0 : 90.0;
     this.setState(prevState => ({
-      viewport: {...prevState.viewport, ...newViewport}
+      viewport: {...prevState.viewport, ...newViewport},
+      viewportToggled: !this.state.viewportToggled
     }));
 
   }
 
   render() {
-    const {viewport, data} = this.state;
+    const {viewport, data, animationDuration, onAnimationInterruption} = this.state;
 
     return (
       <AnimationMapController
         {...viewport}
         onViewportChange={this._onViewportChange.bind(this)}
         animateViewport={true}
-        viewportAnimationDuration={4000}
-        viewportAnimationEasingFunc={easeInOutElastic}>
+        animaitonDuration={animationDuration}
+        viewportAnimationEasingFunc={easeInOutElastic}
+        onAnimationInterruption={onAnimationInterruption}>
         <StaticMap
           {...viewport}
           onViewportChange={this._onViewportChange.bind(this)}

--- a/examples/wip/viewport-animation/README.md
+++ b/examples/wip/viewport-animation/README.md
@@ -1,0 +1,3 @@
+<!--
+// TODO: This is copied from react-map-gl to test viewport animations, add details here.x
+-->

--- a/examples/wip/viewport-animation/app.css
+++ b/examples/wip/viewport-animation/app.css
@@ -1,0 +1,28 @@
+body {
+  margin: 0;
+  font-family: Helvetica, Arial, sans-serif;
+}
+
+.control-panel {
+  position: absolute;
+  top: 0;
+  right: 0;
+  max-width: 320px;
+  background: #fff;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+  padding: 12px 24px;
+  margin: 20px;
+  font-size: 13px;
+  line-height: 2;
+  color: #6b6b76;
+  text-transform: uppercase;
+  outline: none;
+}
+
+.btn {
+  cursor: pointer;
+}
+
+.btn:hover {
+  color: #08f;
+}

--- a/examples/wip/viewport-animation/index.html
+++ b/examples/wip/viewport-animation/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset='UTF-8' />
+    <title>react-map-gl Interaction Example</title>
+    <link rel="stylesheet" type="text/css" href="app.css" />
+  </head>
+  <body>
+    <script src='bundle.js'></script>
+  </body>
+</html>

--- a/examples/wip/viewport-animation/package.json
+++ b/examples/wip/viewport-animation/package.json
@@ -1,0 +1,22 @@
+{
+  "scripts": {
+    "start": "webpack-dev-server --progress --hot --open",
+    "start-local": "webpack-dev-server --env.local --progress --hot --open"
+  },
+  "dependencies": {
+    "immutable": "^3.8.1",
+    "react": "^15.4.1",
+    "react-dom": "^15.4.1",
+    "react-map-gl": "^3.0.0",
+    "tween.js": "^16.6.0"
+  },
+  "devDependencies": {
+    "babel-core": "^6.21.0",
+    "babel-loader": "^6.2.10",
+    "babel-preset-es2015": "^6.18.0",
+    "babel-preset-react": "^6.16.0",
+    "babel-preset-stage-2": "^6.18.0",
+    "webpack": "^2.4.0",
+    "webpack-dev-server": "^2.4.0"
+  }
+}

--- a/examples/wip/viewport-animation/src/app.js
+++ b/examples/wip/viewport-animation/src/app.js
@@ -1,0 +1,101 @@
+/* global window */
+import React, {Component} from 'react';
+import {StaticMap} from 'react-map-gl';
+import {experimental} from 'deck.gl';
+import TWEEN from 'tween.js';
+
+import ControlPanel from './control-panel';
+
+const {AnimationMapController, viewportFlyToAnimation} = experimental;
+const token = process.env.MapboxAccessToken; // eslint-disable-line
+const ENABLE_ZOOM_CHANGE = false;
+const RANDOMIZE_ZOOM = false;
+
+if (!token) {
+  throw new Error('Please specify a valid mapbox token');
+}
+
+// Required by tween.js
+function animate() {
+  TWEEN.update();
+  window.requestAnimationFrame(animate);
+}
+animate();
+
+export default class App extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      viewport: {
+        latitude: 37.7751,
+        longitude: -122.4193,
+        zoom: 11,
+        bearing: 0,
+        pitch: 0,
+        width: 500,
+        height: 500
+      },
+      zoomDelta: ENABLE_ZOOM_CHANGE ? -1.0 : 0.0
+    };
+  }
+
+  componentDidMount() {
+    window.addEventListener('resize', this._resize);
+    this._resize();
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this._resize);
+  }
+
+  _resize() {
+    this.setState({
+      viewport: {
+        ...this.state.viewport,
+        width: this.props.width || window.innerWidth,
+        height: this.props.height || window.innerHeight
+      }
+    });
+  }
+
+  _easeTo({longitude, latitude}) {
+    // Remove existing animations
+    TWEEN.removeAll();
+
+    const {viewport} = this.state;
+
+    let zoom = viewport.zoom + this.state.zoomDelta;
+    zoom = RANDOMIZE_ZOOM ? Math.floor((Math.random() * 15)) : zoom;
+    const newViewport = Object.assign({}, viewport, {longitude, latitude, zoom});
+    this._onViewportChange(newViewport);
+  }
+
+  _onViewportChange(viewport) {
+    this.setState({viewport, zoomDelta: this.state.zoomDelta * -1.0});
+  }
+
+  render() {
+
+    const {viewport, settings} = this.state;
+
+    return (
+      <AnimationMapController
+        {...viewport}
+        onViewportChange={this._onViewportChange.bind(this)}
+        animateViewport={true}
+        viewportAnimationFunc={viewportFlyToAnimation}
+        viewportAnimationDuration={5000}>
+        <StaticMap
+          {...viewport}
+          {...settings}
+          mapStyle="mapbox://styles/mapbox/dark-v9"
+          onViewportChange={this._onViewportChange}
+          dragToRotate={false}
+          mapboxApiAccessToken={token} />
+        <ControlPanel containerComponent={this.props.containerComponent}
+          onViewportChange={this._easeTo.bind(this)} />
+      </AnimationMapController>
+    );
+  }
+
+}

--- a/examples/wip/viewport-animation/src/app.js
+++ b/examples/wip/viewport-animation/src/app.js
@@ -6,10 +6,8 @@ import TWEEN from 'tween.js';
 
 import ControlPanel from './control-panel';
 
-const {AnimationMapController, viewportFlyToAnimation} = experimental;
+const {AnimationMapController, viewportFlyToInterpolator, ANIMATION_EVENTS} = experimental;
 const token = process.env.MapboxAccessToken; // eslint-disable-line
-const ENABLE_ZOOM_CHANGE = false;
-const RANDOMIZE_ZOOM = false;
 
 if (!token) {
   throw new Error('Please specify a valid mapbox token');
@@ -35,7 +33,7 @@ export default class App extends Component {
         width: 500,
         height: 500
       },
-      zoomDelta: ENABLE_ZOOM_CHANGE ? -1.0 : 0.0
+      onAnimationInterruption: ANIMATION_EVENTS.SNAP_TO_END
     };
   }
 
@@ -64,27 +62,26 @@ export default class App extends Component {
 
     const {viewport} = this.state;
 
-    let zoom = viewport.zoom + this.state.zoomDelta;
-    zoom = RANDOMIZE_ZOOM ? Math.floor((Math.random() * 15)) : zoom;
-    const newViewport = Object.assign({}, viewport, {longitude, latitude, zoom});
+    const newViewport = Object.assign({}, viewport, {longitude, latitude, zoom: 11});
     this._onViewportChange(newViewport);
   }
 
   _onViewportChange(viewport) {
-    this.setState({viewport, zoomDelta: this.state.zoomDelta * -1.0});
+    this.setState({viewport});
   }
 
   render() {
 
-    const {viewport, settings} = this.state;
+    const {viewport, settings, onAnimationInterruption} = this.state;
 
     return (
       <AnimationMapController
         {...viewport}
         onViewportChange={this._onViewportChange.bind(this)}
         animateViewport={true}
-        viewportAnimationFunc={viewportFlyToAnimation}
-        viewportAnimationDuration={5000}>
+        animationInterpolator={viewportFlyToInterpolator}
+        animaitonDuration={5000}
+        onAnimationInterruption={onAnimationInterruption}>
         <StaticMap
           {...viewport}
           {...settings}

--- a/examples/wip/viewport-animation/src/control-panel.js
+++ b/examples/wip/viewport-animation/src/control-panel.js
@@ -1,0 +1,41 @@
+import React, {PureComponent} from 'react';
+
+import CITIES from '../../data/cities.json';
+
+const defaultContainer = ({children}) => <div className="control-panel">{children}</div>;
+
+export default class ControlPanel extends PureComponent {
+
+  _renderButton(city, index) {
+    return (
+      <div key={`btn-${index}`} className="input" >
+        <input type="radio" name="city"
+          id={`city-${index}`}
+          defaultChecked={city.city === 'San Francisco'}
+          onClick={() => this.props.onViewportChange(city)} />
+        <label htmlFor={`city-${index}`}>{city.city}</label>
+      </div>
+    );
+  }
+
+  render() {
+    const Container = this.props.containerComponent || defaultContainer;
+
+    return (
+      <Container>
+        <h3>Camera Transition</h3>
+        <p>Smooth animate of the viewport.</p>
+        <div className="source-link">
+          <a
+            href="https://github.com/uber/react-map-gl/tree/master/examples/viewport-animation"
+            target="_new">
+            View Code ↗
+          </a>
+        </div>
+        <hr />
+
+        { CITIES.map(this._renderButton.bind(this)) }
+      </Container>
+    );
+  }
+}

--- a/examples/wip/viewport-animation/src/root.js
+++ b/examples/wip/viewport-animation/src/root.js
@@ -1,0 +1,6 @@
+/* global document */
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from './app';
+
+ReactDOM.render(<App/>, document.body.appendChild(document.createElement('div')));

--- a/examples/wip/viewport-animation/webpack.config.js
+++ b/examples/wip/viewport-animation/webpack.config.js
@@ -1,0 +1,59 @@
+// NOTE: To use this example standalone (e.g. outside of deck.gl repo)
+// delete the local development overrides at the bottom of this file
+
+// avoid destructuring for older Node version support
+const resolve = require('path').resolve;
+const webpack = require('webpack');
+
+// Otherwise modules imported from outside this directory does not compile.
+// Also needed if modules from this directory were imported elsewhere
+// Seems to be a Babel bug
+// https://github.com/babel/babel-loader/issues/149#issuecomment-191991686
+const BABEL_CONFIG = {
+  presets: [
+    'es2015',
+    'react',
+    'stage-2'
+  ].map(function configMap(name) {
+    return require.resolve(`babel-preset-${name}`);
+  })
+};
+
+const config = {
+  entry: {
+    app: resolve('./src/root.js')
+  },
+
+  devtool: 'source-map',
+
+  module: {
+    rules: [{
+      // Compile ES2015 using bable
+      test: /\.js$/,
+      include: [resolve('.')],
+      exclude: [/node_modules/],
+      use: [{
+        loader: 'babel-loader',
+        options: BABEL_CONFIG
+      }]
+    }]
+  },
+
+  resolve: {
+    alias: {
+      // From mapbox-gl-js README. Required for non-browserify bundlers (e.g. webpack):
+      // 'mapbox-gl$': resolve('./node_modules/mapbox-gl/dist/mapbox-gl.js')
+      // 'mapbox-gl$': resolve('../../../mapbox-gl-js/dist/mapbox-gl-dev.js')
+      'mapbox-gl$': resolve('./node_modules/mapbox-gl/dist/mapbox-gl.js')
+    }
+  },
+
+  // Optional: Enables reading mapbox token from environment variable
+  plugins: [
+    new webpack.EnvironmentPlugin(['MapboxAccessToken'])
+  ]
+};
+
+// Enables bundling against src in this repo rather than the installed version
+module.exports = env => env && env.local ?
+  require('../../webpack.config.local')(config)(env) : config;

--- a/src/experimental/react/controllers/viewport-animation-utils.js
+++ b/src/experimental/react/controllers/viewport-animation-utils.js
@@ -1,0 +1,115 @@
+/* eslint max-statements: ["error", 50] */
+
+import {projectFlat, unprojectFlat} from 'viewport-mercator-project';
+import {Vector2} from 'math.gl';
+
+const EPSILON = 0.01;
+
+/**
+ * Performs linear interpolation of two viewports.
+ * @param {Object} startViewport - object containing starting viewport parameters.
+ * @param {Object} endViewport - object containing ending viewport parameters.
+ * @param {Number} t - animation step.
+ * @return {Object} - animated viewport for given step.
+*/
+export function viewportLinearAnimation(startViewport, endViewport, t) {
+  const animatedViewport = Object.assign({}, endViewport);
+  function lerp(start, end, step) {
+    return step * end + (1 - step) * start;
+  }
+
+  for (const p of ['longitude', 'latitude', 'zoom', 'bearing', 'pitch']) {
+    const startValue = startViewport[p];
+    const endValue = endViewport[p];
+    animatedViewport[p] = lerp(startValue, endValue, t);
+  }
+  return animatedViewport;
+}
+
+/**
+ * This method adapts mapbox-gl-js Map#flyTo animation so it can be used in
+ * react/redux architecture.
+ * mapbox-gl-js flyTo : https://www.mapbox.com/mapbox-gl-js/api/#map#flyto.
+ * It implements “Smooth and efficient zooming and panning.” algorithm by
+ * "Jarke J. van Wijk and Wim A.A. Nuij"
+ *
+ * @param {Object} startViewport - object containing starting viewport parameters.
+ * @param {Object} endViewport - object containing ending viewport parameters.
+ * @param {Number} t - animation step.
+ * @return {Object} - animated viewport for given step.
+*/
+export function viewportFlyToAnimation(startViewport, endViewport, t) {
+  // Equations from above paper are referred where needed.
+  const animatedViewport = Object.assign({}, endViewport);
+
+  function lerp(start, end, step) {
+    return step * end + (1 - step) * start;
+  }
+  function zoomToScale(zoom) {
+    return Math.pow(2, zoom);
+  }
+  function scaleToZoom(scale) {
+    return Math.log(scale) / Math.LN2;
+  }
+
+  // TODO: add this as an option for applications.
+  const rho = 1.414;
+
+  const startZoom = startViewport.zoom;
+  const startCenter = [startViewport.longitude, startViewport.latitude];
+  const startScale = zoomToScale(startZoom);
+  const endZoom = endViewport.zoom;
+  const endCenter = [endViewport.longitude, endViewport.latitude];
+  const scale = zoomToScale(endZoom - startZoom);
+
+  const startCenterXY = new Vector2(projectFlat(startCenter, startScale));
+  const endCenterXY = new Vector2(projectFlat(endCenter, startScale));
+  const uDelta = endCenterXY.subtract(startCenterXY);
+
+  const w0 = Math.max(startViewport.width, startViewport.height);
+  const w1 = w0 / scale;
+  const u1 = Math.sqrt((uDelta.x * uDelta.x) + (uDelta.y * uDelta.y));
+  // u0 is treated as '0' in Eq (9).
+
+  // Linearly interpolate 'bearing' and 'pitch'
+  for (const p of ['bearing', 'pitch']) {
+    const startValue = startViewport[p];
+    const endValue = endViewport[p];
+    animatedViewport[p] = lerp(startValue, endValue, t);
+  }
+
+  // If change in center is too small, do linear interpolaiton.
+  if (Math.abs(u1) < EPSILON) {
+    for (const p of ['latitude', 'longitude', 'zoom']) {
+      const startValue = startViewport[p];
+      const endValue = endViewport[p];
+      animatedViewport[p] = lerp(startValue, endValue, t);
+    }
+    return animatedViewport;
+  }
+
+  // Implement Equation (9) from above algorithm.
+  const rho2 = rho * rho;
+  const b0 = (w1 * w1 - w0 * w0 + rho2 * rho2 * u1 * u1) / (2 * w0 * rho2 * u1);
+  const b1 = (w1 * w1 - w0 * w0 - rho2 * rho2 * u1 * u1) / (2 * w1 * rho2 * u1);
+  const r0 = Math.log(Math.sqrt(b0 * b0 + 1) - b0);
+  const r1 = Math.log(Math.sqrt(b1 * b1 + 1) - b1);
+  function w(s) {
+    return (Math.cosh(r0) / Math.cosh(r0 + rho * s));
+  }
+  function u(s) {
+    return w0 * ((Math.cosh(r0) * Math.tanh(r0 + rho * s) - Math.sinh(r0)) / rho2) / u1;
+  }
+  const S = (r1 - r0) / rho;
+  const s = t * S;
+  const scaleIncrement = 1 / w(s); // Using w method for scaling.
+  const newZoom = startZoom + scaleToZoom(scaleIncrement);
+
+  const newCenter = unprojectFlat(
+    (startCenterXY.add(uDelta.scale(u(s)))).scale(scaleIncrement),
+    zoomToScale(newZoom));
+  animatedViewport.longitude = newCenter[0];
+  animatedViewport.latitude = newCenter[1];
+  animatedViewport.zoom = newZoom;
+  return animatedViewport;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -120,11 +120,14 @@ export {default as MapController} from './react/map-controller';
 // Experimental React bindings
 import {default as OrbitController} from './react/experimental/orbit-controller';
 import AnimationMapController from './react/experimental/animation-map-controller';
+import {viewportLinearAnimation, viewportFlyToAnimation} from './experimental/react/controllers/viewport-animation-utils.js';
 
-  // Experimental react bindings
+// Experimental react bindings
 Object.assign(experimental, {
   OrbitController,
-  AnimationMapController
+  AnimationMapController,
+  viewportLinearAnimation,
+  viewportFlyToAnimation
 });
 
 //

--- a/src/index.js
+++ b/src/index.js
@@ -119,15 +119,16 @@ export {default as MapController} from './react/map-controller';
 
 // Experimental React bindings
 import {default as OrbitController} from './react/experimental/orbit-controller';
-import AnimationMapController from './react/experimental/animation-map-controller';
-import {viewportLinearAnimation, viewportFlyToAnimation} from './experimental/react/controllers/viewport-animation-utils.js';
+import AnimationMapController, {ANIMATION_EVENTS} from './react/experimental/animation-map-controller';
+import {viewportLinearInterpolator, viewportFlyToInterpolator} from './react/experimental/viewport-animation-utils';
 
 // Experimental react bindings
 Object.assign(experimental, {
   OrbitController,
   AnimationMapController,
-  viewportLinearAnimation,
-  viewportFlyToAnimation
+  viewportLinearInterpolator,
+  viewportFlyToInterpolator,
+  ANIMATION_EVENTS
 });
 
 //

--- a/src/react/experimental/viewport-animation-utils.js
+++ b/src/react/experimental/viewport-animation-utils.js
@@ -12,7 +12,11 @@ const EPSILON = 0.01;
  * @param {Number} t - animation step.
  * @return {Object} - animated viewport for given step.
 */
-export function viewportLinearAnimation(startViewport, endViewport, t) {
+export function viewportLinearInterpolator(startViewport, endViewport, t) {
+  // here t is easing, check against actual t
+  if (t >= 1.0) {
+    return endViewport;
+  }
   const animatedViewport = Object.assign({}, endViewport);
   function lerp(start, end, step) {
     return step * end + (1 - step) * start;
@@ -38,8 +42,14 @@ export function viewportLinearAnimation(startViewport, endViewport, t) {
  * @param {Number} t - animation step.
  * @return {Object} - animated viewport for given step.
 */
-export function viewportFlyToAnimation(startViewport, endViewport, t) {
+export function viewportFlyToInterpolator(startViewport, endViewport, t) {
   // Equations from above paper are referred where needed.
+
+  // here t is easing, check against actual t
+  if (t >= 1.0) {
+    return endViewport;
+  }
+
   const animatedViewport = Object.assign({}, endViewport);
 
   function lerp(start, end, step) {


### PR DESCRIPTION
- Adding a utility method to achieve flyTo style animation.
- Copy react-map-gl's `viewport-animation` example and update to test flyTo style animation.
- Add new props to support map interaction and loop style animations.

Next steps:
   - documentation.
   - update `viewport-animation` to test all combinations of animation props.
