### PR TITLE
Move text layer to experimental layers

### DIFF
--- a/examples/layer-browser/src/examples/experimental-layers.js
+++ b/examples/layer-browser/src/examples/experimental-layers.js
@@ -1,4 +1,10 @@
-import {MeshLayer, PathOutlineLayer, PathMarkerLayer, Arrow2DGeometry} from 'deck.gl-layers';
+import {
+  MeshLayer,
+  PathOutlineLayer,
+  PathMarkerLayer,
+  Arrow2DGeometry,
+  TextLayer
+} from 'deck.gl-layers';
 
 import {GL} from 'luma.gl';
 import dataSamples from '../immutable-data-samples';
@@ -64,11 +70,29 @@ const PathMarkerExample = {
   }
 };
 
+const TextLayerExample = {
+  layer: TextLayer,
+  getData: () => dataSamples.points.slice(0, 50),
+  props: {
+    id: 'text-layer',
+    getText: x => `${x.PLACEMENT}-${x.YR_INSTALLED}`,
+    getPosition: x => x.COORDINATES,
+    getColor: x => [153, 0, 0],
+    getSize: x => 32,
+    getAngle: x => 0,
+    sizeScale: 1,
+    getTextAnchor: x => 'start',
+    getAlignmentBaseline: x => 'center',
+    getPixelOffset: x => [10, 0]
+  }
+};
+
 /* eslint-disable quote-props */
 export default {
   'Experimental Layers': {
     'MeshLayer': MeshLayerExample,
     'PathOutlineLayer': PathOutlineExample,
-    'PathMarkerLayer': PathMarkerExample
+    'PathMarkerLayer': PathMarkerExample,
+    'TextLayer': TextLayerExample
   }
 };

--- a/src/experimental-layers/src/index.js
+++ b/src/experimental-layers/src/index.js
@@ -7,5 +7,6 @@ export {default as PathMarkerLayer} from './path-marker-layer/path-marker-layer'
 export {default as PathOutlineLayer} from './path-outline-layer/path-outline-layer';
 
 export {default as Arrow2DGeometry} from './path-marker-layer/arrow-2d-geometry';
+export {default as TextLayer} from './text-layer/text-layer';
 
 export {default as outline} from './shaderlib/outline/outline';

--- a/src/experimental-layers/src/text-layer/font-atlas.js
+++ b/src/experimental-layers/src/text-layer/font-atlas.js
@@ -1,0 +1,62 @@
+/* global document */
+import {Texture2D} from 'luma.gl';
+
+const MAX_CANVAS_WIDTH = 1024;
+const fontSize = 64;
+const padding = 2;
+
+const charList = [];
+for (let i = 32; i < 128; i++) {
+  charList.push(String.fromCharCode(i));
+}
+
+function setTextStyle(ctx, fontFamily) {
+  ctx.font = `${fontSize}px ${fontFamily}`;
+  ctx.fillStyle = '#000';
+  ctx.textBaseline = 'hanging';
+  ctx.textAlign = 'left';
+}
+
+export function makeFontAtlas(gl, fontFamily) {
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+  setTextStyle(ctx, fontFamily);
+
+  // measure texts
+  let row = 0;
+  let x = 0;
+  const mapping = {};
+
+  charList.forEach(char => {
+    const {width} = ctx.measureText(char);
+    if (x + width > MAX_CANVAS_WIDTH) {
+      x = 0;
+      row++;
+    }
+    mapping[char] = {
+      x,
+      y: row * (fontSize + padding),
+      width,
+      height: fontSize,
+      mask: true
+    };
+    x += width;
+  });
+
+  canvas.width = MAX_CANVAS_WIDTH;
+  canvas.height = (row + 1) * (fontSize + padding);
+
+  setTextStyle(ctx, fontFamily);
+  for (const char in mapping) {
+    ctx.fillText(char, mapping[char].x, mapping[char].y);
+  }
+
+  return {
+    mapping,
+    texture: new Texture2D(gl, {
+      pixels: canvas
+      // no need to specify texture filter here
+      // icon layer use the most accurate mode by default
+    })
+  };
+}

--- a/src/experimental-layers/src/text-layer/multi-icon-layer/multi-icon-layer-vertex-64.glsl.js
+++ b/src/experimental-layers/src/text-layer/multi-icon-layer/multi-icon-layer-vertex-64.glsl.js
@@ -1,0 +1,106 @@
+// Copyright (c) 2015 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+export default `\
+#define SHADER_NAME multi-icon-layer-vertex-shader-64
+
+attribute vec2 positions;
+
+attribute vec3 instancePositions;
+attribute vec2 instancePositions64xyLow;
+attribute float instanceSizes;
+attribute float instanceAngles;
+attribute vec4 instanceColors;
+attribute vec3 instancePickingColors;
+attribute vec4 instanceIconFrames;
+attribute float instanceColorModes;
+attribute vec2 instanceOffsets;
+
+// the following three attributes are for the multi-icon layer
+attribute float instanceIndexOfIcon;
+attribute float instanceNumOfIcon;
+attribute vec2 instancePixelOffset;
+
+uniform vec2 viewportSize;
+uniform float sizeScale;
+uniform vec2 iconsTextureDim;
+
+varying float vColorMode;
+varying vec4 vColor;
+varying vec2 vTextureCoords;
+
+vec2 rotate_by_angle(vec2 vertex, float angle) {
+  float angle_radian = angle * PI / 180.0;
+  float cos_angle = cos(angle_radian);
+  float sin_angle = sin(angle_radian);
+  mat2 rotationMatrix = mat2(cos_angle, -sin_angle, sin_angle, cos_angle);
+  return rotationMatrix * vertex;
+}
+
+vec2 getShift(float instanceIndexOfIcon, float instanceNumOfIcon) {
+  // calculate the middle index of the string
+  float midIndex = (instanceNumOfIcon - 1.0) / 2.0;
+  // calculate horizontal shift of each letter
+  return vec2(instanceIndexOfIcon - midIndex, 0.0);
+}
+
+void main(void) {
+  vec2 iconSize = instanceIconFrames.zw;
+  // scale icon height to match instanceSize
+  float instanceScale = iconSize.y == 0.0 ? 0.0 : instanceSizes / iconSize.y;
+
+  // scale and rotate vertex in "pixel" value and convert back to fraction in clipspace
+  vec2 shift = getShift(instanceIndexOfIcon, instanceNumOfIcon);
+  vec2 pixelOffset = (positions / 2.0 + shift) * iconSize + instanceOffsets;
+
+  pixelOffset = rotate_by_angle(pixelOffset, instanceAngles) * sizeScale * instanceScale;
+  pixelOffset += instancePixelOffset;
+  pixelOffset.y *= -1.0;
+
+  vec4 instancePositions64xy = vec4(
+  instancePositions.x, instancePositions64xyLow.x,
+  instancePositions.y, instancePositions64xyLow.y);
+
+  vec2 projected_coord_xy[2];
+  project_position_fp64(instancePositions64xy, projected_coord_xy);
+
+  vec2 vertex_pos_modelspace[4];
+  vertex_pos_modelspace[0] = projected_coord_xy[0];
+  vertex_pos_modelspace[1] = projected_coord_xy[1];
+  vertex_pos_modelspace[2] = vec2(project_scale(instancePositions.z), 0.0);
+  vertex_pos_modelspace[3] = vec2(1.0, 0.0);
+
+  gl_Position = project_to_clipspace_fp64(vertex_pos_modelspace);
+  gl_Position += project_pixel_to_clipspace(pixelOffset);
+
+  vTextureCoords = mix(
+    instanceIconFrames.xy,
+    instanceIconFrames.xy + iconSize,
+    (positions.xy + 1.0) / 2.0
+  ) / iconsTextureDim;
+
+  vTextureCoords.y = 1.0 - vTextureCoords.y;
+
+  vColor = instanceColors / 255.;
+  picking_setPickingColor(instancePickingColors);
+
+  vColorMode = instanceColorModes;
+}
+`;

--- a/src/experimental-layers/src/text-layer/multi-icon-layer/multi-icon-layer-vertex.glsl.js
+++ b/src/experimental-layers/src/text-layer/multi-icon-layer/multi-icon-layer-vertex.glsl.js
@@ -1,0 +1,93 @@
+// Copyright (c) 2015 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+export default `\
+#define SHADER_NAME multi-icon-layer-vertex-shader
+
+attribute vec2 positions;
+
+attribute vec3 instancePositions;
+attribute float instanceSizes;
+attribute float instanceAngles;
+attribute vec4 instanceColors;
+attribute vec3 instancePickingColors;
+attribute vec4 instanceIconFrames;
+attribute float instanceColorModes;
+attribute vec2 instanceOffsets;
+
+// the following three attributes are for the multi-icon layer
+attribute float instanceIndexOfIcon;
+attribute float instanceNumOfIcon;
+attribute vec2 instancePixelOffset;
+
+uniform vec2 viewportSize;
+uniform float sizeScale;
+uniform vec2 iconsTextureDim;
+
+varying float vColorMode;
+varying vec4 vColor;
+varying vec2 vTextureCoords;
+
+vec2 rotate_by_angle(vec2 vertex, float angle) {
+  float angle_radian = angle * PI / 180.0;
+  float cos_angle = cos(angle_radian);
+  float sin_angle = sin(angle_radian);
+  mat2 rotationMatrix = mat2(cos_angle, -sin_angle, sin_angle, cos_angle);
+  return rotationMatrix * vertex;
+}
+
+vec2 getShift(float instanceIndexOfIcon, float instanceNumOfIcon) {
+  // calculate the middle index of the string
+  float midIndex = (instanceNumOfIcon - 1.0) / 2.0;
+  // calculate horizontal shift of each letter
+  return vec2(instanceIndexOfIcon - midIndex, 0.0);
+}
+
+void main(void) {
+  vec2 iconSize = instanceIconFrames.zw;
+  // scale icon height to match instanceSize
+  float instanceScale = iconSize.y == 0.0 ? 0.0 : instanceSizes / iconSize.y;
+
+  // scale and rotate vertex in "pixel" value and convert back to fraction in clipspace
+  vec2 shift = getShift(instanceIndexOfIcon, instanceNumOfIcon);
+  vec2 pixelOffset = (positions / 2.0 + shift) * iconSize + instanceOffsets;
+
+  pixelOffset = rotate_by_angle(pixelOffset, instanceAngles) * sizeScale * instanceScale;
+  pixelOffset += instancePixelOffset;
+  pixelOffset.y *= -1.0;
+
+  vec3 center = project_position(instancePositions);
+  gl_Position = project_to_clipspace(vec4(center, 1.0));
+  gl_Position += project_pixel_to_clipspace(pixelOffset);
+
+  vTextureCoords = mix(
+    instanceIconFrames.xy,
+    instanceIconFrames.xy + iconSize,
+    (positions.xy + 1.0) / 2.0
+  ) / iconsTextureDim;
+
+  vTextureCoords.y = 1.0 - vTextureCoords.y;
+
+  vColor = instanceColors / 255.;
+  picking_setPickingColor(instancePickingColors);
+
+  vColorMode = instanceColorModes;
+}
+`;

--- a/src/experimental-layers/src/text-layer/multi-icon-layer/multi-icon-layer.js
+++ b/src/experimental-layers/src/text-layer/multi-icon-layer/multi-icon-layer.js
@@ -1,0 +1,112 @@
+// Copyright (c) 2015 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import {IconLayer, experimental} from 'deck.gl';
+const {enable64bitSupport} = experimental;
+
+import vs from './multi-icon-layer-vertex.glsl';
+import vs64 from './multi-icon-layer-vertex-64.glsl';
+
+const defaultProps = {
+  ...IconLayer.defaultProps,
+  getIndexOfIcon: x => x.index || 0,
+  getNumOfIcon: x => x.len || 1,
+  // 1: left, 0: middle, -1: right
+  getAnchorX: x => x.anchorX || 0,
+  // 1: top, 0: center, -1: bottom
+  getAnchorY: x => x.anchorY || 0,
+  getPixelOffset: x => x.pixelOffset || [0, 0]
+};
+
+export default class MultiIconLayer extends IconLayer {
+  getShaders() {
+    const multiIconVs = enable64bitSupport(this.props) ? vs64 : vs;
+    return Object.assign({}, super.getShaders(), {
+      vs: multiIconVs
+    });
+  }
+
+  initializeState() {
+    super.initializeState();
+
+    const {attributeManager} = this.state;
+    attributeManager.addInstanced({
+      instanceIndexOfIcon: {
+        size: 1,
+        accessor: 'getIndexOfIcon',
+        update: this.calculateInstanceIndexOfIcon
+      },
+      instanceNumOfIcon: {
+        size: 1,
+        accessor: 'getNumOfIcon',
+        update: this.calculateInstanceNumOfIcon
+      },
+      instancePixelOffset: {
+        size: 2,
+        accessor: 'getPixelOffset',
+        update: this.calculatePixelOffset
+      }
+    });
+  }
+
+  calculateInstanceIndexOfIcon(attribute) {
+    const {data, getIndexOfIcon} = this.props;
+    const {value} = attribute;
+    let i = 0;
+    for (const object of data) {
+      value[i++] = getIndexOfIcon(object);
+    }
+  }
+
+  calculateInstanceNumOfIcon(attribute) {
+    const {data, getNumOfIcon} = this.props;
+    const {value} = attribute;
+    let i = 0;
+    for (const object of data) {
+      value[i++] = getNumOfIcon(object);
+    }
+  }
+
+  calculateInstanceOffsets(attribute) {
+    const {data, iconMapping, getIcon, getAnchorX, getAnchorY, getNumOfIcon} = this.props;
+    const {value} = attribute;
+    let i = 0;
+    for (const object of data) {
+      const icon = getIcon(object);
+      const rect = iconMapping[icon] || {};
+      value[i++] = rect.width / 2 * getAnchorX(object) * getNumOfIcon(object) || 0;
+      value[i++] = rect.height / 2 * getAnchorY(object) || 0;
+    }
+  }
+
+  calculatePixelOffset(attribute) {
+    const {data, getPixelOffset} = this.props;
+    const {value} = attribute;
+    let i = 0;
+    for (const object of data) {
+      const pixelOffset = getPixelOffset(object);
+      value[i++] = pixelOffset[0] || 0;
+      value[i++] = pixelOffset[1] || 0;
+    }
+  }
+}
+
+MultiIconLayer.layerName = 'MultiIconLayer';
+MultiIconLayer.defaultProps = defaultProps;

--- a/src/experimental-layers/src/text-layer/text-layer.js
+++ b/src/experimental-layers/src/text-layer/text-layer.js
@@ -1,0 +1,155 @@
+// Copyright (c) 2015 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import {CompositeLayer} from 'deck.gl';
+import MultiIconLayer from './multi-icon-layer/multi-icon-layer';
+import {makeFontAtlas} from './font-atlas';
+
+const DEFAULT_COLOR = [0, 0, 0, 255];
+const TEXT_ANCHOR = {
+  start: 1,
+  middle: 0,
+  end: -1
+};
+const ALIGNMENT_BASELINE = {
+  top: 1,
+  center: 0,
+  bottom: -1
+};
+// currently the font family is invisible to the user
+const FONT_FAMILY = '"Lucida Console", Monaco, monospace';
+
+const defaultProps = {
+  getText: x => x.text,
+  getPosition: x => x.coordinates,
+  getColor: x => x.color || DEFAULT_COLOR,
+  getSize: x => x.size || 32,
+  getAngle: x => x.angle || 0,
+  getTextAnchor: x => x.textAnchor || 'middle',
+  getAlignmentBaseline: x => x.alignmentBaseline || 'center',
+  getPixelOffset: x => x.pixelOffset || [0, 0],
+  fp64: false
+};
+
+export default class TextLayer extends CompositeLayer {
+  initializeState() {
+    const {gl} = this.context;
+    const {mapping, texture} = makeFontAtlas(gl, FONT_FAMILY);
+    this.state = {
+      iconAtlas: texture,
+      iconMapping: mapping
+    };
+  }
+
+  shouldUpdateState({changeFlags}) {
+    return changeFlags.somethingChanged;
+  }
+
+  updateState({props, oldProps, changeFlags}) {
+    if (changeFlags.dataChanged) {
+      this.transformStringToLetters();
+    }
+  }
+
+  transformStringToLetters() {
+    const {data, getText, getPosition} = this.props;
+    if (!data || data.length === 0) {
+      return;
+    }
+
+    const transformedData = data
+      .map(val => {
+        const text = getText(val);
+        const letters = Array.from(text);
+        const position = getPosition(val);
+        if (!text) {
+          return [];
+        }
+        return letters.map((letter, i) =>
+          Object.assign({}, val, {text: letter, position, index: i, len: text.length})
+        );
+      })
+      .reduce((prev, curr) => [...prev, ...curr]);
+
+    this.setState({data: transformedData});
+  }
+
+  getAnchorXFromTextAnchor(textAnchor) {
+    if (!TEXT_ANCHOR.hasOwnProperty(textAnchor)) {
+      throw new Error(`Invalid text anchor parameter: ${textAnchor}`);
+    }
+    return TEXT_ANCHOR[textAnchor];
+  }
+
+  getAnchorYFromAlignmentBaseline(alignmentBaseline) {
+    if (!ALIGNMENT_BASELINE.hasOwnProperty(alignmentBaseline)) {
+      throw new Error(`Invalid alignment baseline parameter: ${alignmentBaseline}`);
+    }
+    return ALIGNMENT_BASELINE[alignmentBaseline];
+  }
+
+  renderLayers() {
+    const {data, iconAtlas, iconMapping} = this.state;
+
+    if (!iconMapping || !iconAtlas || !data) {
+      return null;
+    }
+
+    const {
+      getColor,
+      getSize,
+      getAngle,
+      getTextAnchor,
+      getAlignmentBaseline,
+      getPixelOffset,
+      fp64
+    } = this.props;
+
+    return [
+      new MultiIconLayer(
+        Object.assign({}, this.props, {
+          id: 'multi-icon-layer-for-text-rendering',
+          data,
+          iconAtlas,
+          iconMapping,
+          getIcon: d => d.text,
+          getPosition: d => d.position,
+          getIndexOfIcon: d => d.index,
+          getNumOfIcon: d => d.len,
+          getColor,
+          getSize,
+          getAngle,
+          getAnchorX: d => this.getAnchorXFromTextAnchor(getTextAnchor(d)),
+          getAnchorY: d => this.getAnchorYFromAlignmentBaseline(getAlignmentBaseline(d)),
+          getPixelOffset,
+          fp64,
+          updateTriggers: {
+            getAngle,
+            getColor,
+            getSize
+          }
+        })
+      )
+    ];
+  }
+}
+
+TextLayer.layerName = 'TextLayer';
+TextLayer.defaultProps = defaultProps;

--- a/src/experimental-layers/src/text-layer/text-layer.md
+++ b/src/experimental-layers/src/text-layer/text-layer.md
@@ -1,0 +1,106 @@
+
+# Text Layer
+
+### About
+
+The text layer renders text labels on the map using texture mapping. Compared to the existing label-layer in deck.gl, this version is more scalable as it does not require dynamically generating texture for each label. Instead, each character in the label is regarded as an icon in a [font atlas](./font) and is iteratively rendered.
+This Layer is extended based on [Icon Layer](/docs/layers/icon-layer.md) and wrapped using [Composite Layer](/docs/api-reference/composite-layer.md).
+
+### Example
+
+```js
+
+import DeckGL from 'deck.gl';
+import TextLayer from './text-layer';
+
+const App = ({data, viewport}) => {
+
+  /**
+   * Data format:
+   * [
+   *   {text: '#San Francisco', coordinates: [-122.425586, 37.775049]},
+   *   ...
+   * ]
+   */
+
+  const layers = [
+    new TextLayer({
+      id: 'text-layer',
+      data
+    })
+  ];
+
+  return (<DeckGL {...viewport} layers={[layer]} />);
+};
+```
+
+### Data Accessors
+
+##### `getText` (Function, optional)
+
+- Default: `x => x.text`
+
+Method called to retrieve the content of each text label.
+
+##### `getPosition` (Function, optional)
+
+- Default: `x => x.coordinates`
+
+Method called to retrieve the location of each text label.
+
+### Rendering Options
+
+##### `getSize` (Function, optional)
+
+- Default: `x => x.size || 32`
+
+Method called to retrieve the size of each text label. Default value is 32 in pixel.
+
+##### `getColor` (Function, optional)
+
+- Default: `x => x.color || [0, 0, 0, 255]`
+
+Method called to retrieve the color of each text label. Default value is black.
+
+##### `getAngle` (Function, optional)
+
+- Default: `x => x.angle || 0`
+
+Method called to retrieve the angle to rotate (CCW) of each text label. Default value is 0.
+
+##### `sizeScale` (Number, optional)
+
+- Default: 1
+
+Text size multiplier.
+
+##### `fp64` (Boolean, optional)
+
+- Default: `false`
+
+Whether the layer should be rendered in high-precision 64-bit mode.
+
+### Text Alignment Options
+
+##### `getTextAnchor` (Function, optional)
+
+- Default: `x => x.textAnchor || 'middle'`
+
+Method called to specify the text anchor. Available options include `'start'`, `'middle'` and `'end'`.
+
+##### `getAlignmentBaseline` (Function, optional)
+
+- Default: `x => x.alignmentBaseline || 'center'`
+
+Method called to specify the alignment baseline. Available options include `'top'`, `'center'` and `'bottom'`.
+
+##### `getPixelOffset` (Function, optional)
+
+- Default: `x.pixelOffset || [0, 0]`
+
+Method called to specify screen space offset relative to the `coordinates` in pixel unit. This function is rarely used in common cases.
+
+### Font Style and Character Set Support
+Currently, the layer uses a monospaced font style called [Lucida Console](https://en.wikipedia.org/wiki/Lucida#Lucida_Console). While this meets most of the usage scenarios, you can customize to use your own font styles or unicode characters. Basically, you need to generate the texture atlas for the character set. Look at `font.png` and `font.json` in the `font` folder for details. You may find a few open source libraries for doing this. The one used in this example can be found [here](https://github.com/rivulet-zhang/Font-Atlas-Generator).
+
+In addition, the layer only supports the ASCII character set for now. If the text label happens to contain unicode characters, the layer replaces them with a single space and renders the text label without throwing an error.

--- a/src/experimental-layers/src/text-layer/text-layer.md
+++ b/src/experimental-layers/src/text-layer/text-layer.md
@@ -3,8 +3,7 @@
 
 ### About
 
-The text layer renders text labels on the map using texture mapping. Compared to the existing label-layer in deck.gl, this version is more scalable as it does not require dynamically generating texture for each label. Instead, each character in the label is regarded as an icon in a [font atlas](./font) and is iteratively rendered.
-This Layer is extended based on [Icon Layer](/docs/layers/icon-layer.md) and wrapped using [Composite Layer](/docs/api-reference/composite-layer.md).
+The text layer renders text labels on the map using texture mapping. This Layer is extended based on [Icon Layer](/docs/layers/icon-layer.md) and wrapped using [Composite Layer](/docs/api-reference/composite-layer.md).
 
 ### Example
 
@@ -101,6 +100,4 @@ Method called to specify the alignment baseline. Available options include `'top
 Method called to specify screen space offset relative to the `coordinates` in pixel unit. This function is rarely used in common cases.
 
 ### Font Style and Character Set Support
-Currently, the layer uses a monospaced font style called [Lucida Console](https://en.wikipedia.org/wiki/Lucida#Lucida_Console). While this meets most of the usage scenarios, you can customize to use your own font styles or unicode characters. Basically, you need to generate the texture atlas for the character set. Look at `font.png` and `font.json` in the `font` folder for details. You may find a few open source libraries for doing this. The one used in this example can be found [here](https://github.com/rivulet-zhang/Font-Atlas-Generator).
-
-In addition, the layer only supports the ASCII character set for now. If the text label happens to contain unicode characters, the layer replaces them with a single space and renders the text label without throwing an error.
+Currently, the layer uses a monospaced font style called [Lucida Console](https://en.wikipedia.org/wiki/Lucida#Lucida_Console) and only supports the ASCII character set. If the text label happens to contain unicode characters, the layer replaces them with a single space and renders the text label without throwing an error.


### PR DESCRIPTION
A few changes to the original text layer in the example folder:

- New features added: including `getTextAnchor`, `getAlignmentBaseline`, `getPixelOffset`. (Details in the doc)
- Dynamically generate font atlas once the layer is initialized. No need to read static json and bitmap files. This change avoids the headache of adding additional webpack loaders or plugins to deal with those static assets.
- Use `project_pixel_to_clipspace` in the shader to deal with conversion between pixels and clipspace coordinates. (Will create another PR to make this change to the icon layer)
- An example added in the layer-browser. Run `yarn start-local` to see the result.

Once this is officially added to the core layers, we can remove the duplicated code in the text-layer and tagmap examples.