### PR TITLE
Add `layerFilter` prop

### DIFF
--- a/docs/api-reference/react/deckgl.md
+++ b/docs/api-reference/react/deckgl.md
@@ -62,7 +62,7 @@ The array of deck.gl layers to be rendered. This array is expected to be an arra
 
 ##### `layerFilter`
 
-Optionally takes a function `(layer, viewport) => Boolean` that is called before a layer is rendered. Gives the application an opportunity to filter out layers from the layer list during either rendering or picking. Filtering can be done per viewport or per layer or both. This enables techniques like adding helper layers that work as masks during picking but do not show up during rendering.
+Optionally takes a function `({layer, viewport, isPicking}) => Boolean` that is called before a layer is rendered. Gives the application an opportunity to filter out layers from the layer list during either rendering or picking. Filtering can be done per viewport or per layer or both. This enables techniques like adding helper layers that work as masks during picking but do not show up during rendering.
 
 ##### `viewports`
 

--- a/docs/api-reference/react/deckgl.md
+++ b/docs/api-reference/react/deckgl.md
@@ -56,6 +56,14 @@ Canvas ID to allow style customization in CSS.
 
 The DeckGL component own `canvas` element is rendered last, intentionally on top of all the base maps.
 
+##### `layers` (Array, required)
+
+The array of deck.gl layers to be rendered. This array is expected to be an array of newly allocated instances of your deck.gl layers, created with updated properties derived from the current application state.
+
+##### `layerFilter`
+
+Optionally takes a function `(layer, viewport) => Boolean` that is called before a layer is rendered. Gives the application an opportunity to filter out layers from the layer list during either rendering or picking. Filtering can be done per viewport or per layer or both. This enables techniques like adding helper layers that work as masks during picking but do not show up during rendering.
+
 ##### `viewports`
 
 A singe viewport, or an array of `Viewport`s or "Viewport Descriptors".
@@ -101,10 +109,6 @@ Current bearing - used to define a mercator projection if `viewport` is not supp
 ##### `pitch` (Number, optional)
 
 Current pitch - used to define a mercator projection if `viewport` is not supplied.
-
-##### `layers` (Array, required)
-
-The array of deck.gl layers to be rendered. This array is expected to be an array of newly allocated instances of your deck.gl layers, created with updated properties derived from the current application state.
 
 ##### `style` (Object, optional)
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -44,6 +44,10 @@ Three new `Layer` props (`autoHighlight`, `highlightColor` and `highlightedObjec
 
 The new `useDevicePixelRatio` prop on the `DeckGL` React component can be used to disable usage of full resolution on retina/HD displays. Disabling deck.gl's default behavior of always rendering at maximum device resolution can reduce the render buffer size with a factor of 4x on retina devices and lead to significant performance improvements on typical fragment shader bound rendering. This option can be especially interesting on "retina" type mobile phone displays where pixels are so small that the visual quality loss may be largely imperceptible.
 
+## Layer Filtering
+
+A new `layerFilter: (layer, viewport) => true` prop gives the application an opportunity to filter out layers from the layer list during either rendering or picking. Filtering can be done per viewport or per layer or both. This enables techniques like adding helper layers that work as masks during picking but do not show up during rendering.
+
 
 ## CompositeLayer Improvements
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -46,7 +46,7 @@ The new `useDevicePixelRatio` prop on the `DeckGL` React component can be used t
 
 ## Layer Filtering
 
-A new `layerFilter: (layer, viewport) => true` prop gives the application an opportunity to filter out layers from the layer list during either rendering or picking. Filtering can be done per viewport or per layer or both. This enables techniques like adding helper layers that work as masks during picking but do not show up during rendering.
+A new prop gives the application an opportunity to filter out layers from the layer list during either rendering or picking. Filtering can be done per viewport or per layer or both. This enables techniques like adding helper layers that work as masks during picking but do not show up during rendering.
 
 
 ## CompositeLayer Improvements

--- a/src/core/lib/draw-layers.js
+++ b/src/core/lib/draw-layers.js
@@ -68,7 +68,7 @@ export function drawLayers(gl, {
   drawPickingColors = false,
   deviceRect = null,
   parameters = {},
-  layerFilter = (layer, viewport) => true,
+  layerFilter = null,
   pass = 'draw',
   redrawReason = ''
 }) {
@@ -108,7 +108,7 @@ export function drawPickingBuffer(gl, {
   useDevicePixelRatio,
   pickingFBO,
   deviceRect: {x, y, width, height},
-  layerFilter = (layer, viewport) => true,
+  layerFilter = null,
   redrawReason = ''
 }) {
   // Make sure we clear scissor test and fbo bindings in case of exceptions
@@ -181,7 +181,7 @@ function drawLayersInViewport(gl, {
       shouldDrawLayer = shouldDrawLayer && layer.props.pickable;
     }
     if (shouldDrawLayer && layerFilter) {
-      shouldDrawLayer = layerFilter(layer, viewport);
+      shouldDrawLayer = layerFilter({layer, viewport, isPicking: drawPickingColors});
     }
 
     // Calculate stats

--- a/src/core/lib/layer-manager.js
+++ b/src/core/lib/layer-manager.js
@@ -79,6 +79,7 @@ export default class LayerManager {
       uniforms: {},
       viewports: [],
       viewport: null,
+      layerFilter: null,
       viewportChanged: true,
       pickingFBO: null,
       useDevicePixelRatio: true,
@@ -140,6 +141,10 @@ export default class LayerManager {
 
     if ('layers' in parameters) {
       this.updateLayers({newLayers: parameters.layers});
+    }
+
+    if ('layerFilter' in parameters) {
+      this.context.layerFilter = parameters.layerFilter;
     }
 
     Object.assign(this.context, parameters);
@@ -242,6 +247,7 @@ export default class LayerManager {
       useDevicePixelRatio,
       drawPickingColors,
       pass,
+      layerFilter: this.context.layerFilter,
       redrawReason
     });
 
@@ -249,17 +255,20 @@ export default class LayerManager {
   }
 
   // Pick the closest info at given coordinate
-  pickObject({x, y, mode, radius = 0, layerIds}) {
+  pickObject({x, y, mode, radius = 0, layerIds, layerFilter}) {
     const {gl, useDevicePixelRatio} = this.context;
 
     const layers = this.getLayers({layerIds});
 
     return pickObject(gl, {
+      // User params
       x,
       y,
       radius,
       layers,
       mode,
+      layerFilter,
+      // Injected params
       viewports: this.context.viewports,
       onViewportActive: this._activateViewport.bind(this),
       pickingFBO: this._getPickingBuffer(),
@@ -269,7 +278,7 @@ export default class LayerManager {
   }
 
   // Get all unique infos within a bounding box
-  pickVisibleObjects({x, y, width, height, layerIds}) {
+  pickVisibleObjects({x, y, width, height, layerIds, layerFilter}) {
     const {gl, useDevicePixelRatio} = this.context;
 
     const layers = this.getLayers({layerIds});
@@ -280,7 +289,8 @@ export default class LayerManager {
       width,
       height,
       layers,
-      mode: 'query',
+      layerFilter,
+      mode: 'queryObjects',
       // TODO - how does this interact with multiple viewports?
       viewport: this.context.viewport,
       viewports: this.context.viewports,

--- a/src/core/lib/pick-layers.js
+++ b/src/core/lib/pick-layers.js
@@ -35,15 +35,15 @@ const NO_PICKED_OBJECT = {
 export function pickObject(gl, {
   layers,
   viewports,
-  onViewportActive,
-  pickingFBO,
   x,
   y,
   radius,
-  lastPickedInfo,
-  useDevicePixelRatio,
+  layerFilter,
   mode,
-  layerFilter
+  onViewportActive,
+  pickingFBO,
+  lastPickedInfo,
+  useDevicePixelRatio
 }) {
   // Convert from canvas top-left to WebGL bottom-left coordinates
   // And compensate for pixelRatio
@@ -87,13 +87,14 @@ export function pickObject(gl, {
 export function pickVisibleObjects(gl, {
   layers,
   viewports,
-  onViewportActive,
-  pickingFBO,
   x,
   y,
   width,
   height,
   mode,
+  layerFilter,
+  onViewportActive,
+  pickingFBO,
   useDevicePixelRatio
 }) {
 

--- a/src/core/lib/pick-layers.js
+++ b/src/core/lib/pick-layers.js
@@ -40,9 +40,10 @@ export function pickObject(gl, {
   x,
   y,
   radius,
-  mode,
   lastPickedInfo,
-  useDevicePixelRatio
+  useDevicePixelRatio,
+  mode,
+  layerFilter
 }) {
   // Convert from canvas top-left to WebGL bottom-left coordinates
   // And compensate for pixelRatio
@@ -64,6 +65,7 @@ export function pickObject(gl, {
     useDevicePixelRatio,
     pickingFBO,
     deviceRect,
+    layerFilter,
     redrawReason: mode
   });
 
@@ -81,6 +83,145 @@ export function pickObject(gl, {
   });
 }
 
+// Pick all objects within the given bounding box
+export function pickVisibleObjects(gl, {
+  layers,
+  viewports,
+  onViewportActive,
+  pickingFBO,
+  x,
+  y,
+  width,
+  height,
+  mode,
+  useDevicePixelRatio
+}) {
+
+  // Convert from canvas top-left to WebGL bottom-left coordinates
+  // And compensate for pixelRatio
+  const pixelRatio = getPixelRatio({useDevicePixelRatio});
+
+  const deviceLeft = Math.round(x * pixelRatio);
+  const deviceBottom = Math.round(gl.canvas.height - y * pixelRatio);
+  const deviceRight = Math.round((x + width) * pixelRatio);
+  const deviceTop = Math.round(gl.canvas.height - (y + height) * pixelRatio);
+
+  const deviceRect = {
+    x: deviceLeft,
+    y: deviceTop,
+    width: deviceRight - deviceLeft,
+    height: deviceBottom - deviceTop
+  };
+
+  const pickedColors = drawAndSamplePickingBuffer(gl, {
+    layers,
+    viewports,
+    onViewportActive,
+    pickingFBO,
+    useDevicePixelRatio,
+    deviceRect,
+    layerFilter,
+    redrawReason: mode
+  });
+
+  const pickInfos = getUniquesFromPickingBuffer(gl, {pickedColors, layers});
+
+  // Only return unique infos, identified by info.object
+  const uniqueInfos = new Map();
+
+  pickInfos.forEach(pickInfo => {
+    const viewport = getViewportFromCoordinates({viewports}); // TODO - add coords
+    let info = createInfo([pickInfo.x / pixelRatio, pickInfo.y / pixelRatio], viewport);
+    info.devicePixel = [pickInfo.x, pickInfo.y];
+    info.pixelRatio = pixelRatio;
+    info.color = pickInfo.pickedColor;
+    info.index = pickInfo.pickedObjectIndex;
+    info.picked = true;
+
+    info = getLayerPickingInfo({layer: pickInfo.pickedLayer, info, mode});
+    if (!uniqueInfos.has(info.object)) {
+      uniqueInfos.set(info.object, info);
+    }
+  });
+
+  return Array.from(uniqueInfos.values());
+}
+
+// HELPER METHODS
+
+// returns pickedColor or null if no pickable layers found.
+function drawAndSamplePickingBuffer(gl, {
+  layers,
+  viewports,
+  onViewportActive,
+  useDevicePixelRatio,
+  pickingFBO,
+  deviceRect,
+  layerFilter,
+  redrawReason
+}) {
+  assert(deviceRect);
+  assert((Number.isFinite(deviceRect.width) && deviceRect.width > 0), '`width` must be > 0');
+  assert((Number.isFinite(deviceRect.height) && deviceRect.height > 0), '`height` must be > 0');
+
+  const pickableLayers = layers.filter(layer => layer.isPickable());
+  if (pickableLayers.length < 1) {
+    return null;
+  }
+
+  drawPickingBuffer(gl, {
+    layers,
+    viewports,
+    onViewportActive,
+    useDevicePixelRatio,
+    pickingFBO,
+    deviceRect,
+    layerFilter,
+    redrawReason
+  });
+
+  // Read from an already rendered picking buffer
+  // Returns an Uint8ClampedArray of picked pixels
+  const {x, y, width, height} = deviceRect;
+  const pickedColors = new Uint8Array(width * height * 4);
+  pickingFBO.readPixels({x, y, width, height, pixelArray: pickedColors});
+  return pickedColors;
+}
+
+// Indentifies which viewport, if any corresponds to x and y
+// Returns first viewport if no match
+// TODO - need to determine which viewport we are in
+// TODO - document concept of "primary viewport" that matches all coords?
+// TODO - static method on Viewport class?
+function getViewportFromCoordinates({viewports}) {
+  const viewport = viewports[0];
+  return viewport;
+}
+
+// Calculate a picking rect centered on deviceX and deviceY and clipped to device
+// Returns null if pixel is outside of device
+function getPickingRect({deviceX, deviceY, deviceRadius, deviceWidth, deviceHeight}) {
+  const valid =
+    deviceX >= 0 &&
+    deviceY >= 0 &&
+    deviceX < deviceWidth &&
+    deviceY < deviceHeight;
+
+  // x, y out of bounds.
+  if (!valid) {
+    return null;
+  }
+
+  // Create a box of size `radius * 2 + 1` centered at [deviceX, deviceY]
+  const x = Math.max(0, deviceX - deviceRadius);
+  const y = Math.max(0, deviceY - deviceRadius);
+  const width = Math.min(deviceWidth, deviceX + deviceRadius) - x + 1;
+  const height = Math.min(deviceHeight, deviceY + deviceRadius) - y + 1;
+
+  return {x, y, width, height};
+}
+
+// TODO - break this monster function into 3+ parts
 function processPickInfo({
   pickInfo, lastPickedInfo, mode, layers, viewports, x, y, deviceX, deviceY, pixelRatio
 }) {
@@ -128,7 +269,6 @@ function processPickInfo({
   // https://github.com/uber/deck.gl/issues/443
   // Please be very careful when changing this pattern
   const infos = new Map();
-  const unhandledPickInfos = [];
 
   affectedLayers.forEach(layer => {
     let info = Object.assign({}, baseInfo);
@@ -164,18 +304,26 @@ function processPickInfo({
     }
   });
 
+  const unhandledPickInfos = callLayerPickingCallbacks(infos, mode);
+
+  return unhandledPickInfos;
+}
+
+// Per-layer event handlers (e.g. onClick, onHover) are provided by the
+// user and out of deck.gl's control. It's very much possible that
+// the user calls React lifecycle methods in these function, such as
+// ReactComponent.setState(). React lifecycle methods sometimes induce
+// a re-render and re-generation of props of deck.gl and its layers,
+// which invalidates all layers currently passed to this very function.
+
+// Therefore, per-layer event handlers must be invoked at the end
+// of the picking operation. NO operation that relies on the states of current
+// layers should be called after this code.
+function callLayerPickingCallbacks(infos, mode) {
+  const unhandledPickInfos = [];
+
   infos.forEach(info => {
     let handled = false;
-    // Per-layer event handlers (e.g. onClick, onHover) are provided by the
-    // user and out of deck.gl's control. It's very much possible that
-    // the user calls React lifecycle methods in these function, such as
-    // ReactComponent.setState(). React lifecycle methods sometimes induce
-    // a re-render and re-generation of props of deck.gl and its layers,
-    // which invalidates all layers currently passed to this very function.
-
-    // Therefore, per-layer event handlers must be invoked at the end
-    // of this function. NO operation that relies on the states of current
-    // layers should be called after this code.
     switch (mode) {
     case 'click': handled = info.layer.props.onClick(info); break;
     case 'hover': handled = info.layer.props.onHover(info); break;
@@ -189,142 +337,6 @@ function processPickInfo({
   });
 
   return unhandledPickInfos;
-}
-
-// Pick all objects within the given bounding box
-export function pickVisibleObjects(gl, {
-  layers,
-  viewports,
-  onViewportActive,
-  pickingFBO,
-  x,
-  y,
-  width,
-  height,
-  mode,
-  useDevicePixelRatio
-}) {
-
-  // Convert from canvas top-left to WebGL bottom-left coordinates
-  // And compensate for pixelRatio
-  const pixelRatio = getPixelRatio({useDevicePixelRatio});
-
-  const deviceLeft = Math.round(x * pixelRatio);
-  const deviceBottom = Math.round(gl.canvas.height - y * pixelRatio);
-  const deviceRight = Math.round((x + width) * pixelRatio);
-  const deviceTop = Math.round(gl.canvas.height - (y + height) * pixelRatio);
-
-  const deviceRect = {
-    x: deviceLeft,
-    y: deviceTop,
-    width: deviceRight - deviceLeft,
-    height: deviceBottom - deviceTop
-  };
-
-  const pickedColors = drawAndSamplePickingBuffer(gl, {
-    layers,
-    viewports,
-    onViewportActive,
-    pickingFBO,
-    useDevicePixelRatio,
-    deviceRect,
-    redrawReason: mode
-  });
-
-  const pickInfos = getUniquesFromPickingBuffer(gl, {pickedColors, layers});
-
-  // Only return unique infos, identified by info.object
-  const uniqueInfos = new Map();
-
-  pickInfos.forEach(pickInfo => {
-    const viewport = getViewportFromCoordinates({viewports}); // TODO - add coords
-    let info = createInfo([pickInfo.x / pixelRatio, pickInfo.y / pixelRatio], viewport);
-    info.devicePixel = [pickInfo.x, pickInfo.y];
-    info.pixelRatio = pixelRatio;
-    info.color = pickInfo.pickedColor;
-    info.index = pickInfo.pickedObjectIndex;
-    info.picked = true;
-
-    info = getLayerPickingInfo({layer: pickInfo.pickedLayer, info, mode});
-    if (!uniqueInfos.has(info.object)) {
-      uniqueInfos.set(info.object, info);
-    }
-  });
-
-  return Array.from(uniqueInfos.values());
-}
-
-// HELPER METHODS
-
-// Indentifies which viewport, if any corresponds to x and y
-// Returns first viewport if no match
-// TODO - need to determine which viewport we are in
-// TODO - document concept of "primary viewport" that matches all coords?
-// TODO - static method on Viewport class?
-function getViewportFromCoordinates({viewports}) {
-  const viewport = viewports[0];
-  return viewport;
-}
-
-// returns pickedColor or null if no pickable layers found.
-function drawAndSamplePickingBuffer(gl, {
-  layers,
-  viewports,
-  onViewportActive,
-  useDevicePixelRatio,
-  pickingFBO,
-  deviceRect,
-  redrawReason
-}) {
-
-  assert(deviceRect);
-  assert((Number.isFinite(deviceRect.width) && deviceRect.width > 0), '`width` must be > 0');
-  assert((Number.isFinite(deviceRect.height) && deviceRect.height > 0), '`height` must be > 0');
-
-  const pickableLayers = layers.filter(layer => layer.isPickable());
-  if (pickableLayers.length < 1) {
-    return null;
-  }
-
-  drawPickingBuffer(gl, {
-    layers,
-    viewports,
-    onViewportActive,
-    useDevicePixelRatio,
-    pickingFBO,
-    deviceRect,
-    redrawReason
-  });
-
-  // Read from an already rendered picking buffer
-  // Returns an Uint8ClampedArray of picked pixels
-  const {x, y, width, height} = deviceRect;
-  const pickedColors = new Uint8Array(width * height * 4);
-  pickingFBO.readPixels({x, y, width, height, pixelArray: pickedColors});
-  return pickedColors;
-}
-
-// Calculate a picking rect centered on deviceX and deviceY and clipped to device
-// Returns null if pixel is outside of device
-function getPickingRect({deviceX, deviceY, deviceRadius, deviceWidth, deviceHeight}) {
-  const valid =
-    deviceX >= 0 &&
-    deviceY >= 0 &&
-    deviceX < deviceWidth &&
-    deviceY < deviceHeight;
-
-  // x, y out of bounds.
-  if (!valid) {
-    return null;
-  }
-
-  // Create a box of size `radius * 2 + 1` centered at [deviceX, deviceY]
-  const x = Math.max(0, deviceX - deviceRadius);
-  const y = Math.max(0, deviceY - deviceRadius);
-  const width = Math.min(deviceWidth, deviceX + deviceRadius) - x + 1;
-  const height = Math.min(deviceHeight, deviceY + deviceRadius) - y + 1;
-
-  return {x, y, width, height};
 }
 
 /**

--- a/src/core/pure-js/deck-js.js
+++ b/src/core/pure-js/deck-js.js
@@ -39,6 +39,7 @@ const propTypes = {
   layers: PropTypes.array.isRequired, // Array can contain falsy values
   viewports: PropTypes.array, // Array can contain falsy values
   effects: PropTypes.arrayOf(PropTypes.instanceOf(Effect)),
+  layerFilter: PropTypes.func,
   glOptions: PropTypes.object,
   gl: PropTypes.object,
   pickingRadius: PropTypes.number,
@@ -58,6 +59,7 @@ const propTypes = {
 const defaultProps = {
   id: 'deckgl-overlay',
   pickingRadius: 0,
+  layerFilter: null,
   glOptions: {},
   gl: null,
   effects: [],
@@ -123,13 +125,15 @@ export default class DeckGLJS {
       onLayerClick,
       onLayerHover,
       useDevicePixelRatio,
-      drawPickingColors
+      drawPickingColors,
+      layerFilter
     } = props;
 
     // If more parameters need to be updated on layerManager add them to this method.
     this.layerManager.setParameters({
       useDevicePixelRatio,
-      drawPickingColors
+      drawPickingColors,
+      layerFilter
     });
 
     this.layerManager.setEventHandlingParameters({


### PR DESCRIPTION
A new optional prop that takes (layer, viewport) and allows filtering out layers in specific viewports or from rendering or picking.

Also a bit more functional breakdown in pick-layers.js. No logic changes.