### PR TITLE
Remove luma.gl dependency in package.json to avoid conflict with deck.gl

### DIFF
--- a/examples/js/carto/package.json
+++ b/examples/js/carto/package.json
@@ -4,8 +4,7 @@
     "start-local": "webpack-dev-server --env.local --progress --hot --open"
   },
   "dependencies": {
-    "deck.gl": ">=4.2.0-alpha.9",
-    "luma.gl": ">=4.1.0-alpha.2"
+    "deck.gl": ">=4.2.0-alpha.9"
   },
   "devDependencies": {
     "buble-loader": "^0.4.0",

--- a/examples/js/with-mapbox-map/package.json
+++ b/examples/js/with-mapbox-map/package.json
@@ -7,7 +7,6 @@
   "dependencies": {
     "d3-request": "^1.0.5",
     "deck.gl": ">=4.2.0-alpha.9",
-    "luma.gl": ">=4.1.0-alpha.2",
     "mapbox-gl": "0.38.0",
     "stats.js": "^0.17.0"
   },

--- a/examples/js/without-map/package.json
+++ b/examples/js/without-map/package.json
@@ -4,8 +4,7 @@
     "start-local": "webpack-dev-server --env.local --progress --hot --open"
   },
   "dependencies": {
-    "deck.gl": ">=4.2.0-alpha.9",
-    "luma.gl": ">=4.1.0-alpha.2"
+    "deck.gl": ">=4.2.0-alpha.9"
   },
   "devDependencies": {
     "buble-loader": "^0.4.0",

--- a/examples/plot/package.json
+++ b/examples/plot/package.json
@@ -7,7 +7,6 @@
   "dependencies": {
     "d3-scale": "^1.0.6",
     "deck.gl": ">=4.2.0-alpha.9",
-    "luma.gl": "^4.0.1",
     "react": "^15.4.1",
     "react-dom": "^15.4.1"
   },

--- a/examples/point-cloud-laz/package.json
+++ b/examples/point-cloud-laz/package.json
@@ -9,7 +9,6 @@
   "dependencies": {
     "deck.gl": ">=4.2.0-alpha.9",
     "is-little-endian": "0.0.0",
-    "luma.gl": "^4.0.1",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
     "gl-matrix": "^2.3.2"

--- a/examples/point-cloud-ply/package.json
+++ b/examples/point-cloud-ply/package.json
@@ -9,7 +9,6 @@
   "dependencies": {
     "deck.gl": ">=4.2.0-alpha.9",
     "is-little-endian": "0.0.0",
-    "luma.gl": "^4.0.1",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
     "gl-matrix": "^2.3.2"

--- a/examples/tagmap/package.json
+++ b/examples/tagmap/package.json
@@ -10,7 +10,6 @@
     "d3-request": "^1.0.5",
     "d3-scale": "^1.0.6",
     "deck.gl": "^4.2.0-alpha.15",
-    "luma.gl": "^4.1.0-alpha.6",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
     "react-map-gl": "^3.0.0",

--- a/examples/text-layer/package.json
+++ b/examples/text-layer/package.json
@@ -8,7 +8,6 @@
     "d3-request": "^1.0.5",
     "deck.gl": "^4.2.0-alpha.12",
     "loglevel": "^1.4.1",
-    "luma.gl": "^4.1.0-alpha.6",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
     "react-map-gl": ">=3.0.0-beta.1",


### PR DESCRIPTION
Don't need specify luma.gl version in example's package.json, which could introduce dependency conflicts and make example invalid.

Tested with examples under example folder