### PR TITLE
Fix issues in Orbit Viewport and update examples

### DIFF
--- a/examples/plot/app.js
+++ b/examples/plot/app.js
@@ -15,8 +15,9 @@ class Root extends Component {
       viewport: {
         lookAt: [0, 0, 0],
         distance: 3,
-        rotationX: -30,
-        rotationY: 30,
+        pitchAngle: -30,
+        orbitAngle: 30,
+        orbitAxis: 'Y',
         fov: 50,
         minDistance: 1,
         maxDistance: 20,

--- a/examples/point-cloud-laz/app.js
+++ b/examples/point-cloud-laz/app.js
@@ -59,8 +59,9 @@ class Example extends PureComponent {
       viewport: {
         lookAt: [0, 0, 0],
         distance: 1,
-        rotationX: 0,
-        rotationY: 0,
+        pitchAngle: 0,
+        orbitAngle: 0,
+        orbitAxis: 'Y',
         fov: 30,
         minDistance: 0.5,
         maxDistance: 3
@@ -132,7 +133,7 @@ class Example extends PureComponent {
     this.setState({
       viewport: {
         ...viewport,
-        rotationY: viewport.rotationY + 1
+        orbitAngle: viewport.orbitAngle + 1
       }
     });
 

--- a/examples/point-cloud-ply/app.js
+++ b/examples/point-cloud-ply/app.js
@@ -24,8 +24,9 @@ class Example extends PureComponent {
       viewport: {
         lookAt: [0, 0, 0],
         distance: 100,
-        rotationX: 0,
-        rotationY: 0,
+        pitchAngle: 0,
+        orbitAngle: 0,
+        orbitAxis: 'Y',
         fov: 30,
         minDistance: 1.5,
         maxDistance: 10
@@ -79,7 +80,7 @@ class Example extends PureComponent {
     this.setState({
       viewport: {
         ...viewport,
-        rotationY: viewport.rotationY + 1
+        orbitAngle: viewport.orbitAngle + 1
       }
     });
     window.requestAnimationFrame(this._onUpdate);

--- a/src/core/controllers/orbit-state.js
+++ b/src/core/controllers/orbit-state.js
@@ -6,8 +6,8 @@ import assert from 'assert';
 
 const defaultState = {
   lookAt: [0, 0, 0],
-  rotationX: 0,
-  rotationY: 0,
+  pitchAngle: 0,
+  orbitAngle: 0,
   fov: 50,
   near: 1,
   far: 100,
@@ -50,8 +50,8 @@ export default class OrbitState {
     width, // Width of viewport
     height, // Height of viewport
     distance, // From eye to target
-    rotationX, // Rotation around x axis
-    rotationY, // Rotation around y axis
+    pitchAngle, // Rotation around x axis
+    orbitAngle, // Rotation around orbit axis
 
     // Bounding box of the model, in the shape of {minX, maxX, minY, maxY, minZ, maxZ}
     bounds,
@@ -92,8 +92,8 @@ export default class OrbitState {
       width,
       height,
       distance,
-      rotationX: ensureFinite(rotationX, defaultState.rotationX),
-      rotationY: ensureFinite(rotationY, defaultState.rotationY),
+      pitchAngle: ensureFinite(pitchAngle, defaultState.pitchAngle),
+      orbitAngle: ensureFinite(orbitAngle, defaultState.orbitAngle),
 
       bounds,
       lookAt: lookAt || defaultState.lookAt,
@@ -197,14 +197,14 @@ export default class OrbitState {
   rotate({deltaScaleX, deltaScaleY}) {
     const {startRotateCenter, startRotateViewport} = this._interactiveState;
 
-    let {rotationX, rotationY, translationX, translationY} = startRotateViewport || {};
-    rotationX = ensureFinite(rotationX, this._viewportProps.rotationX);
-    rotationY = ensureFinite(rotationY, this._viewportProps.rotationY);
+    let {pitchAngle, orbitAngle, translationX, translationY} = startRotateViewport || {};
+    pitchAngle = ensureFinite(pitchAngle, this._viewportProps.pitchAngle);
+    orbitAngle = ensureFinite(orbitAngle, this._viewportProps.orbitAngle);
     translationX = ensureFinite(translationX, this._viewportProps.translationX);
     translationY = ensureFinite(translationY, this._viewportProps.translationY);
 
-    const newRotationX = clamp(rotationX - deltaScaleY * 180, -89.999, 89.999);
-    const newRotationY = (rotationY - deltaScaleX * 180) % 360;
+    const newPitchAngle = clamp(pitchAngle - deltaScaleY * 180, -89.999, 89.999);
+    const newOrbitAngle = (orbitAngle - deltaScaleX * 180) % 360;
 
     let newTranslationX = translationX;
     let newTranslationY = translationY;
@@ -215,8 +215,8 @@ export default class OrbitState {
       const oldCenterPos = oldViewport.project(startRotateCenter);
 
       const newViewport = new OrbitViewport(Object.assign({}, startRotateViewport, {
-        rotationX: newRotationX,
-        rotationY: newRotationY
+        pitchAngle: newPitchAngle,
+        orbitAngle: newOrbitAngle
       }));
       const newCenterPos = newViewport.project(startRotateCenter);
 
@@ -225,8 +225,8 @@ export default class OrbitState {
     }
 
     return this._getUpdatedOrbitState({
-      rotationX: newRotationX,
-      rotationY: newRotationY,
+      pitchAngle: newPitchAngle,
+      orbitAngle: newOrbitAngle,
       translationX: newTranslationX,
       translationY: newTranslationY
     });

--- a/src/core/viewports/orbit-viewport.js
+++ b/src/core/viewports/orbit-viewport.js
@@ -31,7 +31,7 @@ export default class OrbitViewport extends Viewport {
     distance, // From eye position to lookAt
     pitchAngle = 0, // Rotating angle around X axis
     orbitAngle = 0, // Rotating angle around orbit axis
-    orbitAxis = 'Z', // Orbit axis with 360 degrees rotating freedom
+    orbitAxis = 'Z', // Orbit axis with 360 degrees rotating freedom, can only be 'Y' or 'Z'
     lookAt = [0, 0, 0], // Which point is camera looking at, default origin
     up = [0, 1, 0], // Defines up direction, default positive y axis
     // projection matrix arguments

--- a/src/core/viewports/orbit-viewport.js
+++ b/src/core/viewports/orbit-viewport.js
@@ -8,7 +8,6 @@ import mat4_translate from 'gl-mat4/translate';
 import mat4_rotateX from 'gl-mat4/rotateX';
 import mat4_rotateY from 'gl-mat4/rotateY';
 import mat4_rotateZ from 'gl-mat4/rotateZ';
-import vec3_add from 'gl-vec3/add';
 
 import {transformVector} from '../math/utils';
 
@@ -52,18 +51,19 @@ export default class OrbitViewport extends Viewport {
       mat4_rotateY(rotationMatrix, rotationMatrix, -orbitAngle / 180 * Math.PI);
     }
 
-    const transformMatrix = mat4_translate([], createMat4(),
+    const translateMatrix = mat4_translate([], createMat4(),
       [translationX / width * 2, translationY / height * 2, 0]);
-    mat4_scale(transformMatrix, transformMatrix, [zoom, zoom, zoom]);
-    mat4_multiply(rotationMatrix, rotationMatrix, transformMatrix);
+    mat4_scale(translateMatrix, translateMatrix, [zoom, zoom, zoom]);
+    mat4_translate(translateMatrix, translateMatrix, [-lookAt[0], -lookAt[1], -lookAt[2]]);
 
-    const viewMatrix = mat4_lookAt([], vec3_add([], lookAt, [0, 0, distance]), lookAt, up);
+    const viewMatrix = mat4_lookAt([], [0, 0, distance], [0, 0, 0], up);
     const fovRadians = fov * DEGREES_TO_RADIANS;
     const aspect = width / height;
     const perspectiveMatrix = mat4_perspective([], fovRadians, aspect, near, far);
 
     super({
-      viewMatrix: mat4_multiply(viewMatrix, viewMatrix, rotationMatrix),
+      viewMatrix: mat4_multiply(viewMatrix, viewMatrix,
+        mat4_multiply(rotationMatrix, rotationMatrix, translateMatrix)),
       projectionMatrix: perspectiveMatrix,
       width,
       height

--- a/src/core/viewports/orbit-viewport.js
+++ b/src/core/viewports/orbit-viewport.js
@@ -5,9 +5,10 @@ import mat4_lookAt from 'gl-mat4/lookAt';
 import mat4_scale from 'gl-mat4/scale';
 import mat4_perspective from 'gl-mat4/perspective';
 import mat4_translate from 'gl-mat4/translate';
+import mat4_rotateX from 'gl-mat4/rotateX';
+import mat4_rotateY from 'gl-mat4/rotateY';
+import mat4_rotateZ from 'gl-mat4/rotateZ';
 import vec3_add from 'gl-vec3/add';
-import vec3_rotateX from 'gl-vec3/rotateX';
-import vec3_rotateY from 'gl-vec3/rotateY';
 
 import {transformVector} from '../math/utils';
 
@@ -29,8 +30,9 @@ export default class OrbitViewport extends Viewport {
     height, // Height of viewport
     // view matrix arguments
     distance, // From eye position to lookAt
-    rotationX = 0,
-    rotationY = 0,
+    pitchAngle = 0, // Rotating angle around X axis
+    orbitAngle = 0, // Rotating angle around orbit axis
+    orbitAxis = 'Z', // Orbit axis with 360 degrees rotating freedom
     lookAt = [0, 0, 0], // Which point is camera looking at, default origin
     up = [0, 1, 0], // Defines up direction, default positive y axis
     // projection matrix arguments
@@ -43,21 +45,26 @@ export default class OrbitViewport extends Viewport {
     translationY = 0, // in pixels
     zoom = 1
   }) {
-    const eye = vec3_add([], lookAt, [0, 0, distance]);
-    vec3_rotateX(eye, eye, lookAt, rotationX / 180 * Math.PI);
-    vec3_rotateY(eye, eye, lookAt, rotationY / 180 * Math.PI);
+    const rotationMatrix = mat4_rotateX([], createMat4(), -pitchAngle / 180 * Math.PI);
+    if (orbitAxis === 'Z') {
+      mat4_rotateZ(rotationMatrix, rotationMatrix, -orbitAngle / 180 * Math.PI);
+    } else {
+      mat4_rotateY(rotationMatrix, rotationMatrix, -orbitAngle / 180 * Math.PI);
+    }
 
-    const fovyRadians = fov * DEGREES_TO_RADIANS;
-    const aspect = width / height;
-    const perspectiveMatrix = mat4_perspective([], fovyRadians, aspect, near, far);
-    const transformMatrix = createMat4();
-    mat4_translate(transformMatrix, transformMatrix,
+    const transformMatrix = mat4_translate([], createMat4(),
       [translationX / width * 2, translationY / height * 2, 0]);
-    mat4_scale(transformMatrix, transformMatrix, [zoom, zoom, 1]);
+    mat4_scale(transformMatrix, transformMatrix, [zoom, zoom, zoom]);
+    mat4_multiply(rotationMatrix, rotationMatrix, transformMatrix);
+
+    const viewMatrix = mat4_lookAt([], vec3_add([], lookAt, [0, 0, distance]), lookAt, up);
+    const fovRadians = fov * DEGREES_TO_RADIANS;
+    const aspect = width / height;
+    const perspectiveMatrix = mat4_perspective([], fovRadians, aspect, near, far);
 
     super({
-      viewMatrix: mat4_lookAt([], eye, lookAt, up),
-      projectionMatrix: mat4_multiply(transformMatrix, transformMatrix, perspectiveMatrix),
+      viewMatrix: mat4_multiply(viewMatrix, viewMatrix, rotationMatrix),
+      projectionMatrix: perspectiveMatrix,
       width,
       height
     });
@@ -65,8 +72,8 @@ export default class OrbitViewport extends Viewport {
     this.width = width;
     this.height = height;
     this.distance = distance;
-    this.rotationX = rotationX;
-    this.rotationY = rotationY;
+    this.pitchAngle = pitchAngle;
+    this.orbitAngle = orbitAngle;
     this.lookAt = lookAt;
     this.up = up;
     this.fov = fov;
@@ -100,8 +107,8 @@ export default class OrbitViewport extends Viewport {
     const {
       width,
       height,
-      rotationX,
-      rotationY,
+      pitchAngle,
+      orbitAngle,
       lookAt,
       up,
       fov,
@@ -117,8 +124,8 @@ export default class OrbitViewport extends Viewport {
     return new OrbitViewport({
       width,
       height,
-      rotationX,
-      rotationY,
+      pitchAngle,
+      orbitAngle,
       up,
       fov,
       near,


### PR DESCRIPTION
1. Can specify both 'Y' and 'Z' axis as orbit axis instead of 'Y' only
2. Change translate to world space instead of screen space
3. Change scale to world space in stead of screen space, which makes frustum clipping fails

Tested with point-cloud-laz, point-cloud-ply and plot examples