### PR TITLE
AttributeManager.invalidateAll() now invalidates all attributes.

### DIFF
--- a/src/core/lib/attribute-manager.js
+++ b/src/core/lib/attribute-manager.js
@@ -234,9 +234,8 @@ export default class AttributeManager {
   }
 
   invalidateAll() {
-    const {attributes} = this;
-    for (const attributeName in attributes) {
-      this._invalidateTrigger(attributeName);
+    for (const attributeName in this.attributes) {
+      this.attributes[attributeName].needsUpdate = true;
     }
 
     // For performance tuning


### PR DESCRIPTION
@georgios-uber  this should resolve the uncertainty around whether `invalidateAll` actually invalidates all attributes.