### PR TITLE
Improved tracking and logging of redraw reason

### DIFF
--- a/src/core/experimental/lib/effect.js
+++ b/src/core/experimental/lib/effect.js
@@ -23,6 +23,7 @@ let counter = 0;
 export default class Effect {
 
   constructor() {
+    this.id = 'effect';
     this.count = counter++;
     this.visible = true;
     this.priority = 0;

--- a/src/core/lib/attribute-manager.js
+++ b/src/core/lib/attribute-manager.js
@@ -299,13 +299,12 @@ export default class AttributeManager {
    *
    * @param {Object} [opts]
    * @param {String} [opts.clearRedrawFlags=false] - whether to clear the flag
-   * @return {Boolean} - whether a redraw is needed.
+   * @return {false|String} - reason a redraw is needed.
    */
   getNeedsRedraw({clearRedrawFlags = false} = {}) {
-    let redraw = this.needsRedraw;
-    redraw = redraw || this.needsRedraw;
+    const redraw = this.needsRedraw;
     this.needsRedraw = this.needsRedraw && !clearRedrawFlags;
-    return redraw;
+    return redraw && this.id;
   }
 
   /**

--- a/src/core/lib/layer.js
+++ b/src/core/lib/layer.js
@@ -184,7 +184,7 @@ export default class Layer {
 
   // Calls attribute manager to update any WebGL attributes, can be redefined
   updateAttributes(props) {
-    const {attributeManager, model} = this.state;
+    const {attributeManager} = this.state;
     if (!attributeManager) {
       return;
     }
@@ -202,6 +202,8 @@ export default class Layer {
       ignoreUnknownAttributes: true
     });
 
+    // TODO - Use getModels?
+    const {model} = this.state;
     if (model) {
       const changedAttributes = attributeManager.getChangedAttributes({clearChangedFlags: true});
       model.setAttributes(changedAttributes);
@@ -477,7 +479,6 @@ export default class Layer {
   }
 
   // Checks state of attributes and model
-  // TODO - is attribute manager needed? - Model should be enough.
   getNeedsRedraw({clearRedrawFlags = false} = {}) {
     // this method may be called by the render loop as soon a the layer
     // has been created, so guard against uninitialized state
@@ -486,12 +487,15 @@ export default class Layer {
     }
 
     let redraw = false;
-    redraw = redraw || this.state.needsRedraw;
+    redraw = redraw || (this.state.needsRedraw && this.id);
     this.state.needsRedraw = this.state.needsRedraw && !clearRedrawFlags;
 
-    const {attributeManager, model} = this.state;
+    // TODO - is attribute manager needed? - Model should be enough.
+    const {attributeManager} = this.state;
     redraw = redraw || (attributeManager && attributeManager.getNeedsRedraw({clearRedrawFlags}));
-    redraw = redraw || (model && model.getNeedsRedraw({clearRedrawFlags}));
+    for (const model of this.getModels()) {
+      redraw = redraw || (model.getNeedsRedraw({clearRedrawFlags}) && model.id);
+    }
 
     return redraw;
   }

--- a/src/core/pure-js/deck-js.js
+++ b/src/core/pure-js/deck-js.js
@@ -240,14 +240,15 @@ export default class DeckGLJS {
   }
 
   _onRenderFrame({gl}) {
-    const redraw = this.layerManager.needsRedraw({clearRedrawFlags: true});
-    if (!redraw) {
+    const redrawReason = this.layerManager.needsRedraw({clearRedrawFlags: true});
+    if (!redrawReason) {
       return;
     }
 
     this.props.onBeforeRender({gl}); // TODO - should be called by AnimationLoop
     this.layerManager.drawLayers({
-      pass: 'render to screen',
+      pass: 'screen',
+      redrawReason,
       // Helps debug layer picking, especially in framebuffer powered layers
       drawPickingColors: this.props.drawPickingColors
     });


### PR DESCRIPTION
This PR enables every redraw call to be logged with a reason to help quickly trace down the root cause of unnecessary redraws

<img width="563" alt="screen shot 2017-10-15 at 4 54 08 pm" src="https://user-images.githubusercontent.com/7025232/31591147-4f01b966-b1d1-11e7-8256-8b8e24e313d6.png">

Depends on #1036 for full functionality (tracing picking reasons) but can be landed independently.