### PR TITLE
Skip picking flow when no layer is pickable

### DIFF
--- a/src/core/lib/layer.js
+++ b/src/core/lib/layer.js
@@ -177,6 +177,11 @@ export default class Layer {
     }
   }
 
+  // Returns true if the layer is pickable and visible.
+  isPickable() {
+    return this.props.pickable && this.props.visible;
+  }
+
   // Calls attribute manager to update any WebGL attributes, can be redefined
   updateAttributes(props) {
     const {attributeManager, model} = this.state;


### PR DESCRIPTION
Verified with `layer-browser`.
Found a regression on master for picking/highlighting feature (#979), will re-test this after it is resolved.