### PR TITLE
4.1.3 patch

### DIFF
--- a/docs/api-reference/layer-manager.md
+++ b/docs/api-reference/layer-manager.md
@@ -5,43 +5,111 @@ The `LayerManager` class handles updates, drawing and picking for a set of layer
 If you are using the [`DeckGL`](/docs/api-reference/deckgl.md) React Component, a layer
 manager is created under the hood to handle rendering cycles.
 
-## Constructor
-
-Parameters:
-
-- `opts` (Object)
-  * `gl` ([WebGLRenderingContext](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext))
-
 ## Methods
 
-##### `setViewport`
+##### constructor
 
-Parameters:
+Creates a new `LayerManager` instance.
 
-- `viewport` ([Viewport](/docs/api-reference/viewport.md)) - The new viewport
+`const layerManager = new LayerManager({gl})`
 
-##### `updateLayers`
+* `gl` ([WebGLRenderingContext](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext))
 
-Parameters:
+##### getLayers
 
-- `updateParams` (Object)
-  * `newLayers` (Array) - Array of layers
+Returns an list of layers, optionally be filtered by a list of layer ids.
 
-##### `drawLayers`
+`const layers = layerManager.getLayers({layerIds=[]})`
 
-Parameters:
+* `layerIds` (String[], optional) - A list of layer id strings. If supplied, the returned list will only contain layers whose `id` property matches (see note) one of the strings in the list.
 
-- `drawParams` (Object)
-  * `pass` (Number) - The render pass identifier, for debugging purpose
+Returns (`Layer[]`) - array of layer instances.
 
-##### `pickLayers`
+Notes:
+* The returned list of layers is "expanded" in the sense that composite layers will have been recursively rendered and the list will thus only contain primitive layers.
+* When supplying the layer id of a composite layer, all the sub layers rendered by that layer will be included.
+* layer id matching checks that a layer id *starts with* one of the supplied strings. This ensures that sublayers rendered by a composite layer with the given id will also be included in the matched list.
 
-Parameters:
+##### setViewport
 
-- `pickParams` (Object)
-  * `x` (Number) - The x position of the pointer
-  * `y` (Number) - The y position of the pointer
-  * `mode` (String) - One of `hover` or `click`
+Updates the current viewport.
+
+`layerManager.setViewport(viewport)`
+
+* `viewport` ([Viewport](/docs/api-reference/viewport.md)) - The new viewport
+
+##### initEventHandling
+
+Registers a source of DOM input events.
+
+`layerManager.initEventHandling(eventManager)`
+
+* `eventManager` - A source of DOM input events
+
+Notes:
+* The event "source" is expected to provide `on()`/`off()` methods for registration, and to call registered handlers with an "Event" object of the following shape:
+ * `offsetCenter` (Object: {x, y}) - center of the event
+ * `srcEvent` (Object) - native JS Event object
+
+##### setEventHandlingParameters
+
+Set parameters for input event handling.
+
+ ```js
+layerManager.setEventHandlingParameters({
+  pickingRadius,
+  onLayerClick,
+  onLayerHover
+});
+```
+
+* `pickingRadius` (`Number`, optional) - "Fuzziness" of picking (px), to support fat-fingering.
+* `onLayerClick` (`Function`, optional) - A handler to be called when any layer is clicked.
+* `onLayerHover` (`Function`, optional) - A handler to be called when any layer is hovered over.
+
+##### updateLayers
+
+Provide a new list of layers. Layers will be matched against old layers, and any composite layers will be recursively expanded into primitive layers.
+
+`layerManager.updateLayers({newLayers})`
+
+* `newLayers` (Layer[]) - Array of layers
+
+##### drawLayers
+
+Draw all layers
+
+`layerManager.drawLayers({pass})`
+
+* `pass` (String) - The render pass identifier, for debugging purpose
+
+##### pickLayer
+
+Pick the closest info at given coordinate
+
+`layerManager.pickLayer({x, y, mode, radius = 0, layerIds})`
+
+* `x` (Number) - The x position of the pointer
+* `y` (Number) - The y position of the pointer
+* `mode` (String) - One of `hover` or `click`
+
+
+##### queryLayer
+
+Get all unique infos within a bounding box
+
+`layerManager.queryLayer({x, y, width, height, layerIds})`
+
+* `x` (Number) - The x position of the pointer
+* `y` (Number) - The y position of the pointer
+
+
+##### needsRedraw
+
+Checks if layers need to be redrawn.
+
+`layerManager.needsRedraw({clearRedrawFlags = false})`
+
 
 ## Source
 [src/lib/layer-manager.js](https://github.com/uber/deck.gl/blob/4.1-release/src/lib/layer-manager.js)

--- a/docs/layers/grid-cell-layer.md
+++ b/docs/layers/grid-cell-layer.md
@@ -47,6 +47,13 @@ Inherits from all [Base Layer](/docs/api-reference/base-layer.md) properties.
 
 Size of each grid cell in meters
 
+##### `coverage` (Number, optional)
+
+- Default: `1`
+
+Cell size scale factor. The size of cell is calculated by
+`cellSize * coverage`.
+
 ##### `elevationScale` (Number, optional)
 
 - Default: `1`

--- a/docs/layers/grid-layer.md
+++ b/docs/layers/grid-layer.md
@@ -62,37 +62,6 @@ Color scale domain, default is set to the range of point counts in each cell.
 Color ranges as an array of colors formatted as `[255, 255, 255]`. Default is
 [colorbrewer](http://colorbrewer2.org/#type=sequential&scheme=YlOrRd&n=6) `6-class YlOrRd`.
 
-##### `getColorValue` (Function, optional)
-
-- Default: `points => points.length`
-
-`getColorValue` is the accessor function to get the value that cell color is based on. 
-It takes an array of points inside each cell as arguments, returns a number. For example, 
-You can pass in `getColorValue` to color the cells by avg/mean/max of a specific attributes of each point.
-By default `getColorValue` returns the length of the points array.
-
-Note: grid layer compares whether `getColorValue` has changed to
-recalculate the value for each bin that its color based on. You should
-pass in the function defined outside the render function so it doesn't create a 
-new function on every rendering pass. 
-
-```
- class MyGridLayer {
-    getColorValue (points) {
-        return points.length;
-    }
-    
-    renderLayers() {
-      return new GridLayer({
-        id: 'grid-layer',
-        getColorValue: this.getColorValue // instead of getColorValue: (points) => { return points.length; }
-        data,
-        cellSize: 500
-      });
-    }
- }
-```
-
 ##### `coverage` (Number, optional)
 
 - Default: `1`
@@ -138,8 +107,23 @@ larger than the upperPercentile will be hidden.
 
 - Default: `0`
 
-Filter bins and re-calculate color by `lowerPercentile`. Cells with value
+Filter cells and re-calculate color by `lowerPercentile`. Cells with value
 smaller than the lowerPercentile will be hidden.
+
+##### `elevationUpperPercentile` (Number, optional)
+
+- Default: `100`
+
+Filter cells and re-calculate elevation by `elevationUpperPercentile`. Cells with elevation value
+larger than the elevationUpperPercentile will be hidden.
+
+##### `elevationLowerPercentile` (Number, optional)
+
+- Default: `100`
+
+Filter cells and re-calculate elevation by `elevationLowerPercentile`. Cells with elevation value
+smaller than the elevationLowerPercentile will be hidden.
+
 
 ##### `fp64` (Boolean, optional)
 
@@ -161,6 +145,58 @@ Be aware that this prop will likely be changed in a future version of deck.gl.
 - Default: `object => object.position`
 
 Method called to retrieve the position of each point.
+
+##### `getColorValue` (Function, optional)
+
+- Default: `points => points.length`
+
+`getColorValue` is the accessor function to get the value that cell color is based on.
+It takes an array of points inside each cell as arguments, returns a number. For example,
+You can pass in `getColorValue` to color the cells by avg/mean/max of a specific attributes of each point.
+By default `getColorValue` returns the length of the points array.
+
+Note: grid layer compares whether `getColorValue` has changed to recalculate the value for each bin that its color based on.
+You should pass in the function defined outside the render function so it doesn't create a new function on every rendering pass.
+
+```
+ class MyGridLayer {
+    getColorValue (points) {
+        return points.length;
+    }
+
+    renderLayers() {
+      return new GridLayer({
+        id: 'grid-layer',
+        getColorValue: this.getColorValue // instead of getColorValue: (points) => { return points.length; }
+        data,
+        cellSize: 500
+      });
+    }
+ }
+```
+
+##### `getElevationValue` (Function, optional)
+
+- Default: `points => points.length`
+
+Similar to `getColorValue`, `getElevationValue` is the accessor function to get the value that cell elevation is based on.
+It takes an array of points inside each cell as arguments, returns a number.
+By default `getElevationValue` returns the length of the points array.
+
+Note: grid layer compares whether `getElevationValue` has changed to recalculate the value for each cell for its elevation.
+You should pass in the function defined outside the render function so it doesn't create a new function on every rendering pass.
+
+##### `onSetColorDomain` (Function, optional)
+
+- Default: `() => {}`
+
+This callback will be called when bin color domain has been calculated.
+
+##### `onSetElevationDomain` (Function, optional)
+
+- Default: `() => {}`
+
+This callback will be called when bin elevation domain has been calculated.
 
 ## Source
 [src/layers/core/grid-layer](https://github.com/uber/deck.gl/tree/4.1-release/src/layers/core/grid-layer)

--- a/docs/layers/hexagon-layer.md
+++ b/docs/layers/hexagon-layer.md
@@ -133,6 +133,19 @@ with the same elevation scale for comparison.
 
 Elevation scale output range
 
+##### `getElevationValue` (Function, optional)
+
+- Default: `points => points.length`
+
+Similar to `getColorValue`, `getElevationValue` is the accessor function to get the value that bin elevation is based on.
+It takes an array of points inside each bin as arguments, returns a number.
+By default `getElevationValue` returns the length of the points array.
+
+Note: hexagon layer compares whether `getElevationValue` has changed to
+recalculate the value for each bin for elevation. You should
+pass in the function defined outside the render function so it doesn't create a
+new function on every rendering pass.
+
 ##### `elevationScale` (Number, optional)
 
 - Default: `1`
@@ -151,15 +164,29 @@ Whether to enable cell elevation. Cell elevation scale by count of points in eac
 
 - Default: `100`
 
-Filter bins and re-calculate color by `upperPercentile`. Hexagons with value
+Filter bins and re-calculate color by `upperPercentile`. Hexagons with color value
 larger than the upperPercentile will be hidden.
 
 ##### `lowerPercentile` (Number, optional)
 
 - Default: `0`
 
-Filter bins and re-calculate color by `lowerPercentile`. Hexagons with value
+Filter bins and re-calculate color by `lowerPercentile`. Hexagons with color value
 smaller than the lowerPercentile will be hidden.
+
+##### `elevationUpperPercentile` (Number, optional)
+
+- Default: `100`
+
+Filter bins and re-calculate elevation by `elevationUpperPercentile`. Hexagons with elevation value
+larger than the elevationUpperPercentile will be hidden.
+
+##### `elevationLowerPercentile` (Number, optional)
+
+- Default: `100`
+
+Filter bins and re-calculate elevation by `elevationLowerPercentile`. Hexagons with elevation value
+smaller than the elevationLowerPercentile will be hidden.
 
 ##### `fp64` (Boolean, optional)
 
@@ -179,6 +206,18 @@ This is an object that contains light settings for extruded polygons.
 - Default: `object => object.position`
 
 Method called to retrieve the position of each point.
+
+##### `onSetColorDomain` (Function, optional)
+
+- Default: `() => {}`
+
+This callback will be called when bin color domain has been calculated.
+
+##### `onSetElevationDomain` (Function, optional)
+
+- Default: `() => {}`
+
+This callback will be called when bin elevation domain has been calculated.
 
 ## Source
 

--- a/docs/layers/scatterplot-layer.md
+++ b/docs/layers/scatterplot-layer.md
@@ -68,6 +68,12 @@ The minimum radius in pixels.
 
 The maximum radius in pixels.
 
+##### `fp64` (Boolean, optional)
+
+- Default: `false`
+
+Whether the layer should be rendered in high-precision 64-bit mode.
+
 ### Data Accessors
 
 ##### `getPosition` (Function, optional)

--- a/docs/layers/solid-polygon-layer.md
+++ b/docs/layers/solid-polygon-layer.md
@@ -50,6 +50,12 @@ Whether to generate a line wireframe of the hexagon. The outline will have
 "horizontal" lines closing the top and bottom polygons and a vertical line
 (a "strut") for each vertex on the polygon.
 
+##### `fp64` (Boolean, optional)
+
+- Default: `false`
+
+Whether the layer should be rendered in high-precision 64-bit mode.
+
 **Remarks:**
 
 * These lines are rendered with `GL.LINE` and will thus always be 1 pixel wide.

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -1,3 +1,8 @@
+# deck.gl v4.1.3
+
+## HexagonLayer / GridLayer: Elevation by Value Support
+Add `getElevationValue` to `HexagonLayer` and `GridLayer` to enable elevation aggregation by value. This allow both color and elevation to be calculated based on customized aggregation function.
+
 # deck.gl v4.1
 
 Release date: July 27th, 2017

--- a/examples/layer-browser/src/examples/core-layers.js
+++ b/examples/layer-browser/src/examples/core-layers.js
@@ -242,20 +242,20 @@ const GridLayerExample = {
     cellSize: {type: 'number', min: 0, max: 1000},
     coverage: {type: 'number', min: 0, max: 1},
     lowerPercentile: {type: 'number', min: 0, max: 100},
-    upperPercentile: {type: 'number', min: 0, max: 100}
+    upperPercentile: {type: 'number', min: 0, max: 100},
+    elevationLowerPercentile: {type: 'number', min: 0, max: 100},
+    elevationUpperPercentile: {type: 'number', min: 0, max: 100}
   },
   props: {
     id: 'gridLayer',
     data: dataSamples.points,
-    // instead of doing getColorValue = () => {}
-    // defined the function outside and pass in here
-    // so it doesn't generate a new function on every render
-    getColorValue,
     cellSize: 200,
     opacity: 1,
     extruded: true,
     pickable: true,
     getPosition: d => get(d, 'COORDINATES'),
+    getColorValue,
+    getElevationValue,
     lightSettings: LIGHT_SETTINGS
   }
 };

--- a/examples/layer-browser/src/examples/core-layers.js
+++ b/examples/layer-browser/src/examples/core-layers.js
@@ -217,12 +217,23 @@ function getMean(pts, key) {
     filtered.reduce((accu, curr) => accu + curr[key], 0) / filtered.length : null;
 }
 
-// grid layer compares whether getColorValue has changed to
+function getMax(pts, key) {
+  const filtered = pts.filter(pt => Number.isFinite(pt[key]));
+
+  return filtered.length ?
+    filtered.reduce((accu, curr) => curr[key] > accu ? curr[key] : accu, -Infinity) : null;
+}
+
+// hexagon/grid layer compares whether getColorValue / getElevationValue has changed to
 // call out bin sorting. Here we pass in the function defined
 // outside props, so it doesn't create a new function on
 // every rendering pass
 function getColorValue(points) {
   return getMean(points, 'SPACES');
+}
+
+function getElevationValue(points) {
+  return getMax(points, 'SPACES');
 }
 
 const GridLayerExample = {
@@ -274,7 +285,9 @@ const HexagonLayerExample = {
     coverage: {type: 'number', min: 0, max: 1},
     radius: {type: 'number', min: 0, max: 3000},
     lowerPercentile: {type: 'number', min: 0, max: 100},
-    upperPercentile: {type: 'number', min: 0, max: 100}
+    upperPercentile: {type: 'number', min: 0, max: 100},
+    elevationLowerPercentile: {type: 'number', min: 0, max: 100},
+    elevationUpperPercentile: {type: 'number', min: 0, max: 100}
   },
   props: {
     id: 'HexagonLayer',
@@ -287,6 +300,8 @@ const HexagonLayerExample = {
     elevationRange: [0, 3000],
     coverage: 1,
     getPosition: d => get(d, 'COORDINATES'),
+    getColorValue,
+    getElevationValue,
     lightSettings: LIGHT_SETTINGS
   }
 };

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "gl": "^4.0.3",
     "immutable": "^3.8.1",
     "jsdom": "^9.11.0",
-    "luma.gl": "^4.0.2",
+    "luma.gl": "^4.0.4",
     "module-alias": "^2.0.0",
     "nyc": "^10.2.0",
     "path-exists-cli": "^1.0.0",
@@ -94,7 +94,7 @@
     "webpack-dev-server": "^2.4.0"
   },
   "peerDependencies": {
-    "luma.gl": "^4.0.2",
+    "luma.gl": "^4.0.4",
     "react": "0.14.x - 15.x",
     "react-dom": "0.14.x - 15.x"
   },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "publish-beta": "npm run build && npm run test && npm run test-dist && npm publish --tag beta",
     "test": "npm run lint && npm run build && npm run test-node",
     "test-fast": "npm run test-node",
-    "test-cover": "NODE_ENV=test tape -r babel-register test/node.js && nyc report",
+    "test-cover": "NODE_ENV=test ./node_modules/tape/bin/tape -r babel-register test/node.js && nyc report",
     "test-node": "node test/node.js",
     "test-dist": "node test/node-dist.js",
     "test-browser": "webpack-dev-server --env.test --progress --hot --open",

--- a/src/layers/core/grid-cell-layer/grid-cell-layer-vertex-64.glsl.js
+++ b/src/layers/core/grid-cell-layer/grid-cell-layer-vertex-64.glsl.js
@@ -39,6 +39,7 @@ uniform vec3 selectedPickingColor;
 // Custom uniforms
 uniform float extruded;
 uniform float cellSize;
+uniform float coverage;
 uniform float opacity;
 uniform float elevationScale;
 
@@ -64,11 +65,15 @@ void main(void) {
 
   vec2 projected_coord_xy[2];
   project_position_fp64(instancePositions64xy, projected_coord_xy);
-
+  
+  // if ahpha == 0.0 or z < 0.0, do not render element
+  float noRender = float(instanceColors.a == 0.0 || instancePositions.w < 0.0);
+  float finalCellSize = cellSize * mix(1.0, 0.0, noRender);
+  
   projected_coord_xy[0] = sum_fp64(projected_coord_xy[0],
-    vec2((positions.x + 1.0) * cellSize / 2.0, 0.0));
+    vec2((positions.x * coverage + 1.0) * finalCellSize / 2.0, 0.0));
   projected_coord_xy[1] = sum_fp64(projected_coord_xy[1],
-    vec2((positions.y + 1.0) * cellSize / 2.0, 0.0));
+    vec2((positions.y * coverage - 1.0) * finalCellSize / 2.0, 0.0));
 
   float elevation = 0.0;
 

--- a/src/layers/core/grid-cell-layer/grid-cell-layer-vertex.glsl.js
+++ b/src/layers/core/grid-cell-layer/grid-cell-layer-vertex.glsl.js
@@ -58,13 +58,14 @@ float isPicked(vec3 pickingColors, vec3 selectedColor) {
 void main(void) {
 
   vec2 topLeftPos = project_position(instancePositions.xy);
-  
-  // if ahpha == 0.0, do not render element
-  float finalCellSize = cellSize * mix(1.0, 0.0, float(instanceColors.a == 0.0));
+
+  // if ahpha == 0.0 or z < 0.0, do not render element
+  float noRender = float(instanceColors.a == 0.0 || instancePositions.w < 0.0);
+  float finalCellSize = cellSize * mix(1.0, 0.0, noRender);
 
   // cube gemoetry vertics are between -1 to 1, scale and transform it to between 0, 1
   vec2 pos = topLeftPos + vec2(
-  (positions.x * coverage + 1.0) / 2.0 * finalCellSize, 
+  (positions.x * coverage + 1.0) / 2.0 * finalCellSize,
   (positions.y * coverage - 1.0) / 2.0 * finalCellSize);
 
   float elevation = 0.0;

--- a/src/layers/core/grid-layer/grid-layer.js
+++ b/src/layers/core/grid-layer/grid-layer.js
@@ -299,11 +299,11 @@ export default class GridLayer extends CompositeLayer {
 
     const elevationDomain = this.props.elevationDomain || elevationValueDomain;
 
-    const isColorValueInDomain = ev >= elevationDomain[0] &&
+    const isElevationValueInDomain = ev >= elevationDomain[0] &&
       ev <= elevationDomain[elevationDomain.length - 1];
 
     // if cell value is outside domain, set elevation to -1
-    return isColorValueInDomain ? elevationScaleFunc(ev) : -1;
+    return isElevationValueInDomain ? elevationScaleFunc(ev) : -1;
   }
 
   getSubLayerProps() {
@@ -336,7 +336,6 @@ export default class GridLayer extends CompositeLayer {
       modelMatrix,
       getColor: this._onGetSublayerColor.bind(this),
       getElevation: this._onGetSublayerElevation.bind(this),
-      getPosition: d => d.position,
       updateTriggers: this.getUpdateTriggers()
     };
   }

--- a/src/layers/core/grid-layer/grid-layer.js
+++ b/src/layers/core/grid-layer/grid-layer.js
@@ -22,23 +22,36 @@ import {CompositeLayer} from '../../../lib';
 import GridCellLayer from '../grid-cell-layer/grid-cell-layer';
 
 import {pointToDensityGridData} from './grid-aggregator';
-import {linearScale, quantizeScale} from '../../../utils/scale-utils';
 import {defaultColorRange} from '../../../utils/color-utils';
+import {getQuantizeScale, getLinearScale} from '../../../utils/scale-utils';
 
 import BinSorter from '../../../utils/bin-sorter';
 
+function nop() {}
+
 const defaultProps = {
-  cellSize: 1000,
-  colorRange: defaultColorRange,
+
+  // color
   colorDomain: null,
-  elevationRange: [0, 1000],
-  elevationDomain: null,
-  elevationScale: 1,
+  colorRange: defaultColorRange,
+  getColorValue: points => points.length,
   lowerPercentile: 0,
   upperPercentile: 100,
+  onSetColorDomain: nop,
+
+  // elevation
+  elevationDomain: null,
+  elevationRange: [0, 1000],
+  getElevationValue: points => points.length,
+  elevationLowerPercentile: 0,
+  elevationUpperPercentile: 100,
+  elevationScale: 1,
+  onSetElevationDomain: nop,
+
+  // grid
+  cellSize: 1000,
   coverage: 1,
   getPosition: x => x.position,
-  getColorValue: points => points.length,
   extruded: false,
   fp64: false,
   // Optional settings for 'lighting' shader module
@@ -56,27 +69,24 @@ export default class GridLayer extends CompositeLayer {
   initializeState() {
     this.state = {
       layerData: [],
-      sortedBins: null,
-      valueDomain: null
+      sortedColorBins: null,
+      sortedElevationBins: null,
+      colorValueDomain: null,
+      elevationValueDomain: null,
+      colorScaleFunc: nop,
+      elevationScaleFunc: nop,
+      dimensionUpdaters: this.getDimensionUpdaters()
     };
   }
 
   updateState({oldProps, props, changeFlags}) {
+    const dimensionChanges = this.getDimensionChanges(oldProps, props);
+
     if (changeFlags.dataChanged || this.needsReProjectPoints(oldProps, props)) {
       // project data into hexagons, and get sortedBins
       this.getLayerData();
-      this.getSortedBins();
-
-      // this needs sortedBins to be set
-      this.getValueDomain();
-    } else if (this.needsReSortBins(oldProps, props)) {
-
-      this.getSortedBins();
-      this.getValueDomain();
-
-    } else if (this.needsRecalculateColorDomain(oldProps, props)) {
-
-      this.getValueDomain();
+    } else if (dimensionChanges) {
+      dimensionChanges.forEach(f => typeof f === 'function' && f.apply(this));
     }
   }
 
@@ -84,13 +94,112 @@ export default class GridLayer extends CompositeLayer {
     return oldProps.cellSize !== props.cellSize;
   }
 
-  needsRecalculateColorDomain(oldProps, props) {
-    return oldProps.lowerPercentile !== props.lowerPercentile ||
-      oldProps.upperPercentile !== props.upperPercentile;
+  getDimensionUpdaters() {
+    // dimension updaters are sequential,
+    // if the first one needs to be called, the 2nd and 3rd one will automatically
+    // be called. e.g. if ColorValue needs to be updated, getColorValueDomain and getColorScale
+    // will automatically be called
+    return {
+      getColor: [
+        {
+          id: 'value',
+          triggers: ['getColorValue'],
+          updater: this.getSortedColorBins
+        }, {
+          id: 'domain',
+          triggers: ['lowerPercentile', 'upperPercentile'],
+          updater: this.getColorValueDomain
+        }, {
+          id: 'scaleFunc',
+          triggers: ['colorDomain', 'colorRange'],
+          updater: this.getColorScale
+        }
+      ],
+      getElevation: [
+        {
+          id: 'value',
+          triggers: ['getElevationValue'],
+          updater: this.getSortedElevationBins
+        }, {
+          id: 'domain',
+          triggers: ['elevationLowerPercentile', 'elevationUpperPercentile'],
+          updater: this.getElevationValueDomain
+        }, {
+          id: 'scaleFunc',
+          triggers: ['elevationDomain', 'elevationRange'],
+          updater: this.getElevationScale
+        }
+      ]
+    };
   }
 
-  needsReSortBins(oldProps, props) {
-    return oldProps.getColorValue !== props.getColorValue;
+  getDimensionChanges(oldProps, props) {
+    const {dimensionUpdaters} = this.state;
+    const updaters = [];
+
+    // get dimension to be updated
+    for (const dimensionKey in dimensionUpdaters) {
+
+      // return the first triggered updater for each dimension
+      const needUpdate = dimensionUpdaters[dimensionKey]
+        .find(item => item.triggers.some(t => oldProps[t] !== props[t]));
+
+      if (needUpdate) {
+        updaters.push(needUpdate.updater);
+      }
+    }
+
+    return updaters.length ? updaters : null;
+  }
+
+  getPickingInfo({info}) {
+    const {sortedColorBins, sortedElevationBins} = this.state;
+
+    const isPicked = info.picked && info.index > -1;
+    let object = null;
+
+    if (isPicked) {
+      const cell = this.state.layerData[info.index];
+
+      const colorValue = sortedColorBins.binMap[cell.index] &&
+        sortedColorBins.binMap[cell.index].value;
+      const elevationValue = sortedElevationBins.binMap[cell.index] &&
+        sortedElevationBins.binMap[cell.index].value;
+
+      object = Object.assign({
+        colorValue,
+        elevationValue
+      }, cell);
+    }
+
+    // add bin colorValue and elevationValue to info
+    return Object.assign(info, {
+      picked: Boolean(object),
+      // override object with picked cell
+      object
+    });
+  }
+
+  getUpdateTriggers() {
+    const {dimensionUpdaters} = this.state;
+
+    // merge all dimension triggers
+    const updateTriggers = {};
+
+    for (const dimensionKey in dimensionUpdaters) {
+
+      updateTriggers[dimensionKey] = {};
+
+      for (const step of dimensionUpdaters[dimensionKey]) {
+
+        step.triggers.forEach(prop => {
+          updateTriggers[dimensionKey][prop] = this.props[prop];
+        });
+
+      }
+    }
+
+    return updateTriggers;
   }
 
   getLayerData() {
@@ -98,72 +207,103 @@ export default class GridLayer extends CompositeLayer {
     const {layerData} = pointToDensityGridData(data, cellSize, getPosition);
 
     this.setState({layerData});
-  }
-
-  getSortedBins() {
-    const sortedBins = new BinSorter(this.state.layerData || [], this.props.getColorValue);
-    this.setState({sortedBins});
+    this.getSortedBins();
   }
 
   getValueDomain() {
-    const {lowerPercentile, upperPercentile} = this.props;
+    this.getColorValueDomain();
+    this.getElevationValueDomain();
+  }
 
-    this.state.valueDomain = this.state.sortedBins
+  getSortedBins() {
+    this.getSortedColorBins();
+    this.getSortedElevationBins();
+  }
+
+  getSortedColorBins() {
+    const {getColorValue} = this.props;
+    const sortedColorBins = new BinSorter(this.state.layerData || [], getColorValue);
+
+    this.setState({sortedColorBins});
+    this.getColorValueDomain();
+  }
+
+  getSortedElevationBins() {
+    const {getElevationValue} = this.props;
+    const sortedElevationBins = new BinSorter(this.state.layerData || [], getElevationValue);
+    this.setState({sortedElevationBins});
+    this.getElevationValueDomain();
+  }
+
+  getColorValueDomain() {
+    const {lowerPercentile, upperPercentile, onSetColorDomain} = this.props;
+
+    this.state.colorValueDomain = this.state.sortedColorBins
       .getValueRange([lowerPercentile, upperPercentile]);
+
+    if (typeof onSetColorDomain === 'function') {
+      onSetColorDomain(this.state.colorValueDomain);
+    }
+
+    this.getColorScale();
   }
 
-  getPickingInfo({info}) {
-    const pickedCell = info.picked && info.index > -1 ?
-      this.state.layerData[info.index] : null;
+  getElevationValueDomain() {
+    const {elevationLowerPercentile, elevationUpperPercentile, onSetElevationDomain} = this.props;
 
-    return Object.assign(info, {
-      picked: Boolean(pickedCell),
-      // override object with picked cell
-      object: pickedCell
-    });
+    this.state.elevationValueDomain = this.state.sortedElevationBins
+      .getValueRange([elevationLowerPercentile, elevationUpperPercentile]);
+
+    if (typeof onSetElevationDomain === 'function') {
+      onSetElevationDomain(this.state.elevationValueDomain);
+    }
+
+    this.getElevationScale();
   }
 
-  getUpdateTriggers() {
-    return {
-      getColor: {
-        colorRange: this.props.colorRange,
-        colorDomain: this.props.colorDomain,
-        getColorValue: this.props.getColorValue,
-        lowerPercentile: this.props.lowerPercentile,
-        upperPercentile: this.props.upperPercentile
-      },
-      getElevation: {
-        elevationRange: this.props.elevationRange,
-        elevationDomain: this.props.elevationDomain
-      }
-    };
+  getColorScale() {
+    const {colorRange} = this.props;
+    const colorDomain = this.props.colorDomain || this.state.colorValueDomain;
+
+    this.state.colorScaleFunc = getQuantizeScale(colorDomain, colorRange);
+  }
+
+  getElevationScale() {
+    const {elevationRange} = this.props;
+    const elevationDomain = this.props.elevationDomain || this.state.elevationValueDomain;
+
+    this.state.elevationScaleFunc = getLinearScale(elevationDomain, elevationRange);
   }
 
   _onGetSublayerColor(cell) {
-    const {colorRange} = this.props;
-    const {valueDomain, sortedBins} = this.state;
-    const value = sortedBins.binMap[cell.index] && sortedBins.binMap[cell.index].value;
+    const {sortedColorBins, colorScaleFunc, colorValueDomain} = this.state;
 
-    const colorDomain = this.props.colorDomain || valueDomain;
-    const color = quantizeScale(colorDomain, colorRange, value);
+    const cv = sortedColorBins.binMap[cell.index] && sortedColorBins.binMap[cell.index].value;
+    const colorDomain = this.props.colorDomain || colorValueDomain;
+
+    const isColorValueInDomain = cv >= colorDomain[0] && cv <= colorDomain[colorDomain.length - 1];
 
     // if cell value is outside domain, set alpha to 0
-    const alpha = value >= valueDomain[0] && value <= valueDomain[1] ?
-      (Number.isFinite(color[3]) ? color[3] : 255) : 0;
+    const color = isColorValueInDomain ? colorScaleFunc(cv) : [0, 0, 0, 0];
 
-    // add final alpha to color
-    color[3] = alpha;
+    // add alpha to color if not defined in colorRange
+    color[3] = Number.isFinite(color[3]) ? color[3] : 255;
 
     return color;
   }
 
   _onGetSublayerElevation(cell) {
-    const {elevationDomain, elevationRange} = this.props;
-    const {sortedBins} = this.state;
+    const {sortedElevationBins, elevationScaleFunc, elevationValueDomain} = this.state;
+    const ev = sortedElevationBins.binMap[cell.index] &&
+      sortedElevationBins.binMap[cell.index].value;
 
-    // elevation is based on counts, it is not affected by percentile
-    const domain = elevationDomain || [0, sortedBins.maxCount];
-    return linearScale(domain, elevationRange, cell.points.length);
+    const elevationDomain = this.props.elevationDomain || elevationValueDomain;
+
+    const isColorValueInDomain = ev >= elevationDomain[0] &&
+      ev <= elevationDomain[elevationDomain.length - 1];
+
+    // if cell value is outside domain, set elevation to -1
+    return isColorValueInDomain ? elevationScaleFunc(ev) : -1;
   }
 
   getSubLayerProps() {

--- a/src/layers/core/hexagon-cell-layer/hexagon-cell-layer-vertex-64.glsl.js
+++ b/src/layers/core/hexagon-cell-layer/hexagon-cell-layer-vertex-64.glsl.js
@@ -72,10 +72,13 @@ void main(void) {
   if (extruded > 0.5) {
     elevation = project_scale(instancePositions.z * (positions.y + 0.5) *
       ELEVATION_SCALE * elevationScale);
-}
-
-  float dotRadius = radius * clamp(coverage, 0.0, 1.0);
-  // // project center of hexagon
+  }
+  
+  // if ahpha == 0.0 or z < 0.0, do not render element  
+  float noRender = float(instanceColors.a == 0.0 || instancePositions.z < 0.0);
+  float dotRadius = radius * mix(coverage, 0.0, noRender);
+  
+  // project center of hexagon
 
   vec4 instancePositions64xy = vec4(
     instancePositions.x, instancePositions64xyLow.x,

--- a/src/layers/core/hexagon-cell-layer/hexagon-cell-layer-vertex.glsl.js
+++ b/src/layers/core/hexagon-cell-layer/hexagon-cell-layer-vertex.glsl.js
@@ -75,6 +75,7 @@ void main(void) {
       ELEVATION_SCALE * elevationScale);
   }
   
+  // if ahpha == 0.0 or z < 0.0, do not render element
   float noRender = float(instanceColors.a == 0.0 || instancePositions.z < 0.0);
   float dotRadius = radius * mix(coverage, 0.0, noRender);
   

--- a/src/layers/core/hexagon-cell-layer/hexagon-cell-layer-vertex.glsl.js
+++ b/src/layers/core/hexagon-cell-layer/hexagon-cell-layer-vertex.glsl.js
@@ -74,10 +74,11 @@ void main(void) {
     elevation = project_scale(instancePositions.z * (positions.y + 0.5) *
       ELEVATION_SCALE * elevationScale);
   }
-
-  float dotRadius = radius * mix(coverage, 0.0, float(instanceColors.a == 0.0));
-  // // project center of hexagon
-
+  
+  float noRender = float(instanceColors.a == 0.0 || instancePositions.z < 0.0);
+  float dotRadius = radius * mix(coverage, 0.0, noRender);
+  
+  // project center of hexagon
   vec4 centroidPosition = vec4(project_position(instancePositions.xy), elevation, 0.0);
 
   vec4 position_worldspace = centroidPosition + vec4(vec2(rotatedPositions.xz * dotRadius), 0., 1.);

--- a/src/layers/core/hexagon-layer/hexagon-layer.js
+++ b/src/layers/core/hexagon-layer/hexagon-layer.js
@@ -340,11 +340,11 @@ export default class HexagonLayer extends CompositeLayer {
 
     const elevationDomain = this.props.elevationDomain || elevationValueDomain;
 
-    const isColorValueInDomain = ev >= elevationDomain[0] &&
+    const isElevationValueInDomain = ev >= elevationDomain[0] &&
       ev <= elevationDomain[elevationDomain.length - 1];
 
     // if cell value is outside domain, set elevation to -1
-    return isColorValueInDomain ? elevationScaleFunc(ev) : -1;
+    return isElevationValueInDomain ? elevationScaleFunc(ev) : -1;
   }
 
   getSubLayerProps() {

--- a/src/layers/core/hexagon-layer/hexagon-layer.js
+++ b/src/layers/core/hexagon-layer/hexagon-layer.js
@@ -22,21 +22,32 @@ import {CompositeLayer} from '../../../lib';
 import HexagonCellLayer from '../hexagon-cell-layer/hexagon-cell-layer';
 import {log} from '../../../lib/utils';
 
-import {quantizeScale, linearScale} from '../../../utils/scale-utils';
+import {getQuantizeScale, getLinearScale} from '../../../utils/scale-utils';
 import {defaultColorRange} from '../../../utils/color-utils';
 import {pointToHexbin} from './hexagon-aggregator';
 
 import BinSorter from '../../../utils/bin-sorter';
 
+function nop() {}
+
 const defaultProps = {
+  // color
   colorDomain: null,
   colorRange: defaultColorRange,
   getColorValue: points => points.length,
-  elevationDomain: null,
-  elevationRange: [0, 1000],
-  elevationScale: 1,
   lowerPercentile: 0,
   upperPercentile: 100,
+  onSetColorDomain: nop,
+
+  // elevation
+  elevationDomain: null,
+  elevationRange: [0, 1000],
+  getElevationValue: points => points.length,
+  elevationLowerPercentile: 0,
+  elevationUpperPercentile: 100,
+  elevationScale: 1,
+  onSetElevationDomain: nop,
+
   radius: 1000,
   coverage: 1,
   extruded: false,
@@ -93,8 +104,13 @@ export default class HexagonLayer extends CompositeLayer {
     this.state = {
       hexagons: [],
       hexagonVertices: null,
-      sortedBins: null,
-      valueDomain: null
+      sortedColorBins: null,
+      sortedElevationBins: null,
+      colorValueDomain: null,
+      elevationValueDomain: null,
+      colorScaleFunc: nop,
+      elevationScaleFunc: nop,
+      dimensionUpdaters: this.getDimensionUpdaters()
     };
   }
 
@@ -103,22 +119,14 @@ export default class HexagonLayer extends CompositeLayer {
   }
 
   updateState({oldProps, props, changeFlags}) {
+    const dimensionChanges = this.getDimensionChanges(oldProps, props);
+
     if (changeFlags.dataChanged || this.needsReProjectPoints(oldProps, props)) {
-      // project data into hexagons, and get sortedBins
+      // project data into hexagons, and get sortedColorBins
       this.getHexagons();
-      this.getSortedBins();
 
-      // this needs sortedBins to be set
-      this.getValueDomain();
-
-    } else if (this.needsReSortBins(oldProps, props)) {
-
-      this.getSortedBins();
-      this.getValueDomain();
-
-    } else if (this.needsRecalculateColorDomain(oldProps, props)) {
-
-      this.getValueDomain();
+    } else if (dimensionChanges) {
+      dimensionChanges.forEach(f => typeof f === 'function' && f.apply(this));
     }
   }
 
@@ -127,13 +135,64 @@ export default class HexagonLayer extends CompositeLayer {
       oldProps.hexagonAggregator !== props.hexagonAggregator;
   }
 
-  needsRecalculateColorDomain(oldProps, props) {
-    return oldProps.lowerPercentile !== props.lowerPercentile ||
-      oldProps.upperPercentile !== props.upperPercentile;
+  getDimensionUpdaters() {
+    // dimension updaters are sequential,
+    // if the first ones needs to be called, the 2nd and third one will automatically
+    // be called. e.g. if value needs to be updated, domain and scaleFunc
+    // will automatically be called
+
+    return {
+      getColor: [
+        {
+          id: 'value',
+          triggers: ['getColorValue'],
+          updater: this.getSortedColorBins
+        }, {
+          id: 'domain',
+          triggers: ['lowerPercentile', 'upperPercentile'],
+          updater: this.getColorValueDomain
+        }, {
+          id: 'scaleFunc',
+          triggers: ['colorDomain', 'colorRange'],
+          updater: this.getColorScale
+        }
+      ],
+      getElevation: [
+        {
+          id: 'value',
+          triggers: ['getElevationValue'],
+          updater: this.getSortedElevationBins
+        }, {
+          id: 'domain',
+          triggers: ['elevationLowerPercentile', 'elevationUpperPercentile'],
+          updater: this.getElevationValueDomain
+        }, {
+          id: 'scaleFunc',
+          triggers: ['elevationDomain', 'elevationRange'],
+          updater: this.getElevationScale
+        }
+      ]
+    };
   }
 
-  needsReSortBins(oldProps, props) {
-    return oldProps.getColorValue !== props.getColorValue;
+  getDimensionChanges(oldProps, props) {
+    const {dimensionUpdaters} = this.state;
+    // dimension should be updated
+
+    const updaters = Object.keys(dimensionUpdaters).reduce((accu, key) => {
+
+      // return the first triggered updater for each dimension
+      const updater = dimensionUpdaters[key]
+        .find(item => item.triggers.some(t => oldProps[t] !== props[t]));
+
+      if (updater) {
+        accu.push(updater.updater);
+      }
+
+      return accu;
+    }, []);
+
+    return updaters.length ? updaters : null;
   }
 
   getHexagons() {
@@ -141,11 +200,7 @@ export default class HexagonLayer extends CompositeLayer {
     const {viewport} = this.context;
     const {hexagons, hexagonVertices} = hexagonAggregator(this.props, viewport);
     this.setState({hexagons, hexagonVertices});
-  }
-
-  getSortedBins() {
-    const sortedBins = new BinSorter(this.state.hexagons || [], this.props.getColorValue);
-    this.setState({sortedBins});
+    this.getSortedBins();
   }
 
   getPickingInfo({info}) {
@@ -160,53 +215,117 @@ export default class HexagonLayer extends CompositeLayer {
   }
 
   getUpdateTriggers() {
-    return {
-      getColor: {
-        colorRange: this.props.colorRange,
-        colorDomain: this.props.colorDomain,
-        getColorValue: this.props.getColorValue,
-        lowerPercentile: this.props.lowerPercentile,
-        upperPercentile: this.props.upperPercentile
-      },
-      getElevation: {
-        elevationRange: this.props.elevationRange,
-        elevationDomain: this.props.elevationDomain
-      }
-    };
+    const {dimensionUpdaters} = this.state;
+    // merge all dimension triggers
+    return Object.keys(dimensionUpdaters).reduce((accu, dimension) => {
+
+      accu[dimension] = dimensionUpdaters[dimension].reduce((triggers, step) => {
+
+        step.triggers.forEach(key => {
+          triggers[key] = this.props[key];
+        });
+
+        return triggers;
+      }, {});
+
+      return accu;
+    }, {});
   }
 
   getValueDomain() {
-    const {lowerPercentile, upperPercentile} = this.props;
+    this.getColorValueDomain();
+    this.getElevationValueDomain();
+  }
 
-    this.state.valueDomain = this.state.sortedBins
+  getSortedBins() {
+    this.getSortedColorBins();
+    this.getSortedElevationBins();
+  }
+
+  getSortedColorBins() {
+    const {getColorValue} = this.props;
+    const sortedColorBins = new BinSorter(this.state.hexagons || [], getColorValue);
+
+    this.setState({sortedColorBins});
+    this.getColorValueDomain();
+  }
+
+  getSortedElevationBins() {
+    const {getElevationValue} = this.props;
+    const sortedElevationBins = new BinSorter(this.state.hexagons || [], getElevationValue);
+    this.setState({sortedElevationBins});
+    this.getElevationValueDomain();
+  }
+
+  getColorValueDomain() {
+    const {lowerPercentile, upperPercentile, onSetColorDomain} = this.props;
+
+    this.state.colorValueDomain = this.state.sortedColorBins
       .getValueRange([lowerPercentile, upperPercentile]);
+
+    if (typeof onSetColorDomain === 'function') {
+      onSetColorDomain(this.state.colorValueDomain);
+    }
+
+    this.getColorScale();
+  }
+
+  getElevationValueDomain() {
+    const {elevationLowerPercentile, elevationUpperPercentile, onSetElevationDomain} = this.props;
+
+    this.state.elevationValueDomain = this.state.sortedElevationBins
+      .getValueRange([elevationLowerPercentile, elevationUpperPercentile]);
+
+    if (typeof onSetElevationDomain === 'function') {
+      onSetElevationDomain(this.state.elevationValueDomain);
+    }
+
+    this.getElevationScale();
+  }
+
+  getColorScale() {
+    const {colorRange} = this.props;
+    const colorDomain = this.props.colorDomain || this.state.colorValueDomain;
+
+    this.state.colorScaleFunc = getQuantizeScale(colorDomain, colorRange);
+  }
+
+  getElevationScale() {
+    const {elevationRange} = this.props;
+    const elevationDomain = this.props.elevationDomain || this.state.elevationValueDomain;
+
+    this.state.elevationScaleFunc = getLinearScale(elevationDomain, elevationRange);
   }
 
   _onGetSublayerColor(cell) {
-    const {colorRange} = this.props;
-    const {valueDomain, sortedBins} = this.state;
-    const value = sortedBins.binMap[cell.index] && sortedBins.binMap[cell.index].value;
+    const {sortedColorBins, colorScaleFunc, colorValueDomain} = this.state;
 
-    const colorDomain = this.props.colorDomain || valueDomain;
-    const color = quantizeScale(colorDomain, colorRange, value);
+    const cv = sortedColorBins.binMap[cell.index] && sortedColorBins.binMap[cell.index].value;
+    const colorDomain = this.props.colorDomain || colorValueDomain;
+
+    const isColorValueInDomain = cv >= colorDomain[0] && cv <= colorDomain[colorDomain.length - 1];
 
     // if cell value is outside domain, set alpha to 0
-    const alpha = value >= valueDomain[0] && value <= valueDomain[1] ?
-      (Number.isFinite(color[3]) ? color[3] : 255) : 0;
+    const color = isColorValueInDomain ? colorScaleFunc(cv) : [0, 0, 0, 0];
 
-    // add final alpha to color
-    color[3] = alpha;
+    // add alpha to color if not defined in colorRange
+    color[3] = Number.isFinite(color[3]) ? color[3] : 255;
 
     return color;
   }
 
   _onGetSublayerElevation(cell) {
-    const {elevationDomain, elevationRange} = this.props;
-    const {sortedBins} = this.state;
+    const {sortedElevationBins, elevationScaleFunc, elevationValueDomain} = this.state;
+    const ev = sortedElevationBins.binMap[cell.index] &&
+      sortedElevationBins.binMap[cell.index].value;
 
-    // elevation is based on counts, it is not affected by percentile
-    const domain = elevationDomain || [0, sortedBins.maxCount];
-    return linearScale(domain, elevationRange, cell.points.length);
+    const elevationDomain = this.props.elevationDomain || elevationValueDomain;
+
+    const isColorValueInDomain = ev >= elevationDomain[0] &&
+      ev <= elevationDomain[elevationDomain.length - 1];
+
+    // if cell value is outside domain, set elevation to -1
+    return isColorValueInDomain ? elevationScaleFunc(ev) : -1;
   }
 
   getSubLayerProps() {

--- a/src/lib/composite-layer.js
+++ b/src/lib/composite-layer.js
@@ -53,6 +53,25 @@ export default class CompositeLayer extends Layer {
     return null;
   }
 
+  // Returns props that should be forwarded to children
+  // TODO - implement autoforwarding?
+  getForwardProps() {
+    const {
+      // base layer props
+      opacity, pickable, visible, parameters, getPolygonOffset,
+      highlightedObjectIndex, autoHighlight, highlightColor,
+      // viewport props
+      coordinateSystem, coordinateOrigin, modelMatrix
+    } = this.props;
+
+    return {
+      // Forward layer props
+      opacity, pickable, visible, parameters, getPolygonOffset,
+      highlightedObjectIndex, autoHighlight, highlightColor,
+      coordinateSystem, coordinateOrigin, modelMatrix
+    };
+  }
+
   _renderLayers(updateParams) {
     if (!this.shouldUpdateState(updateParams)) {
       log.log(2, 'Composite layer reusing sublayers', this.state.oldSubLayers);

--- a/src/lib/draw-and-pick.js
+++ b/src/lib/draw-and-pick.js
@@ -236,6 +236,23 @@ function getClosestFromPickingBuffer(gl, {
   deviceY,
   deviceRadius
 }) {
+  let closestResultToCenter = {
+    pickedColor: EMPTY_PIXEL,
+    pickedLayer: null,
+    pickedObjectIndex: -1
+  };
+
+  if (
+    deviceX < 0 ||
+    deviceY < 0 ||
+    deviceX > pickingFBO.width ||
+    deviceY > pickingFBO.height ||
+    layers.length <= 0
+  ) {
+    // x, y out of bounds or no layers to pick.
+    return closestResultToCenter;
+  }
+
   // Create a box of size `radius * 2 + 1` centered at [deviceX, deviceY]
   const x = Math.max(0, deviceX - deviceRadius);
   const y = Math.max(0, deviceY - deviceRadius);
@@ -247,11 +264,6 @@ function getClosestFromPickingBuffer(gl, {
   // Traverse all pixels in picking results and find the one closest to the supplied
   // [deviceX, deviceY]
   let minSquareDistanceToCenter = deviceRadius * deviceRadius;
-  let closestResultToCenter = {
-    pickedColor: EMPTY_PIXEL,
-    pickedLayer: null,
-    pickedObjectIndex: -1
-  };
   let i = 0;
 
   for (let row = 0; row < height; row++) {
@@ -330,7 +342,8 @@ function getPickedColors(gl, {
   return withParameters(gl, {
     framebuffer: pickingFBO,
     scissorTest: true,
-    scissor: [x, y, width, height]
+    scissor: [x, y, width, height],
+    clearColor: [0, 0, 0, 0]
   }, () => {
 
     // Clear the frame buffer
@@ -355,8 +368,7 @@ function getPickedColors(gl, {
           parameters: Object.assign({}, layer.props.parameters || {}, {
             blend: true,
             blendFunc: [gl.ONE, gl.ZERO, gl.CONSTANT_ALPHA, gl.ZERO],
-            blendEquation: gl.FUNC_ADD,
-            clearColor: [0, 0, 0, 0]
+            blendEquation: gl.FUNC_ADD
           })
         });
       }

--- a/src/utils/bin-sorter.js
+++ b/src/utils/bin-sorter.js
@@ -39,11 +39,20 @@ export default class BinSorter {
    */
   getSortedBins(bins, getValue) {
     return bins
-      .map((h, i) => ({
-        i: Number.isFinite(h.index) ? h.index : i,
-        value: getValue(h.points),
-        counts: h.points.length
-      }))
+      .reduce((accu, h, i) => {
+        const value = getValue(h.points);
+
+        if (value !== null || value !== undefined) {
+          // filter bins if value is null or undefined
+          accu.push({
+            i: Number.isFinite(h.index) ? h.index : i,
+            value,
+            counts: h.points.length
+          });
+        }
+
+        return accu;
+      }, [])
       .sort((a, b) => a.value - b.value);
   }
 
@@ -70,7 +79,7 @@ export default class BinSorter {
    * @return {Number | Boolean} max count
    */
   getMaxCount() {
-    return Math.max.apply(null, this.sortedBins.map(b => b.counts));
+    return Math.max(...this.sortedBins.map(b => b.counts));
   }
 
   /**

--- a/src/utils/scale-utils.js
+++ b/src/utils/scale-utils.js
@@ -34,6 +34,22 @@ export function quantizeScale(domain, range, value) {
   return range[clampIdx];
 }
 
+// return a quantize scale function
+export function getQuantizeScale(domain, range) {
+  return value => {
+    const step = (domain[1] - domain[0]) / range.length;
+    const idx = Math.floor((value - domain[0]) / step);
+    const clampIdx = Math.max(Math.min(idx, range.length - 1), 0);
+
+    return range[clampIdx];
+  };
+}
+
+// return a linear scale funciton
+export function getLinearScale(domain, range) {
+  return value => (value - domain[0]) / (domain[1] - domain[0]) * (range[1] - range[0]) + range[0];
+}
+
 export function clamp([min, max], value) {
   return Math.min(max, Math.max(min, value));
 }

--- a/test/layers/grid-layer.spec.js
+++ b/test/layers/grid-layer.spec.js
@@ -34,6 +34,7 @@ import {
 import {GridLayer, GridCellLayer} from 'deck.gl';
 
 const getColorValue = points => points.length;
+const getElevationValue = points => points.length;
 const getPosition = d => d.COORDINATES;
 
 const TEST_CASES = {
@@ -53,11 +54,23 @@ const TEST_CASES = {
       t.ok(oldState.layerData !== layer.state.layerData,
         'should update layer data');
 
-      t.ok(oldState.sortedBins !== layer.state.sortedBins,
-        'should update sortedBins');
+      t.ok(oldState.sortedColorBins !== layer.state.sortedColorBins,
+        'should update sortedColorBins');
 
-      t.ok(oldState.valueDomain !== layer.state.valueDomain,
+      t.ok(oldState.colorValueDomain !== layer.state.colorValueDomain,
         'should update valueDomain');
+
+      t.ok(oldState.colorScaleFunc !== layer.state.colorScaleFunc,
+        'should update colorScaleFunc');
+
+      t.ok(oldState.sortedElevationBins !== layer.state.sortedElevationBins,
+        'should update sortedElevationBins');
+
+      t.ok(oldState.elevationValueDomain !== layer.state.elevationValueDomain,
+        'should update elevationValueDomain');
+
+      t.ok(oldState.elevationScaleFunc !== layer.state.elevationScaleFunc,
+        'should update elevationScaleFunc');
     }
   }, {
     updateProps: {
@@ -67,11 +80,23 @@ const TEST_CASES = {
       t.ok(oldState.layerData === layer.state.layerData,
         'should not update layer data');
 
-      t.ok(oldState.sortedBins !== layer.state.sortedBins,
-        'should update sortedBins');
+      t.ok(oldState.sortedColorBins !== layer.state.sortedColorBins,
+        'should not update sortedColorBins');
 
-      t.ok(oldState.valueDomain !== layer.state.valueDomain,
-        'should re calculate valueDomain');
+      t.ok(oldState.sortedElevationBins === layer.state.sortedElevationBins,
+        'should update sortedElevationBins');
+
+      t.ok(oldState.colorValueDomain !== layer.state.colorValueDomain,
+        'should re calculate colorValueDomain');
+
+      t.ok(oldState.elevationValueDomain === layer.state.elevationValueDomain,
+        'should not update elevationValueDomain');
+
+      t.ok(oldState.colorScaleFunc !== layer.state.colorScaleFunc,
+        'should update colorScaleFunc');
+
+      t.ok(oldState.elevationScaleFunc === layer.state.elevationScaleFunc,
+        'should not update colorScaleFunc');
     }
   }, {
     updateProps: {
@@ -81,11 +106,127 @@ const TEST_CASES = {
       t.ok(oldState.layerData === layer.state.layerData,
         'should not update layer data');
 
-      t.ok(oldState.sortedBins === layer.state.sortedBins,
-        'should not update sortedBins');
+      t.ok(oldState.sortedColorBins === layer.state.sortedColorBins,
+        'should not update sortedColorBins');
 
-      t.ok(oldState.valueDomain !== layer.state.valueDomain,
-        'should re calculate valueDomain');
+      t.ok(oldState.colorValueDomain !== layer.state.colorValueDomain,
+        'should re calculate colorValueDomain');
+
+      t.ok(oldState.colorScaleFunc !== layer.state.colorScaleFunc,
+        'should update colorScaleFunc');
+
+      t.ok(oldState.sortedElevationBins === layer.state.sortedElevationBins,
+        'should not update sortedElevationBins');
+
+      t.ok(oldState.elevationValueDomain === layer.state.elevationValueDomain,
+        'should not update elevationValueDomain');
+
+      t.ok(oldState.elevationScaleFunc === layer.state.elevationScaleFunc,
+        'should not update elevationScaleFunc');
+    }
+  }, {
+    updateProps: {
+      colorDomain: [0, 10]
+    },
+    assert: (layer, oldState, t) => {
+      t.ok(oldState.layerData === layer.state.layerData,
+        'should not update layer data');
+
+      t.ok(oldState.sortedColorBins === layer.state.sortedColorBins,
+        'should not update sortedColorBins');
+
+      t.ok(oldState.colorValueDomain === layer.state.colorValueDomain,
+        'should not re calculate colorValueDomain');
+
+      t.ok(oldState.colorScaleFunc !== layer.state.colorScaleFunc,
+        'should update colorScaleFunc');
+
+      t.ok(oldState.sortedElevationBins === layer.state.sortedElevationBins,
+        'should not update sortedElevationBins');
+
+      t.ok(oldState.elevationValueDomain === layer.state.elevationValueDomain,
+        'should not update elevationValueDomain');
+
+      t.ok(oldState.elevationScaleFunc === layer.state.elevationScaleFunc,
+        'should not update elevationScaleFunc');
+    }
+  }, {
+    updateProps: {
+      getElevationValue
+    },
+    assert: (layer, oldState, t) => {
+      t.ok(oldState.layerData === layer.state.layerData,
+        'should not update layer data');
+
+      t.ok(oldState.sortedElevationBins !== layer.state.sortedElevationBins,
+        'should update sortedElevationBins');
+
+      t.ok(oldState.elevationValueDomain !== layer.state.elevationValueDomain,
+        'should re calculate elevationValueDomain');
+
+      t.ok(oldState.elevationScaleFunc !== layer.state.elevationScaleFunc,
+        'should update elevationScaleFunc');
+
+      t.ok(oldState.sortedColorBins === layer.state.sortedColorBins,
+        'should not update sortedColorBins');
+
+      t.ok(oldState.colorValueDomain === layer.state.colorValueDomain,
+        'should not re calculate colorValueDomain');
+
+      t.ok(oldState.colorScaleFunc === layer.state.colorScaleFunc,
+        'should not update colorScaleFunc');
+    }
+  }, {
+    updateProps: {
+      elevationLowerPercentile: 1
+    },
+    assert: (layer, oldState, t) => {
+      t.ok(oldState.layerData === layer.state.layerData,
+        'should not update layer data');
+
+      t.ok(oldState.sortedElevationBins === layer.state.sortedElevationBins,
+        'should not update sortedElevationBins');
+
+      t.ok(oldState.elevationValueDomain !== layer.state.elevationValueDomain,
+        'should re calculate elevationValueDomain');
+
+      t.ok(oldState.elevationScaleFunc !== layer.state.elevationScaleFunc,
+        'should update elevationScaleFunc');
+
+      t.ok(oldState.sortedColorBins === layer.state.sortedColorBins,
+        'should not update sortedColorBins');
+
+      t.ok(oldState.colorValueDomain === layer.state.colorValueDomain,
+        'should not re calculate colorValueDomain');
+
+      t.ok(oldState.colorScaleFunc === layer.state.colorScaleFunc,
+        'should not update colorScaleFunc');
+    }
+  }, {
+    updateProps: {
+      elevationRange: [1, 10]
+    },
+    assert: (layer, oldState, t) => {
+      t.ok(oldState.layerData === layer.state.layerData,
+        'should not update layer data');
+
+      t.ok(oldState.sortedElevationBins === layer.state.sortedElevationBins,
+        'should not update sortedElevationBins');
+
+      t.ok(oldState.elevationValueDomain === layer.state.elevationValueDomain,
+        'should not re calculate elevationValueDomain');
+
+      t.ok(oldState.elevationScaleFunc !== layer.state.elevationScaleFunc,
+        'should update elevationScaleFunc');
+
+      t.ok(oldState.sortedColorBins === layer.state.sortedColorBins,
+        'should not update sortedColorBins');
+
+      t.ok(oldState.colorValueDomain === layer.state.colorValueDomain,
+        'should not re calculate colorValueDomain');
+
+      t.ok(oldState.colorScaleFunc === layer.state.colorScaleFunc,
+        'should not update colorScaleFunc');
     }
   }]
 };
@@ -140,6 +281,26 @@ const SUBLAYER_TEST_CASES = {
     }
   }, {
     updateProps: {
+      getElevationValue
+    },
+    assert: (subLayer, spies, t) => {
+      t.ok(!spies._onGetSublayerColor.called,
+        'update getElevationValue should not call _onGetSublayerColor');
+      t.ok(spies._onGetSublayerElevation.called,
+        'update getElevationValue should call _onGetSublayerElevation');
+    }
+  }, {
+    updateProps: {
+      elevationUpperPercentile: 99
+    },
+    assert: (subLayer, spies, t) => {
+      t.ok(!spies._onGetSublayerColor.called,
+        'update elevationUpperPercentile should not call _onGetSublayerColor');
+      t.ok(spies._onGetSublayerElevation.called,
+        'update elevationUpperPercentile should call _onGetSublayerElevation');
+    }
+  }, {
+    updateProps: {
       elevationRange: [0, 100]
     },
     assert: (subLayer, spies, t) => {
@@ -161,20 +322,29 @@ test('GridLayer#constructor', t => {
 
   testInitializeLayer({layer});
 
-  const {layerData, sortedBins, valueDomain} = layer.state;
+  const {layerData, sortedColorBins, sortedElevationBins,
+    colorValueDomain, elevationValueDomain} = layer.state;
 
   t.ok(layerData.length > 0, 'GridLayer.state.layerDate calculated');
-  t.ok(sortedBins, 'GridLayer.state.sortedBins calculated');
-  t.ok(Array.isArray(valueDomain), 'GridLayer.state.valueDomain calculated');
+  t.ok(sortedColorBins, 'GridLayer.state.sortedColorBins calculated');
+  t.ok(sortedElevationBins, 'GridLayer.state.sortedColorBins calculated');
+  t.ok(Array.isArray(colorValueDomain), 'GridLayer.state.valueDomain calculated');
+  t.ok(Array.isArray(elevationValueDomain), 'GridLayer.state.valueDomain calculated');
 
-  t.ok(Array.isArray(sortedBins.sortedBins), 'GridLayer.state.sortedBins.sortedBins calculated');
-  t.ok(Number.isFinite(sortedBins.maxCount), 'GridLayer.state.sortedBins.maxCount calculated');
+  t.ok(Array.isArray(sortedColorBins.sortedBins),
+    'GridLayer.state.sortedColorBins.sortedBins calculated');
+  t.ok(Array.isArray(sortedElevationBins.sortedBins),
+    'GridLayer.state.sortedColorBins.sortedBins calculated');
+  t.ok(Number.isFinite(sortedColorBins.maxCount),
+    'GridLayer.state.sortedColorBins.maxCount calculated');
+  t.ok(Number.isFinite(sortedElevationBins.maxCount),
+    'GridLayer.state.sortedColorBins.maxCount calculated');
 
-  const firstSortedBin = sortedBins.sortedBins[0];
+  const firstSortedBin = sortedColorBins.sortedBins[0];
   const binTocell = layerData.find(d => d.index === firstSortedBin.i);
 
-  t.ok(sortedBins.binMap[binTocell.index] === firstSortedBin,
-    'Correct GridLayer.state.sortedBins.binMap created');
+  t.ok(sortedColorBins.binMap[binTocell.index] === firstSortedBin,
+    'Correct GridLayer.state.sortedColorBins.binMap created');
 
   const subLayer = layer.renderLayers();
   t.ok(subLayer instanceof GridCellLayer, 'GridCellLayer rendered');

--- a/test/layers/hexagon-layer.spec.js
+++ b/test/layers/hexagon-layer.spec.js
@@ -31,6 +31,7 @@ import {
 import {HexagonLayer, HexagonCellLayer} from 'deck.gl';
 
 const getColorValue = points => points.length;
+const getElevationValue = points => points.length;
 const getPosition = d => d.COORDINATES;
 
 const TEST_CASES = {
@@ -49,11 +50,23 @@ const TEST_CASES = {
       t.ok(oldState.hexagons !== layer.state.hexagons,
         'should update layer data');
 
-      t.ok(oldState.sortedBins !== layer.state.sortedBins,
-        'should update sortedBins');
+      t.ok(oldState.sortedColorBins !== layer.state.sortedColorBins,
+        'should update sortedColorBins');
 
-      t.ok(oldState.valueDomain !== layer.state.valueDomain,
+      t.ok(oldState.colorValueDomain !== layer.state.colorValueDomain,
         'should update valueDomain');
+
+      t.ok(oldState.colorScaleFunc !== layer.state.colorScaleFunc,
+        'should update colorScaleFunc');
+
+      t.ok(oldState.sortedElevationBins !== layer.state.sortedElevationBins,
+        'should update sortedElevationBins');
+
+      t.ok(oldState.elevationValueDomain !== layer.state.elevationValueDomain,
+        'should update elevationValueDomain');
+
+      t.ok(oldState.elevationScaleFunc !== layer.state.elevationScaleFunc,
+        'should update elevationScaleFunc');
     }
   }, {
     updateProps: {
@@ -63,11 +76,23 @@ const TEST_CASES = {
       t.ok(oldState.hexagons === layer.state.hexagons,
         'should not update layer data');
 
-      t.ok(oldState.sortedBins !== layer.state.sortedBins,
-       'should update sortedBins');
+      t.ok(oldState.sortedColorBins !== layer.state.sortedColorBins,
+       'should not update sortedColorBins');
 
-      t.ok(oldState.valueDomain !== layer.state.valueDomain,
-        'should re calculate valueDomain');
+      t.ok(oldState.sortedElevationBins === layer.state.sortedElevationBins,
+        'should update sortedElevationBins');
+
+      t.ok(oldState.colorValueDomain !== layer.state.colorValueDomain,
+        'should re calculate colorValueDomain');
+
+      t.ok(oldState.elevationValueDomain === layer.state.elevationValueDomain,
+        'should not update elevationValueDomain');
+
+      t.ok(oldState.colorScaleFunc !== layer.state.colorScaleFunc,
+        'should update colorScaleFunc');
+
+      t.ok(oldState.elevationScaleFunc === layer.state.elevationScaleFunc,
+        'should not update colorScaleFunc');
     }
   }, {
     updateProps: {
@@ -77,11 +102,127 @@ const TEST_CASES = {
       t.ok(oldState.hexagons === layer.state.hexagons,
         'should not update layer data');
 
-      t.ok(oldState.sortedBins === layer.state.sortedBins,
-       'should not update sortedBins');
+      t.ok(oldState.sortedColorBins === layer.state.sortedColorBins,
+       'should not update sortedColorBins');
 
-      t.ok(oldState.valueDomain !== layer.state.valueDomain,
-        'should re calculate valueDomain');
+      t.ok(oldState.colorValueDomain !== layer.state.colorValueDomain,
+        'should re calculate colorValueDomain');
+
+      t.ok(oldState.colorScaleFunc !== layer.state.colorScaleFunc,
+        'should update colorScaleFunc');
+
+      t.ok(oldState.sortedElevationBins === layer.state.sortedElevationBins,
+        'should not update sortedElevationBins');
+
+      t.ok(oldState.elevationValueDomain === layer.state.elevationValueDomain,
+        'should not update elevationValueDomain');
+
+      t.ok(oldState.elevationScaleFunc === layer.state.elevationScaleFunc,
+        'should not update elevationScaleFunc');
+    }
+  }, {
+    updateProps: {
+      colorDomain: [0, 10]
+    },
+    assert: (layer, oldState, t) => {
+      t.ok(oldState.hexagons === layer.state.hexagons,
+        'should not update layer data');
+
+      t.ok(oldState.sortedColorBins === layer.state.sortedColorBins,
+        'should not update sortedColorBins');
+
+      t.ok(oldState.colorValueDomain === layer.state.colorValueDomain,
+        'should not re calculate colorValueDomain');
+
+      t.ok(oldState.colorScaleFunc !== layer.state.colorScaleFunc,
+        'should update colorScaleFunc');
+
+      t.ok(oldState.sortedElevationBins === layer.state.sortedElevationBins,
+        'should not update sortedElevationBins');
+
+      t.ok(oldState.elevationValueDomain === layer.state.elevationValueDomain,
+        'should not update elevationValueDomain');
+
+      t.ok(oldState.elevationScaleFunc === layer.state.elevationScaleFunc,
+        'should not update elevationScaleFunc');
+    }
+  }, {
+    updateProps: {
+      getElevationValue
+    },
+    assert: (layer, oldState, t) => {
+      t.ok(oldState.hexagons === layer.state.hexagons,
+        'should not update layer data');
+
+      t.ok(oldState.sortedElevationBins !== layer.state.sortedElevationBins,
+        'should update sortedElevationBins');
+
+      t.ok(oldState.elevationValueDomain !== layer.state.elevationValueDomain,
+        'should re calculate elevationValueDomain');
+
+      t.ok(oldState.elevationScaleFunc !== layer.state.elevationScaleFunc,
+        'should update elevationScaleFunc');
+
+      t.ok(oldState.sortedColorBins === layer.state.sortedColorBins,
+        'should not update sortedColorBins');
+
+      t.ok(oldState.colorValueDomain === layer.state.colorValueDomain,
+        'should not re calculate colorValueDomain');
+
+      t.ok(oldState.colorScaleFunc === layer.state.colorScaleFunc,
+        'should not update colorScaleFunc');
+    }
+  }, {
+    updateProps: {
+      elevationLowerPercentile: 1
+    },
+    assert: (layer, oldState, t) => {
+      t.ok(oldState.hexagons === layer.state.hexagons,
+        'should not update layer data');
+
+      t.ok(oldState.sortedElevationBins === layer.state.sortedElevationBins,
+        'should not update sortedElevationBins');
+
+      t.ok(oldState.elevationValueDomain !== layer.state.elevationValueDomain,
+        'should re calculate elevationValueDomain');
+
+      t.ok(oldState.elevationScaleFunc !== layer.state.elevationScaleFunc,
+        'should update elevationScaleFunc');
+
+      t.ok(oldState.sortedColorBins === layer.state.sortedColorBins,
+        'should not update sortedColorBins');
+
+      t.ok(oldState.colorValueDomain === layer.state.colorValueDomain,
+        'should not re calculate colorValueDomain');
+
+      t.ok(oldState.colorScaleFunc === layer.state.colorScaleFunc,
+        'should not update colorScaleFunc');
+    }
+  }, {
+    updateProps: {
+      elevationRange: [1, 10]
+    },
+    assert: (layer, oldState, t) => {
+      t.ok(oldState.hexagons === layer.state.hexagons,
+        'should not update layer data');
+
+      t.ok(oldState.sortedElevationBins === layer.state.sortedElevationBins,
+        'should not update sortedElevationBins');
+
+      t.ok(oldState.elevationValueDomain === layer.state.elevationValueDomain,
+        'should not re calculate elevationValueDomain');
+
+      t.ok(oldState.elevationScaleFunc !== layer.state.elevationScaleFunc,
+        'should update elevationScaleFunc');
+
+      t.ok(oldState.sortedColorBins === layer.state.sortedColorBins,
+        'should not update sortedColorBins');
+
+      t.ok(oldState.colorValueDomain === layer.state.colorValueDomain,
+        'should not re calculate colorValueDomain');
+
+      t.ok(oldState.colorScaleFunc === layer.state.colorScaleFunc,
+        'should not update colorScaleFunc');
     }
   }]
 };
@@ -133,6 +274,26 @@ const SUBLAYER_TEST_CASES = {
         'update upperPercentile should call _onGetSublayerColor');
       t.ok(!spies._onGetSublayerElevation.called,
         'update upperPercentile should not call _onGetSublayerElevation');
+    }
+  }, {
+    updateProps: {
+      getElevationValue
+    },
+    assert: (subLayer, spies, t) => {
+      t.ok(!spies._onGetSublayerColor.called,
+        'update getElevationValue should not call _onGetSublayerColor');
+      t.ok(spies._onGetSublayerElevation.called,
+        'update getElevationValue should call _onGetSublayerElevation');
+    }
+  }, {
+    updateProps: {
+      elevationUpperPercentile: 99
+    },
+    assert: (subLayer, spies, t) => {
+      t.ok(!spies._onGetSublayerColor.called,
+        'update elevationUpperPercentile should not call _onGetSublayerColor');
+      t.ok(spies._onGetSublayerElevation.called,
+        'update elevationUpperPercentile should call _onGetSublayerElevation');
     }
   }, {
     updateProps: {

--- a/test/lib/index.js
+++ b/test/lib/index.js
@@ -19,7 +19,8 @@
 // THE SOFTWARE.
 
 import './utils';
+import './props.spec';
 import './viewports';
 import './attribute-manager.spec';
 import './layer.spec';
-import './props.spec';
+import './layer-manager.spec';

--- a/test/lib/layer-manager.spec.js
+++ b/test/lib/layer-manager.spec.js
@@ -1,0 +1,66 @@
+// Copyright (c) 2015 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+/* eslint-disable func-style, no-console, max-len */
+import test from 'tape-catch';
+import {LayerManager, Viewport, Layer, CompositeLayer} from 'deck.gl';
+import gl from '../test-utils/setup-gl';
+
+class TestLayer extends Layer {
+  initializeState() {}
+}
+
+TestLayer.layerName = 'TestLayer';
+
+class TestCompositeLayer extends CompositeLayer {
+  renderLayers() {
+    return [
+      new TestLayer(Object.assign({id: `${this.props.id}-sublayer-1`}, this.getForwardProps())),
+      new TestLayer(Object.assign({id: `${this.props.id}-sublayer-2`}, this.getForwardProps()))
+    ];
+  }
+}
+
+TestCompositeLayer.layerName = 'TestCompositeLayer';
+
+const LAYERS = [
+  new TestLayer({id: 'primitive'}),
+  new TestCompositeLayer({id: 'composite', stroked: true, filled: true})
+];
+
+test('LayerManager#constructor', t => {
+  t.ok(LayerManager, 'LayerManager imported');
+  const layerManager = new LayerManager({gl});
+  t.ok(layerManager, 'LayerManager created');
+  layerManager.setViewport(new Viewport());
+  t.end();
+});
+
+test('LayerManager#getLayers', t => {
+  const layerManager = new LayerManager({gl});
+  layerManager.setViewport(new Viewport());
+  layerManager.updateLayers({newLayers: LAYERS});
+  let layers = layerManager.getLayers();
+  t.equal(layers.length, 4, 'LayerManager.getLayers()');
+  layers = layerManager.getLayers({layerIds: ['composite']});
+  t.equal(layers.length, 3, 'LayerManager.getLayers()');
+  layers = layerManager.getLayers({layerIds: ['non-existent-id']});
+  t.equal(layers.length, 0, 'LayerManager.getLayers()');
+  t.end();
+});

--- a/test/test-utils/setup-gl.js
+++ b/test/test-utils/setup-gl.js
@@ -1,4 +1,6 @@
 import {createGLContext} from 'luma.gl';
 import global from 'global';
 
-global.glContext = createGLContext();
+global.glContext = global.glContext || createGLContext();
+
+export default global.glContext;


### PR DESCRIPTION
Cherry picked following from master :
- Fix picking buffer clear color. (#931)
- Handle recursive layer ids, update LayerManager docs and tests. (#933)
- Hexagon Layer: Add getElevationValue to calculate hexagon elevation by aggregation (#938)
- Update docs with missing layer props. (#959)
- Grid Layer: Add getElevationValue to enable grid elevation by aggregation (#954)
- Hexagon/Grid Layer: Fix FP64 mode rendering when elevation < 0.0 (#968)

Had to selectively pick changes from #933 as some of the changes are on top of 4.2 changes.

Tested with `test-browser` and all layers in `layer-browser`.
