### PR TITLE
 [Hexagon/Grid] add no render when elevation < 0.0 to vertex-64

### DIFF
--- a/src/core-layers/grid-cell-layer/grid-cell-layer-vertex-64.glsl.js
+++ b/src/core-layers/grid-cell-layer/grid-cell-layer-vertex-64.glsl.js
@@ -34,6 +34,7 @@ attribute vec3 instancePickingColors;
 // Custom uniforms
 uniform float extruded;
 uniform float cellSize;
+uniform float coverage;
 uniform float opacity;
 uniform float elevationScale;
 
@@ -58,9 +59,9 @@ void main(void) {
   float finalCellSize = cellSize * mix(1.0, 0.0, noRender);
   
   projected_coord_xy[0] = sum_fp64(projected_coord_xy[0],
-    vec2((positions.x + 1.0) * finalCellSize / 2.0, 0.0));
+    vec2((positions.x * coverage + 1.0) * finalCellSize / 2.0, 0.0));
   projected_coord_xy[1] = sum_fp64(projected_coord_xy[1],
-    vec2((positions.y + 1.0) * finalCellSize / 2.0, 0.0));
+    vec2((positions.y * coverage - 1.0) * finalCellSize / 2.0, 0.0));
 
   float elevation = 0.0;
 

--- a/src/core-layers/grid-cell-layer/grid-cell-layer-vertex-64.glsl.js
+++ b/src/core-layers/grid-cell-layer/grid-cell-layer-vertex-64.glsl.js
@@ -52,11 +52,15 @@ void main(void) {
 
   vec2 projected_coord_xy[2];
   project_position_fp64(instancePositions64xy, projected_coord_xy);
-
+  
+  // if ahpha == 0.0 or z < 0.0, do not render element
+  float noRender = float(instanceColors.a == 0.0 || instancePositions.w < 0.0);
+  float finalCellSize = cellSize * mix(1.0, 0.0, noRender);
+  
   projected_coord_xy[0] = sum_fp64(projected_coord_xy[0],
-    vec2((positions.x + 1.0) * cellSize / 2.0, 0.0));
+    vec2((positions.x + 1.0) * finalCellSize / 2.0, 0.0));
   projected_coord_xy[1] = sum_fp64(projected_coord_xy[1],
-    vec2((positions.y + 1.0) * cellSize / 2.0, 0.0));
+    vec2((positions.y + 1.0) * finalCellSize / 2.0, 0.0));
 
   float elevation = 0.0;
 

--- a/src/core-layers/grid-cell-layer/grid-cell-layer-vertex.glsl.js
+++ b/src/core-layers/grid-cell-layer/grid-cell-layer-vertex.glsl.js
@@ -47,8 +47,9 @@ void main(void) {
 
   vec2 topLeftPos = project_position(instancePositions.xy);
 
-  // if ahpha == 0.0, do not render element
-  float finalCellSize = cellSize * mix(1.0, 0.0, float(instanceColors.a == 0.0));
+  // if ahpha == 0.0 or z < 0.0, do not render element
+  float noRender = float(instanceColors.a == 0.0 || instancePositions.w < 0.0);
+  float finalCellSize = cellSize * mix(1.0, 0.0, noRender);
 
   // cube gemoetry vertics are between -1 to 1, scale and transform it to between 0, 1
   vec2 pos = topLeftPos + vec2(

--- a/src/core-layers/grid-layer/grid-layer.js
+++ b/src/core-layers/grid-layer/grid-layer.js
@@ -299,11 +299,11 @@ export default class GridLayer extends CompositeLayer {
 
     const elevationDomain = this.props.elevationDomain || elevationValueDomain;
 
-    const isColorValueInDomain = ev >= elevationDomain[0] &&
+    const isElevationValueInDomain = ev >= elevationDomain[0] &&
       ev <= elevationDomain[elevationDomain.length - 1];
 
     // if cell value is outside domain, set elevation to -1
-    return isColorValueInDomain ? elevationScaleFunc(ev) : -1;
+    return isElevationValueInDomain ? elevationScaleFunc(ev) : -1;
   }
 
   // for subclassing, override this method to return
@@ -327,7 +327,6 @@ export default class GridLayer extends CompositeLayer {
 
       getColor: this._onGetSublayerColor.bind(this),
       getElevation: this._onGetSublayerElevation.bind(this),
-      getPosition: d => d.position,
       updateTriggers: this.getUpdateTriggers()
     });
   }

--- a/src/core-layers/hexagon-cell-layer/hexagon-cell-layer-vertex-64.glsl.js
+++ b/src/core-layers/hexagon-cell-layer/hexagon-cell-layer-vertex-64.glsl.js
@@ -61,10 +61,14 @@ void main(void) {
   if (extruded > 0.5) {
     elevation = project_scale(instancePositions.z * (positions.y + 0.5) *
       ELEVATION_SCALE * elevationScale);
-}
-
-  float dotRadius = radius * clamp(coverage, 0.0, 1.0);
-  // // project center of hexagon
+  }
+  
+  // if ahpha == 0.0 or z < 0.0, do not render element  
+  float noRender = float(instanceColors.a == 0.0 || instancePositions.z < 0.0);
+  float dotRadius = radius * mix(coverage, 0.0, noRender);
+  // float dotRadius = radius * clamp(coverage, 0.0, 1.0);
+  
+  // project center of hexagon
 
   vec4 instancePositions64xy = vec4(
     instancePositions.x, instancePositions64xyLow.x,

--- a/src/core-layers/hexagon-cell-layer/hexagon-cell-layer-vertex-64.glsl.js
+++ b/src/core-layers/hexagon-cell-layer/hexagon-cell-layer-vertex-64.glsl.js
@@ -66,7 +66,6 @@ void main(void) {
   // if ahpha == 0.0 or z < 0.0, do not render element  
   float noRender = float(instanceColors.a == 0.0 || instancePositions.z < 0.0);
   float dotRadius = radius * mix(coverage, 0.0, noRender);
-  // float dotRadius = radius * clamp(coverage, 0.0, 1.0);
   
   // project center of hexagon
 

--- a/src/core-layers/hexagon-cell-layer/hexagon-cell-layer-vertex.glsl.js
+++ b/src/core-layers/hexagon-cell-layer/hexagon-cell-layer-vertex.glsl.js
@@ -63,6 +63,7 @@ void main(void) {
       ELEVATION_SCALE * elevationScale);
   }
   
+  // if ahpha == 0.0 or z < 0.0, do not render element
   float noRender = float(instanceColors.a == 0.0 || instancePositions.z < 0.0);
   float dotRadius = radius * mix(coverage, 0.0, noRender);
   

--- a/src/core-layers/hexagon-layer/hexagon-layer.js
+++ b/src/core-layers/hexagon-layer/hexagon-layer.js
@@ -339,11 +339,11 @@ export default class HexagonLayer extends CompositeLayer {
 
     const elevationDomain = this.props.elevationDomain || elevationValueDomain;
 
-    const isColorValueInDomain = ev >= elevationDomain[0] &&
+    const isElevationValueInDomain = ev >= elevationDomain[0] &&
       ev <= elevationDomain[elevationDomain.length - 1];
 
     // if cell value is outside domain, set elevation to -1
-    return isColorValueInDomain ? elevationScaleFunc(ev) : -1;
+    return isElevationValueInDomain ? elevationScaleFunc(ev) : -1;
   }
 
   // for subclassing, override this method to return


### PR DESCRIPTION

- Add checks in grid fp64 to hide cell when filtered by elevation (same operation as the none fp64, this is a patch to #954 
- Fix grid cell layer position shifts on fp64 #962 