### PR TITLE
Move unaudited APIs to experimental

### DIFF
--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -3,9 +3,6 @@
 import {
   // COORDINATE_SYSTEM,
   WebMercatorViewport,
-  FirstPersonViewport,
-  MapState,
-  // FirstPersonState,
   experimental
 } from 'deck.gl';
 
@@ -13,6 +10,9 @@ import {
 import DeckGL, {ViewportController} from 'deck.gl';
 
 const {
+  FirstPersonViewport,
+  MapState,
+  // FirstPersonState,
   ReflectionEffect
 } = experimental;
 

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -29,25 +29,32 @@ export {default as CompositeLayer} from './lib/composite-layer';
 // Viewports
 export {default as Viewport} from './viewports/viewport';
 export {default as FirstPersonViewport} from './viewports/first-person-viewport';
-export {default as ThirdPersonViewport} from './viewports/third-person-viewport';
 export {default as WebMercatorViewport} from './viewports/web-mercator-viewport';
 export {default as PerspectiveViewport} from './viewports/perspective-viewport';
 export {default as OrthographicViewport} from './viewports/orthographic-viewport';
-// TODO: orbit-viewport to be merged w/ third-person-viewport
-export {default as OrbitViewport} from './viewports/orbit-viewport';
 
-// TODO - Do we need to export? Move to experimental?
-export {default as ViewportControls} from './controllers/viewport-controls';
-export {default as FirstPersonState} from './controllers/first-person-state';
-export {default as OrbitState} from './controllers/orbit-state';
-export {default as MapState} from './controllers/map-state';
-
+// Transitions
 export {TRANSITION_EVENTS} from './lib/transition-manager';
 export {default as LinearInterpolator} from './transitions/linear-interpolator';
 export {default as ViewportFlyToInterpolator} from './transitions/viewport-fly-to-interpolator';
 
 // Import shaderlib to make sure shader modules are initialized
 import './shaderlib';
+
+// DEPREPECATED EXPORTS
+import {default as FirstPersonState} from './controllers/first-person-state';
+import {default as OrbitState} from './controllers/orbit-state';
+import {default as MapState} from './controllers/map-state';
+
+// EXPERIMENTAL EXPORTS
+// Controllers
+import {default as Controller} from './controllers/viewport-controls';
+import {default as MapController} from './controllers/map-controls';
+// import {default as FirstPersonController} from './controllers/first-person-controller';
+// import {default as OrbitController} from './controllers/orbit-controller';
+
+import {default as OrbitViewport} from './viewports/orbit-viewport';
+import {default as ThirdPersonViewport} from './viewports/third-person-viewport';
 
 // Experimental Features (May change in minor version bumps, use at your own risk)
 // Experimental Pure JS (non-React) bindings
@@ -57,8 +64,12 @@ import {default as MapControllerJS} from './pure-js/map-controller-js';
 import {default as EffectManager} from './experimental/lib/effect-manager';
 import {default as Effect} from './experimental/lib/effect';
 
+// INTERNAL EXPORTS
+
 import TransitionManager from './lib/transition-manager';
 import {extractViewportFrom} from './transitions/transition-utils';
+
+// Layer utilities
 
 // Layer utilities
 import {default as log} from './utils/log';
@@ -66,20 +77,29 @@ import {get} from './utils/get';
 import {count} from './utils/count';
 
 import {default as BinSorter} from './utils/bin-sorter';
-import {
-  linearScale, getLinearScale,
-  quantizeScale, getQuantizeScale,
-  clamp
-} from './utils/scale-utils';
 import {defaultColorRange} from './utils/color-utils';
+import {linearScale, getLinearScale, quantizeScale, getQuantizeScale} from './utils/scale-utils';
+import {clamp} from './utils/scale-utils';
 
+import {flatten, countVertices, flattenVertices, fillArray} from './utils/flatten';
 // TODO - just expose as layer methods instead?
 import {enable64bitSupport} from './utils/fp64';
 import {fp64ify} from './utils/fp64';
 
-import {flatten, countVertices, flattenVertices, fillArray} from './utils/flatten';
-
 export const experimental = {
+  ViewportControls: Controller,
+  FirstPersonState,
+  OrbitState,
+  MapState,
+
+  Controller,
+  MapController,
+  // FirstPersonController,
+  // OrbitController,
+
+  OrbitViewport,
+  ThirdPersonViewport,
+
   DeckGLJS,
   MapControllerJS,
   EffectManager,
@@ -99,13 +119,15 @@ export const experimental = {
   defaultColorRange,
 
   log,
+
   get,
   count,
-  enable64bitSupport,
-  fp64ify,
 
   flatten,
   countVertices,
   flattenVertices,
-  fillArray
+  fillArray,
+
+  enable64bitSupport,
+  fp64ify
 };

--- a/src/index.js
+++ b/src/index.js
@@ -26,91 +26,82 @@ const experimental = {};
 //
 
 export {
+  // LIB
   COORDINATE_SYSTEM,
   LayerManager,
   AttributeManager,
   Layer,
-  CompositeLayer
-} from './core';
+  CompositeLayer,
 
-// Viewports
-export {
+  // Viewports
   Viewport,
   FirstPersonViewport,
-  ThirdPersonViewport,
   WebMercatorViewport,
   PerspectiveViewport,
   OrthographicViewport,
-  // TODO: orbit-viewport to be merged w/ third-person-viewport
-  OrbitViewport
-} from './core';
 
-// TODO - Do we need to export? Move to experimental?
-export {
-  ViewportControls,
-  FirstPersonState,
-  OrbitState,
-  MapState
-} from './core';
-
-// Transition bindings
-export {
+  // Transition bindings
   TRANSITION_EVENTS,
   LinearInterpolator,
   ViewportFlyToInterpolator
-  // TransitionManager (Does the TransitionManager need to be exported?)
 } from './core';
 
 // Deprecated Core Lib Classes
 export {assembleShaders} from 'luma.gl'; // Forward the luma.gl version (note: now integrated with Model)
 
 // EXPERIMENTAL CORE LIB CLASSES (May change in minor version bumps, use at your own risk)
-import {default as DeckGLJS} from './core/pure-js/deck-js';
-import {default as MapControllerJS} from './core/pure-js/map-controller-js';
-import {default as EffectManager} from './core/experimental/lib/effect-manager';
-import {default as Effect} from './core/experimental/lib/effect';
+import {experimental as CoreExperimental} from './core';
 
-Object.assign(experimental, {
-  // Pure JS (non-React) support
+const {
+  // View States
+  ViewState,
+  FirstPersonState,
+  OrbitState,
+  MapState,
+
+  // Controllers
+  Controller,
+  MapController,
+  FirstPersonController,
+  OrbitController,
+
+  // Viewports
+  OrbitViewport,
+
   DeckGLJS,
   MapControllerJS,
+
+  EffectManager,
+  Effect
+} = CoreExperimental;
+
+Object.assign(experimental, {
+  // Unfinished controller/viewport classes
+  ViewState,
+  FirstPersonState,
+  OrbitState,
+  MapState,
+
+  Controller,
+  MapController,
+  FirstPersonController,
+  OrbitController,
+
+  OrbitViewport,
+
+  // Pure JS (non-React) API
+  DeckGLJS,
+  MapControllerJS,
+
   // Effects base classes
   EffectManager,
   Effect
 });
 
-// Core utilities for layers
-
 // Experimental Data Accessor Helpers
-import {get} from './core/utils/get';
-import {count} from './core/utils/count';
-
-// Experimental Aggregation Utilities
-import {default as BinSorter} from './core/utils/bin-sorter';
-import {linearScale} from './core/utils/scale-utils';
-import {quantizeScale} from './core/utils/scale-utils';
-import {clamp} from './core/utils/scale-utils';
-import {defaultColorRange} from './core/utils/color-utils';
-
-// Experimental 64 bit helpers
-// TODO - just expose as layer methods instead?
-import {enable64bitSupport} from './core/utils/fp64';
-import {fp64ify} from './core/utils/fp64';
-
-Object.assign(experimental, {
-  // The following are mainly for sub-layers
-  get,
-  count,
-
-  BinSorter,
-  linearScale,
-  quantizeScale,
-  clamp,
-  defaultColorRange,
-
-  enable64bitSupport,
-  fp64ify
-});
+// INTERNAL - TODO remove from experimental exports
+const {get, count} = CoreExperimental;
+Object.assign(experimental, {get, count});
 
 //
 // CORE LAYERS PACKAGE
@@ -162,14 +153,18 @@ Object.assign(experimental, {
 export {
   default as default,
   DeckGL,
-  ViewportController,
-  MapController
+  ViewportController // TODO - merge with deck.gl?
 } from './react';
 
-// Experimental React bindings
-import {default as OrbitController} from './react/experimental/orbit-controller';
+// TODO - do we need to expose these?
+import {
+  MapController as ReactMapController,
+  OrbitController as ReactOrbitController
+} from './react';
+
 Object.assign(experimental, {
-  OrbitController
+  ReactMapController,
+  ReactOrbitController
 });
 
 //

--- a/src/react/index.js
+++ b/src/react/index.js
@@ -21,13 +21,9 @@
 export {default as DeckGL} from './deckgl';
 export {default as default} from './deckgl';
 
+// TODO - should react controllers be exported or just integrated into deck.gl API?
 export {default as ViewportController} from './viewport-controller';
 export {default as MapController} from './map-controller';
+export {default as OrbitController} from './experimental/orbit-controller';
 
 export {default as autobind} from './utils/autobind';
-
-// Experimental React bindings
-import {default as OrbitController} from './experimental/orbit-controller';
-export const experimental = {
-  OrbitController
-};

--- a/src/react/viewport-controller.js
+++ b/src/react/viewport-controller.js
@@ -2,8 +2,8 @@ import {PureComponent, createElement} from 'react';
 import PropTypes from 'prop-types';
 
 import {EventManager} from 'mjolnir.js';
-import {ViewportControls, experimental} from '../core';
-const {TransitionManager} = experimental;
+import {experimental} from '../core';
+const {ViewportControls, TransitionManager} = experimental;
 
 import CURSOR from './utils/cursors';
 


### PR DESCRIPTION
This PR rather "aggressively" moves unfinished APIs (i.e. classes that I consider unaudited) to `experimental`

All classes that were not experimental in 4.1 should still be available here, but most new controller/viewport classes are in the `experimental` namespace.

This PR will be presented/discussed in today's audit meeting before landing.
