### PR TITLE
Path Layer Code Cleanup Step 1

### DIFF
--- a/src/core-layers/path-layer/path-layer-vertex.glsl.js
+++ b/src/core-layers/path-layer/path-layer-vertex.glsl.js
@@ -55,17 +55,13 @@ float flipIfTrue(bool flag) {
 }
 
 // calculate line join positions
-vec3 lineJoin(vec3 prevPoint, vec3 currPoint, vec3 nextPoint) {
-
-  float width = clamp(project_scale(instanceStrokeWidths * widthScale),
-    widthMinPixels, widthMaxPixels) / 2.0;
-
+vec3 lineJoin(
+  vec3 prevPoint, vec3 currPoint, vec3 nextPoint,
+  float relativePosition, bool isEnd, bool isJoint,
+  float width
+) {
   vec2 deltaA = currPoint.xy - prevPoint.xy;
   vec2 deltaB = nextPoint.xy - currPoint.xy;
-
-  vec2 offsetVec;
-  float offsetScale;
-  float offsetDirection;
 
   float lenA = length(deltaA);
   float lenB = length(deltaB);
@@ -74,8 +70,10 @@ vec3 lineJoin(vec3 prevPoint, vec3 currPoint, vec3 nextPoint) {
   // assume they are the same point to avoid precision issue
   lenA = lenA > PIXEL_EPSILON ? lenA : 0.0;
   lenB = lenB > PIXEL_EPSILON ? lenB : 0.0;
+
   vec2 dirA = lenA > 0. ? normalize(deltaA) : vec2(0.0, 0.0);
   vec2 dirB = lenB > 0. ? normalize(deltaB) : vec2(0.0, 0.0);
+
   vec2 perpA = vec2(-dirA.y, dirA.x);
   vec2 perpB = vec2(-dirB.y, dirB.x);
 
@@ -85,41 +83,36 @@ vec3 lineJoin(vec3 prevPoint, vec3 currPoint, vec3 nextPoint) {
   // direction of the corner
   vec2 miterVec = vec2(-tangent.y, tangent.x);
   // width offset from current position
-  vec2 perp = mix(perpB, perpA, positions.x);
-  float L = mix(lenB, lenA, positions.x);
+  vec2 perp = isEnd ? perpA : perpB;
+  float L = isEnd ? lenA : lenB;
 
   // cap super sharp angles
   float sinHalfA = abs(dot(miterVec, perp));
   float cosHalfA = abs(dot(dirA, miterVec));
+
   bool turnsRight = dirA.x * dirB.y > dirA.y * dirB.x;
 
-  // relative position to the corner:
-  // -1: inside (smaller side of the angle)
-  // 0: center
-  // 1: outside (bigger side of the angle)
-  float cornerPosition = mix(
-    flipIfTrue(turnsRight == (positions.y > 0.0)),
-    0.0,
-    positions.z
-  );
+  float offsetScale = 1.0 / max(sinHalfA, EPSILON);
 
-  offsetScale = 1.0 / max(sinHalfA, EPSILON);
+  float cornerPosition = isJoint ?
+    0.0 :
+    flipIfTrue(turnsRight == (relativePosition > 0.0));
 
   // do not bevel if line segment is too short
-  cornerPosition *= float(cornerPosition <= 0.0 || sinHalfA < min(lenA, lenB) / width * cosHalfA);
-  // trim if inside corner extends further than the line segment
-  offsetScale = mix(
-    offsetScale,
-    min(offsetScale, L / width / max(cosHalfA, EPSILON)),
-    float(cornerPosition < 0.0)
-  );
+  cornerPosition *=
+    float(cornerPosition <= 0.0 || sinHalfA < min(lenA, lenB) / width * cosHalfA);
 
-  vMiterLength = mix(
-    offsetScale * cornerPosition,
-    mix(offsetScale, 0.0, cornerPosition),
-    step(0.0, cornerPosition)
-  ) - sinHalfA * jointType;
-  offsetDirection = mix(
+  // trim if inside corner extends further than the line segment
+  if (cornerPosition < 0.0) {
+    offsetScale = min(offsetScale, L / width / max(cosHalfA, EPSILON));
+  }
+
+  vMiterLength = cornerPosition >= 0.0 ?
+    mix(offsetScale, 0.0, cornerPosition) :
+    offsetScale * cornerPosition;
+  vMiterLength -= sinHalfA * jointType;
+
+  float offsetDirection = mix(
     positions.y,
     mix(
       flipIfTrue(turnsRight),
@@ -128,47 +121,75 @@ vec3 lineJoin(vec3 prevPoint, vec3 currPoint, vec3 nextPoint) {
     ),
     step(0.0, cornerPosition)
   );
-  offsetVec = mix(miterVec, -tangent, step(0.5, cornerPosition));
+
+  vec2 offsetVec = mix(miterVec, -tangent, step(0.5, cornerPosition));
   offsetScale = mix(offsetScale, 1.0 / max(cosHalfA, 0.001), step(0.5, cornerPosition));
 
   // special treatment for start cap and end cap
-  float isStartCap = step(0.0, -lenA);
-  float isEndCap = step(0.0, -lenB);
-  float isCap = max(isStartCap, isEndCap);
+  // TODO - This has an issue. len is always positive because it is length.
+  // Step returns zero if -lenA<0, so practically this is a comparison of
+  // lenA with zero, with lots of problems because of the -lenA. Can we use EPSILON?
+  bool isStartCap = step(0.0, -lenA) > 0.5;
+  bool isEndCap = step(0.0, -lenB) > 0.5;
+  bool isCap = isStartCap || isEndCap;
 
   // 0: center, 1: side
-  cornerPosition = isCap * (1.0 - positions.z);
+  cornerPosition = isCap ? (1.0 - positions.z) : 0.;
 
   // start of path: use next - curr
-  offsetVec = mix(offsetVec, mix(dirB, perpB, cornerPosition), isStartCap);
+  if (isStartCap) {
+    offsetVec = mix(dirB, perpB, cornerPosition);
+  }
+
   // end of path: use curr - prev
-  offsetVec = mix(offsetVec, mix(dirA, perpA, cornerPosition), isEndCap);
+  if (isEndCap) {
+    offsetVec = mix(dirA, perpA, cornerPosition);
+  }
 
   // extend out a triangle to envelope the round cap
-  offsetScale = mix(
-    offsetScale,
-    mix(4.0 * jointType, 1.0, cornerPosition),
-    isCap
-  );
-  vMiterLength = mix(vMiterLength, 1.0 - cornerPosition, isCap);
-
-  offsetDirection = mix(
-    offsetDirection,
-    mix(flipIfTrue(isStartCap > 0.), positions.y, cornerPosition),
-    isCap
-  );
+  if (isCap) {
+    offsetScale = mix(4.0 * jointType, 1.0, cornerPosition);
+    vMiterLength = 1.0 - cornerPosition;
+    offsetDirection = mix(flipIfTrue(isStartCap), positions.y, cornerPosition);
+  }
 
   vCornerOffset = offsetVec * offsetDirection * offsetScale;
 
   // Generate variables for dash calculation
   vDashArray = instanceDashArrays;
   vPathLength = L / width;
-  float isEnd = positions.x;
-  vec2 offsetFromStartOfPath = mix(vCornerOffset, vCornerOffset + deltaA / width, isEnd);
-  vec2 dir = mix(dirB, dirA, isEnd);
+  // vec2 offsetFromStartOfPath = isEnd ? vCornerOffset + deltaA / width : vCornerOffset;
+  vec2 offsetFromStartOfPath = vCornerOffset;
+  if (isEnd) {
+    offsetFromStartOfPath += deltaA / width;
+  }
+  vec2 dir = isEnd ? dirA : dirB;
   vPathPosition = dot(offsetFromStartOfPath, dir);
 
   return currPoint + vec3(vCornerOffset * width, 0.0);
+}
+
+// calculate line join positions
+// extract params from attributes and uniforms
+vec3 lineJoin(vec3 prevPoint, vec3 currPoint, vec3 nextPoint) {
+
+  // relative position to the corner:
+  // -1: inside (smaller side of the angle)
+  // 0: center
+  // 1: outside (bigger side of the angle)
+
+  float relativePosition = positions.y;
+  bool isEnd = positions.x > EPSILON;
+  bool isJoint = positions.z > EPSILON;
+
+  float width = clamp(project_scale(instanceStrokeWidths * widthScale),
+    widthMinPixels, widthMaxPixels) / 2.0;
+
+  return lineJoin(
+    prevPoint, currPoint, nextPoint,
+    relativePosition, isEnd, isJoint,
+    width
+  );
 }
 
 void main() {
@@ -188,9 +209,7 @@ void main() {
   vec3 nextPosition = mix(vec3(0.0), instanceRightDeltas, isEnd) + instanceEndPositions;
   nextPosition = project_position(nextPosition);
 
-  vec3 pos;
-
-  pos = lineJoin(prevPosition, currPosition, nextPosition);
+  vec3 pos = lineJoin(prevPosition, currPosition, nextPosition);
 
   gl_Position = project_to_clipspace(vec4(pos, 1.0));
 }


### PR DESCRIPTION
Simple initial set of code changes to `PathLayer`:
* Many instances of `mix` replaced with `if` and `?:`.
* More descriptive variable names in a few places.
* Includes METER_OFFSET PathLayer example