### PR TITLE
Fix log import errors

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -57,7 +57,7 @@ import TransitionManager from './lib/transition-manager';
 import {extractViewportFrom} from './lib/viewport-transition-utils';
 
 // Layer utilities
-import log from './utils/log';
+import {default as log} from './utils/log';
 import {get} from './lib/utils/get';
 import {count} from './lib/utils/count';
 

--- a/src/react/deckgl.js
+++ b/src/react/deckgl.js
@@ -20,8 +20,8 @@
 
 import React, {createElement, cloneElement} from 'react';
 import autobind from './utils/autobind';
-import {experimental, log} from '../core';
-const {DeckGLJS} = experimental;
+import {experimental} from '../core';
+const {DeckGLJS, log} = experimental;
 
 export default class DeckGL extends React.Component {
 


### PR DESCRIPTION
Found some warnings while using latest alpha release, after investigation the log import is not correct.

WARNING in ./~/deck.gl/dist-es6/react/deckgl.js
70:6-9 "export 'log' was not found in '../core'

WARNING in ./~/deck.gl/dist-es6/react/deckgl.js
88:6-9 "export 'log' was not found in '../core'