### PR TITLE
Recycle model resources on reset.

### DIFF
--- a/src/core/lib/layer.js
+++ b/src/core/lib/layer.js
@@ -204,8 +204,9 @@ export default class Layer {
   // Public API
 
   // Updates selected state members and marks the object for redraw
-  setState(updateObject) {
-    Object.assign(this.state, updateObject);
+  setState(newState) {
+    this._deleteResources(newState);
+    Object.assign(this.state, newState);
     this.state.needsRedraw = true;
   }
 
@@ -575,6 +576,17 @@ export default class Layer {
         message += `\nPlease use props.${newProp} instead.`;
       }
       log.once(0, message);
+    }
+  }
+
+  _deleteResources(newState) {
+    // model
+    if (
+      this.state.model &&
+      newState.model &&
+      this.state.model !== newState.model
+    ) {
+      this.state.model.delete();
     }
   }
 


### PR DESCRIPTION
When resetting Model on layer, call Model.delete() to trigger resource recycle.
Fixes performance regression issue seen in : #1126 

This triggers Program object recycling in luma.gl (https://github.com/uber/luma.gl/pull/352)

Verified with examples, and layer-browser (change props, toggling `fp64` multiple times).