### PR TITLE
Separate common ViewState from FirstPersonState and MapState

### DIFF
--- a/examples/wip/first-person-map/app.js
+++ b/examples/wip/first-person-map/app.js
@@ -60,7 +60,7 @@ class Root extends Component {
     super(props);
     this.state = {
       viewportMode: true,
-      fov: 60,
+      fov: 50,
 
       viewportProps: {
         ...DEFAULT_VIEWPORT_PROPS,

--- a/examples/wip/first-person-map/app.js
+++ b/examples/wip/first-person-map/app.js
@@ -59,7 +59,6 @@ class Root extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      viewportMode: true,
       fov: 50,
 
       viewportProps: {
@@ -82,7 +81,6 @@ class Root extends Component {
       .then(data => this.setState({trips: data}));
 
     this._onViewportChange = this._onViewportChange.bind(this);
-    this._onViewportModeChange = this._onViewportModeChange.bind(this);
     this._onFovChange = this._onFovChange.bind(this);
   }
 
@@ -123,10 +121,6 @@ class Root extends Component {
     });
   }
 
-  _onViewportModeChange() {
-    this.setState({viewportMode: !this.state.viewportMode});
-  }
-
   _onFovChange() {
     this.setState({fov: this.state.fov === 60 ? 35 : 60});
   }
@@ -142,11 +136,8 @@ class Root extends Component {
             justifyContent: 'center'
           }}
         >
-          <button key="mode" onClick={this._onViewportModeChange}>
-            {this.state.viewportMode ? 'First Person' : 'Mercator'}
-          </button>
           <button key="fov" onClick={this._onFovChange}>
-            {this.state.fov}
+            {`FOV : ${this.state.fov}`}
           </button>
           <div style={{color: 'white'}}>
             {Object.keys(this.state.viewportProps).map(key => (

--- a/examples/wip/first-person-map/package.json
+++ b/examples/wip/first-person-map/package.json
@@ -5,9 +5,9 @@
     "start-es6": "webpack-dev-server --env.es6 --progress --hot --open"
   },
   "dependencies": {
-    "deck.gl": ">=4.1.0",
-    "luma.gl": ">=4.1.0-alpha.1",
-    "math.gl": ">=1.0.0-alpha.3",
+    "deck.gl": ">=4.2.0-alpha.12",
+    "luma.gl": ">=4.1.0-alpha.4",
+    "math.gl": ">=1.0.0-alpha.7",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
     "react-map-gl": "^3.0.0"

--- a/examples/wip/first-person-map/package.json
+++ b/examples/wip/first-person-map/package.json
@@ -5,8 +5,8 @@
     "start-es6": "webpack-dev-server --env.es6 --progress --hot --open"
   },
   "dependencies": {
-    "deck.gl": ">=4.2.0-alpha.12",
-    "luma.gl": ">=4.1.0-alpha.4",
+    "deck.gl": ">=4.2.0-alpha.15",
+    "luma.gl": ">=4.1.0-alpha.7",
     "math.gl": ">=1.0.0-alpha.7",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",

--- a/src/core/controllers/map-state.js
+++ b/src/core/controllers/map-state.js
@@ -1,3 +1,4 @@
+import ViewState from './view-state';
 import PerspectiveMercatorViewport from '../viewports/web-mercator-viewport';
 import assert from 'assert';
 
@@ -25,7 +26,7 @@ function ensureFinite(value, fallbackValue) {
   return Number.isFinite(value) ? value : fallbackValue;
 }
 
-export default class MapState {
+export default class MapState extends ViewState {
 
   constructor({
     /** Mapbox viewport properties */
@@ -68,20 +69,19 @@ export default class MapState {
     /** Zoom when current zoom operation started */
     startZoom
   } = {}) {
-    assert(Number.isFinite(width), '`width` must be supplied');
-    assert(Number.isFinite(height), '`height` must be supplied');
     assert(Number.isFinite(longitude), '`longitude` must be supplied');
     assert(Number.isFinite(latitude), '`latitude` must be supplied');
     assert(Number.isFinite(zoom), '`zoom` must be supplied');
 
-    this._viewportProps = this._applyConstraints({
+    super({
       width,
       height,
       latitude,
       longitude,
       zoom,
-      bearing: ensureFinite(bearing, defaultState.bearing),
-      pitch: ensureFinite(pitch, defaultState.pitch),
+      bearing,
+      pitch,
+
       altitude: ensureFinite(altitude, defaultState.altitude),
       maxZoom: ensureFinite(maxZoom, MAPBOX_LIMITS.maxZoom),
       minZoom: ensureFinite(minZoom, MAPBOX_LIMITS.minZoom),
@@ -99,10 +99,6 @@ export default class MapState {
   }
 
   /* Public API */
-
-  getViewportProps() {
-    return this._viewportProps;
-  }
 
   getInteractiveState() {
     return this._interactiveState;

--- a/src/core/controllers/view-state.js
+++ b/src/core/controllers/view-state.js
@@ -1,0 +1,91 @@
+import {Vector3, experimental} from 'math.gl';
+const {SphericalCoordinates} = experimental;
+import assert from 'assert';
+
+const defaultState = {
+  position: [0, 0, 0],
+  lookAt: [0, 0, 0],
+  up: [0, 0, 1],
+
+  rotationX: 0,
+  rotationY: 0,
+
+  fov: 50,
+  near: 1,
+  far: 100
+};
+
+/* Helpers */
+
+function ensureFinite(value, fallbackValue) {
+  return Number.isFinite(value) ? value : fallbackValue;
+}
+
+const DEFAULT_POSITION = [0, 0, 0];
+
+export default class ViewState {
+  constructor(opts) {
+    const {
+      /* Viewport arguments */
+      width, // Width of viewport
+      height, // Height of viewport
+
+      // Position and orientation
+      position = DEFAULT_POSITION, // typically in meters from anchor point
+
+      bearing, // Rotation around y axis
+      pitch, // Rotation around x axis
+
+      // Geospatial anchor
+      longitude,
+      latitude,
+      zoom
+    } = opts;
+
+    assert(Number.isFinite(width), '`width` must be supplied');
+    assert(Number.isFinite(height), '`height` must be supplied');
+
+    this._viewportProps = this._applyConstraints(Object.assign({}, opts, {
+      width,
+      height,
+      position: new Vector3(
+        ensureFinite(position && position[0], defaultState.position[0]),
+        ensureFinite(position && position[1], defaultState.position[1]),
+        ensureFinite(position && position[2], defaultState.position[2])
+      ),
+      bearing: ensureFinite(bearing, defaultState.bearing),
+      pitch: ensureFinite(pitch, defaultState.pitch),
+      longitude,
+      latitude,
+      zoom
+    }));
+  }
+
+  getViewportProps() {
+    return this._viewportProps;
+  }
+
+  getDirection() {
+    const spherical = new SphericalCoordinates({
+      bearing: this._viewportProps.bearing,
+      pitch: this._viewportProps.pitch
+    });
+    const direction = spherical.toVector3().normalize();
+    return direction;
+  }
+
+  getDirectionFromBearing(bearing) {
+    const spherical = new SphericalCoordinates({
+      bearing,
+      pitch: 90
+    });
+    const direction = spherical.toVector3().normalize();
+    return direction;
+  }
+
+  // Redefined by subclass
+  // Apply any constraints (mathematical or defined by _viewportProps) to map state
+  _applyConstraints(props) {
+    return props;
+  }
+}

--- a/src/core/viewports/first-person-viewport.js
+++ b/src/core/viewports/first-person-viewport.js
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 import Viewport from './viewport';
-import {Vector3, Matrix4, experimental} from 'math.gl';
+import {Matrix4, experimental} from 'math.gl';
 const {SphericalCoordinates} = experimental;
 
 function getDirectionFromBearingAndPitch({bearing, pitch}) {
@@ -35,16 +35,14 @@ export default class FirstPersonViewport extends Viewport {
       // view matrix arguments
       modelMatrix = null,
       bearing,
-      direction, // Which direction camera is looking at
       up = [0, 0, 1] // Defines up direction, default positive z axis,
     } = opts;
 
-    const dir =
-      new Vector3(direction) ||
-      getDirectionFromBearingAndPitch({
-        bearing,
-        pitch: 89
-      });
+    // Always calculate direction from bearing and pitch
+    const dir = getDirectionFromBearingAndPitch({
+      bearing,
+      pitch: 89
+    });
 
     // Direction is relative to model coordinates, of course
     const center = modelMatrix ? modelMatrix.transformDirection(dir) : dir;

--- a/src/react/viewport-controller.js
+++ b/src/react/viewport-controller.js
@@ -31,7 +31,7 @@ const propTypes = {
   // Note: Non-public API, see https://github.com/mapbox/mapbox-gl-js/issues/1137
   altitude: PropTypes.number,
   // Camera position for FirstPersonViewport
-  position: PropTypes.object,
+  position: PropTypes.array,
 
   /** Viewport constraints */
   // Max zoom level


### PR DESCRIPTION
Per discussion in https://github.com/uber/deck.gl/issues/986
Additional fixes:
- Firstperson Viewport: Always calculate `direction` from `bearing` and `pitch`.
- Cleanup the `first-person-map` example.
- Fix `ViewportController` prop type for `position`.

Verified with `layer-browser` and `first-person-map` example.