### PR TITLE
Fix viewport-mercator-project version dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "mjolnir.js": ">=0.1.0",
     "prop-types": "^15.5.8",
     "seer": "^0.2.3",
-    "viewport-mercator-project": ">= 4.2.0-alpha.2"
+    "viewport-mercator-project": "^4.2.0-alpha.2"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",


### PR DESCRIPTION
Use `^` to lock on major version to avoid any breaking changes in next major version.

Tested with `wip/viewport-transition` that uses project methods from `viewport-mercator-project`.