### PR TITLE
More rigorous changeFlags handling.

### DIFF
--- a/src/core/lib/composite-layer.js
+++ b/src/core/lib/composite-layer.js
@@ -35,11 +35,6 @@ export default class CompositeLayer extends Layer {
   initializeState() {
   }
 
-  // No-op for the invalidateAttribute function as the composite
-  // layer has no AttributeManager
-  invalidateAttribute() {
-  }
-
   // called to augment the info object that is bubbled up from a sublayer
   // override Layer.getPickingInfo() because decoding / setting uniform do
   // not apply to a composite layer.
@@ -71,11 +66,19 @@ export default class CompositeLayer extends Layer {
     };
   }
 
+  // Called by layer manager to render sublayers
   _renderLayers(updateParams) {
-    if (this.state.oldSubLayers && !this.shouldUpdateState(updateParams)) {
-      log.log(2, `Composite layer reused sublayers ${this}`, this.state.oldSubLayers);
-      return this.state.oldSubLayers;
-    }
+    // TODO - won't updateLayer also be called? Avoid "double diffing"
+    // const {oldProps, props} = updateParams;
+    // this.diffProps(oldProps, props);
+
+    // TODO - Bug: Composite layers need to call the shouldUpdateState method
+    // of all its cached sublayers to ensure they all get properly updated
+    // it is not a "reuse all or none"...
+    // if (this.state.oldSubLayers && !this.shouldUpdateState(updateParams)) {
+    //   log.log(2, `Composite layer reused sublayers ${this}`, this.state.oldSubLayers);
+    //   return this.state.oldSubLayers;
+    // }
     const subLayers = this.renderLayers();
     this.state.oldSubLayers = subLayers;
     log.log(2, `Composite layer rendered new sublayers ${this}`, this.state.oldSubLayers);

--- a/src/core/lib/composite-layer.js
+++ b/src/core/lib/composite-layer.js
@@ -69,16 +69,13 @@ export default class CompositeLayer extends Layer {
   // Called by layer manager to render sublayers
   _renderLayers(updateParams) {
     // TODO - won't updateLayer also be called? Avoid "double diffing"
-    // const {oldProps, props} = updateParams;
-    // this.diffProps(oldProps, props);
+    const {oldProps, props} = updateParams;
+    this.diffProps(oldProps, props);
 
-    // TODO - Bug: Composite layers need to call the shouldUpdateState method
-    // of all its cached sublayers to ensure they all get properly updated
-    // it is not a "reuse all or none"...
-    // if (this.state.oldSubLayers && !this.shouldUpdateState(updateParams)) {
-    //   log.log(2, `Composite layer reused sublayers ${this}`, this.state.oldSubLayers);
-    //   return this.state.oldSubLayers;
-    // }
+    if (this.state.oldSubLayers && !this.shouldUpdateState(updateParams)) {
+      log.log(2, `Composite layer reused sublayers ${this}`, this.state.oldSubLayers);
+      return this.state.oldSubLayers;
+    }
     const subLayers = this.renderLayers();
     this.state.oldSubLayers = subLayers;
     log.log(2, `Composite layer rendered new sublayers ${this}`, this.state.oldSubLayers);

--- a/src/core/lib/layer-manager.js
+++ b/src/core/lib/layer-manager.js
@@ -352,7 +352,8 @@ export default class LayerManager {
       // TODO - don't set viewportChanged during setViewports?
       if (this.context.viewportChanged) {
         for (const layer of this.layers) {
-          this._updateLayer(layer, {viewportChanged: true});
+          layer.setChangeFlags({viewportChanged: 'Viewport changed'});
+          this._updateLayer(layer);
         }
       }
     }
@@ -443,8 +444,7 @@ export default class LayerManager {
           oldProps,
           props,
           context: this.context,
-          oldContext: this.oldContext,
-          changeFlags: newLayer.diffProps(oldProps, props, this.context)
+          oldContext: this.oldContext
         }) : null;
         // End layer lifecycle method: render sublayers
 
@@ -524,13 +524,11 @@ export default class LayerManager {
     if (!layer.state) {
       log(LOG_PRIORITY_LIFECYCLE, `initializing ${layerName(layer)}`);
       try {
-
         layer.initializeLayer({
           oldProps: {},
           props: layer.props,
           oldContext: this.oldContext,
-          context: this.context,
-          changeFlags: layer.diffProps({}, layer.props, this.context)
+          context: this.context
         });
 
         layer.lifecycle = LIFECYCLE.INITIALIZED;
@@ -555,19 +553,17 @@ export default class LayerManager {
     return error;
   }
 
-  // Updates a single layer, calling layer methods, calculates changeFlags if not provided
-  _updateLayer(layer, changeFlags = null) {
+  // Updates a single layer, calling layer methods
+  _updateLayer(layer) {
     const {oldProps, props} = layer;
     let error = null;
     if (oldProps) {
-      changeFlags = changeFlags || layer.diffProps(oldProps, props, this.context);
       try {
         layer.updateLayer({
           oldProps,
           props,
           context: this.context,
-          oldContext: this.oldContext,
-          changeFlags
+          oldContext: this.oldContext
         });
       } catch (err) {
         log.once(0, `error during update of ${layerName(layer)}`, err);

--- a/src/core/lib/layer.js
+++ b/src/core/lib/layer.js
@@ -522,15 +522,11 @@ export default class Layer {
     }
 
     // Update composite flags
-    changeFlags.propsOrDataChanged = changeFlags.propsOrDataChanged ||
-      flags.dataChanged ||
-      flags.updateTriggersChanged ||
-      flags.propsChanged;
+    const propsOrDataChanged =
+      flags.dataChanged || flags.updateTriggersChanged || flags.propsChanged;
+    changeFlags.propsOrDataChanged = changeFlags.propsOrDataChanged || propsOrDataChanged;
     changeFlags.somethingChanged = changeFlags.somethingChanged ||
-      flags.dataChanged ||
-      flags.updateTriggersChanged ||
-      flags.propsChanged ||
-      flags.viewportChanged;
+      propsOrDataChanged || flags.viewportChanged;
 
     return changeFlags;
   }

--- a/src/core/lib/layer.js
+++ b/src/core/lib/layer.js
@@ -502,23 +502,23 @@ export default class Layer {
     // Update primary flags
     if (flags.dataChanged && !changeFlags.dataChanged) {
       changeFlags.dataChanged = flags.dataChanged;
-      log.log(LOG_PRIORITY_UPDATE,
-        `dataChanged: ${flags.dataChanged} in ${this.id}`);
+      log.log(LOG_PRIORITY_UPDATE + 1,
+        () => `dataChanged: ${flags.dataChanged} in ${this.id}`);
     }
     if (flags.updateTriggersChanged && !changeFlags.updateTriggersChanged) {
       changeFlags.updateTriggersChanged = flags.updateTriggersChanged;
-      log.log(LOG_PRIORITY_UPDATE,
-        `updateTriggersChanged: ${flags.updateTriggersChanged} in ${this.id}`);
+      log.log(LOG_PRIORITY_UPDATE + 1,
+        () => `updateTriggersChanged: ${flags.updateTriggersChanged} in ${this.id}`);
     }
     if (flags.propsChanged && !changeFlags.propsChanged) {
-      changeFlags.propsChanged = changeFlags.propsChanged;
-      log.log(LOG_PRIORITY_UPDATE,
-        `propsChanged: ${flags.propsChanged} in ${this.id}`);
+      changeFlags.propsChanged = flags.propsChanged;
+      log.log(LOG_PRIORITY_UPDATE + 1,
+        () => `propsChanged: ${flags.propsChanged} in ${this.id}`);
     }
     if (flags.viewportChanged && !changeFlags.viewportChanged) {
       changeFlags.viewportChanged = flags.viewportChanged;
       log.log(LOG_PRIORITY_UPDATE + 2,
-        `propsChanged: ${flags.viewportChanged} in ${this.id}`);
+        () => `propsChanged: ${flags.viewportChanged} in ${this.id}`);
     }
 
     // Update composite flags

--- a/src/core/lib/layer.js
+++ b/src/core/lib/layer.js
@@ -494,37 +494,47 @@ export default class Layer {
   // Helper methods
 
   // Dirty some change flags, will be handled by updateLayer
+  /* eslint-disable complexity */
   setChangeFlags(flags) {
     this.state.changeFlags = this.state.changeFlags || {};
     const changeFlags = this.state.changeFlags;
+
+    // Update primary flags
     if (flags.dataChanged && !changeFlags.dataChanged) {
       changeFlags.dataChanged = flags.dataChanged;
-      changeFlags.propsOrDataChanged = flags.dataChanged;
-      changeFlags.somethingChanged = flags.dataChanged;
       log.log(LOG_PRIORITY_UPDATE,
         `dataChanged: ${flags.dataChanged} in ${this.id}`);
     }
-    if (flags.updateTriggersChanged && !changeFlags.dataChanged) {
+    if (flags.updateTriggersChanged && !changeFlags.updateTriggersChanged) {
       changeFlags.updateTriggersChanged = flags.updateTriggersChanged;
-      changeFlags.propsOrDataChanged = flags.updateTriggersChanged;
-      changeFlags.somethingChanged = flags.updateTriggersChanged;
       log.log(LOG_PRIORITY_UPDATE,
         `updateTriggersChanged: ${flags.updateTriggersChanged} in ${this.id}`);
     }
     if (flags.propsChanged && !changeFlags.propsChanged) {
-      changeFlags.propsChanged = true;
-      changeFlags.propsOrDataChanged = true;
-      changeFlags.somethingChanged = true;
+      changeFlags.propsChanged = changeFlags.propsChanged;
       log.log(LOG_PRIORITY_UPDATE,
-        `propsChanged: ${flags.reason} in ${this.id}`);
+        `propsChanged: ${flags.propsChanged} in ${this.id}`);
     }
     if (flags.viewportChanged && !changeFlags.viewportChanged) {
-      changeFlags.viewportChanged = true;
-      changeFlags.somethingChanged = true;
+      changeFlags.viewportChanged = flags.viewportChanged;
+      log.log(LOG_PRIORITY_UPDATE + 2,
+        `propsChanged: ${flags.viewportChanged} in ${this.id}`);
     }
+
+    // Update composite flags
+    changeFlags.propsOrDataChanged = changeFlags.propsOrDataChanged ||
+      flags.dataChanged ||
+      flags.updateTriggersChanged ||
+      flags.propsChanged;
+    changeFlags.somethingChanged = changeFlags.somethingChanged ||
+      flags.dataChanged ||
+      flags.updateTriggersChanged ||
+      flags.propsChanged ||
+      flags.viewportChanged;
 
     return changeFlags;
   }
+  /* eslint-enable complexity */
 
   // Clear all changeFlags, typically after an update
   clearChangeFlags() {
@@ -549,39 +559,6 @@ export default class Layer {
     changeFlags = this.setChangeFlags(changeFlags);
     return changeFlags;
   }
-
-  /*
-  diffProps(oldProps, newProps) {
-    const changeFlags = diffProps(oldProps, newProps, this._onUpdateTriggered.bind(this));
-    const {propsChanged, dataChanged, updateTriggersChanged} = changeFlags;
-
-    const viewportChanged = this.context.viewportChanged;
-    const propsOrDataChanged = propsChanged || dataChanged || updateTriggersChanged;
-    const somethingChanged = propsOrDataChanged || viewportChanged;
-
-    // Trace what happened
-    if (dataChanged) {
-      log.log(LOG_PRIORITY_UPDATE, `dataChanged: ${dataChanged} in ${this.id}`);
-    } else if (propsChanged) {
-      log.log(LOG_PRIORITY_UPDATE, `propsChanged: ${propsChanged} in ${this.id}`);
-    }
-
-    return {
-      propsChanged,
-      dataChanged,
-      updateTriggersChanged,
-      propsOrDataChanged,
-      viewportChanged,
-      somethingChanged,
-      reason:
-        dataChanged ||
-        propsChanged ||
-        (viewportChanged && 'Viewport changed') ||
-        (updateTriggersChanged && 'updateTriggers changed') ||
-        'unknown reason'
-    };
-  }
-  */
 
   // PRIVATE METHODS
 

--- a/src/core/lib/props.js
+++ b/src/core/lib/props.js
@@ -96,7 +96,7 @@ export function compareProps({
 }
 /* eslint-enable max-statements, max-depth, complexity */
 
-// PRIVATE METHODS
+// HELPERS
 
 // The comparison of the data prop requires special handling
 // the dataComparator should be used if supplied
@@ -121,7 +121,6 @@ function diffDataProps(oldProps, props) {
 
 // Checks if any update triggers have changed, and invalidate
 // attributes accordingly.
-/* eslint-disable max-statements */
 function diffUpdateTriggers(oldProps, props, onUpdateTriggered) {
   // const {attributeManager} = this.state;
   // const updateTriggerMap = attributeManager.getUpdateTriggerMap();
@@ -147,9 +146,6 @@ function diffUpdateTriggers(oldProps, props, onUpdateTriggered) {
 
   return change;
 }
-/* eslint-enable max-statements */
-
-// HELPERS
 
 // Constructors have their super class constructors as prototypes
 function getOwnProperty(object, prop) {

--- a/src/core/lib/props.js
+++ b/src/core/lib/props.js
@@ -60,13 +60,13 @@ export function compareProps({
   for (const key in oldProps) {
     if (!(key in ignoreProps)) {
       if (!newProps.hasOwnProperty(key)) {
-        return `${triggerName} ${key} dropped: ${oldProps[key]} -> (undefined)`;
+        return `${triggerName}.${key} dropped: ${oldProps[key]} -> undefined`;
       }
 
       // If object has an equals function, invoke it
       let equals = newProps[key] && oldProps[key] && newProps[key].equals;
       if (equals && !equals.call(newProps[key], oldProps[key])) {
-        return `${triggerName} ${key} changed deeply: ${oldProps[key]} -> ${newProps[key]}`;
+        return `${triggerName}.${key} changed deeply: ${oldProps[key]} -> ${newProps[key]}`;
       }
 
       // If both new and old value are functions, ignore differences
@@ -78,7 +78,7 @@ export function compareProps({
       }
 
       if (!equals && oldProps[key] !== newProps[key]) {
-        return `${triggerName} ${key} changed shallowly: ${oldProps[key]} -> ${newProps[key]}`;
+        return `${triggerName}.${key} changed shallowly: ${oldProps[key]} -> ${newProps[key]}`;
       }
     }
   }
@@ -87,7 +87,7 @@ export function compareProps({
   for (const key in newProps) {
     if (!(key in ignoreProps)) {
       if (!oldProps.hasOwnProperty(key)) {
-        return `${triggerName} ${key} added: (undefined) -> ${newProps[key]}`;
+        return `${triggerName}.${key} added: undefined -> ${newProps[key]}`;
       }
     }
   }
@@ -119,32 +119,49 @@ function diffDataProps(oldProps, props) {
   return null;
 }
 
-// Checks if any update triggers have changed, and invalidate
-// attributes accordingly.
+// Checks if any update triggers have changed
+// also calls callback to invalidate attributes accordingly.
 function diffUpdateTriggers(oldProps, props, onUpdateTriggered) {
   // const {attributeManager} = this.state;
   // const updateTriggerMap = attributeManager.getUpdateTriggerMap();
   if (oldProps === null) {
-    return true; // oldProps is null, initial diff
+    return 'oldProps is null, initial diff';
   }
 
-  let change = false;
+  let reason = false;
 
-  for (const propName in props.updateTriggers) {
-    const oldTriggers = oldProps.updateTriggers[propName] || {};
-    const newTriggers = props.updateTriggers[propName] || {};
-    const diffReason = compareProps({
-      oldProps: oldTriggers,
-      newProps: newTriggers,
-      triggerName: propName
-    });
+  // If the 'all' updateTrigger fires, ignore testing others
+  if ('all' in props.updateTriggers) {
+    const diffReason = diffUpdateTrigger(oldProps, props, 'all');
     if (diffReason) {
-      onUpdateTriggered(propName);
-      change = true;
+      onUpdateTriggered('all');
+      return diffReason;
     }
   }
 
-  return change;
+  // If the 'all' updateTrigger didn't fire, need to check all others
+  for (const triggerName in props.updateTriggers) {
+    if (triggerName !== 'all') {
+      const diffReason = diffUpdateTrigger(oldProps, props, triggerName);
+      if (diffReason) {
+        onUpdateTriggered(triggerName);
+        reason = reason || diffReason;
+      }
+    }
+  }
+
+  return reason;
+}
+
+function diffUpdateTrigger(oldProps, props, triggerName) {
+  const oldTriggers = oldProps.updateTriggers[triggerName] || {};
+  const newTriggers = props.updateTriggers[triggerName] || {};
+  const diffReason = compareProps({
+    oldProps: oldTriggers,
+    newProps: newTriggers,
+    triggerName
+  });
+  return diffReason;
 }
 
 // Constructors have their super class constructors as prototypes

--- a/src/core/utils/log.js
+++ b/src/core/utils/log.js
@@ -24,16 +24,6 @@ import assert from 'assert';
 
 const cache = {};
 
-function formatArgs(firstArg, ...args) {
-  if (typeof firstArg === 'string') {
-    args.unshift(`deck.gl ${firstArg}`);
-  } else {
-    args.unshift(firstArg);
-    args.unshift('deck.gl');
-  }
-  return args;
-}
-
 function log(priority, arg, ...args) {
   assert(Number.isFinite(priority), 'log priority must be a number');
   if (priority <= log.priority) {
@@ -47,20 +37,6 @@ function log(priority, arg, ...args) {
   }
 }
 
-// Assertions don't generate standard exceptions and don't print nicely
-function checkForAssertionErrors(args) {
-  const isAssertion =
-    args && args.length > 0 &&
-    typeof args[0] === 'object' && args[0] !== null &&
-    args[0].name === 'AssertionError';
-
-  if (isAssertion) {
-    args = Array.prototype.slice.call(args);
-    args.unshift(`assert(${args[0].message})`);
-  }
-  return args;
-}
-
 function once(priority, arg, ...args) {
   if (!cache[arg] && priority <= log.priority) {
     args = checkForAssertionErrors(args);
@@ -72,8 +48,8 @@ function once(priority, arg, ...args) {
 function warn(priority, arg, ...args) {
   if (priority <= log.priority && !cache[arg]) {
     console.warn(`deck.gl: ${arg}`, ...args);
+    cache[arg] = true;
   }
-  cache[arg] = true;
 }
 
 function error(priority, arg, ...args) {
@@ -108,6 +84,35 @@ function timeEnd(priority, label) {
       console.info(label);
     }
   }
+}
+
+// Helper functions
+
+function formatArgs(firstArg, ...args) {
+  if (typeof firstArg === 'function') {
+    firstArg = firstArg();
+  }
+  if (typeof firstArg === 'string') {
+    args.unshift(`deck.gl ${firstArg}`);
+  } else {
+    args.unshift(firstArg);
+    args.unshift('deck.gl');
+  }
+  return args;
+}
+
+// Assertions don't generate standard exceptions and don't print nicely
+function checkForAssertionErrors(args) {
+  const isAssertion =
+    args && args.length > 0 &&
+    typeof args[0] === 'object' && args[0] !== null &&
+    args[0].name === 'AssertionError';
+
+  if (isAssertion) {
+    args = Array.prototype.slice.call(args);
+    args.unshift(`assert(${args[0].message})`);
+  }
+  return args;
 }
 
 log.priority = 0;

--- a/test/src/core/lib/layer.spec.js
+++ b/test/src/core/lib/layer.spec.js
@@ -19,12 +19,12 @@
 // THE SOFTWARE.
 
 import test from 'tape-catch';
-import {Layer} from 'deck.gl';
+import {Layer, AttributeManager} from 'deck.gl';
+import {testInitializeLayer} from 'deck.gl/test/test-utils/layer-utils';
+import makeSpy from 'deck.gl/test/test-utils/spy';
 
 const dataVariants = [
   {data: ['a', 'b', 'c'], size: 3}
-  //  {data: , size: 3},
-  //  {data: , size: 3}
 ];
 
 const LAYER_PROPS = {
@@ -57,16 +57,29 @@ const LAYER_CONSTRUCT_TEST_CASES = [
   }
 ];
 
-class SubLayer extends Layer {}
+class SubLayer extends Layer {
+  initializeState() {
+    this.state.attributeManager.addInstanced({
+      time: {size: 1, accessor: 'getTime', defaultValue: 0, update: this.calculateTime}
+    });
+  }
+}
+
 SubLayer.layerName = 'SubLayer';
 SubLayer.defaultProps = {
-  getColor: x => x.color
+  getTime: x => x.time
 };
 
-class SubLayer2 extends Layer {}
+class SubLayer2 extends Layer {
+  initializeState() {}
+}
+
 SubLayer2.layerName = 'SubLayer2';
 
-class SubLayer3 extends Layer {}
+class SubLayer3 extends Layer {
+  initializeState() {}
+}
+
 SubLayer3.layerName = 'SubLayer2';
 
 test('Layer#constructor', t => {
@@ -101,15 +114,6 @@ test('SubLayer3#constructor (no layerName, no defaultProps)', t => {
   t.end();
 });
 
-// test('Layer#constructor with bad or missing props', t => {
-//   t.throws(
-//     () => new Layer({...LAYER_PROPS, zoom: undefined}),
-//     /Property zoom undefined in layer testLayer/,
-//     'Expected invalid prop to throw an error'
-//   );
-//   t.end();
-// });
-
 test('Layer#getNumInstances', t => {
   for (const dataVariant of dataVariants) {
     const layer = new Layer(Object.assign({}, LAYER_PROPS, {data: dataVariant.data}));
@@ -120,7 +124,8 @@ test('Layer#getNumInstances', t => {
 
 test('Layer#diffProps', t => {
   const layer = new SubLayer(LAYER_PROPS);
-  layer.context = {viewportChanged: false};
+  testInitializeLayer({layer});
+
   let diff;
 
   diff = layer.diffProps(LAYER_PROPS,
@@ -136,27 +141,15 @@ test('Layer#diffProps', t => {
   t.true(diff.propsChanged, 'props changed');
 
   // Dummy attribute manager to avoid diffUpdateTriggers failure
-  initMockLayerState(layer);
   diff = layer.diffProps(LAYER_PROPS,
     Object.assign({}, LAYER_PROPS, {updateTriggers: {time: 100}}));
   t.true(diff.propsOrDataChanged, 'props changed');
 
-  initMockLayerState(layer);
+  const spy = makeSpy(AttributeManager.prototype, 'invalidate');
   diff = layer.diffProps(layer.props,
-    Object.assign({}, LAYER_PROPS, {updateTriggers: {color: {version: 0}}}));
-  t.is(layer.state.invalidatedName, 'color', 'updateTriggers fired');
+    Object.assign({}, LAYER_PROPS, {updateTriggers: {time: {version: 0}}}));
+  t.ok(spy.called, 'updateTriggers fired');
+  spy.restore();
 
   t.end();
 });
-
-function initMockLayerState(layer) {
-  layer.state = {
-    attributeManager: {
-      invalidate: name => {
-        layer.state.invalidatedName = name;
-      },
-      getAccessors: () => ({})
-    },
-    invaldiateName: null
-  };
-}

--- a/test/test-utils/layer-utils.js
+++ b/test/test-utils/layer-utils.js
@@ -19,7 +19,6 @@
 // THE SOFTWARE.
 
 import WebMercatorViewport from 'deck.gl/core/viewports/web-mercator-viewport';
-import {mergeDefaultProps} from 'deck.gl/core/lib/props';
 
 import spy from './spy';
 import global from 'global';
@@ -68,22 +67,8 @@ export function testInitializeLayer({gl, layer, viewport}) {
   try {
     layer.context = context;
 
-    layer.initializeLayer({
-      oldProps: {},
-      props: layer.props,
-      oldContext,
-      context,
-      changeFlags: layer.diffProps({}, layer.props, context)
-    });
-
-    layer.updateLayer({
-      oldProps: {},
-      props: layer.props,
-      oldContext,
-      context,
-      changeFlags: layer.diffProps({}, layer.props, context)
-    });
-
+    layer.initializeLayer({props: layer.props, oldProps: {}, context, oldContext});
+    layer.updateLayer({props: layer.props, oldProps: {}, context, oldContext});
   } catch (error) {
     console.log(error.message); // eslint-disable-line
     failures = error;
@@ -98,20 +83,13 @@ export function testUpdateLayer({gl, layer, viewport, newProps}) {
 
   const oldContext = layer.context || {gl, viewport};
   const context = {gl, viewport};
-  const oldProps = layer.oldProps || layer.props || {};
 
-  const mergedDefaultProps = mergeDefaultProps(layer);
-  layer.props = Object.assign({}, mergedDefaultProps, newProps);
+  layer.oldProps = layer.props;
+  layer.props = layer._normalizeProps(newProps);
 
   let failure = false;
   try {
-    layer.updateLayer({
-      oldProps,
-      props: layer.props,
-      oldContext,
-      context,
-      changeFlags: layer.diffProps(oldProps, layer.props, context)
-    });
+    layer.updateLayer({props: layer.props, oldProps: layer.oldProps, context, oldContext});
   } catch (error) {
     failure = error;
   }

--- a/test/test-utils/spy.js
+++ b/test/test-utils/spy.js
@@ -1,5 +1,10 @@
 // Inspired by https://github.com/popomore/spy
-export default function(obj, func) {
+// Attach a spy to the function. The spy has the following methods and fields
+//  * restore() - remove spy completely
+//  * reset() - reset call count
+//  * callCount - number of calls
+//  * called - whether spy was called
+export default function makeSpy(obj, func) {
   let methodName;
 
   if (!obj && !func) {


### PR DESCRIPTION
This PR is an initial effort towards making our layer life cycle more rigorous, this one focuses on change flag handling

* changeFlags handling now goes through `layer.setChangeFlags` and `layer.clearChangeFlags`
    * The idea here is that this will enable us to decouple setting of changeFlags and actual updates, allowing changeFlags to accumulate but postponing the update until we need to do it. Think layers with `visible: false`
* `LayerManager` is now no longer responsible for sending changeFlags to layer.updateLayer. It sets the changeFlags and then calls updateLayer. This simplifies logic in `LayerManager` which is where simplification really counts.
* Drops `Layer.invalidateAttribute` which added nothing and just created one more method for layer writers to be confused by.