### PR TITLE
Part-1 : 4.2 API changes as per Audit.

### DIFF
--- a/dev-docs/RFCs/v4.1/picking-improvements-rfc.md
+++ b/dev-docs/RFCs/v4.1/picking-improvements-rfc.md
@@ -73,7 +73,7 @@ To have better picking arbitration when using “color-coded” picking, we need
 
 ### Proposal: Rectangular selection using color-coding picking
 
-The process of rectangular selection starts with correctly identifying a mouse down, mouse drag and mouse up event sequence. deck.gl will rely on its new event handling system to detect this kind of gesture. Then, a new deck.gl method named `queryVisibleObjects(topLeft, bottomRight)` is triggered to calculate the actual picked elements. In this new function, the picking framebuffer is read back and pixels within the rectangle area specified by the` topLeft` and `bottomRight` arguments are checked in a loop. Indices of rendered element present in this rectangular picking area will then by put into an array for output.
+The process of rectangular selection starts with correctly identifying a mouse down, mouse drag and mouse up event sequence. deck.gl will rely on its new event handling system to detect this kind of gesture. Then, a new deck.gl method named `pickObjects(topLeft, bottomRight)` is triggered to calculate the actual picked elements. In this new function, the picking framebuffer is read back and pixels within the rectangle area specified by the` topLeft` and `bottomRight` arguments are checked in a loop. Indices of rendered element present in this rectangular picking area will then by put into an array for output.
 
 After the array of picked elements is assembled, a callback function send in as the `onElementSelected` prop of deck.gl will get called and so that the application could manipulate the list of picked elements.
 

--- a/docs/advanced/performance.md
+++ b/docs/advanced/performance.md
@@ -83,10 +83,9 @@ Some profiling techniques:
 ## Common Issues
 
 A couple of particular things to watch out for that tend to have a big impact on performance:
-* Be careful when enabling Retina/High DPI rendering. It generetes 4x the number of pixels (fragments) and can have a big performance impact that depends on which computer or monitor is being used. This feature can be controlled using `useDevicePixelRatio` prop of `DeckGL` component.
+* If not needed disable Retina/High DPI rendering. It generetes 4x the number of pixels (fragments) and can have a big performance impact that depends on which computer or monitor is being used. This feature can be controlled using `useDevicePixels` prop of `DeckGL` component and it is on by default.
 
 * Avoid using luma.gl debug mode in production. It queries the GPU error status after each operation which has a big impact on performance.
 
 Smaller considerations:
 * Enabling picking can have a small performance penalty so make sure the `pickable` property is `false` in layers that do not need picking (this is the default value).
-

--- a/docs/api-reference/layer-manager.md
+++ b/docs/api-reference/layer-manager.md
@@ -45,14 +45,14 @@ Updates the current viewport.
 Updates parameters
 
 `layerManager.setParameters({
-	useDevicePixelRatio,
+	useDevicePixels,
     pickingRadius,
     onLayerClick,
     onLayerHover
 })
 `
 
-* `useDevicePixelRatio` (`Boolean`, optional) - Whether to use retina/HD display or not.
+* `useDevicePixels` (`Boolean`, optional) - Whether to use retina/HD display or not.
 * `eventManager` - A source of DOM input events
 
 * `pickingRadius` (`Number`, optional) - "Fuzziness" of picking (px), to support fat-fingering.

--- a/docs/api-reference/react/deckgl.md
+++ b/docs/api-reference/react/deckgl.md
@@ -191,8 +191,6 @@ The picking methods are supplied to enable applications to use their own event h
 
 ##### pickObject
 
-NOTE: replaces deprecated method `queryObject`.
-
 Get the closest pickable and visible object at screen coordinate.
 
 `deck.pickObject({x, y, radius, layerIds})`
@@ -207,9 +205,9 @@ Parameters:
 
 Returns: a single [`info`](/docs/get-started/interactivity.md#the-picking-info-object) object, or `null` if nothing is found.
 
-##### pickObjects
+NOTE: replaces deprecated method `queryObject`.
 
-NOTE: replaces deprecated method `queryVisibleObjects`.
+##### pickObjects
 
 Get all pickable and visible objects within a bounding box.
 
@@ -230,6 +228,8 @@ Remarks:
 - This query methods are designed to quickly find objects by utilizing the picking buffer. They offer more flexibility for developers to handle events in addition to the built-in hover and click callbacks.
 - Note there is a limitation in the query methods: occluded objects are not returned. To improve the results, you may try setting the `layerIds` parameter to limit the query to fewer layers.
 - * Since deck.gl is WebGL based, it can only render into a single canvas. Thus all its viewports need to be in the same canvas (unless you use multiple DeckGL instances, but that can have significant resource and performance impact).
+
+NOTE: replaces deprecated method `queryVisibleObjects`.
 
 
 ### Deprecated Properties

--- a/docs/api-reference/react/deckgl.md
+++ b/docs/api-reference/react/deckgl.md
@@ -58,7 +58,7 @@ The array of deck.gl layers to be rendered. This array is expected to be an arra
 
 ##### `layerFilter`
 
-Optionally takes a function `({layer, viewport, isPicking}) => Boolean` that is called before a layer is rendered. Gives the application an opportunity to filter out layers from the layer list during either rendering or picking. Filtering can be done per viewport or per layer or both. This enables techniques like adding helper layers that work as masks during picking but do not show up during rendering.
+Optionally takes a function `({layer, viewport, isPicking}) => Boolean` that is called before a layer is rendered. Gives the application an opportunity to filter out layers from the layer list during either rendering or picking. Filtering can be done per viewport or per layer or both. This enables techniques like adding helper layers that work as masks during picking but do not show up during rendering. All the lifecycle methods are still triggered even a if a layer is filtered out using this prop.
 
 ##### `viewports`
 
@@ -130,7 +130,7 @@ Css styles for the deckgl-canvas.
 
 Extra pixels around the pointer to include while picking. This is helpful when rendered objects are difficult to target, for example irregularly shaped icons, small moving circles or interaction by touch. Default `0`.
 
-##### `useDevicePixelRatio` (Boolean, optional)
+##### `useDevicePixels` (Boolean, optional)
 
 When true, device's full resolution will be used for rendering, this value can change per frame, like when moving windows between screens or when changing zoom level of the browser.
 
@@ -189,11 +189,13 @@ object for the topmost picked layer at the coordinate, null when no object is pi
 
 The picking methods are supplied to enable applications to use their own event handling.
 
-##### queryObject
+##### pickObject
+
+NOTE: replaces deprecated method `queryObject`.
 
 Get the closest pickable and visible object at screen coordinate.
 
-`deck.queryObject({x, y, radius, layerIds})`
+`deck.pickObject({x, y, radius, layerIds})`
 
 Parameters:
 - `options` (Object)
@@ -205,11 +207,13 @@ Parameters:
 
 Returns: a single [`info`](/docs/get-started/interactivity.md#the-picking-info-object) object, or `null` if nothing is found.
 
-##### queryVisibleObjects
+##### pickObjects
+
+NOTE: replaces deprecated method `queryVisibleObjects`.
 
 Get all pickable and visible objects within a bounding box.
 
-`deck.queryVisibleObjects({x, y, width, height, layerIds})`
+`deck.pickObjects({x, y, width, height, layerIds})`
 
 Parameters:
 - `options` (Object)

--- a/docs/get-started/interactivity.md
+++ b/docs/get-started/interactivity.md
@@ -33,13 +33,13 @@ The picking engine returns "picking info" objects which contains a variety of fi
 
 The picking engine is exposed through the [`DeckGL.queryObject`]((/docs/api-reference/deckgl.md) and [`DeckGL.queryVisibleObject`]((/docs/api-reference/deckgl.md) methods. These methods allow you to query what layers and objects within those layers are under a specific point or within a specified rectangle. They return `Picking Info` objects as described below.
 
-`queryObject` allows an application to define its own event handling. When it comes to how to actually do event handling in a browser, there are many options. In a React application, perhaps the simplest is to just use React's "synthetic" event handling together with `queryObject`:
+`pickObject` allows an application to define its own event handling. When it comes to how to actually do event handling in a browser, there are many options. In a React application, perhaps the simplest is to just use React's "synthetic" event handling together with `pickObject`:
 
 ```js
 class MyComponent extends React.Component {
   ...
   onClickHandler = (event) => {
-    const pickInfo = this.deckGL.queryObject({x: event.clientX, y: event.clientY, ...});
+    const pickInfo = this.deckGL.pickObject({x: event.clientX, y: event.clientY, ...});
     console.log(pickInfo.lngLat);
   }
 

--- a/docs/layers/path-layer.md
+++ b/docs/layers/path-layer.md
@@ -78,7 +78,7 @@ Only works if `rounded` is `false`.
 
 Whether the layer should be rendered in high-precision 64-bit mode
 
-##### `justified` (Boolean, optional)
+##### `dashJustified` (Boolean, optional)
 
 - Default: `false`
 
@@ -124,4 +124,3 @@ If this accessor is not specified, all paths are drawn as solid lines.
 ## Source
 
 [src/layers/core/path-layer](https://github.com/uber/deck.gl/tree/4.1-release/src/layers/core/path-layer)
-

--- a/docs/shader-modules/project.md
+++ b/docs/shader-modules/project.md
@@ -46,7 +46,7 @@ The GLSL uniforms of the `project` module are quite central to shader code and a
 | project_uModelMatrix | mat4 | model matrix (identity if not supplied) |
 | project_uViewProjectionMatrix | mat4 | combined view projection matrix |
 | project_uViewportSize | vec2 | size of viewport in pixels |
-| project_uDevicePixelRatio | float | device pixel ratio of current viewport (aligned with `useDevicePixels` prop) |
+| project_uDevicePixelRatio | float | device pixel ratio of current viewport (value depends on `useDevicePixels` prop) |
 | project_uFocalDistance | float | distance where "pixel sizes" are display in 1:1 ratio (modulo `devicePixelRatio`) |
 | project_uCameraPosition | float | position of camera in world space |
 
@@ -95,4 +95,4 @@ Returns values in clip space offsets that can be added directly to `gl_Position`
 
 * For consistent results, pixels are logical pixels, not device pixels, i.e. this method multiplies `pixels` with `project_uDevicePixelRatio`.
 * The pixels offsets will be divided by the `w` coordinate of `gl_Position`. This is simply the GPUs standard treatment of any coordinate. This means that there will be more pixels closer to the camera and less pixels further away from the camer. Setting the `focalDistance` uniform controls this.
-* To avoid pixel sizes scaling with distance from camera, simply set `focalDistance` to 1 and multiply clispace poffset with `gl_Position.w`
+* To avoid pixel sizes scaling with distance from camera, simply set `focalDistance` to 1 and multiply clipspace offset with `gl_Position.w`

--- a/docs/shader-modules/project.md
+++ b/docs/shader-modules/project.md
@@ -46,7 +46,7 @@ The GLSL uniforms of the `project` module are quite central to shader code and a
 | project_uModelMatrix | mat4 | model matrix (identity if not supplied) |
 | project_uViewProjectionMatrix | mat4 | combined view projection matrix |
 | project_uViewportSize | vec2 | size of viewport in pixels |
-| project_uDevicePixelRatio | float | device pixel ratio of current viewport (aligned with `useDevicePixelRatio` prop) |
+| project_uDevicePixelRatio | float | device pixel ratio of current viewport (aligned with `useDevicePixels` prop) |
 | project_uFocalDistance | float | distance where "pixel sizes" are display in 1:1 ratio (modulo `devicePixelRatio`) |
 | project_uCameraPosition | float | position of camera in world space |
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -35,19 +35,24 @@ deck.gl's controller classes have been significantly refactored, providing you w
 TBA...
 
 
-## Automatic Highlighting of Hovered Elements
-
-Three new `Layer` props (`autoHighlight`, `highlightColor` and `highlightedObjectIndex`) have been added to enable simple and efficient highlighting of a single object in a layer. Highlighting is either automatic on hover, or programmatically controlled through specifying the index of the selected object. The actual highlighting is done on the GPU and this feature is thus very performant, in particular as it lets applications avoid cumbersome techniques like modifying data or using a secondary layer for highlighting.
-
-
-## Control over DevicePixelRatio
+## DeckGL: Control over DevicePixelRatio
 
 The new `useDevicePixels` prop on the `DeckGL` React component can be used to disable usage of full resolution on retina/HD displays. Disabling deck.gl's default behavior of always rendering at maximum device resolution can reduce the render buffer size with a factor of 4x on retina devices and lead to significant performance improvements on typical fragment shader bound rendering. This option can be especially interesting on "retina" type mobile phone displays where pixels are so small that the visual quality loss may be largely imperceptible.
 
 
-## Layer Filtering
+## DeckGL: Layer Filtering
 
 A new `DeckGL` prop `layerFilter` gives the application an opportunity to filter out layers from the layer list during rendering and/or picking. Filtering can be done per viewport or per layer or both. This enables techniques like adding helper layers that work as masks during picking but do not show up during rendering, or rendering different additional information in different viewports.
+
+
+## DeckGL: Picking methods renamed
+
+To avoid confusion, `DeckGL.queryObject` is renamed to `DeckGL.pickObject` and `DeckGL.queryVisibleObjects` is renamed to `DeckGL.pickObjects`. Old functions are still supported with deprecated warning, and will be removed in next version.
+
+
+## Layer: Automatic Highlighting of Hovered Elements
+
+Three new `Layer` props (`autoHighlight`, `highlightColor` and `highlightedObjectIndex`) have been added to enable simple and efficient highlighting of a single object in a layer. Highlighting is either automatic on hover, or programmatically controlled through specifying the index of the selected object. The actual highlighting is done on the GPU and this feature is thus very performant, in particular as it lets applications avoid cumbersome techniques like modifying data or using a secondary layer for highlighting.
 
 
 ## CompositeLayer: Property Forwarding Support
@@ -63,9 +68,6 @@ Added new props (`getDashArray` and `dashJustified`) enabling you render paths a
 ## HexagonLayer / GridLayer: Elevation by Value Support
 
 Add `getElevationValue` to `HexagonLayer` and `GridLayer` to enable elevation aggregation by value. This allow both color and elevation to be calculated based on customized aggregation function.
-
-## Picking methods renamed
-To avoid confusion, `DeckGL.queryObject` is renamed to `DeckGL.pickObject` and `DeckGL.queryVisibleObjects` is renamed to `DeckGL.pickObjects`. Old functions are still supported with deprecated warning, and will be removed in next version.
 
 ## Shader Modules
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -42,7 +42,7 @@ Three new `Layer` props (`autoHighlight`, `highlightColor` and `highlightedObjec
 
 ## Control over DevicePixelRatio
 
-The new `useDevicePixelRatio` prop on the `DeckGL` React component can be used to disable usage of full resolution on retina/HD displays. Disabling deck.gl's default behavior of always rendering at maximum device resolution can reduce the render buffer size with a factor of 4x on retina devices and lead to significant performance improvements on typical fragment shader bound rendering. This option can be especially interesting on "retina" type mobile phone displays where pixels are so small that the visual quality loss may be largely imperceptible.
+The new `useDevicePixels` prop on the `DeckGL` React component can be used to disable usage of full resolution on retina/HD displays. Disabling deck.gl's default behavior of always rendering at maximum device resolution can reduce the render buffer size with a factor of 4x on retina devices and lead to significant performance improvements on typical fragment shader bound rendering. This option can be especially interesting on "retina" type mobile phone displays where pixels are so small that the visual quality loss may be largely imperceptible.
 
 
 ## Layer Filtering
@@ -57,18 +57,20 @@ A new method `CompositeLayer.getSubLayerProps()` simplifies forwarding base laye
 
 ## PathLayer & GeoJsonLayer: Dashed Line Support
 
-Added new props (`getDashArray` and `justified`) enabling you render paths as dashed lines. Naturally these props are also accessible in composite layers built on top of the `PathLayer`, such as the `GeoJsonLayer`.
+Added new props (`getDashArray` and `dashJustified`) enabling you render paths as dashed lines. Naturally these props are also accessible in composite layers built on top of the `PathLayer`, such as the `GeoJsonLayer`.
 
 
 ## HexagonLayer / GridLayer: Elevation by Value Support
 
 Add `getElevationValue` to `HexagonLayer` and `GridLayer` to enable elevation aggregation by value. This allow both color and elevation to be calculated based on customized aggregation function.
 
+## Query methods renamed
+To avoid confusion, `DeckGL.queryObject` is renamed to `DeckGL.pickObject` and `DeckGL.queryVisibleObjects` is renamed to `DeckGL.pickObjects`. Old functions are still supported with deprecated warning, and will be removed in next version.
 
 ## Shader Modules
 
 * Shader module documentation is much improved, both in deck.gl and luma.gl. In the deck.gl docs, shader modules are listed in the "API Reference" section, after the JavaScript classes.
-* The `project` module provides a new function `project_pixel_to_clipspace` for screen space calculations that takes variables like `useDevicePixelRatio` and "focal distance" into account, making pixel space calculation simpler and less prone to fail when parameters change.
+* The `project` module provides a new function `project_pixel_to_clipspace` for screen space calculations that takes variables like `useDevicePixels` and "focal distance" into account, making pixel space calculation simpler and less prone to fail when parameters change.
 * The core deck.gl shader modules (`project` etc) now conform to the luma.gl shadertools conventions, making this module easier to describe and use. In spite of these changes, backwards compatible uniforms are of course provided to ensure that existing layers do not break.
 
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -64,7 +64,7 @@ Added new props (`getDashArray` and `dashJustified`) enabling you render paths a
 
 Add `getElevationValue` to `HexagonLayer` and `GridLayer` to enable elevation aggregation by value. This allow both color and elevation to be calculated based on customized aggregation function.
 
-## Query methods renamed
+## Picking methods renamed
 To avoid confusion, `DeckGL.queryObject` is renamed to `DeckGL.pickObject` and `DeckGL.queryVisibleObjects` is renamed to `DeckGL.pickObjects`. Old functions are still supported with deprecated warning, and will be removed in next version.
 
 ## Shader Modules

--- a/examples/graph/app.js
+++ b/examples/graph/app.js
@@ -167,9 +167,9 @@ class Root extends Component {
   }
 
   _onMouseDown(event) {
-    // Use DeckGL.queryObject() to find the object under the mouse,
+    // Use DeckGL.pickObject() to find the object under the mouse,
     // and store it for updating on mouse move.
-    const info = this.deckGL.queryObject({x: event.clientX, y: event.clientY});
+    const info = this.deckGL.pickObject({x: event.clientX, y: event.clientY});
     if (info) {
       this.setState({
         clicked: info,

--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -73,7 +73,7 @@ class App extends PureComponent {
       },
       settings: {
         multiview: false,
-        useDevicePixelRatio: true,
+        useDevicePixels: true,
         pickingRadius: 0,
         drawPickingColors: false,
 
@@ -146,9 +146,9 @@ class App extends PureComponent {
     this.setState({clickedItem: info});
   }
 
-  _onQueryVisibleObjects() {
+  _onPickObjects() {
     const {width, height} = this.state;
-    const infos = this.refs.deckgl.queryVisibleObjects({x: 0, y: 0, width, height});
+    const infos = this.refs.deckgl.pickObjects({x: 0, y: 0, width, height});
     console.log(infos); // eslint-disable-line
     this.setState({queriedItems: infos});
   }
@@ -245,7 +245,7 @@ class App extends PureComponent {
 
   _renderMap() {
     const {width, height, mapViewState, settings} = this.state;
-    const {effects, pickingRadius, drawPickingColors, useDevicePixelRatio} = settings;
+    const {effects, pickingRadius, drawPickingColors, useDevicePixels} = settings;
 
     const viewports = this._getViewports();
 
@@ -272,7 +272,7 @@ class App extends PureComponent {
             onLayerClick={this._onClick}
             initWebGLParameters
 
-            useDevicePixelRatio={useDevicePixelRatio}
+            useDevicePixels={useDevicePixels}
 
             debug={false}
             drawPickingColors={drawPickingColors}
@@ -313,8 +313,8 @@ class App extends PureComponent {
         {!MapboxAccessToken && this._renderNoTokenWarning()}
         <div id="control-panel">
           <div style={{textAlign: 'center', padding: '5px 0 5px'}}>
-            <button onClick={this._onQueryVisibleObjects}>
-              <b>Query Visble Objects</b>
+            <button onClick={this._onPickObjects}>
+              <b>Pick Objects</b>
             </button>
           </div>
           <LayerControls

--- a/examples/wind/package.json
+++ b/examples/wind/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "babel-core": "^6.21.0",
-    "babel-loader": "^6.2.10",
+    "buble-loader": "^0.4.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-2": "^6.18.0",

--- a/examples/wind/src/app.js
+++ b/examples/wind/src/app.js
@@ -37,7 +37,7 @@ class Root extends Component {
         showParticles: false,
         showWindDemo: false,
         showElevation: false,
-        useDevicePixelRatio: true
+        useDevicePixels: true
       }
     };
     autobind(this);

--- a/examples/wind/src/control-panel.js
+++ b/examples/wind/src/control-panel.js
@@ -47,7 +47,7 @@ export default class ControlPanel extends Component {
         { this._renderToggle('showParticles', 'particles') }
         { this._renderToggle('showWind', 'field') }
         { this._renderToggle('showElevation', 'elevation') }
-        { this._renderToggle('useDevicePixelRatio', 'retina') }
+        { this._renderToggle('useDevicePixels', 'Retina/HD') }
         { this._renderSlider('time', 'time', {min: 0, max: 70, step: 0.1}) }
       </div>
     );

--- a/examples/wind/src/wind-demo.js
+++ b/examples/wind/src/wind-demo.js
@@ -111,7 +111,7 @@ export default class WindDemo extends Component {
         glOptions={{webgl2: true}}
         {...viewport}
         layers={layers}
-        useDevicePixelRatio={settings.useDevicePixelRatio}
+        useDevicePixels={settings.useDevicePixels}
       />
     );
   }

--- a/src/core-layers/path-layer/path-layer.js
+++ b/src/core-layers/path-layer/path-layer.js
@@ -35,7 +35,7 @@ const defaultProps = {
   rounded: false,
   miterLimit: 4,
   fp64: false,
-  justified: false,
+  dashJustified: false,
 
   getPath: object => object.path,
   getColor: object => object.color || DEFAULT_COLOR,
@@ -124,12 +124,12 @@ export default class PathLayer extends Layer {
 
   draw({uniforms}) {
     const {
-      rounded, miterLimit, widthScale, widthMinPixels, widthMaxPixels, justified
+      rounded, miterLimit, widthScale, widthMinPixels, widthMaxPixels, dashJustified
     } = this.props;
 
     this.state.model.render(Object.assign({}, uniforms, {
       jointType: Number(rounded),
-      alignMode: Number(justified),
+      alignMode: Number(dashJustified),
       widthScale,
       miterLimit,
       widthMinPixels,

--- a/src/core-layers/polygon-layer/polygon-layer.js
+++ b/src/core-layers/polygon-layer/polygon-layer.js
@@ -172,7 +172,7 @@ export default class PolygonLayer extends CompositeLayer {
           widthMaxPixels: lineWidthMaxPixels,
           rounded: lineJointRounded,
           miterLimit: lineMiterLimit,
-          justified: lineDashJustified,
+          dashJustified: lineDashJustified,
 
           getPath: x => x.path,
           getColor: x => getLineColor(x.object),

--- a/src/core/lib/draw-layers.js
+++ b/src/core/lib/draw-layers.js
@@ -28,9 +28,9 @@ const LOG_PRIORITY_DRAW = 2;
 let renderCount = 0;
 
 // TODO - Exported for pick-layers.js - Move to util?
-export const getPixelRatio = ({useDevicePixelRatio}) => {
-  assert(typeof useDevicePixelRatio === 'boolean', 'Invalid useDevicePixelRatio');
-  return useDevicePixelRatio && typeof window !== 'undefined' ? window.devicePixelRatio : 1;
+export const getPixelRatio = ({useDevicePixels}) => {
+  assert(typeof useDevicePixels === 'boolean', 'Invalid useDevicePixels');
+  return useDevicePixels && typeof window !== 'undefined' ? window.devicePixelRatio : 1;
 };
 
 // Convert viewport top-left CSS coordinates to bottom up WebGL coordinates
@@ -49,8 +49,8 @@ const getGLViewport = (gl, {viewport, pixelRatio}) => {
 
 // Helper functions
 
-function clearCanvas(gl, {useDevicePixelRatio}) {
-  // const pixelRatio = getPixelRatio({useDevicePixelRatio});
+function clearCanvas(gl, {useDevicePixels}) {
+  // const pixelRatio = getPixelRatio({useDevicePixels});
   const width = gl.drawingBufferWidth;
   const height = gl.drawingBufferHeight;
   // clear depth and color buffers, restoring transparency
@@ -64,7 +64,7 @@ export function drawLayers(gl, {
   layers,
   viewports,
   onViewportActive,
-  useDevicePixelRatio,
+  useDevicePixels,
   drawPickingColors = false,
   deviceRect = null,
   parameters = {},
@@ -72,7 +72,7 @@ export function drawLayers(gl, {
   pass = 'draw',
   redrawReason = ''
 }) {
-  clearCanvas(gl, {useDevicePixelRatio});
+  clearCanvas(gl, {useDevicePixels});
 
   // effectManager.preDraw();
 
@@ -86,7 +86,7 @@ export function drawLayers(gl, {
     drawLayersInViewport(gl, {
       layers,
       viewport,
-      useDevicePixelRatio,
+      useDevicePixels,
       drawPickingColors,
       deviceRect,
       parameters,
@@ -105,7 +105,7 @@ export function drawPickingBuffer(gl, {
   layers,
   viewports,
   onViewportActive,
-  useDevicePixelRatio,
+  useDevicePixels,
   pickingFBO,
   deviceRect: {x, y, width, height},
   layerFilter = null,
@@ -127,7 +127,7 @@ export function drawPickingBuffer(gl, {
       layers,
       viewports,
       onViewportActive,
-      useDevicePixelRatio,
+      useDevicePixels,
       drawPickingColors: true,
       layerFilter,
       pass: 'picking',
@@ -149,7 +149,7 @@ export function drawPickingBuffer(gl, {
 function drawLayersInViewport(gl, {
   layers,
   viewport,
-  useDevicePixelRatio,
+  useDevicePixels,
   drawPickingColors = false,
   deviceRect = null,
   parameters = {},
@@ -157,7 +157,7 @@ function drawLayersInViewport(gl, {
   pass = 'draw',
   redrawReason = ''
 }) {
-  const pixelRatio = getPixelRatio({useDevicePixelRatio});
+  const pixelRatio = getPixelRatio({useDevicePixels});
   const glViewport = getGLViewport(gl, {viewport, pixelRatio});
 
   // render layers in normal colors

--- a/src/core/lib/layer-manager.js
+++ b/src/core/lib/layer-manager.js
@@ -48,7 +48,7 @@ const initialContext = {
   layerFilter: null,
   viewportChanged: true,
   pickingFBO: null,
-  useDevicePixelRatio: true,
+  useDevicePixels: true,
   lastPickedInfo: {
     index: -1,
     layerId: null
@@ -159,7 +159,7 @@ export default class LayerManager {
   /**
    * Set parameters needed for layer rendering and picking.
    * Parameters are to be passed as a single object, with the following values:
-   * @param {Boolean} useDevicePixelRatio
+   * @param {Boolean} useDevicePixels
    */
   setParameters(parameters) {
     if ('eventManager' in parameters) {
@@ -238,14 +238,14 @@ export default class LayerManager {
   }
 
   drawLayers({pass = 'render to screen', redrawReason = 'unknown reason'} = {}) {
-    const {gl, useDevicePixelRatio, drawPickingColors} = this.context;
+    const {gl, useDevicePixels, drawPickingColors} = this.context;
 
     // render this viewport
     drawLayers(gl, {
       layers: this.layers,
       viewports: this.getViewports(),
       onViewportActive: this._activateViewport.bind(this),
-      useDevicePixelRatio,
+      useDevicePixels,
       drawPickingColors,
       pass,
       layerFilter: this.context.layerFilter,
@@ -255,7 +255,7 @@ export default class LayerManager {
 
   // Pick the closest info at given coordinate
   pickObject({x, y, mode, radius = 0, layerIds, layerFilter}) {
-    const {gl, useDevicePixelRatio} = this.context;
+    const {gl, useDevicePixels} = this.context;
 
     const layers = this.getLayers({layerIds});
 
@@ -272,13 +272,13 @@ export default class LayerManager {
       onViewportActive: this._activateViewport.bind(this),
       pickingFBO: this._getPickingBuffer(),
       lastPickedInfo: this.context.lastPickedInfo,
-      useDevicePixelRatio
+      useDevicePixels
     });
   }
 
   // Get all unique infos within a bounding box
   pickObjects({x, y, width, height, layerIds, layerFilter}) {
-    const {gl, useDevicePixelRatio} = this.context;
+    const {gl, useDevicePixels} = this.context;
 
     const layers = this.getLayers({layerIds});
 
@@ -295,7 +295,7 @@ export default class LayerManager {
       viewports: this.getViewports(),
       onViewportActive: this._activateViewport.bind(this),
       pickingFBO: this._getPickingBuffer(),
-      useDevicePixelRatio
+      useDevicePixels
     });
   }
 

--- a/src/core/lib/layer.js
+++ b/src/core/lib/layer.js
@@ -270,7 +270,7 @@ export default class Layer {
 
   // TODO - needs to refer to context
   screenToDevicePixels(screenPixels) {
-    log.deprecated('screenToDevicePixels', 'DeckGL prop useDevicePixelRatio for conversion');
+    log.deprecated('screenToDevicePixels', 'DeckGL prop useDevicePixels for conversion');
     const devicePixelRatio = typeof window !== 'undefined' ?
       window.devicePixelRatio : 1;
     return screenPixels * devicePixelRatio;

--- a/src/core/lib/pick-layers.js
+++ b/src/core/lib/pick-layers.js
@@ -43,11 +43,11 @@ export function pickObject(gl, {
   onViewportActive,
   pickingFBO,
   lastPickedInfo,
-  useDevicePixelRatio
+  useDevicePixels
 }) {
   // Convert from canvas top-left to WebGL bottom-left coordinates
   // And compensate for pixelRatio
-  const pixelRatio = getPixelRatio({useDevicePixelRatio});
+  const pixelRatio = getPixelRatio({useDevicePixels});
   const deviceX = Math.round(x * pixelRatio);
   const deviceY = Math.round(gl.canvas.height - y * pixelRatio);
   const deviceRadius = Math.round(radius * pixelRatio);
@@ -62,7 +62,7 @@ export function pickObject(gl, {
     layers,
     viewports,
     onViewportActive,
-    useDevicePixelRatio,
+    useDevicePixels,
     pickingFBO,
     deviceRect,
     layerFilter,
@@ -95,12 +95,12 @@ export function pickVisibleObjects(gl, {
   layerFilter,
   onViewportActive,
   pickingFBO,
-  useDevicePixelRatio
+  useDevicePixels
 }) {
 
   // Convert from canvas top-left to WebGL bottom-left coordinates
   // And compensate for pixelRatio
-  const pixelRatio = getPixelRatio({useDevicePixelRatio});
+  const pixelRatio = getPixelRatio({useDevicePixels});
 
   const deviceLeft = Math.round(x * pixelRatio);
   const deviceBottom = Math.round(gl.canvas.height - y * pixelRatio);
@@ -119,7 +119,7 @@ export function pickVisibleObjects(gl, {
     viewports,
     onViewportActive,
     pickingFBO,
-    useDevicePixelRatio,
+    useDevicePixels,
     deviceRect,
     layerFilter,
     redrawReason: mode
@@ -155,7 +155,7 @@ function drawAndSamplePickingBuffer(gl, {
   layers,
   viewports,
   onViewportActive,
-  useDevicePixelRatio,
+  useDevicePixels,
   pickingFBO,
   deviceRect,
   layerFilter,
@@ -174,7 +174,7 @@ function drawAndSamplePickingBuffer(gl, {
     layers,
     viewports,
     onViewportActive,
-    useDevicePixelRatio,
+    useDevicePixels,
     pickingFBO,
     deviceRect,
     layerFilter,

--- a/src/core/pure-js/deck-js.js
+++ b/src/core/pure-js/deck-js.js
@@ -49,7 +49,7 @@ const propTypes = {
   onAfterRender: PropTypes.func,
   onLayerClick: PropTypes.func,
   onLayerHover: PropTypes.func,
-  useDevicePixelRatio: PropTypes.bool,
+  useDevicePixels: PropTypes.bool,
 
   // Debug settings
   debug: PropTypes.bool,
@@ -69,7 +69,7 @@ const defaultProps = {
   onAfterRender: noop,
   onLayerClick: null,
   onLayerHover: null,
-  useDevicePixelRatio: true,
+  useDevicePixels: true,
 
   debug: false,
   drawPickingColors: false
@@ -93,12 +93,12 @@ export default class DeckGLJS {
 
     this.canvas = this._createCanvas(props);
 
-    const {width, height, gl, glOptions, debug, useDevicePixelRatio} = props;
+    const {width, height, gl, glOptions, debug, useDevicePixels} = props;
 
     this.animationLoop = new AnimationLoop({
       width,
       height,
-      useDevicePixelRatio,
+      useDevicePixelRatio: useDevicePixels,
       onCreateContext: opts =>
         gl || createGLContext(Object.assign({}, glOptions, {canvas: this.canvas, debug})),
       onInitialize: this._onRendererInitialized,
@@ -125,7 +125,7 @@ export default class DeckGLJS {
       pickingRadius,
       onLayerClick,
       onLayerHover,
-      useDevicePixelRatio,
+      useDevicePixels,
       drawPickingColors,
       layerFilter
     } = props;
@@ -143,7 +143,7 @@ export default class DeckGLJS {
     this.layerManager.setParameters({
       layers,
       viewports,
-      useDevicePixelRatio,
+      useDevicePixels,
       drawPickingColors,
       layerFilter,
       pickingRadius,
@@ -153,7 +153,7 @@ export default class DeckGLJS {
 
     // TODO - unify setParameters/setOptions/setProps etc naming.
     this.animationLoop.setViewParameters({
-      useDevicePixelRatio
+      useDevicePixelRatio: useDevicePixels
     });
   }
 
@@ -169,12 +169,12 @@ export default class DeckGLJS {
 
   // Public API
 
-  queryObject({x, y, radius = 0, layerIds = null}) {
+  pickObject({x, y, radius = 0, layerIds = null}) {
     const selectedInfos = this.layerManager.pickObject({x, y, radius, layerIds, mode: 'query'});
     return selectedInfos.length ? selectedInfos[0] : null;
   }
 
-  queryVisibleObjects({x, y, width = 1, height = 1, layerIds = null}) {
+  pickObjects({x, y, width = 1, height = 1, layerIds = null}) {
     return this.layerManager.pickObjects({x, y, width, height, layerIds});
   }
 

--- a/src/core/shaderlib/project/viewport-uniforms.js
+++ b/src/core/shaderlib/project/viewport-uniforms.js
@@ -162,7 +162,7 @@ export function getUniformsFromViewport({
   // Calculate projection pixels per unit
   const distanceScales = viewport.getDistanceScales();
 
-  // TODO - does this depend on useDevicePixelRatio?
+  // TODO - does this depend on useDevicePixels?
   const devicePixelRatio = (window && window.devicePixelRatio) || 1;
   const viewportSize = [viewport.width * devicePixelRatio, viewport.height * devicePixelRatio];
 

--- a/src/experimental-layers/src/path-outline-layer/path-outline-layer.js
+++ b/src/experimental-layers/src/path-outline-layer/path-outline-layer.js
@@ -68,10 +68,18 @@ export default class PathOutlineLayer extends PathLayer {
   // Override draw to add render module
   draw({moduleParameters = {}, parameters, uniforms, context}) {
     // Need to calculate same uniforms as base layer
-    const {rounded, miterLimit, widthScale, widthMinPixels, widthMaxPixels, justified} = this.props;
+    const {
+      rounded,
+      miterLimit,
+      widthScale,
+      widthMinPixels,
+      widthMaxPixels,
+      dashJustified
+    } = this.props;
+
     uniforms = Object.assign({}, uniforms, {
       jointType: Number(rounded),
-      alignMode: Number(justified),
+      alignMode: Number(dashJustified),
       widthScale,
       miterLimit,
       widthMinPixels,

--- a/src/react/deckgl.js
+++ b/src/react/deckgl.js
@@ -20,7 +20,7 @@
 
 import React, {createElement, cloneElement} from 'react';
 import autobind from './utils/autobind';
-import {experimental} from '../core';
+import {experimental, log} from '../core';
 const {DeckGLJS} = experimental;
 
 export default class DeckGL extends React.Component {
@@ -47,12 +47,22 @@ export default class DeckGL extends React.Component {
 
   // Public API
 
-  queryObject({x, y, radius = 0, layerIds = null}) {
-    return this.deck.queryObject({x, y, radius, layerIds});
+  queryObject(opts) {
+    log.deprecated('queryObject', 'pickObject');
+    return this.deck.pickObject(opts);
   }
 
-  queryVisibleObjects({x, y, width = 1, height = 1, layerIds = null}) {
-    return this.deck.queryVisibleObjects({x, y, width, height, layerIds});
+  pickObject({x, y, radius = 0, layerIds = null}) {
+    return this.deck.pickObject({x, y, radius, layerIds});
+  }
+
+  queryVisibleObjects(opts) {
+    log.deprecated('queryVisibleObjects', 'pickObjects');
+    return this.pickObjects(opts);
+  }
+
+  pickObjects({x, y, width = 1, height = 1, layerIds = null}) {
+    return this.deck.pickObjects({x, y, width, height, layerIds});
   }
 
   // Private Helpers


### PR DESCRIPTION
- Query API 
  - Rename : queryVisibleObjects -> pickObjects, queryObject -> pickObject
  - Support old methods with a deprecated message.
  - Add an  item to whats-news section in docs.

- Rename: useDevicePixelRatio -> useDevicePixels (AnimationLoop class in luma.gl still has useDevicePixelRatio, will change that in a separate PR)
  - Update docs.

- PathLayer:
  - Rename 'justified' to 'dashJustified', update docs.

Tested with layer-browser (toggle `useDevicePixels`, picking, pickObjects) and website/examples.