### PR TITLE
Picking: Use 'null' instead of 'PICKING_NULL_COLOR`.

### DIFF
--- a/examples/layer-browser/package.json
+++ b/examples/layer-browser/package.json
@@ -9,7 +9,7 @@
     "deck.gl": ">=4.2.0-alpha.15",
     "deck.gl-layers": ">=0.0.2",
     "extrude-polyline": "^1.0.6",
-    "luma.gl": ">=4.1.0-alpha.9",
+    "luma.gl": ">=4.1.0-beta.1",
     "react": "^15.4.1",
     "react-autobind": "^1.0.6",
     "react-dom": "^15.4.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "d3-hexbin": "^0.2.1",
     "earcut": "^2.0.6",
     "lodash.flattendeep": "^4.4.0",
-    "luma.gl": ">=4.1.0-alpha.9",
+    "luma.gl": ">=4.1.0-beta.1",
     "math.gl": ">= 1.0.0-alpha.8",
     "mjolnir.js": ">=0.1.0",
     "prop-types": "^15.5.8",

--- a/src/core/lib/layer.js
+++ b/src/core/lib/layer.js
@@ -26,7 +26,7 @@ import {getDefaultProps, diffProps} from './props';
 import {count} from '../utils/count';
 import log from '../utils/log';
 import {applyPropOverrides, removeLayerInSeer} from './seer-integration';
-import {GL, withParameters, PICKING_NULL_COLOR} from 'luma.gl';
+import {GL, withParameters} from 'luma.gl';
 import assert from 'assert';
 
 const LOG_PRIORITY_UPDATE = 1;
@@ -162,10 +162,7 @@ export default class Layer {
     // Backward compitability for old custom picking feature.
     // This uniform should be removed in 5.0 version.
     if (mode === 'hover') {
-      const selectedPickingColor = new Float32Array(3);
-      selectedPickingColor[0] = color[0] === PICKING_NULL_COLOR[0] ? 0 : color[0];
-      selectedPickingColor[1] = color[1] === PICKING_NULL_COLOR[1] ? 0 : color[1];
-      selectedPickingColor[2] = color[2] === PICKING_NULL_COLOR[2] ? 0 : color[2];
+      const selectedPickingColor = color || new Float32Array([0, 0, 0]);
       for (const model of this.getModels()) {
         model.setUniforms({selectedPickingColor});
       }

--- a/src/core/lib/pick-layers.js
+++ b/src/core/lib/pick-layers.js
@@ -20,11 +20,10 @@
 
 import {drawPickingBuffer, getPixelRatio} from './draw-layers';
 import log from '../utils/log';
-import {PICKING_NULL_COLOR} from 'luma.gl';
 import assert from 'assert';
 
 const NO_PICKED_OBJECT = {
-  pickedColor: PICKING_NULL_COLOR,
+  pickedColor: null,
   pickedLayer: null,
   pickedObjectIndex: -1
 };
@@ -290,7 +289,7 @@ function processPickInfo({
     const pickingSelectedColor = (
       layer.props.autoHighlight &&
       pickedLayer === layer
-    ) ? pickedColor : PICKING_NULL_COLOR;
+    ) ? pickedColor : null;
 
     const pickingParameters = {
       pickingSelectedColor
@@ -426,7 +425,7 @@ function getUniquesFromPickingBuffer(gl, {pickedColors, layers}) {
 function createInfo(pixel, viewport) {
   // Assign a number of potentially useful props to the "info" object
   return {
-    color: PICKING_NULL_COLOR,
+    color: null,
     layer: null,
     index: -1,
     picked: false,

--- a/website/package.json
+++ b/website/package.json
@@ -25,7 +25,7 @@
     "expr-eval": "^1.0.0",
     "highlight.js": "^9.7.0",
     "immutable": "^3.7.5",
-    "luma.gl": "^4.1.0-alpha.6",
+    "luma.gl": "^4.1.0-beta.1",
     "marked": "^0.3.6",
     "prop-types": "^15.5.8",
     "rbush": "^2.0.1",


### PR DESCRIPTION
* Remove `PICKING_NULL_COLOR` and use `null` as default value. When no layers are picked , it will remain 'null' and luma.gl picking module sets a flag to indicate the picking color is invalid.

Verified picking/highlighting with latest luma.gl code on several layers using `layer-browser`.

NOTE: This change requires 'https://github.com/uber/luma.gl/pull/365' , once this PR is approved, I will also bump luma.gl version to an alpha release containing above change.