### PR TITLE
Specify meter unit for getLineWidth in geojson layer

### DIFF
--- a/docs/layers/geojson-layer.md
+++ b/docs/layers/geojson-layer.md
@@ -169,7 +169,7 @@ Called to retrieve the radius of `Point` and `MultiPoint` feature.
 
 - Default: `f => f.properties.lineWidth || 1`
 
-Called to retrieve the line width for a GeoJson feature.
+Called to retrieve the line width in meters for a GeoJson feature.
 
 Note: This accessor is called for `LineString` and `MultiLineString`
 features. It is called for `Polygon` and `MultiPolygon` features if the


### PR DESCRIPTION
Per request in #1027, add meter as the unit.