### PR TITLE
Revert "More rigorous changeFlags handling."

### DIFF
--- a/src/core/lib/composite-layer.js
+++ b/src/core/lib/composite-layer.js
@@ -35,6 +35,11 @@ export default class CompositeLayer extends Layer {
   initializeState() {
   }
 
+  // No-op for the invalidateAttribute function as the composite
+  // layer has no AttributeManager
+  invalidateAttribute() {
+  }
+
   // called to augment the info object that is bubbled up from a sublayer
   // override Layer.getPickingInfo() because decoding / setting uniform do
   // not apply to a composite layer.
@@ -66,12 +71,7 @@ export default class CompositeLayer extends Layer {
     };
   }
 
-  // Called by layer manager to render sublayers
   _renderLayers(updateParams) {
-    // TODO - won't updateLayer also be called? Avoid "double diffing"
-    const {oldProps, props} = updateParams;
-    this.diffProps(oldProps, props);
-
     if (this.state.oldSubLayers && !this.shouldUpdateState(updateParams)) {
       log.log(2, `Composite layer reused sublayers ${this}`, this.state.oldSubLayers);
       return this.state.oldSubLayers;

--- a/src/core/lib/layer.js
+++ b/src/core/lib/layer.js
@@ -117,9 +117,8 @@ export default class Layer {
   // Default implementation, all attributes will be invalidated and updated
   // when data changes
   updateState({oldProps, props, oldContext, context, changeFlags}) {
-    const {attributeManager} = this.state;
-    if (changeFlags.dataChanged && attributeManager) {
-      attributeManager.invalidateAll();
+    if (changeFlags.dataChanged) {
+      this.invalidateAttribute('all');
     }
   }
 
@@ -152,6 +151,15 @@ export default class Layer {
 
   // END LIFECYCLE METHODS
   // //////////////////////////////////////////////////
+
+  // Default implementation of attribute invalidation, can be redefine
+  invalidateAttribute(name = 'all') {
+    if (name === 'all') {
+      this.state.attributeManager.invalidateAll();
+    } else {
+      this.state.attributeManager.invalidate(name);
+    }
+  }
 
   // Returns true if the layer is pickable and visible.
   isPickable() {
@@ -339,35 +347,34 @@ export default class Layer {
   // Called by layer manager when a new layer is found
   /* eslint-disable max-statements */
   initializeLayer(updateParams) {
-    assert(this.context.gl);
-    assert(!this.state);
+    assert(this.context.gl, 'Layer context missing gl');
+    assert(!this.state, 'Layer missing state');
 
-    const attributeManager = new AttributeManager({id: this.props.id});
+    this.state = {};
+    this.state.stats = new Stats({id: 'draw'});
+
+    // Initialize state only once
+    this.setState({
+      attributeManager: new AttributeManager({id: this.props.id}),
+      model: null,
+      needsRedraw: true,
+      dataChanged: true
+    });
+
+    const {attributeManager} = this.state;
     // All instanced layers get instancePickingColors attribute by default
     // Their shaders can use it to render a picking scene
-    // TODO - this slightly slows down non instanced layers
+    // TODO - this slows down non instanced layers
     attributeManager.addInstanced({
       instancePickingColors: {
-        type: GL.UNSIGNED_BYTE, size: 3, update: this.calculateInstancePickingColors
+        type: GL.UNSIGNED_BYTE,
+        size: 3,
+        update: this.calculateInstancePickingColors
       }
     });
 
-    this.state = {
-      attributeManager,
-      model: null,
-      needsRedraw: true,
-      stats: new Stats({id: 'draw'})
-    };
-    this.setChangeFlags({dataChanged: true, propsChange: true, viewportChanged: true});
-
-    this.initializeState(this.context);
-
-    this.setChangeFlags({dataChanged: true, propsChange: true, viewportChanged: true});
-    updateParams = Object.assign({}, this.context, updateParams, {
-      changeFlags: this.state.changeFlags
-    });
-
     // Call subclass lifecycle methods
+    this.initializeState(this.context);
     this.updateState(updateParams);
     // End subclass lifecycle methods
 
@@ -384,29 +391,17 @@ export default class Layer {
       model.geometry.id = `${this.props.id}-geometry`;
       model.setAttributes(attributeManager.getAttributes());
     }
-
-    this.clearChangeFlags();
   }
 
-  // Called by layer manager
-  // if this layer is new (not matched with an existing layer) oldProps will be empty object
-  updateLayer({oldProps = {}, oldContext = {}}) {
-    this.oldProps = oldProps;
+  // Called by layer manager when existing layer is getting new props
+  updateLayer(updateParams) {
+    // Check for deprecated method
+    if (this.shouldUpdate) {
+      log.deprecated('shouldUpdate', 'shouldUpdateState');
+    }
 
-    this.diffProps(this.props, oldProps);
-
-    // TODO - check change flags and return if no change?
-    // if (!state.changeFlags.somethingChanged) {
-    // return
-    // }
-
-    const updateParams = {
-      props: this.props,
-      oldProps,
-      context: this.context,
-      oldContext,
-      changeFlags: this.state.changeFlags
-    };
+    // Ensure context is available
+    updateParams = Object.assign({}, this.context, updateParams);
 
     // Call subclass lifecycle method
     const stateNeedsUpdate = this.shouldUpdateState(updateParams);
@@ -426,8 +421,6 @@ export default class Layer {
       if (this.state.model) {
         this.state.model.setInstanceCount(this.getNumInstances());
       }
-
-      this.clearChangeFlags();
     }
   }
   /* eslint-enable max-statements */
@@ -492,69 +485,38 @@ export default class Layer {
     return redraw;
   }
 
-  // Helper methods
-
-  // Dirty some change flags, will be handled by updateLayer
-  /* eslint-disable complexity */
-  setChangeFlags(flags) {
-    this.state.changeFlags = this.state.changeFlags || {};
-    const changeFlags = this.state.changeFlags;
-
-    // Update primary flags
-    if (flags.dataChanged && !changeFlags.dataChanged) {
-      changeFlags.dataChanged = flags.dataChanged;
-      log.log(LOG_PRIORITY_UPDATE + 1,
-        () => `dataChanged: ${flags.dataChanged} in ${this.id}`);
-    }
-    if (flags.updateTriggersChanged && !changeFlags.updateTriggersChanged) {
-      changeFlags.updateTriggersChanged = flags.updateTriggersChanged;
-      log.log(LOG_PRIORITY_UPDATE + 1,
-        () => `updateTriggersChanged: ${flags.updateTriggersChanged} in ${this.id}`);
-    }
-    if (flags.propsChanged && !changeFlags.propsChanged) {
-      changeFlags.propsChanged = flags.propsChanged;
-      log.log(LOG_PRIORITY_UPDATE + 1,
-        () => `propsChanged: ${flags.propsChanged} in ${this.id}`);
-    }
-    if (flags.viewportChanged && !changeFlags.viewportChanged) {
-      changeFlags.viewportChanged = flags.viewportChanged;
-      log.log(LOG_PRIORITY_UPDATE + 2,
-        () => `propsChanged: ${flags.viewportChanged} in ${this.id}`);
-    }
-
-    // Update composite flags
-    const propsOrDataChanged =
-      flags.dataChanged || flags.updateTriggersChanged || flags.propsChanged;
-    changeFlags.propsOrDataChanged = changeFlags.propsOrDataChanged || propsOrDataChanged;
-    changeFlags.somethingChanged = changeFlags.somethingChanged ||
-      propsOrDataChanged || flags.viewportChanged;
-
-    return changeFlags;
-  }
-  /* eslint-enable complexity */
-
-  // Clear all changeFlags, typically after an update
-  clearChangeFlags() {
-    this.state.changeFlags = {
-      // Primary changeFlags, can be strings stating reason for change
-      propsChanged: false,
-      dataChanged: false,
-      updateTriggersChanged: false,
-      viewportChanged: false,
-
-      // Derived changeFlags
-      propsOrDataChanged: false,
-      somethingChanged: false
-    };
-  }
-
   // Compares the layers props with old props from a matched older layer
   // and extracts change flags that describe what has change so that state
   // can be update correctly with minimal effort
   diffProps(oldProps, newProps) {
-    let changeFlags = diffProps(oldProps, newProps, this._onUpdateTriggered.bind(this));
-    changeFlags = this.setChangeFlags(changeFlags);
-    return changeFlags;
+    const changeFlags = diffProps(oldProps, newProps, this._onUpdateTriggered.bind(this));
+    const {propsChanged, dataChanged, updateTriggersChanged} = changeFlags;
+
+    const viewportChanged = this.context.viewportChanged;
+    const propsOrDataChanged = propsChanged || dataChanged || updateTriggersChanged;
+    const somethingChanged = propsOrDataChanged || viewportChanged;
+
+    // Trace what happened
+    if (dataChanged) {
+      log.log(LOG_PRIORITY_UPDATE, `dataChanged: ${dataChanged} in ${this.id}`);
+    } else if (propsChanged) {
+      log.log(LOG_PRIORITY_UPDATE, `propsChanged: ${propsChanged} in ${this.id}`);
+    }
+
+    return {
+      propsChanged,
+      dataChanged,
+      updateTriggersChanged,
+      propsOrDataChanged,
+      viewportChanged,
+      somethingChanged,
+      reason:
+        dataChanged ||
+        propsChanged ||
+        (viewportChanged && 'Viewport changed') ||
+        (updateTriggersChanged && 'updateTriggers changed') ||
+        'unknown reason'
+    };
   }
 
   // PRIVATE METHODS

--- a/src/core/lib/props.js
+++ b/src/core/lib/props.js
@@ -60,13 +60,13 @@ export function compareProps({
   for (const key in oldProps) {
     if (!(key in ignoreProps)) {
       if (!newProps.hasOwnProperty(key)) {
-        return `${triggerName}.${key} dropped: ${oldProps[key]} -> undefined`;
+        return `${triggerName} ${key} dropped: ${oldProps[key]} -> (undefined)`;
       }
 
       // If object has an equals function, invoke it
       let equals = newProps[key] && oldProps[key] && newProps[key].equals;
       if (equals && !equals.call(newProps[key], oldProps[key])) {
-        return `${triggerName}.${key} changed deeply: ${oldProps[key]} -> ${newProps[key]}`;
+        return `${triggerName} ${key} changed deeply: ${oldProps[key]} -> ${newProps[key]}`;
       }
 
       // If both new and old value are functions, ignore differences
@@ -78,7 +78,7 @@ export function compareProps({
       }
 
       if (!equals && oldProps[key] !== newProps[key]) {
-        return `${triggerName}.${key} changed shallowly: ${oldProps[key]} -> ${newProps[key]}`;
+        return `${triggerName} ${key} changed shallowly: ${oldProps[key]} -> ${newProps[key]}`;
       }
     }
   }
@@ -87,7 +87,7 @@ export function compareProps({
   for (const key in newProps) {
     if (!(key in ignoreProps)) {
       if (!oldProps.hasOwnProperty(key)) {
-        return `${triggerName}.${key} added: undefined -> ${newProps[key]}`;
+        return `${triggerName} ${key} added: (undefined) -> ${newProps[key]}`;
       }
     }
   }
@@ -96,7 +96,7 @@ export function compareProps({
 }
 /* eslint-enable max-statements, max-depth, complexity */
 
-// HELPERS
+// PRIVATE METHODS
 
 // The comparison of the data prop requires special handling
 // the dataComparator should be used if supplied
@@ -119,50 +119,37 @@ function diffDataProps(oldProps, props) {
   return null;
 }
 
-// Checks if any update triggers have changed
-// also calls callback to invalidate attributes accordingly.
+// Checks if any update triggers have changed, and invalidate
+// attributes accordingly.
+/* eslint-disable max-statements */
 function diffUpdateTriggers(oldProps, props, onUpdateTriggered) {
   // const {attributeManager} = this.state;
   // const updateTriggerMap = attributeManager.getUpdateTriggerMap();
   if (oldProps === null) {
-    return 'oldProps is null, initial diff';
+    return true; // oldProps is null, initial diff
   }
 
-  let reason = false;
+  let change = false;
 
-  // If the 'all' updateTrigger fires, ignore testing others
-  if ('all' in props.updateTriggers) {
-    const diffReason = diffUpdateTrigger(oldProps, props, 'all');
+  for (const propName in props.updateTriggers) {
+    const oldTriggers = oldProps.updateTriggers[propName] || {};
+    const newTriggers = props.updateTriggers[propName] || {};
+    const diffReason = compareProps({
+      oldProps: oldTriggers,
+      newProps: newTriggers,
+      triggerName: propName
+    });
     if (diffReason) {
-      onUpdateTriggered('all');
-      return diffReason;
+      onUpdateTriggered(propName);
+      change = true;
     }
   }
 
-  // If the 'all' updateTrigger didn't fire, need to check all others
-  for (const triggerName in props.updateTriggers) {
-    if (triggerName !== 'all') {
-      const diffReason = diffUpdateTrigger(oldProps, props, triggerName);
-      if (diffReason) {
-        onUpdateTriggered(triggerName);
-        reason = reason || diffReason;
-      }
-    }
-  }
-
-  return reason;
+  return change;
 }
+/* eslint-enable max-statements */
 
-function diffUpdateTrigger(oldProps, props, triggerName) {
-  const oldTriggers = oldProps.updateTriggers[triggerName] || {};
-  const newTriggers = props.updateTriggers[triggerName] || {};
-  const diffReason = compareProps({
-    oldProps: oldTriggers,
-    newProps: newTriggers,
-    triggerName
-  });
-  return diffReason;
-}
+// HELPERS
 
 // Constructors have their super class constructors as prototypes
 function getOwnProperty(object, prop) {

--- a/src/core/utils/log.js
+++ b/src/core/utils/log.js
@@ -24,6 +24,16 @@ import assert from 'assert';
 
 const cache = {};
 
+function formatArgs(firstArg, ...args) {
+  if (typeof firstArg === 'string') {
+    args.unshift(`deck.gl ${firstArg}`);
+  } else {
+    args.unshift(firstArg);
+    args.unshift('deck.gl');
+  }
+  return args;
+}
+
 function log(priority, arg, ...args) {
   assert(Number.isFinite(priority), 'log priority must be a number');
   if (priority <= log.priority) {
@@ -37,6 +47,20 @@ function log(priority, arg, ...args) {
   }
 }
 
+// Assertions don't generate standard exceptions and don't print nicely
+function checkForAssertionErrors(args) {
+  const isAssertion =
+    args && args.length > 0 &&
+    typeof args[0] === 'object' && args[0] !== null &&
+    args[0].name === 'AssertionError';
+
+  if (isAssertion) {
+    args = Array.prototype.slice.call(args);
+    args.unshift(`assert(${args[0].message})`);
+  }
+  return args;
+}
+
 function once(priority, arg, ...args) {
   if (!cache[arg] && priority <= log.priority) {
     args = checkForAssertionErrors(args);
@@ -48,8 +72,8 @@ function once(priority, arg, ...args) {
 function warn(priority, arg, ...args) {
   if (priority <= log.priority && !cache[arg]) {
     console.warn(`deck.gl: ${arg}`, ...args);
-    cache[arg] = true;
   }
+  cache[arg] = true;
 }
 
 function error(priority, arg, ...args) {
@@ -84,35 +108,6 @@ function timeEnd(priority, label) {
       console.info(label);
     }
   }
-}
-
-// Helper functions
-
-function formatArgs(firstArg, ...args) {
-  if (typeof firstArg === 'function') {
-    firstArg = firstArg();
-  }
-  if (typeof firstArg === 'string') {
-    args.unshift(`deck.gl ${firstArg}`);
-  } else {
-    args.unshift(firstArg);
-    args.unshift('deck.gl');
-  }
-  return args;
-}
-
-// Assertions don't generate standard exceptions and don't print nicely
-function checkForAssertionErrors(args) {
-  const isAssertion =
-    args && args.length > 0 &&
-    typeof args[0] === 'object' && args[0] !== null &&
-    args[0].name === 'AssertionError';
-
-  if (isAssertion) {
-    args = Array.prototype.slice.call(args);
-    args.unshift(`assert(${args[0].message})`);
-  }
-  return args;
 }
 
 log.priority = 0;

--- a/test/test-utils/spy.js
+++ b/test/test-utils/spy.js
@@ -1,10 +1,5 @@
 // Inspired by https://github.com/popomore/spy
-// Attach a spy to the function. The spy has the following methods and fields
-//  * restore() - remove spy completely
-//  * reset() - reset call count
-//  * callCount - number of calls
-//  * called - whether spy was called
-export default function makeSpy(obj, func) {
+export default function(obj, func) {
   let methodName;
 
   if (!obj && !func) {


### PR DESCRIPTION
Reverts uber/deck.gl#1051 - since this is part of a series of life cycle change PRs that all have a risk of introducing issues, will move this work to a `4.2-dev` branch to keep `master` stable.