### PR TITLE
Examples: set useDevicePixelRatio by default

### DIFF
--- a/dev-docs/RFCs/v5.0/multi-viewport-rfc.md
+++ b/dev-docs/RFCs/v5.0/multi-viewport-rfc.md
@@ -169,7 +169,6 @@ Since deck.gl is WebGL based, all its viewports need to be in the same canvas (u
         width={viewportProps.width}
         height={viewportProps.height}
         viewports={viewports}
-        useDevicePixelRatio={false}
         layers={this._renderLayers()} />
 
     </ViewportLayout>

--- a/docs/advanced/viewports.md
+++ b/docs/advanced/viewports.md
@@ -141,7 +141,6 @@ In this example the `StaticMap` component gets automatically position under the 
           width={viewportProps.width}
           height={viewportProps.height}
           viewports={viewports}
-          useDevicePixelRatio={false}
           layers={this._renderLayers()} />
 
       </ViewportLayout>

--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -55,7 +55,7 @@ class App extends PureComponent {
       },
       settings: {
         multiview: false,
-        useDevicePixelRatio: false,
+        useDevicePixelRatio: true,
         pickingRadius: 0,
         drawPickingColors: false,
 

--- a/examples/wip/first-person-map/app.js
+++ b/examples/wip/first-person-map/app.js
@@ -269,7 +269,6 @@ class Root extends Component {
             width={viewportProps.width}
             height={viewportProps.height}
             viewports={viewports}
-            useDevicePixelRatio={false}
             layers={this._renderLayers()}
             initWebGLParameters
           >


### PR DESCRIPTION
Before this feature is added layer-browser rendered with full device pixel ratio, match the behavior by setting `useDevicePixelRatio` default value to true in the example. 