### PR TITLE
Add flag for viewport transition updates

### DIFF
--- a/src/core/lib/transition-manager.js
+++ b/src/core/lib/transition-manager.js
@@ -195,7 +195,7 @@ export default class TransitionManager {
     this.state.viewport = extractViewportFrom(Object.assign({}, this.props, viewport));
 
     if (this.props.onViewportChange) {
-      this.props.onViewportChange(this.state.viewport);
+      this.props.onViewportChange(this.state.viewport, {inTransition: true});
     }
 
     if (shouldEnd) {


### PR DESCRIPTION
* Add `inTransition: true` argument to `onViewportChange`, so application know the source of the callback.

Verified with layer-browser and viewport transition examples.