### PR TITLE
Fix OrthograhicViewport bug and examples

### DIFF
--- a/examples/graph/deckgl-overlay.js
+++ b/examples/graph/deckgl-overlay.js
@@ -34,8 +34,8 @@ export default class DeckGLOverlay extends Component {
 
     // recalculate viewport on container size change.
     const left = -width / 2;
-    const top = -height / 2;
-    const glViewport = new OrthographicViewport({width, height, left, top});
+    const bottom = -height / 2;
+    const glViewport = new OrthographicViewport({width, height, left, bottom});
 
     // TODO: clean up viewport / glViewport
     return (

--- a/examples/svg-interoperability/app.js
+++ b/examples/svg-interoperability/app.js
@@ -124,8 +124,8 @@ class Root extends PureComponent {
   render() {
     const {width, height, viewMode} = this.state;
     const left = -Math.min(width, height) / 2;
-    const top = -Math.min(width, height) / 2;
-    const glViewport = new OrthographicViewport({width, height, left, top});
+    const bottom = -Math.min(width, height) / 2;
+    const glViewport = new OrthographicViewport({width, height, left, bottom});
 
     return width && height && <div>
       {(viewMode === VIEW_MODE.SVG || viewMode === VIEW_MODE.HYBRID) &&

--- a/src/core/deprecated/viewports/orthographic-viewport.js
+++ b/src/core/deprecated/viewports/orthographic-viewport.js
@@ -35,13 +35,13 @@ export default class OrthographicViewport extends Viewport {
     near = 1, // Distance of near clipping plane
     far = 100, // Distance of far clipping plane
     left, // Left bound of the frustum
-    top, // Top bound of the frustum
+    bottom, // Top bound of the frustum
     // automatically calculated
     right = null, // Right bound of the frustum
-    bottom = null // Bottom bound of the frustum
+    top = null // Bottom bound of the frustum
   }) {
     right = Number.isFinite(right) ? right : left + width;
-    bottom = Number.isFinite(bottom) ? bottom : top + height;
+    top = Number.isFinite(top) ? top : bottom + height;
     super({
       viewMatrix: mat4_lookAt([], eye, lookAt, up),
       projectionMatrix: mat4_ortho([], left, right, bottom, top, near, far),


### PR DESCRIPTION
Per issue #1012, found that the OrthographicViewport's top and bottom are inverted. Here change them back and fixed examples.

Tested with graph & svn-interoperability examples.