### PR TITLE
Pass useDevicePixelRatio to picking flow

### DIFF
--- a/src/core/lib/pick-layers.js
+++ b/src/core/lib/pick-layers.js
@@ -194,6 +194,7 @@ export function pickVisibleObjects(gl, {
     viewports,
     onViewportActive,
     pickingFBO,
+    useDevicePixelRatio,
     deviceRect: {
       x: deviceLeft,
       y: deviceTop,
@@ -374,6 +375,7 @@ function getUniquesFromPickingBuffer(gl, {
   viewports,
   onViewportActive,
   pickingFBO,
+  useDevicePixelRatio,
   deviceRect: {x, y, width, height}
 }) {
   const pickedColors = getPickedColors(gl, {
@@ -381,6 +383,7 @@ function getUniquesFromPickingBuffer(gl, {
     viewports,
     onViewportActive,
     pickingFBO,
+    useDevicePixelRatio,
     deviceRect: {x, y, width, height}
   });
   const uniqueColors = new Map();


### PR DESCRIPTION
Verified with: `test-browser`, `examples`, `layer-browser` (Query Visible Object with/without retina).