### PR TITLE
Orbit Controller refactor to improve pan, rotation and zoom

### DIFF
--- a/examples/plot/app.js
+++ b/examples/plot/app.js
@@ -15,8 +15,8 @@ class Root extends Component {
       viewport: {
         lookAt: [0, 0, 0],
         distance: 3,
-        pitchAngle: -30,
-        orbitAngle: 30,
+        rotationX: -30,
+        rotationOrbit: 30,
         orbitAxis: 'Y',
         fov: 50,
         minDistance: 1,

--- a/examples/point-cloud-laz/app.js
+++ b/examples/point-cloud-laz/app.js
@@ -59,8 +59,8 @@ class Example extends PureComponent {
       viewport: {
         lookAt: [0, 0, 0],
         distance: 1,
-        pitchAngle: 0,
-        orbitAngle: 0,
+        rotationX: 0,
+        rotationOrbit: 0,
         orbitAxis: 'Y',
         fov: 30,
         minDistance: 0.5,
@@ -133,7 +133,7 @@ class Example extends PureComponent {
     this.setState({
       viewport: {
         ...viewport,
-        orbitAngle: viewport.orbitAngle + 1
+        rotationOrbit: viewport.rotationOrbit + 1
       }
     });
 

--- a/examples/point-cloud-ply/app.js
+++ b/examples/point-cloud-ply/app.js
@@ -24,8 +24,8 @@ class Example extends PureComponent {
       viewport: {
         lookAt: [0, 0, 0],
         distance: 100,
-        pitchAngle: 0,
-        orbitAngle: 0,
+        rotationX: 0,
+        rotationOrbit: 0,
         orbitAxis: 'Y',
         fov: 30,
         minDistance: 1.5,
@@ -80,7 +80,7 @@ class Example extends PureComponent {
     this.setState({
       viewport: {
         ...viewport,
-        orbitAngle: viewport.orbitAngle + 1
+        rotationOrbit: viewport.rotationOrbit + 1
       }
     });
     window.requestAnimationFrame(this._onUpdate);

--- a/src/core/controllers/orbit-state.js
+++ b/src/core/controllers/orbit-state.js
@@ -3,8 +3,8 @@ import assert from 'assert';
 
 const defaultState = {
   lookAt: [0, 0, 0],
-  pitchAngle: 0,
-  orbitAngle: 0,
+  rotationX: 0,
+  rotationOrbit: 0,
   fov: 50,
   near: 1,
   far: 100,
@@ -36,8 +36,8 @@ export default class OrbitState {
     width, // Width of viewport
     height, // Height of viewport
     distance, // From eye to target
-    pitchAngle, // Rotation around x axis
-    orbitAngle, // Rotation around orbit axis
+    rotationX, // Rotation around x axis
+    rotationOrbit, // Rotation around orbit axis
     orbitAxis, // Orbit axis with 360 degrees rotating freedom, can only be 'Y' or 'Z'
     // Bounding box of the model, in the shape of {minX, maxX, minY, maxY, minZ, maxZ}
     bounds,
@@ -79,8 +79,8 @@ export default class OrbitState {
       width,
       height,
       distance,
-      pitchAngle: ensureFinite(pitchAngle, defaultState.pitchAngle),
-      orbitAngle: ensureFinite(orbitAngle, defaultState.orbitAngle),
+      rotationX: ensureFinite(rotationX, defaultState.rotationX),
+      rotationOrbit: ensureFinite(rotationOrbit, defaultState.rotationOrbit),
       orbitAxis,
 
       bounds,
@@ -195,16 +195,16 @@ export default class OrbitState {
 
     const {startRotateViewport} = this._interactiveState;
 
-    let {pitchAngle, orbitAngle} = startRotateViewport || {};
-    pitchAngle = ensureFinite(pitchAngle, this._viewportProps.pitchAngle);
-    orbitAngle = ensureFinite(orbitAngle, this._viewportProps.orbitAngle);
+    let {rotationX, rotationOrbit} = startRotateViewport || {};
+    rotationX = ensureFinite(rotationX, this._viewportProps.rotationX);
+    rotationOrbit = ensureFinite(rotationOrbit, this._viewportProps.rotationOrbit);
 
-    const newPitchAngle = clamp(pitchAngle - deltaScaleY * 180, -89.999, 89.999);
-    const newOrbitAngle = (orbitAngle - deltaScaleX * 180) % 360;
+    const newRotationX = clamp(rotationX - deltaScaleY * 180, -89.999, 89.999);
+    const newRotationOrbit = (rotationOrbit - deltaScaleX * 180) % 360;
 
     return this._getUpdatedOrbitState({
-      pitchAngle: newPitchAngle,
-      orbitAngle: newOrbitAngle,
+      rotationX: newRotationX,
+      rotationOrbit: newRotationOrbit,
       isRotating: true
     });
   }

--- a/src/core/viewports/orbit-viewport.js
+++ b/src/core/viewports/orbit-viewport.js
@@ -29,8 +29,8 @@ export default class OrbitViewport extends Viewport {
     height, // Height of viewport
     // view matrix arguments
     distance, // From eye position to lookAt
-    pitchAngle = 0, // Rotating angle around X axis
-    orbitAngle = 0, // Rotating angle around orbit axis
+    rotationX = 0, // Rotating angle around X axis
+    rotationOrbit = 0, // Rotating angle around orbit axis
     orbitAxis = 'Z', // Orbit axis with 360 degrees rotating freedom, can only be 'Y' or 'Z'
     lookAt = [0, 0, 0], // Which point is camera looking at, default origin
     up = [0, 1, 0], // Defines up direction, default positive y axis
@@ -40,11 +40,11 @@ export default class OrbitViewport extends Viewport {
     far = 100, // Distance of far clipping plane
     zoom = 1
   }) {
-    const rotationMatrix = mat4_rotateX([], createMat4(), -pitchAngle / 180 * Math.PI);
+    const rotationMatrix = mat4_rotateX([], createMat4(), -rotationX / 180 * Math.PI);
     if (orbitAxis === 'Z') {
-      mat4_rotateZ(rotationMatrix, rotationMatrix, -orbitAngle / 180 * Math.PI);
+      mat4_rotateZ(rotationMatrix, rotationMatrix, -rotationOrbit / 180 * Math.PI);
     } else {
-      mat4_rotateY(rotationMatrix, rotationMatrix, -orbitAngle / 180 * Math.PI);
+      mat4_rotateY(rotationMatrix, rotationMatrix, -rotationOrbit / 180 * Math.PI);
     }
 
     const translateMatrix = createMat4();
@@ -67,8 +67,8 @@ export default class OrbitViewport extends Viewport {
     this.width = width;
     this.height = height;
     this.distance = distance;
-    this.pitchAngle = pitchAngle;
-    this.orbitAngle = orbitAngle;
+    this.rotationX = rotationX;
+    this.rotationOrbit = rotationOrbit;
     this.orbitAxis = orbitAxis;
     this.lookAt = lookAt;
     this.up = up;
@@ -101,8 +101,8 @@ export default class OrbitViewport extends Viewport {
     const {
       width,
       height,
-      pitchAngle,
-      orbitAngle,
+      rotationX,
+      rotationOrbit,
       orbitAxis,
       lookAt,
       up,
@@ -119,8 +119,8 @@ export default class OrbitViewport extends Viewport {
     return new OrbitViewport({
       width,
       height,
-      pitchAngle,
-      orbitAngle,
+      rotationX,
+      rotationOrbit,
       orbitAxis,
       up,
       fov,

--- a/src/core/viewports/orbit-viewport.js
+++ b/src/core/viewports/orbit-viewport.js
@@ -38,10 +38,6 @@ export default class OrbitViewport extends Viewport {
     fov = 75, // Field of view covered by camera
     near = 1, // Distance of near clipping plane
     far = 100, // Distance of far clipping plane
-
-    // after projection
-    translationX = 0, // in pixels
-    translationY = 0, // in pixels
     zoom = 1
   }) {
     const rotationMatrix = mat4_rotateX([], createMat4(), -pitchAngle / 180 * Math.PI);
@@ -51,8 +47,7 @@ export default class OrbitViewport extends Viewport {
       mat4_rotateY(rotationMatrix, rotationMatrix, -orbitAngle / 180 * Math.PI);
     }
 
-    const translateMatrix = mat4_translate([], createMat4(),
-      [translationX / width * 2, translationY / height * 2, 0]);
+    const translateMatrix = createMat4();
     mat4_scale(translateMatrix, translateMatrix, [zoom, zoom, zoom]);
     mat4_translate(translateMatrix, translateMatrix, [-lookAt[0], -lookAt[1], -lookAt[2]]);
 
@@ -74,13 +69,12 @@ export default class OrbitViewport extends Viewport {
     this.distance = distance;
     this.pitchAngle = pitchAngle;
     this.orbitAngle = orbitAngle;
+    this.orbitAxis = orbitAxis;
     this.lookAt = lookAt;
     this.up = up;
     this.fov = fov;
     this.near = near;
     this.far = far;
-    this.translationX = translationX;
-    this.translationY = translationY;
     this.zoom = zoom;
   }
 
@@ -109,6 +103,7 @@ export default class OrbitViewport extends Viewport {
       height,
       pitchAngle,
       orbitAngle,
+      orbitAxis,
       lookAt,
       up,
       fov,
@@ -126,6 +121,7 @@ export default class OrbitViewport extends Viewport {
       height,
       pitchAngle,
       orbitAngle,
+      orbitAxis,
       up,
       fov,
       near,


### PR DESCRIPTION
This is the second round to improve Orbit Controller, includes these items.
1. Continue to move panning from clip space to world space, which can avoid rendering distortion and inaccurate depth clipping
2. Change the old Orbit State modeling from (lookAt, translateX, translateY, pitchAngle, rotationAngle) to (lookAt, pitchAngle, rotationAngle), cause translate and rotation is dependent with each other which makes the logic much more complicated.
3. Clean up code for pan, rotation and zoom to adapt new modeling

Tested with plot, point-cloud-laz and point-cloud