### PR TITLE
layer-browser: show picking buffer, support luma.gl override during local dev

### DIFF
--- a/examples/layer-browser/package.json
+++ b/examples/layer-browser/package.json
@@ -5,14 +5,14 @@
     "start-es6": "webpack-dev-server --env.es6 --progress --hot --open"
   },
   "dependencies": {
-    "deck.gl": ">=4.1.0-beta.9",
+    "deck.gl": ">=4.1.0-alpha.10",
     "colorbrewer": "^1.0.0",
     "extrude-polyline": "^1.0.6",
-    "luma.gl": "^4.0.1",
+    "luma.gl": ">=4.1.0-alpha.3",
     "react": "^15.4.1",
     "react-autobind": "^1.0.6",
     "react-dom": "^15.4.1",
-    "react-map-gl": ">=3.0.0-alpha.12",
+    "react-map-gl": "^3.0.0",
     "react-stats": "^0.0.5",
     "s2-geometry": "^1.2.9"
   },

--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -59,7 +59,8 @@ class App extends PureComponent {
         // effects: false,
         multiview: false,
         separation: 0,
-        pickingRadius: 0
+        pickingRadius: 0,
+        drawPickingColors: false
         // the rotation controls works only for layers in
         // meter offset projection mode. They are commented out
         // here since layer browser currently only have one layer
@@ -224,7 +225,8 @@ class App extends PureComponent {
   }
 
   _renderMap() {
-    const {width, height, mapViewState, settings: {effects, pickingRadius}} = this.state;
+    const {width, height, mapViewState, settings} = this.state;
+    const {effects, pickingRadius, drawPickingColors} = settings;
 
     const viewports = this._getViewports();
 
@@ -245,12 +247,14 @@ class App extends PureComponent {
             viewports={viewports}
             layers={this._renderExamples()}
             effects={effects ? this._effects : []}
-            debug={true}
             useDefaultGLSettings
             pickingRadius={pickingRadius}
             onLayerHover={this._onHover}
             onLayerClick={this._onClick}
             initWebGLParameters
+
+            debug={true}
+            drawPickingColors={drawPickingColors}
           >
             <FPSStats isActive/>
 

--- a/examples/layer-browser/webpack.config.js
+++ b/examples/layer-browser/webpack.config.js
@@ -58,4 +58,4 @@ const CONFIG = {
 };
 
 // This line enables bundling against src in this repo rather than installed deck.gl module
-module.exports = env => env ? require('../webpack.config.local')(CONFIG)(env) : CONFIG;
+module.exports = env => env ? require('../webpack.config.local')(CONFIG, __dirname)(env) : CONFIG;


### PR DESCRIPTION
* New option to show picking buffer contents, helpful for debugging picking in complex framebuffer based layers
* Allows luma version to be controlled in start-local etc, allows testing latest luma patches in layer browser