### PR TITLE
add triggers changed to changeFlags.updateTriggersChanged

### DIFF
--- a/src/core/lib/layer.js
+++ b/src/core/lib/layer.js
@@ -599,7 +599,7 @@ ${flags.viewportChanged ? 'viewport' : ''}\
     if (changeFlags.updateTriggersChanged) {
       for (const key in changeFlags.updateTriggersChanged) {
         if (changeFlags.updateTriggersChanged[key]) {
-          this._onUpdateTriggered(key);
+          this._activeUpdateTrigger(key);
         }
       }
     }
@@ -687,15 +687,9 @@ ${flags.viewportChanged ? 'viewport' : ''}\
     this.diffProps();
   }
 
-  // Callback for `diffProps`, will be called when an updateTrigger fires
-  _onUpdateTriggered(propName, diffReason) {
-    switch (propName) {
-    case 'all':
-      this.invalidateAttribute('all', diffReason);
-      break;
-    default:
-      this.invalidateAttribute(propName, diffReason);
-    }
+  // Operate on each changed triggers, will be called when an updateTrigger changes
+  _activeUpdateTrigger(propName) {
+    this.invalidateAttribute(propName);
   }
 
   //  Helper to check that required props are supplied

--- a/src/core/lib/layer.js
+++ b/src/core/lib/layer.js
@@ -537,7 +537,8 @@ export default class Layer {
     if (flags.updateTriggersChanged && !changeFlags.updateTriggersChanged) {
       changeFlags.updateTriggersChanged = flags.updateTriggersChanged;
       log.log(LOG_PRIORITY_UPDATE + 1,
-        () => `updateTriggersChanged: ${flags.updateTriggersChanged} in ${this.id}`);
+        () => `updateTriggersChanged: 
+        ${Object.keys(flags.updateTriggersChanged).join(', ')} in ${this.id}`);
     }
     if (flags.propsChanged && !changeFlags.propsChanged) {
       changeFlags.propsChanged = flags.propsChanged;

--- a/src/core/lib/props.js
+++ b/src/core/lib/props.js
@@ -130,7 +130,6 @@ function diffUpdateTriggers(props, oldProps) {
   if ('all' in props.updateTriggers) {
     const diffReason = diffUpdateTrigger(oldProps, props, 'all');
     if (diffReason) {
-      // onUpdateTriggered('all');
       return {all: true};
     }
   }
@@ -142,7 +141,6 @@ function diffUpdateTriggers(props, oldProps) {
     if (triggerName !== 'all') {
       const diffReason = diffUpdateTrigger(oldProps, props, triggerName);
       if (diffReason) {
-        // onUpdateTriggered(triggerName);
         triggerChanged[triggerName] = true;
         reason = triggerChanged;
       }

--- a/src/core/lib/props.js
+++ b/src/core/lib/props.js
@@ -2,7 +2,7 @@ import log from '../utils/log';
 import assert from 'assert';
 
 // Returns an object with "change flags", either false or strings indicating reason for change
-export function diffProps(props, oldProps, onUpdateTriggered = () => {}) {
+export function diffProps(props, oldProps) {
   // First check if any props have changed (ignore props that will be examined separately)
   const propsChangedReason = compareProps({
     newProps: props,
@@ -17,7 +17,7 @@ export function diffProps(props, oldProps, onUpdateTriggered = () => {}) {
   // Note - if data has changed, all attributes will need regeneration, so skip this step
   let updateTriggersChangedReason = false;
   if (!dataChangedReason) {
-    updateTriggersChangedReason = diffUpdateTriggers(props, oldProps, onUpdateTriggered);
+    updateTriggersChangedReason = diffUpdateTriggers(props, oldProps);
   }
 
   return {
@@ -121,7 +121,7 @@ function diffDataProps(props, oldProps) {
 
 // Checks if any update triggers have changed
 // also calls callback to invalidate attributes accordingly.
-function diffUpdateTriggers(props, oldProps, onUpdateTriggered) {
+function diffUpdateTriggers(props, oldProps) {
   if (oldProps === null) {
     return 'oldProps is null, initial diff';
   }
@@ -130,24 +130,26 @@ function diffUpdateTriggers(props, oldProps, onUpdateTriggered) {
   if ('all' in props.updateTriggers) {
     const diffReason = diffUpdateTrigger(oldProps, props, 'all');
     if (diffReason) {
-      onUpdateTriggered('all');
+      // onUpdateTriggered('all');
       return {all: true};
     }
   }
 
   const triggerChanged = {};
+  let reason = false;
   // If the 'all' updateTrigger didn't fire, need to check all others
   for (const triggerName in props.updateTriggers) {
     if (triggerName !== 'all') {
       const diffReason = diffUpdateTrigger(oldProps, props, triggerName);
       if (diffReason) {
-        onUpdateTriggered(triggerName);
+        // onUpdateTriggered(triggerName);
         triggerChanged[triggerName] = true;
+        reason = triggerChanged;
       }
     }
   }
 
-  return Object.keys(triggerChanged).length > 0 && triggerChanged;
+  return reason;
 }
 
 function diffUpdateTrigger(props, oldProps, triggerName) {

--- a/src/core/lib/props.js
+++ b/src/core/lib/props.js
@@ -122,35 +122,32 @@ function diffDataProps(props, oldProps) {
 // Checks if any update triggers have changed
 // also calls callback to invalidate attributes accordingly.
 function diffUpdateTriggers(props, oldProps, onUpdateTriggered) {
-  // const {attributeManager} = this.state;
-  // const updateTriggerMap = attributeManager.getUpdateTriggerMap();
   if (oldProps === null) {
     return 'oldProps is null, initial diff';
   }
-
-  let reason = false;
 
   // If the 'all' updateTrigger fires, ignore testing others
   if ('all' in props.updateTriggers) {
     const diffReason = diffUpdateTrigger(oldProps, props, 'all');
     if (diffReason) {
       onUpdateTriggered('all');
-      return diffReason;
+      return {all: true};
     }
   }
 
+  const triggerChanged = {};
   // If the 'all' updateTrigger didn't fire, need to check all others
   for (const triggerName in props.updateTriggers) {
     if (triggerName !== 'all') {
       const diffReason = diffUpdateTrigger(oldProps, props, triggerName);
       if (diffReason) {
         onUpdateTriggered(triggerName);
-        reason = reason || diffReason;
+        triggerChanged[triggerName] = true;
       }
     }
   }
 
-  return reason;
+  return Object.keys(triggerChanged).length > 0 && triggerChanged;
 }
 
 function diffUpdateTrigger(props, oldProps, triggerName) {


### PR DESCRIPTION
This PR is to prepare the fixes for `PolygonLayer`, where `updateTriggers` change does not trigger polygon tessellation. This PR adds the changed triggers to `changeFlags.updateTriggersChanged`, so that each layer has knowledge of which triggers have changed.

- If any trigger has changed. `changeFlags.updateTriggersChanged` will be an object `{getElevation: true}` or `{all: true}`
- If none has changed `changeFlags.updateTriggersChanged`  will be `false`