### PR TITLE
Move prop diffing from layer.js to props.js

### DIFF
--- a/src/core/lib/layer.js
+++ b/src/core/lib/layer.js
@@ -506,7 +506,12 @@ export default class Layer {
       propsOrDataChanged,
       viewportChanged,
       somethingChanged,
-      reason: dataChanged || propsChanged || 'Viewport changed'
+      reason:
+        dataChanged ||
+        propsChanged ||
+        (viewportChanged && 'Viewport changed') ||
+        (updateTriggersChanged && 'updateTriggers changed') ||
+        'unknown reason'
     };
   }
 

--- a/src/core/lib/props.js
+++ b/src/core/lib/props.js
@@ -1,6 +1,32 @@
 import {log} from './utils';
 import assert from 'assert';
 
+// Returns an object with "change flags", either false or strings indicating reason for change
+export function diffProps(oldProps, newProps, onUpdateTriggered = () => {}) {
+  // First check if any props have changed (ignore props that will be examined separately)
+  const propsChangedReason = compareProps({
+    newProps,
+    oldProps,
+    ignoreProps: {data: null, updateTriggers: null}
+  });
+
+  // Now check if any data related props have changed
+  const dataChangedReason = diffDataProps(oldProps, newProps);
+
+  // Check update triggers to determine if any attributes need regeneration
+  // Note - if data has changed, all attributes will need regeneration, so skip this step
+  let updateTriggersChangedReason = false;
+  if (!dataChangedReason) {
+    updateTriggersChangedReason = diffUpdateTriggers(oldProps, newProps, onUpdateTriggered);
+  }
+
+  return {
+    dataChanged: dataChangedReason,
+    propsChanged: propsChangedReason,
+    updateTriggersChanged: updateTriggersChangedReason
+  };
+}
+
 /**
  * Performs equality by iterating through keys on an object and returning false
  * when any key has values which are not strictly equal between the arguments.
@@ -57,6 +83,59 @@ export function compareProps({oldProps, newProps, ignoreProps = {}, triggerName 
   return null;
 }
 /* eslint-enable max-statements, complexity */
+
+// PRIVATE METHODS
+
+// The comparison of the data prop requires special handling
+// the dataComparator should be used if supplied
+function diffDataProps(oldProps, props) {
+  if (oldProps === null) {
+    return 'oldProps is null, initial diff';
+  }
+
+  // Support optional app defined comparison of data
+  const {dataComparator} = props;
+  if (dataComparator) {
+    if (!dataComparator(props.data, oldProps.data)) {
+      return 'Data comparator detected a change';
+    }
+  // Otherwise, do a shallow equal on props
+  } else if (props.data !== oldProps.data) {
+    return 'A new data container was supplied';
+  }
+
+  return null;
+}
+
+// Checks if any update triggers have changed, and invalidate
+// attributes accordingly.
+/* eslint-disable max-statements */
+function diffUpdateTriggers(oldProps, props, onUpdateTriggered) {
+  // const {attributeManager} = this.state;
+  // const updateTriggerMap = attributeManager.getUpdateTriggerMap();
+  if (oldProps === null) {
+    return true; // oldProps is null, initial diff
+  }
+
+  let change = false;
+
+  for (const propName in props.updateTriggers) {
+    const oldTriggers = oldProps.updateTriggers[propName] || {};
+    const newTriggers = props.updateTriggers[propName] || {};
+    const diffReason = compareProps({
+      oldProps: oldTriggers,
+      newProps: newTriggers,
+      triggerName: propName
+    });
+    if (diffReason) {
+      onUpdateTriggered(propName);
+      change = true;
+    }
+  }
+
+  return change;
+}
+/* eslint-enable max-statements */
 
 // HELPERS
 

--- a/test/src/core/lib/layer.spec.js
+++ b/test/src/core/lib/layer.spec.js
@@ -120,19 +120,19 @@ test('Layer#getNumInstances', t => {
 
 test('Layer#diffProps', t => {
   const layer = new SubLayer(LAYER_PROPS);
-  const context = {viewportChanged: false};
+  layer.context = {viewportChanged: false};
   let diff;
 
   diff = layer.diffProps(LAYER_PROPS,
-    Object.assign({}, LAYER_PROPS), context);
+    Object.assign({}, LAYER_PROPS));
   t.false(diff.somethingChanged, 'same props');
 
   diff = layer.diffProps(LAYER_PROPS,
-    Object.assign({}, LAYER_PROPS, {data: dataVariants[0]}), context);
+    Object.assign({}, LAYER_PROPS, {data: dataVariants[0]}));
   t.true(diff.dataChanged, 'data changed');
 
   diff = layer.diffProps(LAYER_PROPS,
-    Object.assign({}, LAYER_PROPS, {size: 0}), context);
+    Object.assign({}, LAYER_PROPS, {size: 0}));
   t.true(diff.propsChanged, 'props changed');
 
   // Dummy attribute manager to avoid diffUpdateTriggers failure
@@ -140,7 +140,7 @@ test('Layer#diffProps', t => {
     attributeManager: {invalidate: () => {}}
   };
   diff = layer.diffProps(LAYER_PROPS,
-    Object.assign({}, LAYER_PROPS, {updateTriggers: {time: 100}}), context);
+    Object.assign({}, LAYER_PROPS, {updateTriggers: {time: 100}}));
   t.true(diff.propsOrDataChanged, 'props changed');
 
   let invalidatedName = null;
@@ -153,7 +153,7 @@ test('Layer#diffProps', t => {
   };
 
   diff = layer.diffProps(layer.props,
-    Object.assign({}, LAYER_PROPS, {updateTriggers: {color: {version: 0}}}), context);
+    Object.assign({}, LAYER_PROPS, {updateTriggers: {color: {version: 0}}}));
   t.is(invalidatedName, 'color', 'updateTriggers fired');
 
   t.end();


### PR DESCRIPTION
Consolidates prop diffing and moves prop related code from `layer.js` to `props.js`. 
* Will make layer code easier to work with, and to prepare for features like more sophisticated prop diffing, prop types and prop animations/transitions.
* simple interface, the new `diffProps` function just returns an object with changeFlags.
* and a callback is supplied by the layer to handle any detected updateTriggers.

Tested in layer-browser.
