### PR TITLE
Fix blending in ScatterplotLayer example

### DIFF
--- a/examples/layer-browser/src/examples/core-layers.js
+++ b/examples/layer-browser/src/examples/core-layers.js
@@ -171,7 +171,7 @@ const ScatterplotLayerExample = {
     getPosition: d => get(d, 'COORDINATES'),
     getColor: d => [255, 128, 0],
     getRadius: d => get(d, 'SPACES'),
-    opacity: 0.5,
+    opacity: 1,
     pickable: true,
     radiusScale: 30,
     radiusMinPixels: 1,


### PR DESCRIPTION
Micro fix for blending in our scatterplot layer example.  Before and after:
<img width="549" alt="screen shot 2017-10-15 at 8 53 35 am" src="https://user-images.githubusercontent.com/7025232/31590711-d8f7ae80-b1c9-11e7-969b-6b5b7bce9549.png">
<img width="672" alt="screen shot 2017-10-15 at 8 53 25 am" src="https://user-images.githubusercontent.com/7025232/31590710-d728779c-b1c9-11e7-9e77-dd4893580567.png">

