### PR TITLE
Fix useDevicePixelRatio prop usage

### DIFF
--- a/examples/wind/src/app.js
+++ b/examples/wind/src/app.js
@@ -36,7 +36,8 @@ class Root extends Component {
         time: 0,
         showParticles: false,
         showWindDemo: false,
-        showElevation: false
+        showElevation: false,
+        useDevicePixelRatio: true
       }
     };
     autobind(this);

--- a/examples/wind/src/control-panel.js
+++ b/examples/wind/src/control-panel.js
@@ -47,6 +47,7 @@ export default class ControlPanel extends Component {
         { this._renderToggle('showParticles', 'particles') }
         { this._renderToggle('showWind', 'field') }
         { this._renderToggle('showElevation', 'elevation') }
+        { this._renderToggle('useDevicePixelRatio', 'retina') }
         { this._renderSlider('time', 'time', {min: 0, max: 70, step: 0.1}) }
       </div>
     );

--- a/examples/wind/src/wind-demo.js
+++ b/examples/wind/src/wind-demo.js
@@ -111,6 +111,7 @@ export default class WindDemo extends Component {
         glOptions={{webgl2: true}}
         {...viewport}
         layers={layers}
+        useDevicePixelRatio={settings.useDevicePixelRatio}
       />
     );
   }

--- a/src/core/lib/layer.js
+++ b/src/core/lib/layer.js
@@ -262,6 +262,7 @@ export default class Layer {
   }
 
   screenToDevicePixels(screenPixels) {
+    log.deprecated('screenToDevicePixels', 'DeckGL prop useDevicePixelRatio for conversion');
     const devicePixelRatio = typeof window !== 'undefined' ?
       window.devicePixelRatio : 1;
     return screenPixels * devicePixelRatio;

--- a/src/core/pure-js/deck-js.js
+++ b/src/core/pure-js/deck-js.js
@@ -67,7 +67,7 @@ const defaultProps = {
   onAfterRender: noop,
   onLayerClick: null,
   onLayerHover: null,
-  useDevicePixelRatio: false,
+  useDevicePixelRatio: true,
 
   debug: false,
   drawPickingColors: false
@@ -91,12 +91,12 @@ export default class DeckGLJS {
 
     this.canvas = this._createCanvas(props);
 
-    const {width, height, gl, glOptions, debug} = props;
+    const {width, height, gl, glOptions, debug, useDevicePixelRatio} = props;
 
     this.animationLoop = new AnimationLoop({
       width,
       height,
-      useDevicePixelRatio: false,
+      useDevicePixelRatio,
       onCreateContext: opts =>
         gl || createGLContext(Object.assign({}, glOptions, {canvas: this.canvas, debug})),
       onInitialize: this._onRendererInitialized,
@@ -152,6 +152,8 @@ export default class DeckGLJS {
     if (props.layers) {
       this.layerManager.updateLayers({newLayers: props.layers});
     }
+
+    this.animationLoop.setViewParameters({useDevicePixelRatio});
   }
 
   finalize() {


### PR DESCRIPTION
Fix for #843 
- Turn 'useDevicePixelRatio' to true, to match previous behavior.
- Add an option to toggle 'useDevicePixelRatio' to wind example. (This is useful in testing as layer-browser rendering doesn't change much when toggling this option.)

Verified with: `test-browser`, `layer-browser` (picking/highlighing/toggling useDevicePixelRatio) and `examples`.