### PR TITLE
ViewportTransitions: remove recursive children update, fix props update

### DIFF
--- a/examples/wip/viewport-animation-geojson/app.js
+++ b/examples/wip/viewport-animation-geojson/app.js
@@ -3,7 +3,7 @@ import React, {Component} from 'react';
 import {render} from 'react-dom';
 import {StaticMap} from 'react-map-gl';
 import DeckGLOverlay from './deckgl-overlay.js';
-import {ViewportController, MapState, experimental} from 'deck.gl';
+import {ViewportController, MapState, TRANSITION_EVENTS} from 'deck.gl';
 import {json as requestJson} from 'd3-request';
 
 // Set your mapbox token here
@@ -89,7 +89,7 @@ class Root extends Component {
         onViewportChange={this._onViewportChange.bind(this)}
         transitionDuration={transitionDuration}
         transitionEasing={easeInOutElastic}
-        transitionInterruption={experimental.TRANSITION_EVENTS.SNAP_TO_END}>
+        transitionInterruption={TRANSITION_EVENTS.SNAP_TO_END}>
         <StaticMap
           {...viewport}
           onViewportChange={this._onViewportChange.bind(this)}

--- a/examples/wip/viewport-animation/src/app.js
+++ b/examples/wip/viewport-animation/src/app.js
@@ -1,11 +1,15 @@
 /* global window */
 import React, {Component} from 'react';
 import {StaticMap} from 'react-map-gl';
-import {experimental, ViewportController, MapState} from 'deck.gl';
+import {
+  viewportFlyToInterpolator,
+  TRANSITION_EVENTS,
+  ViewportController,
+  MapState
+} from 'deck.gl';
 
 import ControlPanel from './control-panel';
 
-const {viewportFlyToInterpolator, TRANSITION_EVENTS} = experimental;
 const token = process.env.MapboxAccessToken; // eslint-disable-line
 const interruptionStyles = [
   {

--- a/src/core/lib/transition-manager.js
+++ b/src/core/lib/transition-manager.js
@@ -57,6 +57,7 @@ export default class TransitionManager {
 
     const isTransitionInProgress = this._isTransitionInProgress();
     const currentProps = this.props;
+    // Set this.props here as '_triggerTransition' calls '_updateViewport' that uses this.props.
     this.props = nextProps;
 
     if (this._isTransitionEnabled(nextProps)) {

--- a/src/core/lib/transition-manager.js
+++ b/src/core/lib/transition-manager.js
@@ -45,36 +45,42 @@ export default class TransitionManager {
   }
 
   // Process the vewiport change, either ignore or trigger a new transiton.
+  // Return true if a new transition is triggered, false otherwise.
   processViewportChange(nextProps) {
+    let transitionTriggered = false;
 
     // NOTE: Be cautious re-ordering statements in this function.
     if (this._shouldIgnoreViewportChange(nextProps)) {
       this.props = nextProps;
-      return;
+      return transitionTriggered;
     }
 
     const isTransitionInProgress = this._isTransitionInProgress();
+    const currentProps = this.props;
+    this.props = nextProps;
 
     if (this._isTransitionEnabled(nextProps)) {
-      const currentViewport = this.state.viewport || extractViewportFrom(this.props);
+      const currentViewport = this.state.viewport || extractViewportFrom(currentProps);
       const endViewport = this.state.endViewport;
 
       const startViewport = this.state.interruption === TRANSITION_EVENTS.SNAP_TO_END ?
         (endViewport || currentViewport) :
         currentViewport;
 
-      this._triggerTransition(startViewport, nextProps);
-
       if (isTransitionInProgress) {
-        this.props.onTransitionInterrupt();
+        currentProps.onTransitionInterrupt();
       }
-      nextProps.onTransitionStart();
+      this.props.onTransitionStart();
+
+      this._triggerTransition(startViewport);
+
+      transitionTriggered = true;
     } else if (isTransitionInProgress) {
-      this.props.onTransitionInterrupt();
+      currentProps.onTransitionInterrupt();
       this._endTransition();
     }
 
-    this.props = nextProps;
+    return transitionTriggered;
   }
 
   // Helper methods
@@ -114,18 +120,18 @@ export default class TransitionManager {
     return false;
   }
 
-  _triggerTransition(startViewport, nextProps) {
-    assert(nextProps.transitionDuration !== 0);
-    const endViewport = extractViewportFrom(nextProps);
+  _triggerTransition(startViewport) {
+    assert(this.props.transitionDuration !== 0);
+    const endViewport = extractViewportFrom(this.props);
 
     cancelAnimationFrame(this.state.animation);
 
     this.state = {
       // Save current transition props
-      duration: nextProps.transitionDuration,
-      easing: nextProps.transitionEasing,
-      interpolator: nextProps.transitionInterpolator,
-      interruption: nextProps.transitionInterruption,
+      duration: this.props.transitionDuration,
+      easing: this.props.transitionEasing,
+      interpolator: this.props.transitionInterpolator,
+      interruption: this.props.transitionInterruption,
 
       startTime: Date.now(),
       startViewport,
@@ -163,6 +169,7 @@ export default class TransitionManager {
 
     const viewport = interpolator(startViewport, endViewport, t);
     this.state.viewport = extractViewportFrom(Object.assign({}, this.props, viewport));
+
     if (this.props.onViewportChange) {
       this.props.onViewportChange(this.state.viewport);
     }

--- a/src/react/viewport-controller.js
+++ b/src/react/viewport-controller.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import {EventManager} from 'mjolnir.js';
 import {ViewportControls, experimental} from '../core';
-const {TransitionManager, extractViewportFrom} = experimental;
+const {TransitionManager} = experimental;
 
 import CURSOR from './utils/cursors';
 

--- a/src/react/viewport-controller.js
+++ b/src/react/viewport-controller.js
@@ -1,4 +1,4 @@
-import {PureComponent, createElement, cloneElement, Children, isValidElement} from 'react';
+import {PureComponent, createElement} from 'react';
 import PropTypes from 'prop-types';
 
 import {EventManager} from 'mjolnir.js';
@@ -109,9 +109,6 @@ export default class ViewportController extends PureComponent {
     this.state = {
       isDragging: false      // Whether the cursor is down
     };
-
-    this._recursiveUpdateChildren = this._recursiveUpdateChildren.bind(this);
-    this._updateChildrenViewport = this._updateChildrenViewport.bind(this);
   }
 
   componentDidMount() {
@@ -131,12 +128,18 @@ export default class ViewportController extends PureComponent {
     this._transitionManger = new TransitionManager(this.props);
   }
 
+  shouldComponentUpdate(nextProps, nextState) {
+    if (this._transitionManger) {
+      const transitionTriggered = this._transitionManger.processViewportChange(nextProps);
+      // Skip this render to avoid jump during viewport transitions.
+      return !transitionTriggered;
+    }
+    return true;
+  }
+
   componentWillUpdate(nextProps) {
     if (this._controls) {
       this._controls.setOptions(nextProps);
-    }
-    if (this._transitionManger) {
-      this._transitionManger.processViewportChange(nextProps);
     }
   }
 
@@ -150,40 +153,6 @@ export default class ViewportController extends PureComponent {
     }
   }
 
-  _recursiveUpdateChildren(children, viewport) {
-    // TODO: use component key or a custom prop to identify which child to modify.
-    return Children.map(children, child => {
-      if (!isValidElement(child)) {
-        return child;
-      }
-      let childProps = {};
-      // NOTE: disabling until full multi-vewport transition is added.
-      // if (child.props.viewports) {
-      //   const childViewports = [];
-      //   child.props.viewports.forEach((childViewport) => {
-      //     childViewports.push(Object.assign({}, childViewport, viewport));
-      //   });
-      //   childProps = Object.assign({}, {viewports: childViewports});
-      // } else {
-      //   childProps = Object.assign({}, viewport, {viewport});
-      // }
-      childProps = Object.assign({}, viewport, {viewport});
-
-      childProps.children = this._recursiveUpdateChildren(child.props.children, viewport);
-      const cloned = cloneElement(child, childProps);
-      return cloned;
-    });
-  }
-
-  _updateChildrenViewport() {
-    const viewport = (this._transitionManger && this._transitionManger.getViewportInTransition()) ||
-      extractViewportFrom(this.props);
-    const childrenWithProps = this._recursiveUpdateChildren(
-        this.props.children,
-        viewport);
-    return childrenWithProps;
-  }
-
   render() {
     const {width, height, getCursor} = this.props;
 
@@ -194,15 +163,13 @@ export default class ViewportController extends PureComponent {
       cursor: getCursor(this.state)
     };
 
-    const childrenWithProps = this._updateChildrenViewport();
-
     return (
       createElement('div', {
         key: 'map-controls',
         ref: 'eventCanvas',
         style: eventCanvasStyle
       },
-        childrenWithProps
+        this.props.children
       )
     );
   }


### PR DESCRIPTION
This includes following two changes :
1. `ViewportController` intercepts and updates all children props to avoid a jump when viewport is updated with transition enabled, this can be achieved by using `shouldComponentUpdate()`, which returns false when a new transition is triggered and hence skipping the render for itself and all its children. All following viewport updates are handled by 'onViewportChange()' called by `TransitionManger`. This should make code a lot less complicated and also makes it easy to integrate Viewport Transitions with Multi-viewports feature.
2. In `TransitionManger`, this.props should be set before calling '_triggerTransition()' which calls `_updateViewport` that uses this.props.

Verified with all 3 viewport-animation examples and layer-manager. #2 fixes an issue in `viewport-animation-3d-heatmap` example, where app uses wrong width/height.