### PR TITLE
Fix issue that visible object query in layer-brower returns empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,22 @@
 
 [![docs](http://i.imgur.com/mvfvgf0.jpg)](https://uber.github.io/deck.gl)
 
-Provides tested, highly performant layers for data visualization
-use cases, such as scatterplots, choropleths etc in 2 and 3 dimensions.
+Provides tested, highly performant layers for data visualization,
+such as scatterplots, arcs, geometries defined in GeoJSON, etc...
 
     npm install --save deck.gl
 
-## Example
+## Using deck.gl
+
+To learn how to use deck.gl through examples coming with the deck.gl repo,
+please clone the latest **release** branch.
+
+`git clone -b 4.1-release --single-branch https://github.com/uber/deck.gl.git`
+
+A very simple usage of deck.gl is showcased in the [hello-world examples](./examples),
+using both [webpack2](./examples/hello-world-webpack2) and
+[browserify](./examples/hello-world-browserify),
+so you can choose which setup you prefer or are more familiar with.
 
 ```javascript
 import DeckGL from 'deck.gl';
@@ -41,15 +51,12 @@ const flights = new ArcLayer({
 <DeckGL width={1920} height={1080} layers={[flights]} />
 ```
 
-A very simple usage of deck.gl is showcased in the [hello-world examples](./examples),
-using both [webpack2](./examples/hello-world-webpack2) and
-[browserify](./examples/hello-world-browserify),
-so you can choose which setup you prefer or are more familiar with.
-
 You can also take a look at the [docs website](https://uber.github.io/deck.gl)
 or browse directly the [docs folder](./docs).
 
-## Developing
+## Developing deck.gl
+
+The **master** branch is the active development branch.
 
     npm install # or yarn
     npm test
@@ -81,6 +88,7 @@ Either upgrade to a supported version, or install something like
 #### Install yarn
 On macOS deck.gl uses [yarn](https://www.npmjs.com/package/yarn) to manage packages.
 To develop deck.gl, [install yarn](https://yarnpkg.com/en/docs/install) with brew
+
 ```
 brew update
 brew install yarn

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,10 +17,10 @@ These are intended to be absolutely minimal (in terms of application code,
 package.json, webpack config etc) examples of how to get deck.gl and a base
 map working together.
 
-* [Hello World (webpack2)](./hello-world-webpack2/README.md): Bundles a minimal app with
+* [Hello World (webpack2)](./react/hello-world-webpack2/README.md): Bundles a minimal app with
   [webpack 2](https://github.com/webpack/webpack) and serves it with webpack-dev-server.
   Transpiles with buble.
-* [Hello World (browserify)](./hello-world-browserify/README.md) Bundles a minimal app with
+* [Hello World (browserify)](./react/hello-world-browserify/README.md) Bundles a minimal app with
   [browserify](https://github.com/substack/node-browserify) and serves it with
   [budo](https://github.com/mattdesl/budo).
   Transpiles with babel.

--- a/examples/wind/src/app.js
+++ b/examples/wind/src/app.js
@@ -36,7 +36,8 @@ class Root extends Component {
         time: 0,
         showParticles: false,
         showWindDemo: false,
-        showElevation: false
+        showElevation: false,
+        useDevicePixelRatio: true
       }
     };
     autobind(this);

--- a/examples/wind/src/control-panel.js
+++ b/examples/wind/src/control-panel.js
@@ -47,6 +47,7 @@ export default class ControlPanel extends Component {
         { this._renderToggle('showParticles', 'particles') }
         { this._renderToggle('showWind', 'field') }
         { this._renderToggle('showElevation', 'elevation') }
+        { this._renderToggle('useDevicePixelRatio', 'retina') }
         { this._renderSlider('time', 'time', {min: 0, max: 70, step: 0.1}) }
       </div>
     );

--- a/examples/wind/src/wind-demo.js
+++ b/examples/wind/src/wind-demo.js
@@ -111,6 +111,7 @@ export default class WindDemo extends Component {
         glOptions={{webgl2: true}}
         {...viewport}
         layers={layers}
+        useDevicePixelRatio={settings.useDevicePixelRatio}
       />
     );
   }

--- a/src/core/lib/layer.js
+++ b/src/core/lib/layer.js
@@ -262,6 +262,7 @@ export default class Layer {
   }
 
   screenToDevicePixels(screenPixels) {
+    log.deprecated('screenToDevicePixels', 'DeckGL prop useDevicePixelRatio for conversion');
     const devicePixelRatio = typeof window !== 'undefined' ?
       window.devicePixelRatio : 1;
     return screenPixels * devicePixelRatio;

--- a/src/core/lib/pick-layers.js
+++ b/src/core/lib/pick-layers.js
@@ -374,23 +374,25 @@ function getUniquesFromPickingBuffer(gl, {
   const uniqueColors = new Map();
 
   // Traverse all pixels in picking results and get unique colors
-  for (let i = 0; i < pickedColors && pickedColors.length; i += 4) {
-    // Decode picked layer from color
-    const pickedLayerIndex = pickedColors[i + 3] - 1;
+  if (pickedColors) {
+    for (let i = 0; i < pickedColors.length; i += 4) {
+      // Decode picked layer from color
+      const pickedLayerIndex = pickedColors[i + 3] - 1;
 
-    if (pickedLayerIndex >= 0) {
-      const pickedColor = pickedColors.slice(i, i + 4);
-      const colorKey = pickedColor.join(',');
-      if (!uniqueColors.has(colorKey)) {
-        const pickedLayer = layers[pickedLayerIndex];
-        if (pickedLayer) { // eslint-disable-line
-          uniqueColors.set(colorKey, {
-            pickedColor,
-            pickedLayer,
-            pickedObjectIndex: pickedLayer.decodePickingColor(pickedColor)
-          });
-        } else {
-          log.error(0, 'Picked non-existent layer. Is picking buffer corrupt?');
+      if (pickedLayerIndex >= 0) {
+        const pickedColor = pickedColors.slice(i, i + 4);
+        const colorKey = pickedColor.join(',');
+        if (!uniqueColors.has(colorKey)) { // eslint-disable-line
+          const pickedLayer = layers[pickedLayerIndex];
+          if (pickedLayer) { // eslint-disable-line
+            uniqueColors.set(colorKey, {
+              pickedColor,
+              pickedLayer,
+              pickedObjectIndex: pickedLayer.decodePickingColor(pickedColor)
+            });
+          } else {
+            log.error(0, 'Picked non-existent layer. Is picking buffer corrupt?');
+          }
         }
       }
     }

--- a/src/core/pure-js/deck-js.js
+++ b/src/core/pure-js/deck-js.js
@@ -67,7 +67,7 @@ const defaultProps = {
   onAfterRender: noop,
   onLayerClick: null,
   onLayerHover: null,
-  useDevicePixelRatio: false,
+  useDevicePixelRatio: true,
 
   debug: false,
   drawPickingColors: false
@@ -91,12 +91,12 @@ export default class DeckGLJS {
 
     this.canvas = this._createCanvas(props);
 
-    const {width, height, gl, glOptions, debug} = props;
+    const {width, height, gl, glOptions, debug, useDevicePixelRatio} = props;
 
     this.animationLoop = new AnimationLoop({
       width,
       height,
-      useDevicePixelRatio: false,
+      useDevicePixelRatio,
       onCreateContext: opts =>
         gl || createGLContext(Object.assign({}, glOptions, {canvas: this.canvas, debug})),
       onInitialize: this._onRendererInitialized,
@@ -152,6 +152,8 @@ export default class DeckGLJS {
     if (props.layers) {
       this.layerManager.updateLayers({newLayers: props.layers});
     }
+
+    this.animationLoop.setViewParameters({useDevicePixelRatio});
   }
 
   finalize() {

--- a/src/index.js
+++ b/src/index.js
@@ -43,31 +43,57 @@ export {default as FirstPersonState} from './core/controllers/first-person-state
 export {default as OrbitState} from './core/controllers/orbit-state';
 export {default as MapState} from './core/controllers/map-state';
 
-// Experimental Pure JS (non-React) bindings
-import {default as DeckGLJS} from './core/pure-js/deck-js';
-import {default as MapControllerJS} from './core/pure-js/map-controller-js';
-
-// Experimental Features (May change in minor version bumps, use at your own risk)
-import {get} from './core/lib/utils/get';
-import {count} from './core/lib/utils/count';
-import {default as EffectManager} from './core/experimental/lib/effect-manager';
-import {default as Effect} from './core/experimental/lib/effect';
-
 // Deprecated Core Lib Classes
 export {default as OrbitViewport} from './core/viewports/orbit-viewport';
 export {default as PerspectiveViewport} from './core/deprecated/viewports/perspective-viewport';
 export {default as OrthographicViewport} from './core/deprecated/viewports/orthographic-viewport';
 export {assembleShaders} from 'luma.gl'; // Forward the luma.gl version (note: now integrated with Model)
 
+// EXPERIMENTAL FEATURES (May change in minor version bumps, use at your own risk)
+import {default as EffectManager} from './core/experimental/lib/effect-manager';
+import {default as Effect} from './core/experimental/lib/effect';
+
+// Experimental Pure JS (non-React) bindings
+import {default as DeckGLJS} from './core/pure-js/deck-js';
+import {default as MapControllerJS} from './core/pure-js/map-controller-js';
+
+// Experimental Data Accessor Helpers
+import {get} from './core/lib/utils/get';
+import {count} from './core/lib/utils/count';
+
+// Experimental Aggregation Utilities
+import {default as BinSorter} from './core/utils/bin-sorter';
+import {linearScale} from './core/utils/scale-utils';
+import {quantizeScale} from './core/utils/scale-utils';
+import {clamp} from './core/utils/scale-utils';
+import {defaultColorRange} from './core/utils/color-utils';
+
+// Experimental 64 bit helpers
+// TODO - just expose as layer methods instead?
+import {enable64bitSupport} from './core/lib/utils/fp64';
+import {fp64ify} from './core/lib/utils/fp64';
+
 Object.assign(experimental, {
-  get,
-  count,
+  // Pure JS (non-React) support
+  DeckGLJS,
+  MapControllerJS,
+
+  // Effects base classes
   EffectManager,
   Effect,
 
-  // Pure JS (i.e. non-React) support
-  DeckGLJS,        // Integrate into `LayerManager`?
-  MapControllerJS  // Integrate into `MapController` JS class?
+  // The following are mainly for sub-layers
+  get,
+  count,
+
+  BinSorter,
+  linearScale,
+  quantizeScale,
+  clamp,
+  defaultColorRange,
+
+  enable64bitSupport,
+  fp64ify
 });
 
 //

--- a/test/bench/browser.js
+++ b/test/bench/browser.js
@@ -41,4 +41,5 @@ window.Benchmark = Benchmark;
   }
 })();
 
+require('../test-utils/setup-gl');
 require('./index');

--- a/test/bench/index.js
+++ b/test/bench/index.js
@@ -38,6 +38,8 @@ import {getUniformsFromViewport} from 'deck.gl/core/shaderlib/project/viewport-u
 
 import {testInitializeLayer} from 'deck.gl/test/test-utils';
 
+import SolidPolygonLayer from 'deck.gl/core-layers/solid-polygon-layer/solid-polygon-layer';
+
 const suite = new Suite();
 
 const COLOR_STRING = '#FFEEBB';
@@ -82,10 +84,13 @@ suite
   return new GeoJsonLayer({data: data.choropleths});
 })
 .add('PolygonLayer#construct', () => {
-  return new PolygonLayer({data: data.choropleths});
+  return new PolygonLayer({data: data.choropleths.features});
+})
+.add('SolidPolygonLayer#construct', () => {
+  return new PolygonLayer({data: data.choropleths.features});
 })
 .add('ScatterplotLayer#initialize', () => {
-  const layer = new ScatterplotLayer({data: data.points});
+  const layer = new ScatterplotLayer({data: data.points, getPosition: d => d.COORDINATES});
   testInitializeLayer({layer});
 })
 .add('PathLayer#initialize', () => {
@@ -97,25 +102,48 @@ suite
   testInitializeLayer({layer});
 })
 .add('PolygonLayer#initialize (flat)', () => {
-  const layer = new PolygonLayer({data: data.choropleths});
+  const layer = new PolygonLayer({data: data.choropleths.features,
+    getPolygon: f => f.geometry.coordinates
+  });
   testInitializeLayer({layer});
 })
 .add('PolygonLayer#initialize (extruded)', () => {
-  const layer = new PolygonLayer({data: data.choropleths, extruded: true});
+  const layer = new PolygonLayer({data: data.choropleths.features,
+    getPolygon: f => f.geometry.coordinates,
+    extruded: true
+  });
   testInitializeLayer({layer});
 })
 .add('PolygonLayer#initialize (wireframe)', () => {
-  const layer = new PolygonLayer({data: data.choropleths, extruded: true, wireframe: true});
+  const layer = new PolygonLayer({data: data.choropleths.features,
+    getPolygon: f => f.geometry.coordinates,
+    extruded: true, wireframe: true
+  });
+  testInitializeLayer({layer});
+})
+.add('SolidPolygonLayer#initialize (flat)', () => {
+  const layer = new SolidPolygonLayer({data: data.choropleths.features});
+  testInitializeLayer({layer});
+})
+.add('SolidPolygonLayer#initialize (extruded)', () => {
+  const layer = new SolidPolygonLayer({data: data.choropleths.features,
+    extruded: true
+  });
+  testInitializeLayer({layer});
+})
+.add('SolidPolygonLayer#initialize (wireframe)', () => {
+  const layer = new SolidPolygonLayer({data: data.choropleths.features,
+    extruded: true, wireframe: true
+  });
   testInitializeLayer({layer});
 })
 .add('encoding picking color', () => {
   testIdx++;
+  if ((testIdx + 1) >> 24) {
+    testIdx = 0;
+  }
   testLayer.encodePickingColor(testIdx);
 })
-// .add('ScatterplotLayer#initialize', () => {
-//   const layer = new ScatterplotLayer({data: data.points});
-//   testInitializeLayer({layer});
-// })
 // add listeners
 .on('start', (event) => {
   console.log('Starting bench...');

--- a/test/bench/node.js
+++ b/test/bench/node.js
@@ -38,4 +38,5 @@ require('babel-polyfill');
 // Import headless luma support
 require('luma.gl/headless');
 
+require('../test-utils/setup-gl');
 require('./index');

--- a/test/test-utils/layer-utils.js
+++ b/test/test-utils/layer-utils.js
@@ -85,6 +85,7 @@ export function testInitializeLayer({gl, layer, viewport}) {
     });
 
   } catch (error) {
+    console.log(error.message); // eslint-disable-line
     failures = error;
   }
 


### PR DESCRIPTION
As said in #1000, the query visible object button doesn't work in layer-browser, fix the bug in pick-layers.js where a for loop is not valid because of wrong condition check.

Tested with "npm run test-browser" and "layer-browser" example.