### PR TITLE
temporary fix for orthographic-viewport dependent apps

### DIFF
--- a/examples/point-cloud-ply/app.js
+++ b/examples/point-cloud-ply/app.js
@@ -14,7 +14,6 @@ class Example extends PureComponent {
     super(props);
 
     this._onResize = this._onResize.bind(this);
-    this._onInitialized = this._onInitialized.bind(this);
     this._onViewportChange = this._onViewportChange.bind(this);
     this._onUpdate = this._onUpdate.bind(this);
 

--- a/src/core/deprecated/viewports/orthographic-viewport.js
+++ b/src/core/deprecated/viewports/orthographic-viewport.js
@@ -18,11 +18,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import FirstPersonViewport from '../../viewports/first-person-viewport';
+import Viewport from '../../viewports/viewport';
 import mat4_lookAt from 'gl-mat4/lookAt';
 import mat4_ortho from 'gl-mat4/ortho';
 
-export default class OrthographicViewport extends FirstPersonViewport {
+export default class OrthographicViewport extends Viewport {
   constructor({
     // viewport arguments
     width, // Width of viewport

--- a/src/core/deprecated/viewports/perspective-viewport.js
+++ b/src/core/deprecated/viewports/perspective-viewport.js
@@ -18,13 +18,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import FirstPersonViewport from '../../viewports/first-person-viewport';
+import Viewport from '../../viewports/viewport';
 import mat4_lookAt from 'gl-mat4/lookAt';
 import mat4_perspective from 'gl-mat4/perspective';
 
 const DEGREES_TO_RADIANS = Math.PI / 180;
 
-export default class PerspectiveViewport extends FirstPersonViewport {
+export default class PerspectiveViewport extends Viewport {
   constructor({
     // viewport arguments
     width, // Width of viewport


### PR DESCRIPTION
This is a temporary fix to bring OrthographicViewport-dependent apps to a good state.
Later the OrthographicViewport will extend the ThirdPersonViewport instead of the base Viewport once all functions are fully tested in new ThirdPersonViewport.

To test:
Use either the `svg-interoperability` or the `graph` example in the /examples folder.
Before: nothing/partially visible in the viewport.
After: visual elements are properly rendered.
(There's a bug in the graph example that the hovered info is y-flipped, will fix in a later PR)