### PR TITLE
Add support for old picking uniforms

### DIFF
--- a/docs/advanced/picking.md
+++ b/docs/advanced/picking.md
@@ -73,12 +73,36 @@ calculatePickingColors(attribute) {
 
 ## Custom Shaders
 
-Deck.gl layers use luma.gl's [`Picking Module`](http://uber.github.io/luma.gl/#/documentation/api-reference/shader-module). If you are writing custom shaders for your layers, please refer to above luma.gl documentation on how to add picking logic to your shaders. Also make sure to create `Model` object with `picking` module. ()
+All core layers (including composite layers) support picking using luma.gl's `picking module`. If you are using custom shaders with any of the core layers or building custom layers with your own shaders following steps are needed to achieve `Picking`.
+
+### getShaders()
+
+`getShaders()` return value should include picking module in `modules` array.
 
 ```
-const model = new Model(gl, {
-  fs: CUSTOM_FS,
-  vs: CUSTOM_VS,
-  modules: ['picking', ...],
-});
+getShaders() {
+  return {
+    vs: CUSTOM_VS,
+    fs: CUSTOM_FS,
+    modules: ['picking', ...]
+  }
+}
 ```
+
+### Vertex Shader
+
+Vertex shader should set current picking color using `picking_setPickingColor` method provided by picking shader module.
+
+```
+attribute vec3 instancePickingColors;
+
+void main(void) {
+  ...
+
+  picking_setPickingColor(instancePickingColors);
+
+  ....
+}
+```
+
+For more details refer to luma.gl's [`Picking Module`](http://uber.github.io/luma.gl/#/documentation/api-reference/shader-toosl/shadertools-picking.md).

--- a/docs/advanced/picking.md
+++ b/docs/advanced/picking.md
@@ -71,22 +71,21 @@ calculatePickingColors(attribute) {
 - For more information about how to implement picking in shaders see: [`renderPickingBuffer`](/docswriting-shaders.md#-float-renderpickingbuffer-)
 
 
-## Custom Shaders
+## Implementing Picking in Custom Shaders
 
 All core layers (including composite layers) support picking using luma.gl's `picking module`. If you are using custom shaders with any of the core layers or building custom layers with your own shaders following steps are needed to achieve `Picking`.
 
-### getShaders()
+### Model object creation.
 
-`getShaders()` return value should include picking module in `modules` array.
+When creating `Model` object, add picking module to `modules` array.
 
 ```
-getShaders() {
-  return {
-    vs: CUSTOM_VS,
-    fs: CUSTOM_FS,
-    modules: ['picking', ...]
-  }
-}
+new Model(gl, {
+  ...
+  vs: CUSTOM_VS,
+  fs: CUSTOM_FS,
+  modules: ['picking', ...]
+});
 ```
 
 ### Vertex Shader
@@ -102,6 +101,21 @@ void main(void) {
   picking_setPickingColor(instancePickingColors);
 
   ....
+}
+```
+
+### Fragment Shader
+
+Fragment shader should use `picking_filterPickingColor` to update `gl_FragColor`, which outputs picking color if it is the picking pass.
+
+```
+attribute vec3 instancePickingColors;
+
+void main(void) {
+  ...
+
+  // Should be the last Fragment shader instruction that updates gl_FragColor
+  gl_FragColor = picking_filterPickingColor(gl_FragColor);
 }
 ```
 

--- a/docs/advanced/writing-shaders.md
+++ b/docs/advanced/writing-shaders.md
@@ -64,6 +64,34 @@ The layerIndex is a small integer that starts at zero and is incremented for eac
 
 In the fragment shader, multiply the fragment color with the opacity uniform.
 
+### Picking uniforms (deprecated)
+
+NOTE: Following uniforms (`renderPickingBuffer` and `selectedPickingColor`) are supported as deprecated, and will be removed in next major version. It is recommended to use `luma.gl` picking module for any picking needs. For more details refer to [`Picking`](/docs/advanced/picking.md).
+
+##### `float renderPickingBuffer`
+
+If you choose to implement picking through picking colors, make sure
+the `pickingColors` or `instancePickingColors` attribute is correctly set up,
+and ensure that you return the picking color when `renderPickingBuffer`
+uniform is set. Alternatively call the `layerColor` method on your
+fragment color before assigning to `gl_FragColor`.
+
+Note that the picking color must be rendered exactly as is with an alpha
+channel of 1. Beware blending in opacity as it can result in the rendered
+color not matching the picking color, causing the wrong index to be picked.
+
+```glsl
+gl_FragColor = mix(
+  vec4(instanceColor.rgb, instanceColor.a * opacity),
+  vec4(instancePickingColor, 1.),
+  renderPickingBuffer
+);
+```
+
+##### `vec3 selectedPickingColor`
+
+This uniform is set if `props.pickable` is enabled on the layer and reflects the color
+of the last picked pixel. If no pixel is selected, the value will be `[0, 0, 0]`.
 
 ### Shader Module Uniforms
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -28,9 +28,15 @@ Following methods and props have been renamed for clarity.
 | `useDevicePixelRatio` | `useDevicePixels` | |
 
 
+### Picking uniforms
+
+`renderPickingBuffer` and `selectedPickingColor` are deprecated, and will be removed in next major version. It is recommended to use `luma.gl` picking module.
+
+
 ### Viewports
 
 TODO: add a document explaining the hierarchies and recommended practices of using the provided viewports.
+
 
 ## Upgrading from deck.gl v4 to v4.1
 


### PR DESCRIPTION
Fixes #1179 

* Add back `selectedPickingColor` uniform to support old custom picking.
* Docs :
   * Mark `renderPickingBuffer` and `selectedPickingColor` as deprecated.
   * Add picking documentation for custom shaders.