### PR TITLE
Fix picking and highlighting regressions.

### DIFF
--- a/dev-docs/RFCs/v5.0/auto-highlighting-rfc.md
+++ b/dev-docs/RFCs/v5.0/auto-highlighting-rfc.md
@@ -36,7 +36,7 @@ Layer props:
 
 2. **highlightedObjectIndex** {Int: default: -1} : [**Proposed**] - If set, the object (if any) at that index will be shown as selected. If the value doesn’t point to valid index, no object is selected.
 
-3. **autoHighlight** {Boolean, default: false} : [**Proposed**] for now, this is a boolean value, indicating that deck.gl will automatically track the hovered over object. Note: This could be extended in future to specify ‘hover’ , ‘click’ etc events, for different types of tracking. **highlightedObjectIndex** prop takes precedence when both **highlightedObjectIndex**and **autoHighlight** are set to valid values.
+3. **autoHighlight** {Boolean, default: false} : [**Proposed**] for now, this is a boolean value, indicating that deck.gl will automatically track the hovered over object. Note: This could be extended in future to specify ‘hover’ , ‘click’ etc events, for different types of tracking. **highlightedObjectIndex** prop takes precedence when both **highlightedObjectIndex** and **autoHighlight** are set to valid values.
 
 4. **highlightColor **{vec4: default: transparent light-blue color [0, 0, 128, 128]} : [**Proposed**] - This indicates which color should be used to display the selected object, if any.
 

--- a/docs/api-reference/react/deckgl.md
+++ b/docs/api-reference/react/deckgl.md
@@ -155,7 +155,7 @@ Callback - called when the object under the pointer changes.
 
 Callback Arguments:
 - `info` - the [`info`](/docs/get-started/interactivity.md#the-picking-info-object)
-object for the topmost picked layer at the coordinate
+object for the topmost picked layer at the coordinate, null when no object is picked.
 - `pickedInfos` - an array of info objects for all pickable layers that
 are affected.
 - `event` - the original [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) object
@@ -166,7 +166,7 @@ Callback - called when clicking on the layer.
 
 Callback Arguments:
 - `info` - the [`info`](/docs/get-started/interactivity.md#the-picking-info-object)
-object for the topmost picked layer at the coordinate
+object for the topmost picked layer at the coordinate, null when no object is picked.
 - `pickedInfos` - an array of info objects for all pickable layers that are affected.
 - `event` - the original [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) object
 

--- a/src/core/lib/draw-layers.js
+++ b/src/core/lib/draw-layers.js
@@ -197,10 +197,10 @@ function drawLayersInViewport(gl, {
       );
 
       // Blend parameters must not be overriden
-      let layerParameters = Object.assign({viewport: glViewport}, layer.props.parameters || {});
+      const layerParameters = Object.assign({viewport: glViewport}, layer.props.parameters || {});
 
       if (drawPickingColors) {
-        layerParameters = Object.assign(layerParameters, {
+        Object.assign(layerParameters, {
           blendColor: [0, 0, 0, (layerIndex + 1) / 255]
         });
       }

--- a/src/core/lib/draw-layers.js
+++ b/src/core/lib/draw-layers.js
@@ -197,10 +197,10 @@ function drawLayersInViewport(gl, {
       );
 
       // Blend parameters must not be overriden
-      parameters = Object.assign({viewport: glViewport}, layer.props.parameters || {}, parameters);
+      let layerParameters = Object.assign({viewport: glViewport}, layer.props.parameters || {});
 
       if (drawPickingColors) {
-        parameters = Object.assign(parameters, {
+        layerParameters = Object.assign(layerParameters, {
           blendColor: [0, 0, 0, (layerIndex + 1) / 255]
         });
       }
@@ -208,7 +208,7 @@ function drawLayersInViewport(gl, {
       withParameters(gl, parameters, () => {
         layer.drawLayer({
           uniforms,
-          parameters
+          parameters: layerParameters
         });
       });
     }
@@ -239,11 +239,11 @@ function updateLayerHighlightColor(layer) {
   // TODO - inefficient to update settings every render?
   // TODO: Add warning if 'highlightedObjectIndex' is > numberOfInstances of the model.
 
-  if (layer.state.model) {
-    const pickingSelectedColorValid = layer.props.highlightedObjectIndex >= 0;
-    const pickingSelectedColor = pickingSelectedColorValid ?
-      layer.encodePickingColor(layer.props.highlightedObjectIndex) :
-      layer.nullPickingColor();
+  // Update picking module settings if highlightedObjectIndex is set.
+  // This will overwrite any settings from auto highlighting.
+  const pickingSelectedColorValid = layer.props.highlightedObjectIndex >= 0;
+  if (layer.state.model && pickingSelectedColorValid) {
+    const pickingSelectedColor = layer.encodePickingColor(layer.props.highlightedObjectIndex);
 
     // TODO - handle multimodel layers?
     layer.state.model.updateModuleSettings({

--- a/src/core/lib/layer-manager.js
+++ b/src/core/lib/layer-manager.js
@@ -69,6 +69,7 @@ export default class LayerManager {
     this._onClick = this._onClick.bind(this);
     this._onPointerMove = this._onPointerMove.bind(this);
     this._onPointerLeave = this._onPointerLeave.bind(this);
+    this._pickAndCallback = this._pickAndCallback.bind(this);
 
     this._initSeer = this._initSeer.bind(this);
     this._editSeer = this._editSeer.bind(this);
@@ -626,17 +627,15 @@ export default class LayerManager {
    *                        {Object} srcEvent:             native JS Event object
    */
   _onClick(event) {
-    const pos = event.offsetCenter;
-    if (!pos) {
+    if (!event.offsetCenter) {
+      // Do not trigger onHover callbacks when click position is invalid.
       return;
     }
-    const radius = this._pickingRadius;
-    const selectedInfos = this.pickObject({x: pos.x, y: pos.y, radius, mode: 'click'});
-
-    const firstInfo = selectedInfos.find(info => info.index >= 0);
-    if (firstInfo && this._onLayerClick) {
-      this._onLayerClick(firstInfo, selectedInfos, event.srcEvent);
-    }
+    this._pickAndCallback({
+      callback: this._onLayerClick,
+      event,
+      mode: 'click'
+    });
   }
 
   /**
@@ -651,17 +650,14 @@ export default class LayerManager {
    */
   _onPointerMove(event) {
     if (event.isDown) {
-      // Do not trigger onHover callbacks if mouse button is down
+      // Do not trigger onHover callbacks if mouse button is down.
       return;
     }
-    const pos = event.offsetCenter;
-    const radius = this._pickingRadius;
-    const selectedInfos = this.pickObject({x: pos.x, y: pos.y, radius, mode: 'hover'});
-
-    const firstInfo = selectedInfos.find(info => info.index >= 0) || null;
-    if (this._onLayerHover) {
-      this._onLayerHover(firstInfo, selectedInfos, event.srcEvent);
-    }
+    this._pickAndCallback({
+      callback: this._onLayerHover,
+      event,
+      mode: 'hover'
+    });
   }
 
   _onPointerLeave(event) {
@@ -671,6 +667,17 @@ export default class LayerManager {
       radius: this._pickingRadius,
       mode: 'hover'
     });
+  }
+
+  _pickAndCallback(options) {
+    const pos = options.event.offsetCenter;
+    const radius = this._pickingRadius;
+    const selectedInfos = this.pickObject({x: pos.x, y: pos.y, radius, mode: options.mode});
+    if (options.callback) {
+      const firstInfo = selectedInfos.find(info => info.index >= 0) || null;
+      // As per documentation, send null value when no valid object is picked.
+      options.callback(firstInfo, selectedInfos, options.event.srcEvent);
+    }
   }
 
   // SEER INTEGRATION

--- a/src/core/lib/layer-manager.js
+++ b/src/core/lib/layer-manager.js
@@ -658,8 +658,8 @@ export default class LayerManager {
     const radius = this._pickingRadius;
     const selectedInfos = this.pickObject({x: pos.x, y: pos.y, radius, mode: 'hover'});
 
-    const firstInfo = selectedInfos.find(info => info.index >= 0);
-    if (firstInfo && this._onLayerHover) {
+    const firstInfo = selectedInfos.find(info => info.index >= 0) || null;
+    if (this._onLayerHover) {
       this._onLayerHover(firstInfo, selectedInfos, event.srcEvent);
     }
   }


### PR DESCRIPTION
Fix for #979

Verified picking and highlighting with `layer-browser` and running website (examples).