### PR TITLE
Part-2 : 4.2 API changes as per Audit

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -4,12 +4,28 @@
 
 ### Layer Props
 
-Coordinate system related props have been renamed for clarity
+Coordinate system related props have been renamed for clarity.
 
 | Layer            | Old Prop           | New Prop             | Comment |
 | ---              | ---                | ---                  | ---     |
 | Layer            | `projectionMode`   | `coordinateSystem`   | Any constant from `COORDINATE_SYSTEM`  |
 | Layer            | `projectionOrigin` | `coordinateOrigin`   | |
+
+
+### DeckGL component
+
+Following methods and props have been renamed for clarity.
+
+
+| Old Method            | New Method        | Comment |
+| ---                   | ---               | ---     |
+| `queryVisibleObjects` | `pickObjects`     | |
+| `queryObject`         | `pickObject`      | |
+
+
+| Old Prop              | New Props         | Comment |
+| ---                   | ---               | ---     |
+| `useDevicePixelRatio` | `useDevicePixels` | |
 
 
 ### Viewports

--- a/src/core/lib/draw-layers.js
+++ b/src/core/lib/draw-layers.js
@@ -287,13 +287,11 @@ function getPickingModuleParameters(layer) {
 
   // Update picking module settings if highlightedObjectIndex is set.
   // This will overwrite any settings from auto highlighting.
-  const pickingSelectedColorValid = layer.props.highlightedObjectIndex >= 0;
-  if (pickingSelectedColorValid) {
+  if (layer.props.highlightedObjectIndex >= 0) {
     const pickingSelectedColor = layer.encodePickingColor(layer.props.highlightedObjectIndex);
 
     return {
-      pickingSelectedColor,
-      pickingSelectedColorValid
+      pickingSelectedColor
     };
   }
   return null;

--- a/src/core/lib/pick-layers.js
+++ b/src/core/lib/pick-layers.js
@@ -21,11 +21,10 @@
 import log from '../utils/log';
 import {drawPickingBuffer, getPixelRatio} from './draw-layers';
 import assert from 'assert';
-
-const EMPTY_PIXEL = new Uint8Array(4);
+import {PICKING_NULL_COLOR} from 'luma.gl';
 
 const NO_PICKED_OBJECT = {
-  pickedColor: EMPTY_PIXEL,
+  pickedColor: PICKING_NULL_COLOR,
   pickedLayer: null,
   pickedObjectIndex: -1
 };
@@ -288,16 +287,13 @@ function processPickInfo({
       infos.set(info.layer.id, info);
     }
 
-    const pickingSelectedColor = pickedColor;
-    const pickingSelectedColorValid = Boolean(
+    const pickingSelectedColor = (
       layer.props.autoHighlight &&
-      pickedLayer === layer &&
-      pickingSelectedColor !== EMPTY_PIXEL
-    );
-    // Note: Auto highlighting only works for single model layers
+      pickedLayer === layer
+    ) ? pickedColor : PICKING_NULL_COLOR;
+
     const pickingParameters = {
-      pickingSelectedColor,
-      pickingSelectedColorValid
+      pickingSelectedColor
     };
 
     for (const model of layer.getModels()) {
@@ -430,7 +426,7 @@ function getUniquesFromPickingBuffer(gl, {pickedColors, layers}) {
 function createInfo(pixel, viewport) {
   // Assign a number of potentially useful props to the "info" object
   return {
-    color: EMPTY_PIXEL,
+    color: PICKING_NULL_COLOR,
     layer: null,
     index: -1,
     picked: false,

--- a/src/core/pure-js/deck-js.js
+++ b/src/core/pure-js/deck-js.js
@@ -98,7 +98,7 @@ export default class DeckGLJS {
     this.animationLoop = new AnimationLoop({
       width,
       height,
-      useDevicePixelRatio: useDevicePixels,
+      useDevicePixels,
       onCreateContext: opts =>
         gl || createGLContext(Object.assign({}, glOptions, {canvas: this.canvas, debug})),
       onInitialize: this._onRendererInitialized,
@@ -152,9 +152,7 @@ export default class DeckGLJS {
     });
 
     // TODO - unify setParameters/setOptions/setProps etc naming.
-    this.animationLoop.setViewParameters({
-      useDevicePixelRatio: useDevicePixels
-    });
+    this.animationLoop.setViewParameters({useDevicePixels});
   }
 
   finalize() {


### PR DESCRIPTION
Requiers luma.gl changes : https://github.com/uber/luma.gl/pull/355

* Device Pixel Ratio: Update AnimationLoop API from `useDevicePixelRatio` to `useDevicePixels`
* Auto-highlighting: Remove setting `pickingSelectedColorValid` and only set `pickingSelectedColor`, internally picking module disables the highlighting if `pickingSelectedColor` is invalid or equal `PICKING_NULL_COLOR`.

Tested with : node, browser, examples and layer-browser (toggle useDevicePixels and auto-higlighting on several layers).