### PR TITLE
Fix Viewport import in OrbitViewport

### DIFF
--- a/src/core/viewports/orbit-viewport.js
+++ b/src/core/viewports/orbit-viewport.js
@@ -1,4 +1,4 @@
-import {Viewport} from 'deck.gl';
+import Viewport from './viewport';
 
 import mat4_multiply from 'gl-mat4/multiply';
 import mat4_lookAt from 'gl-mat4/lookAt';


### PR DESCRIPTION
I have a PureJS use case where only deck.gl core is imported to avoid React dependency. This line breaks it.