### PR TITLE
add viewMatrix back so users can access it in their own vertex shader

### DIFF
--- a/src/core/deprecated/shaderlib/project/project-deprecated.glsl.js
+++ b/src/core/deprecated/shaderlib/project/project-deprecated.glsl.js
@@ -21,6 +21,7 @@
 export default `\
 // Backwards compatibility
 uniform mat4 modelMatrix;
+uniform mat4 viewMatrix;
 uniform mat4 projectionMatrix;
 uniform vec3 projectionPixelsPerUnit;
 uniform float projectionScale; // This is the mercator scale (2 ** zoom)

--- a/src/core/shaderlib/project/viewport-uniforms.js
+++ b/src/core/shaderlib/project/viewport-uniforms.js
@@ -206,7 +206,7 @@ export function getUniformsFromViewport({
 
     projectionOrigin: coordinateOrigin,
     modelMatrix: glModelMatrix,
-
+    viewMatrix: viewport.viewMatrix,
     projectionMatrix: glViewProjectionMatrix,
     projectionPixelsPerUnit: distanceScales.pixelsPerMeter,
     projectionScale: viewport.scale, // This is the mercator scale (2 ** zoom)


### PR DESCRIPTION
When I was porting packed point cloud shaders from ATG to a customized deck.gl layer, found that there is no way to access viewMatrix, here add it back.