### PR TITLE
Solidify viewport descriptor (aka `View`) support

### DIFF
--- a/src/core/lib/draw-layers.js
+++ b/src/core/lib/draw-layers.js
@@ -35,10 +35,9 @@ export const getPixelRatio = ({useDevicePixelRatio}) => {
 
 // Convert viewport top-left CSS coordinates to bottom up WebGL coordinates
 const getGLViewport = (gl, {viewport, pixelRatio}) => {
-  const width = gl.canvas.clientWidth;
   const height = gl.canvas.clientHeight;
   // Convert viewport top-left CSS coordinates to bottom up WebGL coordinates
-  const dimensions = viewport.getDimensions({width, height});
+  const dimensions = viewport;
   return [
     dimensions.x * pixelRatio,
     (height - dimensions.y - dimensions.height) * pixelRatio,

--- a/src/core/lib/layer-manager.js
+++ b/src/core/lib/layer-manager.js
@@ -462,11 +462,6 @@ export default class LayerManager {
     return this;
   }
 
-  // Get a viewport from a view descriptor (which can be a plain viewport)
-  _getViewportFromDescriptor(viewportOrDescriptor) {
-    return viewportOrDescriptor.viewport ? viewportOrDescriptor.viewport : viewportOrDescriptor;
-  }
-
   _getPickingBuffer() {
     const {gl} = this.context;
     // Create a frame buffer if not already available

--- a/src/core/pure-js/deck-js.js
+++ b/src/core/pure-js/deck-js.js
@@ -181,13 +181,6 @@ export default class DeckGLJS {
     return this.layerManager ? this.layerManager.getViewports() : [];
   }
 
-  // Experimental
-
-  // Gets actual viewport from a viewport "descriptor" object: viewport || {viewport: ..., ...}
-  _getViewportFromDescriptor(viewportOrDescriptor) {
-    return this.layerManager._getViewportFromDescriptor(viewportOrDescriptor);
-  }
-
   // Private Methods
 
   _createCanvas(props) {

--- a/src/core/viewports/viewport.js
+++ b/src/core/viewports/viewport.js
@@ -334,19 +334,6 @@ export default class Viewport {
 
   // EXPERIMENTAL METHODS
 
-  // Support for relative viewport dimensions
-  // TODO - parses same strings a number of times
-  getDimensions({width, height}) {
-    return {
-      /* eslint-disable max-len */
-      x: typeof this.x === 'string' ? Math.round(parseFloat(this.x) / 100 * width) : this.x,
-      y: typeof this.y === 'string' ? Math.round(parseFloat(this.y) / 100 * height) : this.y,
-      width: typeof this.width === 'string' ? Math.round(parseFloat(this.width) / 100 * width) : this.width,
-      height: typeof this.height === 'string' ? Math.round(parseFloat(this.x) / 100 * height) : this.height
-      /* eslint-enable max-len */
-    };
-  }
-
   getCameraPosition() {
     return this.cameraPosition;
   }

--- a/src/react/deckgl.js
+++ b/src/react/deckgl.js
@@ -66,8 +66,7 @@ export default class DeckGL extends React.Component {
 
     // Build a viewport id to viewport index
     const viewportMap = {};
-    viewports.forEach(viewportDescriptor => {
-      const viewport = this.deck._getViewportFromDescriptor(viewportDescriptor);
+    viewports.forEach(viewport => {
       if (viewport.id) {
         viewportMap[viewport.id] = viewport;
       }
@@ -79,8 +78,7 @@ export default class DeckGL extends React.Component {
       const viewport = viewportId && viewportMap[viewportId];
       if (viewport) {
         // Resolve potentially relative dimensions using the deck.gl container size
-        const {x, y, width, height} =
-          viewport.getDimensions({width: this.props.width, height: this.props.height});
+        const {x, y, width, height} = viewport;
 
         // Clone the element with width and height set per viewport
         const newProps = Object.assign({}, child.props, {


### PR DESCRIPTION
This is a proposal, for exposition.

The basic idea is that deck will take a list of "view descriptors" in preference to viewports. 
* This will allows deck to auto calculate the actual viewport sizes without passing in exact width and height to every viewport.
* Percentage widths and heights  (and x, y) can also be supported for viewports, significantly simplifying complex viewport layouts in apps.
* Going forward, we can add new parameters to each view, such as layer filters etc, while keeping our Viewport classes laser focused on projection related tasks.
* Also the view descriptors can take `viewState` objects, closing the loop on that line of development.
