### PR TITLE
Fix default alpha blend mode

### DIFF
--- a/src/core/pure-js/deck-js.js
+++ b/src/core/pure-js/deck-js.js
@@ -207,7 +207,7 @@ export default class DeckGLJS {
   _onRendererInitialized({gl, canvas}) {
     setParameters(gl, {
       blend: true,
-      blendFunc: [GL.SRC_ALPHA, GL.ONE_MINUS_SRC_ALPHA],
+      blendFuncSeparate: [GL.SRC_ALPHA, GL.ONE_MINUS_SRC_ALPHA, GL.ONE, GL.ONE_MINUS_SRC_ALPHA],
       polygonOffsetFill: true
     });
 


### PR DESCRIPTION
ScatterplotLayer with `getColor: d => [0, 0, 0, 50]`

Before:
![screen shot 2017-11-17 at 6 45 20 pm](https://user-images.githubusercontent.com/2059298/32976280-ac5da83a-cbc7-11e7-8ee3-c4ba1d8ec410.png)

After:
![screen shot 2017-11-17 at 6 45 11 pm](https://user-images.githubusercontent.com/2059298/32976281-b0ef6000-cbc7-11e7-825e-78d3f0d99a2c.png)
