### PR TITLE
Move uniform updates from draw() to updateState()

### DIFF
--- a/examples/layer-browser/package.json
+++ b/examples/layer-browser/package.json
@@ -1,8 +1,8 @@
 {
   "scripts": {
     "start": "webpack-dev-server --progress --hot --open",
-    "start-local": "webpack-dev-server --env.local --progress --hot --open",
-    "start-es6": "webpack-dev-server --env.es6 --progress --hot --open"
+    "start-local": "webpack-dev-server --env.es6 --progress --hot --open",
+    "start-local-es5": "webpack-dev-server --env.local --progress --hot --open"
   },
   "dependencies": {
     "deck.gl": ">=4.2.0-alpha.10",

--- a/src/core-layers/arc-layer/arc-layer.js
+++ b/src/core-layers/arc-layer/arc-layer.js
@@ -85,20 +85,25 @@ export default class ArcLayer extends Layer {
 
   updateState({props, oldProps, changeFlags}) {
     super.updateState({props, oldProps, changeFlags});
+
     // Re-generate model if geometry changed
     if (props.fp64 !== oldProps.fp64) {
       const {gl} = this.context;
       this.setState({model: this._getModel(gl)});
     }
     this.updateAttribute({props, oldProps, changeFlags});
+
+    // Update props if needed
+    if (changeFlags.propsChanged) {
+      const {strokeWidth} = this.props;
+      this.state.model.setUniforms({
+        strokeWidth
+      });
+    }
   }
 
-  draw({uniforms}) {
-    const {strokeWidth} = this.props;
-
-    this.state.model.render(Object.assign({}, uniforms, {
-      strokeWidth
-    }));
+  draw(opts) {
+    this.state.model.draw(opts);
   }
 
   _getModel(gl) {

--- a/src/core-layers/line-layer/line-layer.js
+++ b/src/core-layers/line-layer/line-layer.js
@@ -88,14 +88,17 @@ export default class LineLayer extends Layer {
       this.setState({model: this._getModel(gl)});
     }
     this.updateAttribute({props, oldProps, changeFlags});
+
+    if (changeFlags.propsChanged) {
+      const {strokeWidth} = this.props;
+      this.state.model.setUniforms({
+        strokeWidth
+      });
+    }
   }
 
-  draw({uniforms}) {
-    const {strokeWidth} = this.props;
-
-    this.state.model.render(Object.assign({}, uniforms, {
-      strokeWidth
-    }));
+  draw(opts) {
+    this.state.model.draw(opts);
   }
 
   _getModel(gl) {

--- a/src/core-layers/path-layer/path-layer.js
+++ b/src/core-layers/path-layer/path-layer.js
@@ -99,7 +99,6 @@ export default class PathLayer extends Layer {
   updateState({oldProps, props, changeFlags}) {
     super.updateState({props, oldProps, changeFlags});
 
-    const {getPath} = this.props;
     const {attributeManager} = this.state;
     if (props.fp64 !== oldProps.fp64) {
       const {gl} = this.context;
@@ -109,27 +108,32 @@ export default class PathLayer extends Layer {
 
     if (changeFlags.dataChanged) {
       // this.state.paths only stores point positions in each path
+      const {getPath} = this.props;
       const paths = props.data.map(getPath);
       const numInstances = paths.reduce((count, path) => count + path.length - 1, 0);
 
       this.setState({paths, numInstances});
       attributeManager.invalidateAll();
     }
+
+    if (changeFlags.propsChanged) {
+      const {
+        rounded, miterLimit, widthScale, widthMinPixels, widthMaxPixels, justified
+      } = this.props;
+
+      this.state.model.setUniforms({
+        jointType: Number(rounded),
+        alignMode: Number(justified),
+        widthScale,
+        miterLimit,
+        widthMinPixels,
+        widthMaxPixels
+      });
+    }
   }
 
-  draw({uniforms}) {
-    const {
-      rounded, miterLimit, widthScale, widthMinPixels, widthMaxPixels, justified
-    } = this.props;
-
-    this.state.model.render(Object.assign({}, uniforms, {
-      jointType: Number(rounded),
-      alignMode: Number(justified),
-      widthScale,
-      miterLimit,
-      widthMinPixels,
-      widthMaxPixels
-    }));
+  draw(opts) {
+    this.state.model.draw(opts);
   }
 
   _getModel(gl) {

--- a/src/core-layers/point-cloud-layer/point-cloud-layer.js
+++ b/src/core-layers/point-cloud-layer/point-cloud-layer.js
@@ -96,13 +96,17 @@ export default class PointCloudLayer extends Layer {
       this.setState({model: this._getModel(gl)});
     }
     this.updateAttribute({props, oldProps, changeFlags});
+
+    if (changeFlags.propsChanged) {
+      const {radiusPixels, lightSettings} = this.props;
+      this.state.model.setUniforms(Object.assign({
+        radiusPixels
+      }, lightSettings));
+    }
   }
 
-  draw({uniforms}) {
-    const {radiusPixels, lightSettings} = this.props;
-    this.state.model.render(Object.assign({}, uniforms, {
-      radiusPixels
-    }, lightSettings));
+  draw(opts) {
+    this.state.model.draw(opts);
   }
 
   _getModel(gl) {

--- a/src/core-layers/scatterplot-layer/scatterplot-layer.js
+++ b/src/core-layers/scatterplot-layer/scatterplot-layer.js
@@ -95,17 +95,21 @@ export default class ScatterplotLayer extends Layer {
       this.setState({model: this._getModel(gl)});
     }
     this.updateAttribute({props, oldProps, changeFlags});
+
+    if (changeFlags.propsChanged) {
+      const {radiusScale, radiusMinPixels, radiusMaxPixels, outline, strokeWidth} = this.props;
+      this.state.model.setUniforms({
+        outline: outline ? 1 : 0,
+        strokeWidth,
+        radiusScale,
+        radiusMinPixels,
+        radiusMaxPixels
+      });
+    }
   }
 
-  draw({uniforms}) {
-    const {radiusScale, radiusMinPixels, radiusMaxPixels, outline, strokeWidth} = this.props;
-    this.state.model.render(Object.assign({}, uniforms, {
-      outline: outline ? 1 : 0,
-      strokeWidth,
-      radiusScale,
-      radiusMinPixels,
-      radiusMaxPixels
-    }));
+  draw(opts) {
+    this.state.model.draw(opts);
   }
 
   _getModel(gl) {

--- a/src/core-layers/screen-grid-layer/screen-grid-layer.js
+++ b/src/core-layers/screen-grid-layer/screen-grid-layer.js
@@ -60,6 +60,7 @@ export default class ScreenGridLayer extends Layer {
     this.setState({model: this._getModel(gl)});
   }
 
+  // Responds to viewport changes
   shouldUpdateState({changeFlags}) {
     return changeFlags.somethingChanged;
   }
@@ -70,21 +71,28 @@ export default class ScreenGridLayer extends Layer {
       props.cellSizePixels !== oldProps.cellSizePixels;
 
     if (cellSizeChanged || changeFlags.viewportChanged) {
-      this.updateCell();
+      this._updateCell();
+    }
+
+    if (changeFlags.propsChanged) {
+      const {minColor, maxColor} = this.props;
+      this.state.model.setUniforms({minColor, maxColor});
     }
   }
 
-  draw({uniforms}) {
-    const {minColor, maxColor, parameters = {}} = this.props;
-    const {model, cellScale, maxCount} = this.state;
-    uniforms = Object.assign({}, uniforms, {minColor, maxColor, cellScale, maxCount});
-    model.draw({
-      uniforms,
+  draw(opts) {
+    const {cellScale, maxCount} = this.state;
+
+    this.state.model.draw(Object.assign({}, opts, {
+      uniforms: Object.assign({}, opts.uniforms, {
+        cellScale,
+        maxCount
+      }),
       parameters: Object.assign({
         depthTest: false,
         depthMask: false
-      }, parameters)
-    });
+      }, opts.parameters)
+    }));
   }
 
   _getModel(gl) {
@@ -99,7 +107,7 @@ export default class ScreenGridLayer extends Layer {
     }));
   }
 
-  updateCell() {
+  _updateCell() {
     const {width, height} = this.context.viewport;
     const {cellSizePixels} = this.props;
 

--- a/src/core-layers/solid-polygon-layer/solid-polygon-layer.js
+++ b/src/core-layers/solid-polygon-layer/solid-polygon-layer.js
@@ -100,15 +100,6 @@ export default class SolidPolygonLayer extends Layer {
     }
   }
 
-  draw({uniforms}) {
-    const {extruded, lightSettings} = this.props;
-
-    this.state.model.render(Object.assign({}, uniforms, {
-      extruded: extruded ? 1.0 : 0.0
-    },
-    lightSettings));
-  }
-
   updateState({props, oldProps, changeFlags}) {
     super.updateState({props, oldProps, changeFlags});
 
@@ -119,6 +110,18 @@ export default class SolidPolygonLayer extends Layer {
       this.setState({model: this._getModel(gl)});
     }
     this.updateAttribute({props, oldProps, changeFlags});
+
+    if (changeFlags.propsChanged) {
+      const {extruded, lightSettings} = this.props;
+      this.state.model.setUniforms(lightSettings);
+      this.state.model.setUniforms({
+        extruded: Number(extruded)
+      });
+    }
+  }
+
+  draw(opts) {
+    this.state.model.draw(opts);
   }
 
   updateGeometry({props, oldProps, changeFlags}) {


### PR DESCRIPTION
Main motivations:
* Based on measurements by @twojtasz `setUniforms` have started to show up as a noticeable contributor to time spent in some apps. Moving updates from `draw` to `updateState` should help reduce the number of calls to `setUniforms`.
* More importantly, in some scenarios it is important to be able to override as many rendering parameters as possible in the layer's draw method (e.g. when creating layer subclasses or doing picking).