### PR TITLE
Apply default values for transition props

### DIFF
--- a/src/react/experimental/transition-manager.js
+++ b/src/react/experimental/transition-manager.js
@@ -28,7 +28,7 @@ const DEFAULT_PROPS = {
 export default class TransitionManager {
   constructor(props, onTransitionUpdate) {
 
-    this.props = Object.assign({}, DEFAULT_PROPS, props);
+    this.props = Object.assign({}, props);
     this.onTransitionUpdate = onTransitionUpdate;
     this.transitionContext = {
       time: 0,
@@ -200,3 +200,5 @@ export default class TransitionManager {
     }
   }
 }
+
+TransitionManager.defaultProps = DEFAULT_PROPS;

--- a/src/react/viewport-controller.js
+++ b/src/react/viewport-controller.js
@@ -90,7 +90,7 @@ const propTypes = {
 
 const getDefaultCursor = ({isDragging}) => isDragging ? CURSOR.GRABBING : CURSOR.GRAB;
 
-const defaultProps = {
+const defaultProps = Object.assign({}, TransitionManager.defaultProps, {
   onViewportChange: null,
 
   scrollZoom: true,
@@ -100,7 +100,7 @@ const defaultProps = {
   touchZoomRotate: true,
 
   getCursor: getDefaultCursor
-};
+});
 
 export default class ViewportController extends PureComponent {
 


### PR DESCRIPTION
Default props of transition params were not always applied, make them part of `ViewportController` `defaultProps`.

Verified with : 
test-browser
layer-browser ( interact with map to trigger viewport change, default values get applied here)
all 3 viewport transition examples.