### PR TITLE
Transitions: Add transitionProps, fix bearing and longitude interpolation.

### DIFF
--- a/examples/wip/viewport-animation-3d-heatmap/app.js
+++ b/examples/wip/viewport-animation-3d-heatmap/app.js
@@ -101,6 +101,7 @@ class Root extends Component {
         {...viewport}
         onViewportChange={this._onViewportChange.bind(this)}
         transitionDuration={transitionDuration}
+        transitionProps={['bearing']}
         onTransitionEnd={this._rotateCamera.bind(this)}>
         <StaticMap
           {...viewport}

--- a/examples/wip/viewport-animation-first-person-map/app.js
+++ b/examples/wip/viewport-animation-first-person-map/app.js
@@ -313,6 +313,7 @@ class Root extends Component {
           height={viewportProps.height}
           onViewportChange={this._onViewportChange}
           transitionDuration={transitionDuration}
+          transitionProps={['longitude', 'latitude', 'zoom', 'bearing', 'pitch', 'position']}
         >
           <DeckGL
             id="first-person"

--- a/examples/wip/viewport-animation/package.json
+++ b/examples/wip/viewport-animation/package.json
@@ -4,6 +4,7 @@
     "start-local": "webpack-dev-server --env.local --progress --hot --open"
   },
   "dependencies": {
+    "deck.gl": ">=4.2.0-alpha.17",
     "immutable": "^3.8.1",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
@@ -12,10 +13,10 @@
   },
   "devDependencies": {
     "babel-core": "^6.21.0",
-    "babel-loader": "^6.2.10",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-2": "^6.18.0",
+    "buble-loader": "^0.4.0",
     "webpack": "^2.4.0",
     "webpack-dev-server": "^2.4.0"
   }

--- a/examples/wip/viewport-animation/package.json
+++ b/examples/wip/viewport-animation/package.json
@@ -12,7 +12,6 @@
     "tween.js": "^16.6.0"
   },
   "devDependencies": {
-    "babel-core": "^6.21.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-2": "^6.18.0",

--- a/examples/wip/viewport-animation/src/app.js
+++ b/examples/wip/viewport-animation/src/app.js
@@ -106,6 +106,7 @@ export default class App extends Component {
         onViewportChange={this._onViewportChange.bind(this)}
         transitionInterpolator={viewportFlyToInterpolator}
         transitionDuration={transitionDuration}
+        transitionProps={['longitude', 'latitude', 'zoom', 'bearing', 'pitch', 'width', 'height']}
         transitionInterruption={this._interruptionStyle}>
         <StaticMap
           {...viewport}

--- a/src/core/controllers/map-state.js
+++ b/src/core/controllers/map-state.js
@@ -1,6 +1,7 @@
 import ViewState from './view-state';
 import PerspectiveMercatorViewport from '../viewports/web-mercator-viewport';
 import assert from 'assert';
+import {mod} from '../math/utils';
 
 // MAPBOX LIMITS
 export const MAPBOX_LIMITS = {
@@ -15,12 +16,6 @@ const defaultState = {
   bearing: 0,
   altitude: 1.5
 };
-
-/* Utils */
-function mod(value, divisor) {
-  const modulus = value % divisor;
-  return modulus < 0 ? divisor + modulus : modulus;
-}
 
 function ensureFinite(value, fallbackValue) {
   return Number.isFinite(value) ? value : fallbackValue;

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -45,6 +45,8 @@ export {default as MapState} from './controllers/map-state';
 export {TRANSITION_EVENTS} from './lib/transition-manager';
 export {viewportLinearInterpolator, viewportFlyToInterpolator} from './lib/viewport-transition-utils';
 
+export {equals} from './math/equals';
+
 // Experimental Features (May change in minor version bumps, use at your own risk)
 // Experimental Pure JS (non-React) bindings
 import {default as DeckGLJS} from './pure-js/deck-js';

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -45,8 +45,6 @@ export {default as MapState} from './controllers/map-state';
 export {TRANSITION_EVENTS} from './lib/transition-manager';
 export {viewportLinearInterpolator, viewportFlyToInterpolator} from './lib/viewport-transition-utils';
 
-export {equals} from './math/equals';
-
 // Experimental Features (May change in minor version bumps, use at your own risk)
 // Experimental Pure JS (non-React) bindings
 import {default as DeckGLJS} from './pure-js/deck-js';

--- a/src/core/lib/transition-manager.js
+++ b/src/core/lib/transition-manager.js
@@ -98,9 +98,9 @@ export default class TransitionManager {
     return props.transitionDuration > 0;
   }
 
-  _isUpdateDueToCurrentTransition(props) {
+  _isUpdateDueToCurrentTransition(nextViewport) {
     if (this.state.viewport) {
-      return areViewportsEqual(extractViewportFrom(props), this.state.viewport);
+      return areViewportsEqual(nextViewport, this.state.viewport);
     }
     return false;
   }
@@ -108,9 +108,10 @@ export default class TransitionManager {
   _shouldIgnoreViewportChange(nextProps) {
     // Ignore update if it is due to current active transition.
     // Ignore update if it is requested to be ignored
+    const nextViewport = extractViewportFrom(nextProps);
     if (this._isTransitionInProgress()) {
       if (this.state.interruption === TRANSITION_EVENTS.IGNORE ||
-        this._isUpdateDueToCurrentTransition(nextProps)) {
+        this._isUpdateDueToCurrentTransition(nextViewport)) {
         return true;
       }
     } else if (!this._isTransitionEnabled(nextProps)) {
@@ -118,7 +119,7 @@ export default class TransitionManager {
     }
 
     // Ignore if none of the viewport props changed.
-    if (areViewportsEqual(extractViewportFrom(this.props), extractViewportFrom(nextProps))) {
+    if (areViewportsEqual(extractViewportFrom(this.props), nextViewport)) {
       return true;
     }
 
@@ -188,6 +189,9 @@ export default class TransitionManager {
     t = easing(t);
 
     const viewport = interpolator(startViewport, endViewport, t);
+
+    // This extractViewportFrom gurantees angle props (bearing, longitude) are normalized
+    // So when viewports are compared they are in same range.
     this.state.viewport = extractViewportFrom(Object.assign({}, this.props, viewport));
 
     if (this.props.onViewportChange) {

--- a/src/core/lib/viewport-transition-utils.js
+++ b/src/core/lib/viewport-transition-utils.js
@@ -1,8 +1,7 @@
 /* eslint max-statements: ["error", 50] */
 
 import {projectFlat, unprojectFlat} from 'viewport-mercator-project';
-import {Vector2} from 'math.gl';
-import {equals} from '../math/equals';
+import {Vector2, equals} from 'math.gl';
 import {mod} from '../math/utils';
 import assert from 'assert';
 
@@ -37,7 +36,7 @@ export function extractViewportFrom(props) {
     assert(isValid(props[key]));
     viewport[key] = props[key];
     // Normalize longitude and bearing into [-180, 180) range
-    // This gurantees they props are in same range when they are interpolated.
+    // This gurantees the props are in same range when they are interpolated.
     if (key === 'longitude' || key === 'bearing') {
       viewport[key] = mod(viewport[key] + 180, 360) - 180;
     }

--- a/src/core/math/utils.js
+++ b/src/core/math/utils.js
@@ -1,5 +1,6 @@
 import vec4_multiply from 'gl-vec4/multiply';
 import vec4_transformMat4 from 'gl-vec4/transformMat4';
+import assert from 'assert';
 
 export function transformVector(matrix, vector) {
   // Handle non-invertible matrix
@@ -25,4 +26,10 @@ export function extractCameraVectors({viewMatrix, viewMatrixInverse}) {
     direction: [viewMatrix[2], viewMatrix[6], viewMatrix[10]],
     up: [viewMatrix[1], viewMatrix[5], viewMatrix[9]]
   };
+}
+
+export function mod(value, divisor) {
+  assert(Number.isFinite(value) && Number.isFinite(value));
+  const modulus = value % divisor;
+  return modulus < 0 ? divisor + modulus : modulus;
 }

--- a/src/react/viewport-controller.js
+++ b/src/react/viewport-controller.js
@@ -58,6 +58,8 @@ const propTypes = {
   transitionInterruption: PropTypes.number,
   // easing function
   transitionEasing: PropTypes.func,
+  // props to transition
+  transitionProps: PropTypes.array,
   // transition status update functions
   onTransitionStart: PropTypes.func,
   onTransitionInterrupt: PropTypes.func,

--- a/website/src/components/home.js
+++ b/website/src/components/home.js
@@ -96,7 +96,7 @@ class Home extends Component {
               <p>
               deck.gl allows complex visualizations to be constructed by
               composing existing layers, and makes it easy to package and
-              share new visulizations as reusable layers. We already offer
+              share new visualizations as reusable layers. We already offer
               a <a href="#/documentation/layer-catalog">catalog of proven layers</a> and
               we have many more in the works.
               </p>


### PR DESCRIPTION
Viewport Transition updates : 
* Normalize angle props (bearing and pitch) before saving them in TransitionManger.
* For angle props, take shortest interpolation path always
   * When interpolating bearing -120 -> 120 (240 degree change), change them to 240 -> 120 (120 degree change)
* Add new prop 'transitionProps', which is an array of viewport props that will be interpolated, this will allow applications to change props (that are not part of `transitionProps`) while animating props specified using `transitionProps`. For example, an application can change `latitude` and `longitude`  while `bearing` and `pitch` are in transition.
* Add asserts to help debugging.

Verified with all 4 viewport-animation examples and layer-browser.