### PR TITLE
Transition manager improvements

### DIFF
--- a/src/react/experimental/transition-manager.js
+++ b/src/react/experimental/transition-manager.js
@@ -1,13 +1,12 @@
-/* global setInterval, clearInterval */
+/* global requestAnimationFrame, cancelAnimationFrame */
 import assert from 'assert';
 import {
   viewportLinearInterpolator,
   extractViewportFrom,
-  VIEWPORT_PROPS
+  areViewportsEqual
 } from './viewport-transition-utils';
 
-const VIEWPORT_TRANSITION_FREQUENCY = 0.06; // 60 times per second.
-const VIEWPORT_TRANSITION_EASING_FUNC = t => t;
+const noop = () => {};
 
 export const TRANSITION_EVENTS = {
   BREAK: 1,
@@ -18,185 +17,159 @@ export const TRANSITION_EVENTS = {
 const DEFAULT_PROPS = {
   transitionDuration: 0,
   transitionInterpolator: viewportLinearInterpolator,
-  transitionEasing: VIEWPORT_TRANSITION_EASING_FUNC,
+  transitionEasing: t => t,
   transitionInterruption: TRANSITION_EVENTS.BREAK,
-  onTransitionStart: () => {},
-  onTransitionInterrupt: () => {},
-  onTransitionEnd: () => {}
+  onTransitionStart: noop,
+  onTransitionInterrupt: noop,
+  onTransitionEnd: noop
+};
+
+const DEFAULT_STATE = {
+  animation: null,
+  viewport: null,
+  startViewport: null,
+  endViewport: null
 };
 
 export default class TransitionManager {
-  constructor(props, onTransitionUpdate) {
+  constructor(props) {
+    this.props = props;
+    this.state = DEFAULT_STATE;
 
-    this.props = Object.assign({}, props);
-    this.onTransitionUpdate = onTransitionUpdate;
-    this.transitionContext = {
-      time: 0,
-      delta: 0,
-      interval: null,
-      viewport: null,
-      startViewport: null,
-      endViewport: null
-    };
+    this._onTransitionFrame = this._onTransitionFrame.bind(this);
   }
 
   // Returns current transitioned viewport.
-  getTransionedViewport() {
-    return this.transitionContext.viewport;
+  getViewportInTransition() {
+    return this.state.viewport;
   }
 
   // Process the vewiport change, either ignore or trigger a new transiton.
-  processViewportChange(props, nextProps) {
+  processViewportChange(nextProps) {
+
     // NOTE: Be cautious re-ordering statements in this function.
     if (this._shouldIgnoreViewportChange(nextProps)) {
+      this.props = nextProps;
       return;
     }
 
-    // Save current transtion details before ending it.
-    const shouldSnapToEnd = this._shouldSnapToEnd();
-    const endViewport = this.transitionContext.endViewport;
-    if (this._isTransitionInProgress()) {
+    const isTransitionInProgress = this._isTransitionInProgress();
+
+    if (this._isTransitionEnabled(nextProps)) {
+      const currentViewport = this.state.viewport || extractViewportFrom(this.props);
+      const endViewport = this.state.endViewport;
+
+      const startViewport = this.state.interruption === TRANSITION_EVENTS.SNAP_TO_END ?
+        (endViewport || currentViewport) :
+        currentViewport;
+
+      this._triggerTransition(startViewport, nextProps);
+
+      if (isTransitionInProgress) {
+        this.props.onTransitionInterrupt();
+      }
+      nextProps.onTransitionStart();
+    } else if (isTransitionInProgress) {
       this.props.onTransitionInterrupt();
       this._endTransition();
     }
 
-    if (this._isTransitionEnabled(nextProps)) {
-      const currentViewport = extractViewportFrom(props);
-      const startViewport = shouldSnapToEnd ?
-        (endViewport || currentViewport) :
-        currentViewport;
-      this._triggerTransition(startViewport, nextProps);
-      if (nextProps.onTransitionStart) {
-        nextProps.onTransitionStart();
-      }
-    }
-
-    const newProps = Object.assign({}, this.props, nextProps);
-    this.props = newProps;
+    this.props = nextProps;
   }
 
   // Helper methods
 
-  /* eslint-disable max-depth */
-  _areViewportsEqual(startViewport, endViewport) {
-    for (const p of VIEWPORT_PROPS) {
-      if (Array.isArray(startViewport[p])) {
-        for (let i = 0; i < startViewport[p].length; ++i) {
-          if (startViewport[p][i] !== endViewport[p][i]) {
-            return false;
-          }
-        }
-      } else if (startViewport[p] !== endViewport[p]) {
-        return false;
-      }
-    }
-    return true;
-  }
-  /* eslint-enable max-depth */
-
-  _createTransitionInterval(updateFrequency) {
-    if (this.transitionContext.interval) {
-      clearInterval(this.transitionContext.interval);
-    }
-    return setInterval(() => this._updateViewport(), updateFrequency);
-  }
-
-  _endTransition() {
-    clearInterval(this.transitionContext.interval);
-    this.transitionContext = {
-      time: 0,
-      delta: 0,
-      interval: null,
-      viewport: null,
-      startViewport: null,
-      endViewport: null
-    };
-  }
-
   _isTransitionInProgress() {
-    return this.transitionContext.interval;
+    return this.state.viewport;
   }
 
   _isTransitionEnabled(props) {
-    return props.transitionDuration !== 0;
+    return props.transitionDuration > 0;
   }
 
-  _isUpdateDueToCurrentTransition(nextProps) {
-    if (this.transitionContext.viewport) {
-      const newViewport = extractViewportFrom(nextProps);
-      return this._areViewportsEqual(newViewport, this.transitionContext.viewport);
+  _isUpdateDueToCurrentTransition(props) {
+    if (this.state.viewport) {
+      return areViewportsEqual(props, this.state.viewport);
     }
     return false;
   }
 
   _shouldIgnoreViewportChange(nextProps) {
     // Ignore update if it is due to current active transition.
-    if (this._isUpdateDueToCurrentTransition(nextProps)) {
-      return true;
-    }
-
     // Ignore update if it is requested to be ignored
-    if (this._isTransitionInProgress() &&
-      this.props.transitionInterruption === TRANSITION_EVENTS.IGNORE) {
+    if (this._isTransitionInProgress()) {
+      if (this.state.interruption === TRANSITION_EVENTS.IGNORE ||
+        this._isUpdateDueToCurrentTransition(nextProps)) {
+        return true;
+      }
+    } else if (!this._isTransitionEnabled(nextProps)) {
       return true;
     }
 
     // Ignore if none of the viewport props changed.
-    const start = extractViewportFrom(this.props);
-    const end = extractViewportFrom(nextProps);
-    if (this._areViewportsEqual(start, end)) {
+    if (areViewportsEqual(this.props, nextProps)) {
       return true;
     }
 
     return false;
   }
 
-  _shouldSnapToEnd() {
-    return (this.transitionContext.interval &&
-      this.props.transitionInterruption === TRANSITION_EVENTS.SNAP_TO_END);
-  }
-
   _triggerTransition(startViewport, nextProps) {
     assert(nextProps.transitionDuration !== 0);
-    const delta = 1.0 / (nextProps.transitionDuration * VIEWPORT_TRANSITION_FREQUENCY);
     const endViewport = extractViewportFrom(nextProps);
-    const interval = this._createTransitionInterval(VIEWPORT_TRANSITION_FREQUENCY);
-    assert(delta < 1.0);
-    this.transitionContext = {
-      time: delta,
-      delta,
+
+    cancelAnimationFrame(this.state.animation);
+
+    this.state = {
+      // Save current transition props
+      duration: nextProps.transitionDuration,
+      easing: nextProps.transitionEasing,
+      interpolator: nextProps.transitionInterpolator,
+      interruption: nextProps.transitionInterruption,
+
+      startTime: Date.now(),
       startViewport,
       endViewport,
-      interval,
+      animation: null,
       viewport: startViewport
     };
+
+    this._onTransitionFrame();
+  }
+
+  _onTransitionFrame() {
+    // _updateViewport() may cancel the animation
+    this.state.animation = requestAnimationFrame(this._onTransitionFrame);
+    this._updateViewport();
+  }
+
+  _endTransition() {
+    cancelAnimationFrame(this.state.animation);
+    this.state = DEFAULT_STATE;
   }
 
   _updateViewport() {
     // NOTE: Be cautious re-ordering statements in this function.
-    const time = this.transitionContext.time;
-    const delta = this.transitionContext.delta;
-    const easing = this.props.transitionEasing(time);
-    const viewport = this.props.transitionInterpolator(
-      this.transitionContext.startViewport,
-      this.transitionContext.endViewport,
-      easing
-    );
-    assert(time <= 1.0);
-    this.transitionContext.viewport = Object.assign(
-      {},
-      this.transitionContext.endViewport,
-      viewport);
-    if (this.onTransitionUpdate) {
-      this.onTransitionUpdate(viewport);
+    const currentTime = Date.now();
+    const {startTime, duration, easing, interpolator, startViewport, endViewport} = this.state;
+
+    let shouldEnd = false;
+    let t = (currentTime - startTime) / duration;
+    if (t >= 1) {
+      t = 1;
+      shouldEnd = true;
+    }
+    t = easing(t);
+
+    const viewport = interpolator(startViewport, endViewport, t);
+    this.state.viewport = Object.assign({}, endViewport, viewport);
+    if (this.props.onViewportChange) {
+      this.props.onViewportChange(this.state.viewport);
     }
 
-    if (time === 1.0) {
+    if (shouldEnd) {
       this._endTransition();
       this.props.onTransitionEnd();
-    } else {
-      // Make sure interplation step is always ends with time = 1.0
-      this.transitionContext.time = (time + delta) > 1.0 ? 1.0 : (time + delta);
     }
   }
 }

--- a/src/react/experimental/transition-manager.js
+++ b/src/react/experimental/transition-manager.js
@@ -162,7 +162,7 @@ export default class TransitionManager {
     t = easing(t);
 
     const viewport = interpolator(startViewport, endViewport, t);
-    this.state.viewport = Object.assign({}, endViewport, viewport);
+    this.state.viewport = extractViewportFrom(Object.assign({}, this.props, viewport));
     if (this.props.onViewportChange) {
       this.props.onViewportChange(this.state.viewport);
     }

--- a/src/react/experimental/viewport-transition-utils.js
+++ b/src/react/experimental/viewport-transition-utils.js
@@ -4,8 +4,28 @@ import {projectFlat, unprojectFlat} from 'viewport-mercator-project';
 import {Vector2} from 'math.gl';
 
 const EPSILON = 0.01;
-export const VIEWPORT_PROPS = ['longitude', 'latitude', 'zoom', 'bearing', 'pitch',
+const VIEWPORT_PROPS = ['longitude', 'latitude', 'zoom', 'bearing', 'pitch',
   'position', 'width', 'height'];
+const VIEWPORT_INTERPOLATION_PROPS =
+  ['longitude', 'latitude', 'zoom', 'bearing', 'pitch', 'position'];
+
+/** Util functions */
+function lerp(start, end, step) {
+  if (Array.isArray(start)) {
+    return start.map((element, index) => {
+      return lerp(element, end[index], step);
+    });
+  }
+  return step * end + (1 - step) * start;
+}
+
+function zoomToScale(zoom) {
+  return Math.pow(2, zoom);
+}
+
+function scaleToZoom(scale) {
+  return Math.log2(scale);
+}
 
 export function extractViewportFrom(props) {
   const viewport = {};
@@ -17,6 +37,23 @@ export function extractViewportFrom(props) {
   return viewport;
 }
 
+/* eslint-disable max-depth */
+export function areViewportsEqual(startViewport, endViewport) {
+  for (const p of VIEWPORT_INTERPOLATION_PROPS) {
+    if (Array.isArray(startViewport[p])) {
+      for (let i = 0; i < startViewport[p].length; ++i) {
+        if (startViewport[p][i] !== endViewport[p][i]) {
+          return false;
+        }
+      }
+    } else if (startViewport[p] !== endViewport[p]) {
+      return false;
+    }
+  }
+  return true;
+}
+/* eslint-enable max-depth */
+
 /**
  * Performs linear interpolation of two viewports.
  * @param {Object} startViewport - object containing starting viewport parameters.
@@ -26,16 +63,6 @@ export function extractViewportFrom(props) {
 */
 export function viewportLinearInterpolator(startViewport, endViewport, t) {
   const viewport = Object.assign({}, endViewport);
-  const VIEWPORT_INTERPOLATION_PROPS =
-    ['longitude', 'latitude', 'zoom', 'bearing', 'pitch', 'position'];
-  function lerp(start, end, step) {
-    if (Array.isArray(start)) {
-      return start.map((element, index) => {
-        return lerp(element, end[index], step);
-      });
-    }
-    return step * end + (1 - step) * start;
-  }
 
   for (const p of VIEWPORT_INTERPOLATION_PROPS) {
     const startValue = startViewport[p];
@@ -64,16 +91,6 @@ export function viewportFlyToInterpolator(startViewport, endViewport, t) {
   // Equations from above paper are referred where needed.
 
   const viewport = Object.assign({}, endViewport);
-
-  function lerp(start, end, step) {
-    return step * end + (1 - step) * start;
-  }
-  function zoomToScale(zoom) {
-    return Math.pow(2, zoom);
-  }
-  function scaleToZoom(scale) {
-    return Math.log(scale) / Math.LN2;
-  }
 
   // TODO: add this as an option for applications.
   const rho = 1.414;
@@ -117,19 +134,17 @@ export function viewportFlyToInterpolator(startViewport, endViewport, t) {
   const b1 = (w1 * w1 - w0 * w0 - rho2 * rho2 * u1 * u1) / (2 * w1 * rho2 * u1);
   const r0 = Math.log(Math.sqrt(b0 * b0 + 1) - b0);
   const r1 = Math.log(Math.sqrt(b1 * b1 + 1) - b1);
-  function w(s) {
-    return (Math.cosh(r0) / Math.cosh(r0 + rho * s));
-  }
-  function u(s) {
-    return w0 * ((Math.cosh(r0) * Math.tanh(r0 + rho * s) - Math.sinh(r0)) / rho2) / u1;
-  }
   const S = (r1 - r0) / rho;
   const s = t * S;
-  const scaleIncrement = 1 / w(s); // Using w method for scaling.
+
+  const w = (Math.cosh(r0) / Math.cosh(r0 + rho * s));
+  const u = w0 * ((Math.cosh(r0) * Math.tanh(r0 + rho * s) - Math.sinh(r0)) / rho2) / u1;
+
+  const scaleIncrement = 1 / w; // Using w method for scaling.
   const newZoom = startZoom + scaleToZoom(scaleIncrement);
 
   const newCenter = unprojectFlat(
-    (startCenterXY.add(uDelta.scale(u(s)))).scale(scaleIncrement),
+    (startCenterXY.add(uDelta.scale(u))).scale(scaleIncrement),
     zoomToScale(newZoom));
   viewport.longitude = newCenter[0];
   viewport.latitude = newCenter[1];

--- a/src/react/experimental/viewport-transition-utils.js
+++ b/src/react/experimental/viewport-transition-utils.js
@@ -62,7 +62,7 @@ export function areViewportsEqual(startViewport, endViewport) {
  * @return {Object} - interpolated viewport for given step.
 */
 export function viewportLinearInterpolator(startViewport, endViewport, t) {
-  const viewport = Object.assign({}, endViewport);
+  const viewport = {};
 
   for (const p of VIEWPORT_INTERPOLATION_PROPS) {
     const startValue = startViewport[p];
@@ -90,7 +90,7 @@ export function viewportLinearInterpolator(startViewport, endViewport, t) {
 export function viewportFlyToInterpolator(startViewport, endViewport, t) {
   // Equations from above paper are referred where needed.
 
-  const viewport = Object.assign({}, endViewport);
+  const viewport = {};
 
   // TODO: add this as an option for applications.
   const rho = 1.414;

--- a/src/react/viewport-controller.js
+++ b/src/react/viewport-controller.js
@@ -113,7 +113,6 @@ export default class ViewportController extends PureComponent {
 
     this._recursiveUpdateChildren = this._recursiveUpdateChildren.bind(this);
     this._updateChildrenViewport = this._updateChildrenViewport.bind(this);
-    this._onTransitionUpdate = this._onTransitionUpdate.bind(this);
   }
 
   componentDidMount() {
@@ -130,7 +129,7 @@ export default class ViewportController extends PureComponent {
       eventManager: this._eventManager
     }));
 
-    this._transitionManger = new TransitionManager(this.props, this._onTransitionUpdate);
+    this._transitionManger = new TransitionManager(this.props);
   }
 
   componentWillUpdate(nextProps) {
@@ -138,21 +137,12 @@ export default class ViewportController extends PureComponent {
       this._controls.setOptions(nextProps);
     }
     if (this._transitionManger) {
-      this._transitionManger.processViewportChange(this.props, nextProps);
+      this._transitionManger.processViewportChange(nextProps);
     }
   }
 
   componentWillUnmount() {
     this._eventManager.destroy();
-  }
-
-  // Helper methods
-  _onTransitionUpdate(viewport) {
-    if (this.props.onViewportChange) {
-      this.props.onViewportChange(viewport);
-    }
-    // Application onViewportChange may or may not trigger a render
-    this.forceUpdate();
   }
 
   _onInteractiveStateChange({isDragging = false}) {
@@ -187,7 +177,7 @@ export default class ViewportController extends PureComponent {
   }
 
   _updateChildrenViewport() {
-    const viewport = (this._transitionManger && this._transitionManger.getTransionedViewport()) ||
+    const viewport = (this._transitionManger && this._transitionManger.getViewportInTransition()) ||
       extractViewportFrom(this.props);
     const childrenWithProps = this._recursiveUpdateChildren(
         this.props.children,


### PR DESCRIPTION
Consolidating changes and feedback from https://github.com/uber/react-map-gl/pull/383

- Fix incorrect timer, replace `setInterval` with `requestAnimationFrame`
- Always use the transition settings from when the transition is triggered (removes the burden from app: set and forget)
- Use `onViewportChange` for transition update callback
- Do not trigger transition on viewport size change
- Do not compare viewports if there's no transition
- Remove nested function definitions in utils
