### PR TITLE
FOR DISCUSSION: Merge ViewportController into DeckGL

### DIFF
--- a/examples/experimental/multi-viewport-transitions/app.js
+++ b/examples/experimental/multi-viewport-transitions/app.js
@@ -4,21 +4,23 @@ import {render} from 'react-dom';
 
 import {
   COORDINATE_SYSTEM,
-  // Unified controller, together with state that determines interaction model
-  FirstPersonState,
-  // Viewport classes provides various views on the state
-  FirstPersonViewport,
-  ThirdPersonViewport,
   WebMercatorViewport,
   PolygonLayer,
   PointCloudLayer,
-  LinearInterpolator
+  LinearInterpolator,
+  FirstPersonViewport,
+  experimental
 } from 'deck.gl';
+
+const {
+  // Viewport classes provides various views on the state
+  ThirdPersonViewport
+} = experimental;
 
 import TripsLayer from '../../trips/trips-layer';
 
 // deck.gl React components
-import {DeckGL, ViewportController} from 'deck.gl';
+import {DeckGL} from 'deck.gl';
 
 import {StaticMap} from 'react-map-gl';
 
@@ -311,39 +313,31 @@ class Root extends Component {
 
     return (
       <div style={{backgroundColor: '#000'}}>
-        <ViewportController
-          viewportState={FirstPersonState}
-          {...viewportProps}
+        <DeckGL
+          id="first-person"
           width={viewportProps.width}
           height={viewportProps.height}
+          viewports={viewports}
           onViewportChange={this._onViewportChange}
           transitionDuration={transitionDuration}
           transitionInterpolator={transitionInterpolator}
+          layers={this._renderLayers()}
+          initWebGLParameters
         >
-          <DeckGL
-            id="first-person"
-            width={viewportProps.width}
-            height={viewportProps.height}
-            viewports={viewports}
-            layers={this._renderLayers()}
-            initWebGLParameters
-          >
-            <StaticMap
-              viewportId="3rd-person"
-              {...viewportProps}
-              mapStyle="mapbox://styles/mapbox/light-v9"
-              mapboxApiAccessToken={MAPBOX_TOKEN}
-            />
-            <StaticMap
-              viewportId="basemap"
-              {...viewportProps}
-              mapStyle="mapbox://styles/mapbox/dark-v9"
-              mapboxApiAccessToken={MAPBOX_TOKEN}
-            />
-          </DeckGL>
-
-          {this._renderOptionsPanel()}
-        </ViewportController>
+          <StaticMap
+            viewportId="3rd-person"
+            {...viewportProps}
+            mapStyle="mapbox://styles/mapbox/light-v9"
+            mapboxApiAccessToken={MAPBOX_TOKEN}
+          />
+          <StaticMap
+            viewportId="basemap"
+            {...viewportProps}
+            mapStyle="mapbox://styles/mapbox/dark-v9"
+            mapboxApiAccessToken={MAPBOX_TOKEN}
+          />
+        </DeckGL>
+        {this._renderOptionsPanel()}
       </div>
     );
   }

--- a/examples/experimental/multi-viewport/app.js
+++ b/examples/experimental/multi-viewport/app.js
@@ -4,22 +4,25 @@ import {render} from 'react-dom';
 
 import {
   COORDINATE_SYSTEM,
-  // Unified controller, together with state that determines interaction model
-  FirstPersonState,
   // Viewport classes provides various views on the state
   FirstPersonViewport,
-  ThirdPersonViewport,
   WebMercatorViewport,
   PolygonLayer,
-  PointCloudLayer
+  PointCloudLayer,
+  experimental
 } from 'deck.gl';
 
 import TripsLayer from '../../trips/trips-layer';
 
 // deck.gl React components
-import {DeckGL, ViewportController} from 'deck.gl';
+import {DeckGL} from 'deck.gl';
 
 import {StaticMap} from 'react-map-gl';
+
+const {
+  // Viewport classes provides various views on the state
+  ThirdPersonViewport
+} = experimental;
 
 // Source data CSV
 const DATA_URL = {
@@ -248,37 +251,29 @@ class Root extends Component {
 
     return (
       <div style={{backgroundColor: '#000'}}>
-        <ViewportController
-          viewportState={FirstPersonState}
-          {...viewportProps}
+        <DeckGL
+          id="first-person"
           width={viewportProps.width}
           height={viewportProps.height}
+          viewports={viewports}
           onViewportChange={this._onViewportChange}
+          layers={this._renderLayers()}
+          initWebGLParameters
         >
-          <DeckGL
-            id="first-person"
-            width={viewportProps.width}
-            height={viewportProps.height}
-            viewports={viewports}
-            layers={this._renderLayers()}
-            initWebGLParameters
-          >
-            <StaticMap
-              viewportId="3rd-person"
-              {...viewportProps}
-              mapStyle="mapbox://styles/mapbox/light-v9"
-              mapboxApiAccessToken={MAPBOX_TOKEN}
-            />
-            <StaticMap
-              viewportId="basemap"
-              {...viewportProps}
-              mapStyle="mapbox://styles/mapbox/dark-v9"
-              mapboxApiAccessToken={MAPBOX_TOKEN}
-            />
-          </DeckGL>
-
-          {this._renderOptionsPanel()}
-        </ViewportController>
+          <StaticMap
+            viewportId="3rd-person"
+            {...viewportProps}
+            mapStyle="mapbox://styles/mapbox/light-v9"
+            mapboxApiAccessToken={MAPBOX_TOKEN}
+          />
+          <StaticMap
+            viewportId="basemap"
+            {...viewportProps}
+            mapStyle="mapbox://styles/mapbox/dark-v9"
+            mapboxApiAccessToken={MAPBOX_TOKEN}
+          />
+        </DeckGL>
+        {this._renderOptionsPanel()}
       </div>
     );
   }

--- a/examples/viewport-transitions-flyTo/src/app.js
+++ b/examples/viewport-transitions-flyTo/src/app.js
@@ -1,15 +1,15 @@
 /* global window */
 import React, {Component} from 'react';
 import {StaticMap} from 'react-map-gl';
-import {
+import DeckGL, {
   ViewportFlyToInterpolator,
   TRANSITION_EVENTS,
-  ViewportController,
-  MapState
+  experimental
 } from 'deck.gl';
 
 import ControlPanel from './control-panel';
 
+const {MapControllerJS} = experimental;
 const token = process.env.MapboxAccessToken; // eslint-disable-line
 const interruptionStyles = [
   {
@@ -93,25 +93,28 @@ export default class App extends Component {
     const {viewport, settings, transitionDuration} = this.state;
 
     return (
-      <ViewportController
-        viewportState={MapState}
-        {...viewport}
-        onViewportChange={this._onViewportChange.bind(this)}
-        transitionInterpolator={new ViewportFlyToInterpolator()}
-        transitionDuration={transitionDuration}
-        transitionInterruption={this._interruptionStyle}>
-        <StaticMap
+      <div>
+        <DeckGL
           {...viewport}
-          {...settings}
-          mapStyle="mapbox://styles/mapbox/dark-v9"
-          onViewportChange={this._onViewportChange}
-          dragToRotate={false}
-          mapboxApiAccessToken={token} />
+          layers = {[]}
+          ControllerType = {MapControllerJS}
+          onViewportChange={this._onViewportChange.bind(this)}
+          transitionInterpolator={new ViewportFlyToInterpolator()}
+          transitionDuration={transitionDuration}
+          transitionInterruption={this._interruptionStyle}>
+          <StaticMap
+            {...viewport}
+            {...settings}
+            mapStyle="mapbox://styles/mapbox/dark-v9"
+            onViewportChange={this._onViewportChange}
+            dragToRotate={false}
+            mapboxApiAccessToken={token} />
+        </DeckGL>
         <ControlPanel containerComponent={this.props.containerComponent}
           onViewportChange={this._easeTo.bind(this)}
           interruptionStyles={interruptionStyles}
           onStyleChange={this._onStyleChange.bind(this)} />
-      </ViewportController>
+      </div>
     );
   }
 

--- a/examples/viewport-transitions-flyTo/src/app.js
+++ b/examples/viewport-transitions-flyTo/src/app.js
@@ -3,13 +3,11 @@ import React, {Component} from 'react';
 import {StaticMap} from 'react-map-gl';
 import DeckGL, {
   ViewportFlyToInterpolator,
-  TRANSITION_EVENTS,
-  experimental
+  TRANSITION_EVENTS
 } from 'deck.gl';
 
 import ControlPanel from './control-panel';
 
-const {MapControllerJS} = experimental;
 const token = process.env.MapboxAccessToken; // eslint-disable-line
 const interruptionStyles = [
   {
@@ -69,7 +67,7 @@ export default class App extends Component {
     });
   }
 
-  _easeTo({longitude, latitude}) {
+  _flyTo({longitude, latitude}) {
 
     this.setState({
       viewport: {...this.state.viewport, longitude, latitude, zoom: 11, pitch: 0, bearing: 0},
@@ -97,7 +95,7 @@ export default class App extends Component {
         <DeckGL
           {...viewport}
           layers = {[]}
-          ControllerType = {MapControllerJS}
+          ControllerType = {'MapController'}
           onViewportChange={this._onViewportChange.bind(this)}
           transitionInterpolator={new ViewportFlyToInterpolator()}
           transitionDuration={transitionDuration}
@@ -111,7 +109,7 @@ export default class App extends Component {
             mapboxApiAccessToken={token} />
         </DeckGL>
         <ControlPanel containerComponent={this.props.containerComponent}
-          onViewportChange={this._easeTo.bind(this)}
+          flyTo={this._flyTo.bind(this)}
           interruptionStyles={interruptionStyles}
           onStyleChange={this._onStyleChange.bind(this)} />
       </div>

--- a/examples/viewport-transitions-flyTo/src/control-panel.js
+++ b/examples/viewport-transitions-flyTo/src/control-panel.js
@@ -12,7 +12,7 @@ export default class ControlPanel extends PureComponent {
         <input type="radio" name="city"
           id={`city-${index}`}
           defaultChecked={city.city === 'San Francisco'}
-          onClick={() => this.props.onViewportChange(city)} />
+          onClick={() => this.props.flyTo(city)} />
         <label htmlFor={`city-${index}`}>{city.city}</label>
       </div>
     );

--- a/examples/viewport-transitions/app.js
+++ b/examples/viewport-transitions/app.js
@@ -3,10 +3,9 @@ import React, {Component} from 'react';
 import {render} from 'react-dom';
 import {StaticMap} from 'react-map-gl';
 import DeckGLOverlay from './deckgl-overlay.js';
-import {LinearInterpolator, experimental} from 'deck.gl';
+import {LinearInterpolator} from 'deck.gl';
 import {csv as requestCsv} from 'd3-request';
 
-const {MapControllerJS} = experimental;
 // Set your mapbox token here
 const MAPBOX_TOKEN = process.env.MapboxAccessToken; // eslint-disable-line
 
@@ -102,7 +101,7 @@ class Root extends Component {
           viewport={viewport}
           transitions={transitions}
           data={data || []}
-          ControllerType = {MapControllerJS}
+          ControllerType = {'MapController'}
         />
       </StaticMap>
     );

--- a/examples/viewport-transitions/app.js
+++ b/examples/viewport-transitions/app.js
@@ -3,9 +3,10 @@ import React, {Component} from 'react';
 import {render} from 'react-dom';
 import {StaticMap} from 'react-map-gl';
 import DeckGLOverlay from './deckgl-overlay.js';
-import {ViewportController, MapState, LinearInterpolator} from 'deck.gl';
+import {LinearInterpolator, experimental} from 'deck.gl';
 import {csv as requestCsv} from 'd3-request';
 
+const {MapControllerJS} = experimental;
 // Set your mapbox token here
 const MAPBOX_TOKEN = process.env.MapboxAccessToken; // eslint-disable-line
 
@@ -26,8 +27,13 @@ class Root extends Component {
         height: 500,
         bearing: 0
       },
+      transitions: {
+        transitionDuration: 0,
+        transitionInterpolator,
+        onViewportChange: this._onViewportChange.bind(this),
+        onTransitionEnd: this._rotateCamera.bind(this)
+      },
       data: null,
-      transitionDuration: 0,
       viewportToggled: false
     };
 
@@ -42,9 +48,6 @@ class Root extends Component {
   componentDidMount() {
     window.addEventListener('resize', this._resize.bind(this));
     this._resize();
-
-    // TODO: this is to just simulate viwport prop change and test animation.
-    // this._interval = setInterval(() => this._toggleViewport(), 8000);
     this._rotateCamera();
   }
 
@@ -58,21 +61,10 @@ class Root extends Component {
   _onViewportChange(viewport) {
     this.setState({
       viewport: {...this.state.viewport, ...viewport},
-      transitionDuration: 0
-    });
-  }
-
-  // TODO: this is to just simulate viwport prop change and test animation.
-  // Add proper UI to change viewport.
-  _toggleViewport() {
-    const newViewport = {};
-    // newViewport.pitch = this.state.viewportToggled ? 60.0 : 0.0;
-    // newViewport.bearing = this.state.viewportToggled ? -90.0 : 0.0;
-    newViewport.bearing = (this.state.viewport.bearing + 120) % 360;
-    this.setState({
-      viewport: {...this.state.viewport, ...newViewport},
-      transitionDuration: 4000,
-      viewportToggled: !this.state.viewportToggled
+      transitions: {
+        ...this.state.transitions,
+        transitionDuration: 0
+      }
     });
   }
 
@@ -87,7 +79,10 @@ class Root extends Component {
         width: window.innerWidth,
         height: window.innerHeight
       },
-      transitionDuration
+      transitions: {
+        ...this.state.transitions,
+        transitionDuration
+      }
     });
   }
 
@@ -95,27 +90,21 @@ class Root extends Component {
     const {
       viewport,
       data,
-      transitionDuration
+      transitions
     } = this.state;
     return (
-      <ViewportController
-        viewportState={MapState}
+      <StaticMap
         {...viewport}
+        mapStyle="mapbox://styles/mapbox/dark-v9"
         onViewportChange={this._onViewportChange.bind(this)}
-        transitionDuration={transitionDuration}
-        transitionInterpolator={transitionInterpolator}
-        onTransitionEnd={this._rotateCamera.bind(this)}>
-        <StaticMap
-          {...viewport}
-          mapStyle="mapbox://styles/mapbox/dark-v9"
-          onViewportChange={this._onViewportChange.bind(this)}
-          mapboxApiAccessToken={MAPBOX_TOKEN}>
-          <DeckGLOverlay
-            viewport={viewport}
-            data={data || []}
-          />
-        </StaticMap>
-      </ViewportController>
+        mapboxApiAccessToken={MAPBOX_TOKEN}>
+        <DeckGLOverlay
+          viewport={viewport}
+          transitions={transitions}
+          data={data || []}
+          ControllerType = {MapControllerJS}
+        />
+      </StaticMap>
     );
   }
 }

--- a/examples/viewport-transitions/app.js
+++ b/examples/viewport-transitions/app.js
@@ -1,13 +1,9 @@
 /* global window,document */
 import React, {Component} from 'react';
 import {render} from 'react-dom';
-import {StaticMap} from 'react-map-gl';
 import DeckGLOverlay from './deckgl-overlay.js';
 import {LinearInterpolator} from 'deck.gl';
 import {csv as requestCsv} from 'd3-request';
-
-// Set your mapbox token here
-const MAPBOX_TOKEN = process.env.MapboxAccessToken; // eslint-disable-line
 
 // Source data CSV
 const DATA_URL = 'https://raw.githubusercontent.com/uber-common/deck.gl-data/master/examples/3d-heatmap/heatmap-data.csv';  // eslint-disable-line
@@ -92,18 +88,11 @@ class Root extends Component {
       transitions
     } = this.state;
     return (
-      <StaticMap
-        {...viewport}
-        mapStyle="mapbox://styles/mapbox/dark-v9"
-        onViewportChange={this._onViewportChange.bind(this)}
-        mapboxApiAccessToken={MAPBOX_TOKEN}>
-        <DeckGLOverlay
-          viewport={viewport}
-          transitions={transitions}
-          data={data || []}
-          ControllerType = {'MapController'}
-        />
-      </StaticMap>
+      <DeckGLOverlay
+        viewport={viewport}
+        transitions={transitions}
+        data={data || []}
+        ControllerType = {'MapController'}/>
     );
   }
 }

--- a/examples/viewport-transitions/deckgl-overlay.js
+++ b/examples/viewport-transitions/deckgl-overlay.js
@@ -98,7 +98,15 @@ export default class DeckGLOverlay extends Component {
   }
 
   render() {
-    const {viewport, data, radius, coverage, upperPercentile} = this.props;
+    const {
+      viewport,
+      data,
+      radius,
+      coverage,
+      upperPercentile,
+      transitions,
+      ControllerType
+    } = this.props;
 
     if (!data) {
       return null;
@@ -123,7 +131,15 @@ export default class DeckGLOverlay extends Component {
       })
     ];
 
-    return <DeckGL {...viewport} layers={layers} initWebGLParameters />;
+    return (
+      <DeckGL
+        {...viewport}
+        {...transitions}
+        ControllerType={ControllerType}
+        layers={layers}
+        initWebGLParameters
+      />
+    );
   }
 }
 

--- a/examples/viewport-transitions/deckgl-overlay.js
+++ b/examples/viewport-transitions/deckgl-overlay.js
@@ -1,6 +1,7 @@
 /* global window */
 import React, {Component} from 'react';
 import DeckGL, {HexagonLayer} from 'deck.gl';
+import {StaticMap} from 'react-map-gl';
 
 const LIGHT_SETTINGS = {
   lightsPosition: [-0.144528, 49.739968, 8000, -3.807751, 54.104682, 8000],
@@ -27,6 +28,9 @@ const defaultProps = {
   upperPercentile: 100,
   coverage: 1
 };
+
+// Set your mapbox token here
+const MAPBOX_TOKEN = process.env.MapboxAccessToken; // eslint-disable-line
 
 export default class DeckGLOverlay extends Component {
 
@@ -137,8 +141,13 @@ export default class DeckGLOverlay extends Component {
         {...transitions}
         ControllerType={ControllerType}
         layers={layers}
-        initWebGLParameters
-      />
+        initWebGLParameters>
+        <StaticMap
+          {...viewport}
+          mapStyle="mapbox://styles/mapbox/dark-v9"
+          onViewportChange={transitions.onViewportChange}
+          mapboxApiAccessToken={MAPBOX_TOKEN} />
+      </DeckGL>
     );
   }
 }

--- a/src/core/lib/transition-manager.js
+++ b/src/core/lib/transition-manager.js
@@ -2,6 +2,7 @@
 import LinearInterpolator from '../transitions/linear-interpolator';
 import {extractViewportFrom} from '../transitions/transition-utils';
 import assert from 'assert';
+import PropTypes from 'prop-types';
 
 const noop = () => {};
 
@@ -9,6 +10,28 @@ export const TRANSITION_EVENTS = {
   BREAK: 1,
   SNAP_TO_END: 2,
   IGNORE: 3
+};
+
+const PROP_TYPES = {
+  // transition duration for viewport change
+  transitionDuration: PropTypes.number,
+  // an instance of ViewportTransitionInterpolator, can be used to perform custom transitions.
+  transitionInterpolator: PropTypes.object,
+  // type of interruption of current transition on update.
+  transitionInterruption: PropTypes.number,
+  // easing function
+  transitionEasing: PropTypes.func,
+  // transition status update functions
+  onTransitionStart: PropTypes.func,
+  onTransitionInterrupt: PropTypes.func,
+  onTransitionEnd: PropTypes.func,
+
+  /**
+   * `onViewportChange` callback is fired when the user interacted with the
+   * map. The object passed to the callback contains viewport properties
+   * such as `longitude`, `latitude`, `zoom` etc.
+   */
+  onViewportChange: PropTypes.func
 };
 
 const DEFAULT_PROPS = {
@@ -176,4 +199,5 @@ export default class TransitionManager {
   }
 }
 
+TransitionManager.propTypes = PROP_TYPES;
 TransitionManager.defaultProps = DEFAULT_PROPS;

--- a/src/core/pure-js/deck-js.js
+++ b/src/core/pure-js/deck-js.js
@@ -23,6 +23,7 @@ import EffectManager from '../experimental/lib/effect-manager';
 import Effect from '../experimental/lib/effect';
 import WebMercatorViewport from '../viewports/web-mercator-viewport';
 import TransitionManager from '../lib/transition-manager';
+import MapControllerJS from './map-controller-js';
 
 import {EventManager} from 'mjolnir.js';
 import {GL, AnimationLoop, createGLContext, setParameters} from 'luma.gl';
@@ -51,7 +52,7 @@ const propTypes = Object.assign({}, TransitionManager.propTypes, {
   onLayerClick: PropTypes.func,
   onLayerHover: PropTypes.func,
   useDevicePixels: PropTypes.bool,
-  ControllerType: PropTypes.func,
+  ControllerType: PropTypes.string,
 
   // Debug settings
   debug: PropTypes.bool,
@@ -108,7 +109,7 @@ export default class DeckGLJS {
       onBeforeRender: props.onBeforeRender,
       onAfterRender: props.onAfterRender
     });
-    this._transitionManger = new TransitionManager(props);
+    this._transitionManager = new TransitionManager(props);
     this._controller = this._createController(props);
 
     this.animationLoop.start();
@@ -177,8 +178,8 @@ export default class DeckGLJS {
 
   // Trigger transition, retur true if a new transition is triggered, false otherwise.
   triggerViewportTransition(nextProps) {
-    return this._transitionManger ?
-      this._transitionManger.processViewportChange(nextProps) : false;
+    return this._transitionManager ?
+      this._transitionManager.processViewportChange(nextProps) : false;
   }
 
   // Public API
@@ -217,11 +218,11 @@ export default class DeckGLJS {
   }
 
   _createController(props) {
-    if (!props.ControllerType) {
+    // For now only 'MapController' is supported
+    if (props.ControllerType !== 'MapController') {
       return null;
     }
-    const ControllerType = props.ControllerType;
-    return new ControllerType(Object.assign({}, props, {canvas: this.canvas}));
+    return new MapControllerJS(Object.assign({}, props, {canvas: this.canvas}));
   }
 
   // Callbacks

--- a/src/index.js
+++ b/src/index.js
@@ -65,6 +65,7 @@ const {
 
   // Viewports
   OrbitViewport,
+  ThirdPersonViewport,
 
   DeckGLJS,
   MapControllerJS,
@@ -84,6 +85,7 @@ Object.assign(experimental, {
   FirstPersonController,
 
   OrbitViewport,
+  ThirdPersonViewport,
 
   // Pure JS (non-React) API
   DeckGLJS,

--- a/src/react/deckgl.js
+++ b/src/react/deckgl.js
@@ -41,6 +41,12 @@ export default class DeckGL extends React.Component {
     }
   }
 
+  shouldComponentUpdate(nextProps, nextState) {
+    const transitionTriggered = this.deck.triggerViewportTransition(nextProps);
+    // Skip render to avoid initial jump when viewport transition is triggered.
+    return !transitionTriggered;
+  }
+
   componentWillUnmount() {
     this.deck.finalize();
   }

--- a/src/react/viewport-controller.js
+++ b/src/react/viewport-controller.js
@@ -7,49 +7,7 @@ const {ViewportControls, TransitionManager} = experimental;
 
 import CURSOR from './utils/cursors';
 
-const propTypes = {
-  viewportState: PropTypes.func,
-  state: PropTypes.object,
-
-  /** Viewport props */
-  /** The width of the map. */
-  width: PropTypes.number.isRequired,
-  /** The height of the map. */
-  height: PropTypes.number.isRequired,
-  /** The longitude of the center of the map. */
-  longitude: PropTypes.number.isRequired,
-  /** The latitude of the center of the map. */
-  latitude: PropTypes.number.isRequired,
-  /** The tile zoom level of the map. */
-  zoom: PropTypes.number.isRequired,
-  /** Specify the bearing of the viewport */
-  bearing: PropTypes.number,
-  /** Specify the pitch of the viewport */
-  pitch: PropTypes.number,
-  /** Altitude of the viewport camera. Default 1.5 "screen heights" */
-  // Note: Non-public API, see https://github.com/mapbox/mapbox-gl-js/issues/1137
-  altitude: PropTypes.number,
-  // Camera position for FirstPersonViewport
-  position: PropTypes.array,
-
-  /** Viewport constraints */
-  // Max zoom level
-  maxZoom: PropTypes.number,
-  // Min zoom level
-  minZoom: PropTypes.number,
-  // Max pitch in degrees
-  maxPitch: PropTypes.number,
-  // Min pitch in degrees
-  minPitch: PropTypes.number,
-
-  /**
-   * `onViewportChange` callback is fired when the user interacted with the
-   * map. The object passed to the callback contains viewport properties
-   * such as `longitude`, `latitude`, `zoom` etc.
-   */
-  onViewportChange: PropTypes.func,
-
-  /** Viewport transition **/
+const TRANSITION_PROP_TYPES = {
   // transition duration for viewport change
   transitionDuration: PropTypes.number,
   // an instance of ViewportTransitionInterpolator, can be used to perform custom transitions.
@@ -61,19 +19,45 @@ const propTypes = {
   // transition status update functions
   onTransitionStart: PropTypes.func,
   onTransitionInterrupt: PropTypes.func,
-  onTransitionEnd: PropTypes.func,
+  onTransitionEnd: PropTypes.func
+};
+
+const propTypes = Object.assign({}, TRANSITION_PROP_TYPES, {
+  viewportState: PropTypes.func,
+  state: PropTypes.object,
+
+  /** Viewport props */
+  width: PropTypes.number.isRequired, /** The width of the map. */
+  height: PropTypes.number.isRequired, /** The height of the map. */
+  longitude: PropTypes.number.isRequired, /** The longitude of the center of the map. */
+  latitude: PropTypes.number.isRequired, /** The latitude of the center of the map. */
+  zoom: PropTypes.number.isRequired, /** The tile zoom level of the map. */
+  bearing: PropTypes.number, /** Specify the bearing of the viewport */
+  pitch: PropTypes.number, /** Specify the pitch of the viewport */
+
+  // Note: Non-public API, see https://github.com/mapbox/mapbox-gl-js/issues/1137
+  altitude: PropTypes.number, /** Altitude of the viewport camera. Default 1.5 "screen heights" */
+  position: PropTypes.array, /* Camera position for FirstPersonViewport */
+
+  /** Viewport constraints */
+  maxZoom: PropTypes.number, // Max zoom level
+  minZoom: PropTypes.number, // Min zoom level
+  maxPitch: PropTypes.number, // Max pitch in degrees
+  minPitch: PropTypes.number, // Min pitch in degrees
+
+  /**
+   * `onViewportChange` callback is fired when the user interacted with the
+   * map. The object passed to the callback contains viewport properties
+   * such as `longitude`, `latitude`, `zoom` etc.
+   */
+  onViewportChange: PropTypes.func,
 
   /** Enables control event handling */
-  // Scroll to zoom
-  scrollZoom: PropTypes.bool,
-  // Drag to pan
-  dragPan: PropTypes.bool,
-  // Drag to rotate
-  dragRotate: PropTypes.bool,
-  // Double click to zoom
-  doubleClickZoom: PropTypes.bool,
-  // Pinch to zoom / rotate
-  touchZoomRotate: PropTypes.bool,
+  scrollZoom: PropTypes.bool, // Scroll to zoom
+  dragPan: PropTypes.bool, // Drag to pan
+  dragRotate: PropTypes.bool, // Drag to rotate
+  doubleClickZoom: PropTypes.bool, // Double click to zoom
+  touchZoomRotate: PropTypes.bool, // Pinch to zoom / rotate
 
   /** Accessor that returns a cursor style to show interactive state */
   getCursor: PropTypes.func,
@@ -85,7 +69,7 @@ const propTypes = {
     events: PropTypes.arrayOf(PropTypes.string),
     handleEvent: PropTypes.func
   })
-};
+});
 
 const getDefaultCursor = ({isDragging}) => isDragging ? CURSOR.GRABBING : CURSOR.GRAB;
 


### PR DESCRIPTION
* Move `TransitionManger` and `MapControllerJS` into `DeckGLJS`.
* Add additional prop types and default props to `DeckGL` component.
* Modify viewport transition examples to use new DeckGL props.

- Now the transitions are exposed using DeckGL API instead of experimental `ViewportController`.
- This aligns with future Controller/Controls refactor where `ControllerType` is passed to `DeckGL` as a prop.

Tested with viewport transition and other examples.