### PR TITLE
apply #1046 to 4.1

### DIFF
--- a/docs/layers/geojson-layer.md
+++ b/docs/layers/geojson-layer.md
@@ -112,6 +112,14 @@ Type of joint. If `true`, draw round joints. Otherwise draw miter joints.
 The maximum extent of a joint in ratio to the stroke width.
 Only works if `lineJointRounded` is `false`.
 
+##### `elevationScale` (Number, optional)
+
+- Default: `1`
+
+Elevation multiplier. The final elevation is calculated by
+  `elevationScale * getElevation(d)`. `elevationScale` is a handy property to scale
+all polygon elevation without updating the data.
+
 ##### `pointRadiusScale` (Number, optional)
 
 - Default: `1`

--- a/docs/layers/polygon-layer.md
+++ b/docs/layers/polygon-layer.md
@@ -93,6 +93,14 @@ Whether to generate a line wireframe of the hexagon. The outline will have
 
 Requires the `extruded` prop to be true.
 
+##### `elevationScale` (Number, optional)
+
+- Default: `1`
+
+Elevation multiplier. The final elevation is calculated by
+  `elevationScale * getElevation(d)`. `elevationScale` is a handy property to scale
+all elevation without updating the data.
+
 ##### `lineWidthScale` (Boolean, optional)
 
 - Default: `1`

--- a/docs/layers/solid-polygon-layer.md
+++ b/docs/layers/solid-polygon-layer.md
@@ -50,6 +50,14 @@ Whether to generate a line wireframe of the hexagon. The outline will have
 "horizontal" lines closing the top and bottom polygons and a vertical line
 (a "strut") for each vertex on the polygon.
 
+##### `elevationScale` (Number, optional)
+
+- Default: `1`
+
+Elevation multiplier. The final elevation is calculated by
+  `elevationScale * getElevation(d)`. `elevationScale` is a handy property to scale
+all elevation without updating the data.
+
 ##### `fp64` (Boolean, optional)
 
 - Default: `false`

--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -123,7 +123,6 @@ class App extends PureComponent {
 
   _renderExampleLayer(example, settings, index) {
     const {layer: Layer, props, getData} = example;
-
     const layerProps = Object.assign({}, props, settings);
 
     if (getData) {

--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -123,6 +123,7 @@ class App extends PureComponent {
 
   _renderExampleLayer(example, settings, index) {
     const {layer: Layer, props, getData} = example;
+
     const layerProps = Object.assign({}, props, settings);
 
     if (getData) {

--- a/examples/layer-browser/src/examples/core-layers.js
+++ b/examples/layer-browser/src/examples/core-layers.js
@@ -114,9 +114,10 @@ const PolygonLayerExample = {
     getFillColor: f => [Math.floor(Math.random() * 255), 0, 0],
     getLineColor: f => [0, 0, 0, 255],
     getWidth: f => 20,
-    getHeight: f => Math.random() * 1000,
+    getElevation: f => Math.random() * 1000,
     opacity: 0.8,
-    pickable: true
+    pickable: true,
+    elevationScale: 0.6
   }
 };
 

--- a/src/layers/core/geojson-layer/geojson-layer.js
+++ b/src/layers/core/geojson-layer/geojson-layer.js
@@ -41,6 +41,8 @@ const defaultProps = {
   lineJointRounded: false,
   lineMiterLimit: 4,
 
+  elevationScale: 1,
+
   pointRadiusScale: 1,
   pointRadiusMinPixels: 0, //  min point radius in pixels
   pointRadiusMaxPixels: Number.MAX_SAFE_INTEGER, // max point radius in pixels
@@ -104,6 +106,7 @@ export default class GeoJsonLayer extends CompositeLayer {
     const {lineWidthScale, lineWidthMinPixels, lineWidthMaxPixels,
       lineJointRounded, lineMiterLimit,
       pointRadiusScale, pointRadiusMinPixels, pointRadiusMaxPixels,
+      elevationScale,
       fp64} = this.props;
 
     // Accessor props for underlying layers
@@ -137,6 +140,7 @@ export default class GeoJsonLayer extends CompositeLayer {
         data: polygonFeatures,
 
         extruded,
+        elevationScale,
         wireframe: false,
         lightSettings,
         getPolygon: getCoordinates,
@@ -156,6 +160,7 @@ export default class GeoJsonLayer extends CompositeLayer {
         data: polygonFeatures,
 
         extruded,
+        elevationScale,
         wireframe: true,
         getPolygon: getCoordinates,
         getElevation,

--- a/src/layers/core/polygon-layer/polygon-layer.js
+++ b/src/layers/core/polygon-layer/polygon-layer.js
@@ -30,6 +30,7 @@ const defaultProps = {
   stroked: true,
   filled: true,
   extruded: false,
+  elevationScale: 1,
   wireframe: false,
 
   lineWidthScale: 1,
@@ -90,7 +91,7 @@ export default class PolygonLayer extends CompositeLayer {
 
   renderLayers() {
     // Layer composition props
-    const {data, id, stroked, filled, extruded, wireframe} = this.props;
+    const {data, id, stroked, filled, extruded, wireframe, elevationScale} = this.props;
 
     // Rendering props underlying layer
     const {lineWidthScale, lineWidthMinPixels, lineWidthMaxPixels,
@@ -115,6 +116,7 @@ export default class PolygonLayer extends CompositeLayer {
       id: `${id}-fill`,
       data,
       extruded,
+      elevationScale,
       wireframe: false,
       fp64,
       opacity,
@@ -141,6 +143,7 @@ export default class PolygonLayer extends CompositeLayer {
         id: `${id}-wireframe`,
         data,
         extruded: true,
+        elevationScale,
         wireframe: true,
         fp64,
         opacity,

--- a/src/layers/core/solid-polygon-layer/solid-polygon-layer-vertex-64.glsl.js
+++ b/src/layers/core/solid-polygon-layer/solid-polygon-layer-vertex-64.glsl.js
@@ -28,6 +28,7 @@ attribute vec4 colors;
 attribute vec3 pickingColors;
 
 uniform float extruded;
+uniform float elevationScale;
 uniform float opacity;
 
 uniform float renderPickingBuffer;
@@ -46,7 +47,7 @@ void main(void) {
   vec2 vertex_pos_modelspace[4];
   vertex_pos_modelspace[0] = projected_coord_xy[0];
   vertex_pos_modelspace[1] = projected_coord_xy[1];
-  vertex_pos_modelspace[2] = vec2(project_scale(positions.z), 0.0);
+  vertex_pos_modelspace[2] = vec2(project_scale(positions.z * elevationScale), 0.0);
   vertex_pos_modelspace[3] = vec2(1.0, 0.0);
 
   gl_Position = project_to_clipspace_fp64(vertex_pos_modelspace);

--- a/src/layers/core/solid-polygon-layer/solid-polygon-layer-vertex.glsl.js
+++ b/src/layers/core/solid-polygon-layer/solid-polygon-layer-vertex.glsl.js
@@ -27,6 +27,7 @@ attribute vec4 colors;
 attribute vec3 pickingColors;
 
 uniform float extruded;
+uniform float elevationScale;
 uniform float opacity;
 
 uniform float renderPickingBuffer;
@@ -37,7 +38,11 @@ uniform float pickingEnabled;
 varying vec4 vPickingColor;
 
 void main(void) {
-  vec4 position_worldspace = vec4(project_position(positions), 1.0);
+  
+  vec4 position_worldspace = vec4(project_position(
+    vec3(positions.x, positions.y, positions.z * elevationScale)),
+    1.0
+  );
   gl_Position = project_to_clipspace(position_worldspace);
 
   if (pickingEnabled < 0.5) {


### PR DESCRIPTION
#1046

tested with
- npm run tests
- All layers in layer-browser able to render
- toggle polygon layer, geojson layer 'extruded'
- slide polygon layer, geojson layer elevationScale