### PR TITLE
Fix WebMercatorViewport.addMetersToLngLat

### DIFF
--- a/src/core/viewports/web-mercator-viewport.js
+++ b/src/core/viewports/web-mercator-viewport.js
@@ -223,7 +223,7 @@ export default class WebMercatorViewport extends Viewport {
    */
   addMetersToLngLat(lngLatZ, xyz) {
     const [lng, lat, Z = 0] = lngLatZ;
-    const [deltaLng, deltaLat, deltaZ = 0] = this.metersToLngLatDelta(lngLatZ, xyz);
+    const [deltaLng, deltaLat, deltaZ = 0] = this.metersToLngLatDelta(xyz);
     return lngLatZ.length === 2 ?
       [lng + deltaLng, lat + deltaLat] :
       [lng + deltaLng, lat + deltaLat, Z + deltaZ];

--- a/test/src/core/viewports/web-mercator-viewport.spec.js
+++ b/test/src/core/viewports/web-mercator-viewport.spec.js
@@ -144,7 +144,11 @@ test('WebMercatorViewport.meterDeltas', t => {
       const deltaLngLat = viewport.metersToLngLatDelta(coordinate);
       const deltaMeters = viewport.lngLatDeltaToMeters(deltaLngLat);
       t.comment(`Comparing [${deltaMeters}] to [${coordinate}]`);
-      t.ok(equals(deltaMeters, coordinate));
+      t.ok(equals(deltaMeters, coordinate), 'deltaLngLat to deltaMeters');
+
+      const offsetCoordinate = viewport.addMetersToLngLat([0, 0, 0], coordinate);
+      t.comment(`Comparing [${deltaLngLat}] to [${offsetCoordinate}]`);
+      t.ok(equals(offsetCoordinate, deltaLngLat), 'addMetersToLngLat');
     }
   }
   t.end();


### PR DESCRIPTION
Was calling `this.metersToLngLatDelta` with incorrect parameters.