### PR TITLE
Quick fix of fitBounds API in orbit-viewport and examples

### DIFF
--- a/examples/plot/app.js
+++ b/examples/plot/app.js
@@ -40,7 +40,7 @@ class Root extends Component {
       height: window.innerHeight
     };
     const newViewport = OrbitController.getViewport(Object.assign(this.state.viewport, size))
-      .fitBounds([[0, 0, 0], [1, 1, 1]]);
+      .fitBounds([3, 3, 3]);
 
     this._onViewportChange(newViewport);
   }

--- a/examples/point-cloud-laz/app.js
+++ b/examples/point-cloud-laz/app.js
@@ -103,7 +103,7 @@ class Example extends PureComponent {
     const size = {width: window.innerWidth, height: window.innerHeight};
     this.setState(size);
     const newViewport = OrbitController.getViewport(Object.assign(this.state.viewport, size))
-      .fitBounds([1.0, 1.0, 1.0]);
+      .fitBounds([1, 1, 1]);
     this._onViewportChange(newViewport);
   }
 

--- a/examples/point-cloud-laz/app.js
+++ b/examples/point-cloud-laz/app.js
@@ -103,7 +103,7 @@ class Example extends PureComponent {
     const size = {width: window.innerWidth, height: window.innerHeight};
     this.setState(size);
     const newViewport = OrbitController.getViewport(Object.assign(this.state.viewport, size))
-      .fitBounds([[0, 0, 0], [1, 1, 1]]);
+      .fitBounds([1.0, 1.0, 1.0]);
     this._onViewportChange(newViewport);
   }
 

--- a/examples/point-cloud-ply/app.js
+++ b/examples/point-cloud-ply/app.js
@@ -64,7 +64,7 @@ class Example extends PureComponent {
     const size = {width: window.innerWidth, height: window.innerHeight};
     this.setState(size);
     const newViewport = OrbitController.getViewport(Object.assign(this.state.viewport, size))
-      .fitBounds([[0, 0, 0], [1, 1, 1]]);
+      .fitBounds([1, 1, 1]);
     this._onViewportChange(newViewport);
   }
 

--- a/src/core/viewports/orbit-viewport.js
+++ b/src/core/viewports/orbit-viewport.js
@@ -92,8 +92,8 @@ export default class OrbitViewport extends Viewport {
     return transformVector(this.pixelUnprojectionMatrix, [x, y2, z, 1]);
   }
 
-  /** Move camera to get a bounding box fit in the viewport.
-   * @param {Array} bounds - [[minX, minY, minZ], [maxX, maxY, maxZ]]
+  /** Move camera to make a model bounding box centered at lookat position fit in the viewport.
+   * @param {Array} max - [maxX, maxY, maxZ]], define the dimensions of bounding box
    * @returns a new OrbitViewport object
    */
   fitBounds(max) {

--- a/src/core/viewports/orbit-viewport.js
+++ b/src/core/viewports/orbit-viewport.js
@@ -96,12 +96,13 @@ export default class OrbitViewport extends Viewport {
    * @param {Array} bounds - [[minX, minY, minZ], [maxX, maxY, maxZ]]
    * @returns a new OrbitViewport object
    */
-  fitBounds([min, max]) {
+  fitBounds(max) {
     const {
       width,
       height,
       rotationX,
       rotationY,
+      lookAt,
       up,
       fov,
       near,
@@ -110,7 +111,7 @@ export default class OrbitViewport extends Viewport {
       translationY,
       zoom
     } = this;
-    const size = Math.max(max[0] - min[0], max[1] - min[1], max[2] - min[2]);
+    const size = Math.max(max[0], max[1], max[2]);
     const newDistance = size / Math.tan(fov / 180 * Math.PI / 2);
 
     return new OrbitViewport({
@@ -125,11 +126,7 @@ export default class OrbitViewport extends Viewport {
       translationX,
       translationY,
       zoom,
-      lookAt: [
-        (min[0] + max[0]) / 2,
-        (min[1] + max[1]) / 2,
-        (min[2] + max[2]) / 2
-      ],
+      lookAt,
       distance: newDistance
     });
   }


### PR DESCRIPTION
Current fitBounds API recalculates user's 'lookat' position and distance based on a bounds to make sure canvas size can fit bound size. But changing of 'lookat' position will trigger new behaviors user doesn't expect, like model rotates on a new axis.
The PR here is to keep 'lookat' position untouched unless user changes it, and the bounds is always centered at 'lookat' position.