### PR TITLE
Cleanup: Remove deprecated API usage from core layers

### DIFF
--- a/examples/layer-browser/package.json
+++ b/examples/layer-browser/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "colorbrewer": "^1.0.0",
-    "deck.gl": ">=4.2.0-alpha.15",
+    "deck.gl": ">=4.2.0-alpha.29",
     "deck.gl-layers": ">=0.0.2",
     "extrude-polyline": "^1.0.6",
     "luma.gl": ">=4.1.0-beta.1",

--- a/examples/plot/package.json
+++ b/examples/plot/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "d3-scale": "^1.0.6",
-    "deck.gl": ">=4.2.0-alpha.9",
+    "deck.gl": ">=4.2.0-alpha.29",
     "react": "^15.4.1",
     "react-dom": "^15.4.1"
   },

--- a/examples/point-cloud-laz/package.json
+++ b/examples/point-cloud-laz/package.json
@@ -11,7 +11,7 @@
     "build": "npm run build-clean && npm run build-script && npm run build-copy"
   },
   "dependencies": {
-    "deck.gl": "4.2.0-alpha.24",
+    "deck.gl": "4.2.0-alpha.29",
     "is-little-endian": "0.0.0",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",

--- a/examples/point-cloud-laz/worker/laslaz.js
+++ b/examples/point-cloud-laz/worker/laslaz.js
@@ -68,8 +68,6 @@
 		o.scale = readAs(arraybuffer, Float64Array, start, 3); start += 24; // 8*3
 		o.offset = readAs(arraybuffer, Float64Array, start, 3); start += 24;
 
-		console.log("Read stuff:", o.scale, o.offset);
-
 
 		var bounds = readAs(arraybuffer, Float64Array, start, 6); start += 48; // 8*6;
 		o.maxs = [bounds[0], bounds[2], bounds[4]];
@@ -157,7 +155,6 @@
 					count = Math.min(count, o.header.pointsCount - o.readOffset);
 					start = o.header.pointsOffset + o.readOffset * o.header.pointsStructSize;
 					var end = start + count * o.header.pointsStructSize;
-					console.log(start, end);
 					res({
 						buffer: o.arraybuffer.slice(start, end),
 						count: count,
@@ -170,7 +167,6 @@
 					var pointsRead = 0;
 
 					var buf = new Uint8Array(bufferSize * o.header.pointsStructSize);
-					console.log("Destination size:", buf.byteLength);
 					for (var i = 0 ; i < pointsToRead ; i ++) {
 						if (i % skip === 0) {
 							start = o.header.pointsOffset + o.readOffset * o.header.pointsStructSize;
@@ -213,14 +209,12 @@
 
 		this.ww.onmessage = function(e) {
 			if (o.nextCB !== null) {
-				console.log('dorr: >>', e.data);
 				o.nextCB(e.data);
 				o.nextCB = null;
 			}
 		};
 
 		this.dorr = function(req, cb) {
-			console.log('dorr: <<', req);
 			o.nextCB = cb;
 			o.ww.postMessage(req);
 		};
@@ -337,8 +331,6 @@
 	// Decodes LAS records into points
 	//
 	var LASDecoder = function(buffer, len, header) {
-    console.log(header);
-		// console.log("POINT FORMAT ID:", header.pointsFormatId);
 		this.arrayb = buffer;
 		this.decoder = pointFormatReaders[header.pointsFormatId];
 		this.pointsCount = len;

--- a/examples/point-cloud-ply/package.json
+++ b/examples/point-cloud-ply/package.json
@@ -7,7 +7,7 @@
     "start-local": "webpack-dev-server --env.local --progress --hot --open"
   },
   "dependencies": {
-    "deck.gl": ">=4.2.0-alpha.9",
+    "deck.gl": ">=4.2.0-alpha.29",
     "is-little-endian": "0.0.0",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",

--- a/examples/sample-layers/bitmap-layer/bitmap-layer.js
+++ b/examples/sample-layers/bitmap-layer/bitmap-layer.js
@@ -93,7 +93,8 @@ export default class BitmapLayer extends Layer {
     }
     this.calculateRadius();
     const {imageSize, desaturate} = props;
-    this.setUniforms({imageSize, desaturate});
+    const {model} = this.state;
+    model.setUniforms({imageSize, desaturate});
   }
 
   calculateRadius(props) {

--- a/examples/wind/src/layers/elevation-layer/elevation-layer.js
+++ b/examples/wind/src/layers/elevation-layer/elevation-layer.js
@@ -51,9 +51,10 @@ export default class ElevationLayer extends Layer {
       this.setState({data: textures[0]});
     });
 
-    this.setState({model: this.getModel(gl)});
+    const model = this.getModel(gl);
+    this.setState({model});
 
-    this.setUniforms({
+    model.setUniforms({
       ...LIGHT_UNIFORMS,
       elevationBounds: ELEVATION_DATA_BOUNDS,
       elevationRange: ELEVATION_RANGE

--- a/src/core-layers/grid-cell-layer/grid-cell-layer.js
+++ b/src/core-layers/grid-cell-layer/grid-cell-layer.js
@@ -127,8 +127,9 @@ export default class GridCellLayer extends Layer {
 
   updateUniforms() {
     const {opacity, extruded, elevationScale, coverage, lightSettings} = this.props;
+    const {model} = this.state;
 
-    this.setUniforms(Object.assign({}, {
+    model.setUniforms(Object.assign({}, {
       extruded,
       elevationScale,
       opacity,

--- a/src/core-layers/hexagon-cell-layer/hexagon-cell-layer.js
+++ b/src/core-layers/hexagon-cell-layer/hexagon-cell-layer.js
@@ -188,8 +188,9 @@ export default class HexagonCellLayer extends Layer {
 
   updateUniforms() {
     const {opacity, elevationScale, extruded, coverage, lightSettings} = this.props;
+    const {model} = this.state;
 
-    this.setUniforms(Object.assign({}, {
+    model.setUniforms(Object.assign({}, {
       extruded,
       opacity,
       coverage,

--- a/src/deprecated-layers/extruded-choropleth-layer-64/extruded-choropleth-layer-64.js
+++ b/src/deprecated-layers/extruded-choropleth-layer-64/extruded-choropleth-layer-64.js
@@ -76,7 +76,7 @@ export default class ExtrudedChoroplethLayer64 extends Layer {
   }
 
   updateState({changeFlags}) {
-    const {attributeManager} = this.state;
+    const {attributeManager, model} = this.state;
     if (changeFlags.dataChanged) {
       this.extractExtrudedChoropleth();
       attributeManager.invalidateAll();
@@ -89,7 +89,7 @@ export default class ExtrudedChoroplethLayer64 extends Layer {
       pointLightAttenuation, materialSpecularColor, materialShininess
     } = this.props;
 
-    this.setUniforms({
+    model.setUniforms({
       elevation: Number.isFinite(elevation) ? elevation : 1,
       uAmbientColor: ambientColor || DEFAULT_AMBIENT_COLOR,
       uPointLightAmbientCoefficient:

--- a/src/index.js
+++ b/src/index.js
@@ -61,9 +61,7 @@ const {
 
   // Controllers
   Controller,
-  MapController,
   FirstPersonController,
-  OrbitController,
 
   // Viewports
   OrbitViewport,
@@ -83,9 +81,7 @@ Object.assign(experimental, {
   MapState,
 
   Controller,
-  MapController,
   FirstPersonController,
-  OrbitController,
 
   OrbitViewport,
 
@@ -211,13 +207,13 @@ export {
 
 // TODO - do we need to expose these?
 import {
-  MapController as ReactMapController,
-  OrbitController as ReactOrbitController
+  MapController,
+  OrbitController
 } from './react';
 
 Object.assign(experimental, {
-  ReactMapController,
-  ReactOrbitController
+  MapController,
+  OrbitController
 });
 
 //


### PR DESCRIPTION
* Remove deprecated API usage from core layers (layer.setUnifroms -> model.setUnifroms)
* Fix Oribt and MapController exports.

Verified with examples.