### PR TITLE
Fix the normal direction of the hexagon layer and lighting module

### DIFF
--- a/src/core-layers/grid-cell-layer/grid-cell-layer-vertex-64.glsl.js
+++ b/src/core-layers/grid-cell-layer/grid-cell-layer-vertex-64.glsl.js
@@ -53,11 +53,11 @@ void main(void) {
 
   vec2 projected_coord_xy[2];
   project_position_fp64(instancePositions64xy, projected_coord_xy);
-  
+
   // if ahpha == 0.0 or z < 0.0, do not render element
   float noRender = float(instanceColors.a == 0.0 || instancePositions.w < 0.0);
   float finalCellSize = cellSize * mix(1.0, 0.0, noRender);
-  
+
   projected_coord_xy[0] = sum_fp64(projected_coord_xy[0],
     vec2((positions.x * coverage + 1.0) * finalCellSize / 2.0, 0.0));
   projected_coord_xy[1] = sum_fp64(projected_coord_xy[1],

--- a/src/core-layers/hexagon-cell-layer/hexagon-cell-layer-vertex-64.glsl.js
+++ b/src/core-layers/hexagon-cell-layer/hexagon-cell-layer-vertex-64.glsl.js
@@ -49,10 +49,10 @@ void main(void) {
   mat2 rotationMatrix = mat2(cos(angle), -sin(angle), sin(angle), cos(angle));
 
   vec2 rPos = rotationMatrix * positions.xz;
-  vec2 rNorm = rotationMatrix * normals.xz;
+  vec2 rNorm = rotationMatrix * normals.xz; // the hexagon cells has y axis as the vertical axis
 
   vec3 rotatedPositions = vec3(rPos.x, positions.y, rPos.y);
-  vec3 rotatedNormals = vec3(rNorm.x, normals.y, rNorm.y);
+  vec3 rotatedNormals = vec3(rNorm.x, rNorm.y, normals.y);
 
   // calculate elevation, if 3d not enabled set to 0
   // cylindar gemoetry height are between -0.5 to 0.5, transform it to between 0, 1
@@ -62,11 +62,11 @@ void main(void) {
     elevation = project_scale(instancePositions.z * (positions.y + 0.5) *
       ELEVATION_SCALE * elevationScale);
   }
-  
-  // if ahpha == 0.0 or z < 0.0, do not render element  
+
+  // if alpha == 0.0 or z < 0.0, do not render element
   float noRender = float(instanceColors.a == 0.0 || instancePositions.z < 0.0);
   float dotRadius = radius * mix(coverage, 0.0, noRender);
-  
+
   // project center of hexagon
 
   vec4 instancePositions64xy = vec4(

--- a/src/core-layers/hexagon-cell-layer/hexagon-cell-layer-vertex.glsl.js
+++ b/src/core-layers/hexagon-cell-layer/hexagon-cell-layer-vertex.glsl.js
@@ -49,10 +49,10 @@ void main(void) {
   mat2 rotationMatrix = mat2(cos(angle), -sin(angle), sin(angle), cos(angle));
 
   vec2 rPos = rotationMatrix * positions.xz;
-  vec2 rNorm = rotationMatrix * normals.xz;
+  vec2 rNorm = rotationMatrix * normals.xz; // the hexagon cells has y axis as the vertical axis
 
   vec3 rotatedPositions = vec3(rPos.x, positions.y, rPos.y);
-  vec3 rotatedNormals = vec3(rNorm.x, normals.y, rNorm.y);
+  vec3 rotatedNormals = vec3(rNorm.x, rNorm.y, normals.y);
 
   // calculate elevation, if 3d not enabled set to 0
   // cylindar gemoetry height are between -0.5 to 0.5, transform it to between 0, 1
@@ -62,11 +62,11 @@ void main(void) {
     elevation = project_scale(instancePositions.z * (positions.y + 0.5) *
       ELEVATION_SCALE * elevationScale);
   }
-  
+
   // if ahpha == 0.0 or z < 0.0, do not render element
   float noRender = float(instanceColors.a == 0.0 || instancePositions.z < 0.0);
   float dotRadius = radius * mix(coverage, 0.0, noRender);
-  
+
   // project center of hexagon
   vec4 centroidPosition = vec4(project_position(instancePositions.xy), elevation, 0.0);
 

--- a/src/core/shaderlib/lighting/lighting.glsl.js
+++ b/src/core/shaderlib/lighting/lighting.glsl.js
@@ -36,7 +36,7 @@ uniform float specularRatio;
 float lighting_getLightWeight(vec3 position_worldspace_vec3, vec3 normals_worldspace) {
   float lightWeight = 0.0;
 
-  vec3 normals_worldspace_vec3 = normals_worldspace.xzy;
+  vec3 normals_worldspace_vec3 = normals_worldspace.xyz;
 
   vec3 camera_pos_worldspace = cameraPos;
   vec3 view_direction = normalize(camera_pos_worldspace - position_worldspace_vec3);


### PR DESCRIPTION
The normals of our layers (hexagon cell and extruded polygon) has y axis as the vertical axis, so our lighting modules apply a transform to correct it. 

`vec3 normals_worldspace_vec3 = normals_worldspace.xzy;`

Now, the extruded polygons has z-axis as vertical (https://github.com/uber/deck.gl/pull/1011), so we need to fix the hexagon cell layer and lighting module to make the lighting correct.

@1chandu @Pessimistress @heshan0131 