### PR TITLE
update sharp end/joint fix for 64bits pathlayer shader

### DIFF
--- a/src/core-layers/path-layer/path-layer-vertex-64.glsl.js
+++ b/src/core-layers/path-layer/path-layer-vertex-64.glsl.js
@@ -50,6 +50,7 @@ varying float vPathPosition;
 varying float vPathLength;
 
 const float EPSILON = 0.001;
+const float PIXEL_EPSILON = 0.1;
 
 float flipIfTrue(bool flag) {
   return -(float(flag) * 2. - 1.);
@@ -79,8 +80,12 @@ vec3 lineJoin(vec2 prevPoint64[2], vec2 currPoint64[2], vec2 nextPoint64[2]) {
   float offsetScale;
   float offsetDirection;
 
-  vec2 dirA = lenA > 0. ? deltaA / lenA : vec2(1.0, 0.0);
-  vec2 dirB = lenB > 0. ? deltaB / lenB : vec2(1.0, 0.0);
+  // when two points are closer than PIXEL_EPSILON in pixels,
+  // assume they are the same point to avoid precision issue
+  lenA = lenA > PIXEL_EPSILON ? lenA : 0.0;
+  lenB = lenB > PIXEL_EPSILON ? lenB : 0.0;
+  vec2 dirA = lenA > 0. ? deltaA / lenA : vec2(0.0, 0.0);
+  vec2 dirB = lenB > 0. ? deltaB / lenB : vec2(0.0, 0.0);
 
   vec2 perpA = vec2(-dirA.y, dirA.x);
   vec2 perpB = vec2(-dirB.y, dirB.x);


### PR DESCRIPTION
Port fix #1200 to 64bits shader, may resolve #896 .

Tested with layer-browser and enabled 64bits flag.