### PR TITLE
Use buildkite and docker for CI

### DIFF
--- a/.buildkite/coverTests
+++ b/.buildkite/coverTests
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+sh /etc/init.d/xvfb
+
+npm run cover
+
+cat coverage/lcov.info | coveralls

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,7 @@
 steps:
   - name: ":docker: :package:"
+    agents:
+      queue: 'uber-builders'
     plugins:
       docker-compose#v1.5.2:
         build: deck-gl

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,17 @@
+steps:
+  - name: ":docker: :package:"
+    plugins:
+      docker-compose#v1.5.2:
+        build: deck-gl
+        image-repository: 296822479253.dkr.ecr.us-east-2.amazonaws.com/fusionjs
+  - wait
+  - name: ":eslint:"
+    command: "npm run lint"
+    plugins:
+      docker-compose#v1.5.2:
+        run: deck-gl
+  - name: ":node:"
+    command: ".buildkite/coverTests"
+    plugins:
+      docker-compose#v1.5.2:
+        run: deck-gl

--- a/.buildkite/xvfb
+++ b/.buildkite/xvfb
@@ -1,0 +1,5 @@
+XVFB=/usr/bin/Xvfb
+XVFBARGS="$DISPLAY -screen 0 1024x768x24 -ac +extension GLX +render -noreset"
+PIDFILE=/var/run/xvfb.pid
+
+start-stop-daemon --start --quiet --pidfile $PIDFILE --make-pidfile --background --exec $XVFB -- $XVFBARGS

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:8.9.0
+
+WORKDIR /deck-gl
+ENV PATH /deck-gl/node_modules/.bin:$PATH
+
+# Install XVFB dependencies into container
+ENV DISPLAY :99
+ADD .buildkite/xvfb /etc/init.d/xvfb
+
+RUN apt-get update
+RUN apt-get -y install xvfb && chmod a+x /etc/init.d/xvfb
+
+COPY package.json yarn.lock /deck-gl/
+
+RUN yarn

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
   <a href="https://travis-ci.org/uber/deck.gl">
     <img src="https://img.shields.io/travis/uber/deck.gl/master.svg?style=flat-square" alt="build" />
   </a>
+  [![Build status](https://badge.buildkite.com/6fb0e59c3c390c392ce334eceb981748290a7d4a1ea515f2ce.svg?branch=master)](https://buildkite.com/uberopensource/deck-gl)
   <a href="https://npmjs.org/package/deck.gl">
     <img src="https://img.shields.io/npm/dm/deck.gl.svg?style=flat-square" alt="downloads" />
   </a>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '2'
+services:
+  deck-gl:
+    build: .
+    volumes:
+      - .:/deck-gl
+      - /deck-gl/node_modules/


### PR DESCRIPTION
This is a WIP proposal to run Buildkite as a CI service alongside Travis. Buildkite allows for easy-to-configure parallelization as well as running within Docker containers. There's still some github configuration that we need to do before landing, but just opening this to get the conversation going.