### PR TITLE
Add new blend mode to initWebGLParameters

### DIFF
--- a/src/core/pure-js/deck-js.js
+++ b/src/core/pure-js/deck-js.js
@@ -212,6 +212,7 @@ export default class DeckGLJS {
     // TODO - these should be set by default starting from next major release
     if (this.props.initWebGLParameters) {
       setParameters(gl, {
+        blendFuncSeparate: [GL.SRC_ALPHA, GL.ONE_MINUS_SRC_ALPHA, GL.ONE, GL.ONE_MINUS_SRC_ALPHA],
         depthTest: true,
         depthFunc: GL.LEQUAL
       });


### PR DESCRIPTION
Per recommendation in https://github.com/uber/deck.gl/issues/1176: enable new blend mode without breaking existing apps.