### PR TITLE
Fix picking when rendereing pickable and non-pickable layers

### DIFF
--- a/src/core/lib/pick-layers.js
+++ b/src/core/lib/pick-layers.js
@@ -252,7 +252,7 @@ function getPickedColors(gl, {
   }
 
   drawPickingBuffer(gl, {
-    layers: pickableLayers,
+    layers,
     viewports,
     onViewportActive,
     useDevicePixelRatio,


### PR DESCRIPTION
- When picking multiple layers, starting with non-pickable layers, if we only render pickable layers, resulting layerIndex is used on original layers, causing wrong layer being picked. Used pickableLayers to only detect early return, but always render all layers.