### PR TITLE
Fix benchmark tests

### DIFF
--- a/test/bench/browser.js
+++ b/test/bench/browser.js
@@ -41,4 +41,5 @@ window.Benchmark = Benchmark;
   }
 })();
 
+require('../test-utils/setup-gl');
 require('./index');

--- a/test/bench/index.js
+++ b/test/bench/index.js
@@ -121,7 +121,7 @@ suite
   });
   testInitializeLayer({layer});
 })
-.add('SolidPolygonLayer#initialize (extruded)', () => {
+.add('SolidPolygonLayer#initialize (flat)', () => {
   const layer = new SolidPolygonLayer({data: data.choropleths.features});
   testInitializeLayer({layer});
 })

--- a/test/bench/index.js
+++ b/test/bench/index.js
@@ -38,6 +38,8 @@ import {getUniformsFromViewport} from 'deck.gl/core/shaderlib/project/viewport-u
 
 import {testInitializeLayer} from 'deck.gl/test/test-utils';
 
+import SolidPolygonLayer from 'deck.gl/core-layers/solid-polygon-layer/solid-polygon-layer';
+
 const suite = new Suite();
 
 const COLOR_STRING = '#FFEEBB';
@@ -82,10 +84,13 @@ suite
   return new GeoJsonLayer({data: data.choropleths});
 })
 .add('PolygonLayer#construct', () => {
-  return new PolygonLayer({data: data.choropleths});
+  return new PolygonLayer({data: data.choropleths.features});
+})
+.add('SolidPolygonLayer#construct', () => {
+  return new PolygonLayer({data: data.choropleths.features});
 })
 .add('ScatterplotLayer#initialize', () => {
-  const layer = new ScatterplotLayer({data: data.points});
+  const layer = new ScatterplotLayer({data: data.points, getPosition: d => d.COORDINATES});
   testInitializeLayer({layer});
 })
 .add('PathLayer#initialize', () => {
@@ -97,25 +102,48 @@ suite
   testInitializeLayer({layer});
 })
 .add('PolygonLayer#initialize (flat)', () => {
-  const layer = new PolygonLayer({data: data.choropleths});
+  const layer = new PolygonLayer({data: data.choropleths.features,
+    getPolygon: f => f.geometry.coordinates
+  });
   testInitializeLayer({layer});
 })
 .add('PolygonLayer#initialize (extruded)', () => {
-  const layer = new PolygonLayer({data: data.choropleths, extruded: true});
+  const layer = new PolygonLayer({data: data.choropleths.features,
+    getPolygon: f => f.geometry.coordinates,
+    extruded: true
+  });
   testInitializeLayer({layer});
 })
 .add('PolygonLayer#initialize (wireframe)', () => {
-  const layer = new PolygonLayer({data: data.choropleths, extruded: true, wireframe: true});
+  const layer = new PolygonLayer({data: data.choropleths.features,
+    getPolygon: f => f.geometry.coordinates,
+    extruded: true, wireframe: true
+  });
+  testInitializeLayer({layer});
+})
+.add('SolidPolygonLayer#initialize (extruded)', () => {
+  const layer = new SolidPolygonLayer({data: data.choropleths.features});
+  testInitializeLayer({layer});
+})
+.add('SolidPolygonLayer#initialize (extruded)', () => {
+  const layer = new SolidPolygonLayer({data: data.choropleths.features,
+    extruded: true
+  });
+  testInitializeLayer({layer});
+})
+.add('SolidPolygonLayer#initialize (wireframe)', () => {
+  const layer = new SolidPolygonLayer({data: data.choropleths.features,
+    extruded: true, wireframe: true
+  });
   testInitializeLayer({layer});
 })
 .add('encoding picking color', () => {
   testIdx++;
+  if ((testIdx + 1) >> 24) {
+    testIdx = 0;
+  }
   testLayer.encodePickingColor(testIdx);
 })
-// .add('ScatterplotLayer#initialize', () => {
-//   const layer = new ScatterplotLayer({data: data.points});
-//   testInitializeLayer({layer});
-// })
 // add listeners
 .on('start', (event) => {
   console.log('Starting bench...');

--- a/test/bench/node.js
+++ b/test/bench/node.js
@@ -38,4 +38,5 @@ require('babel-polyfill');
 // Import headless luma support
 require('luma.gl/headless');
 
+require('../test-utils/setup-gl');
 require('./index');

--- a/test/test-utils/layer-utils.js
+++ b/test/test-utils/layer-utils.js
@@ -85,7 +85,7 @@ export function testInitializeLayer({gl, layer, viewport}) {
     });
 
   } catch (error) {
-    console.log(error.message);
+    console.log(error.message); // eslint-disable-line
     failures = error;
   }
 

--- a/test/test-utils/layer-utils.js
+++ b/test/test-utils/layer-utils.js
@@ -85,6 +85,7 @@ export function testInitializeLayer({gl, layer, viewport}) {
     });
 
   } catch (error) {
+    console.log(error.message);
     failures = error;
   }
 


### PR DESCRIPTION
Fixed:
- Missing gl context error in `Layer.initializeState`
- Wrong `getPosition` accessor for `ScatterplotLayer`
- Wrong `data` format and `getPolygon` accessor for `PolygonLayer`
- Overflow error in `Layer.encodePickingColor`

Added:
- Bench tests for `SolidPoligonLayer` (actually calling the tesselators)