### PR TITLE
Fix the pan event handling of orbit controller

### DIFF
--- a/src/react/experimental/orbit-controller.js
+++ b/src/react/experimental/orbit-controller.js
@@ -100,7 +100,7 @@ export default class OrbitController extends React.Component {
   render() {
     const {width, height} = this.props;
 
-    // Create canvas style with right size.
+    // Create canvas style with right size
     const eventCanvasStyle = {
       width,
       height,

--- a/src/react/experimental/orbit-controller.js
+++ b/src/react/experimental/orbit-controller.js
@@ -100,7 +100,7 @@ export default class OrbitController extends React.Component {
   render() {
     const {width, height} = this.props;
 
-    // Create canvas style with right size
+    // Create canvas style with right size.
     const eventCanvasStyle = {
       width,
       height,

--- a/src/react/experimental/orbit-controller.js
+++ b/src/react/experimental/orbit-controller.js
@@ -98,9 +98,18 @@ export default class OrbitController extends React.Component {
   }
 
   render() {
+    const {width, height} = this.props;
+
+    const eventCanvasStyle = {
+      width,
+      height,
+      position: 'relative'
+    };
+
     return (
       createElement('div', {
-        ref: 'eventCanvas'
+        ref: 'eventCanvas',
+        style: eventCanvasStyle
       }, this.props.children)
     );
   }

--- a/src/react/experimental/orbit-controller.js
+++ b/src/react/experimental/orbit-controller.js
@@ -100,6 +100,7 @@ export default class OrbitController extends React.Component {
   render() {
     const {width, height} = this.props;
 
+    // Create canvas style with right size
     const eventCanvasStyle = {
       width,
       height,


### PR DESCRIPTION
Pan event doesn't work well in orbit controller, can't pan along the Y direction. here add the right canvas size to root element to fix the issue.

Tested with point-cloud-ply example.