### PR TITLE
Conditionally generate fp64 viewport uniforms

### DIFF
--- a/test/bench/viewport.bench.js
+++ b/test/bench/viewport.bench.js
@@ -52,6 +52,22 @@ export default function viewportBench(suite) {
         coordinateSystem: COORDINATE_SYSTEM.METER_OFFSETS
       });
     })
+    .add('getUniformsFromViewport#LNGLAT - FP64', () => {
+      return getUniformsFromViewport({
+        viewport: data.sampleViewport,
+        fp64: true,
+        modelMatrix: data.sampleModelMatrix,
+        coordinateSystem: COORDINATE_SYSTEM.LNGLAT
+      });
+    })
+    .add('getUniformsFromViewport#METER_OFFSETS - FP64', () => {
+      return getUniformsFromViewport({
+        viewport: data.sampleViewport,
+        fp64: true,
+        modelMatrix: data.sampleModelMatrix,
+        coordinateSystem: COORDINATE_SYSTEM.METER_OFFSETS
+      });
+    })
     .add('WebMercatorViewport', () => {
       return new WebMercatorViewport(VIEWPORT_PARAMS);
     })

--- a/test/src/core/shaderlib/project/viewport-uniforms.spec.js
+++ b/test/src/core/shaderlib/project/viewport-uniforms.spec.js
@@ -19,7 +19,6 @@
 // THE SOFTWARE.
 
 import test from 'tape-catch';
-import {Matrix4} from 'luma.gl';
 
 import {COORDINATE_SYSTEM, Viewport, WebMercatorViewport} from 'deck.gl';
 import {getUniformsFromViewport} from 'deck.gl/core/shaderlib/project/viewport-uniforms';
@@ -54,12 +53,13 @@ const UNIFORMS = {
   project_uModelMatrix: Array,
   project_uViewProjectionMatrix: Array,
 
-  // 64 bit support
-  project_uViewProjectionMatrixFP64: Array,
-
   // This is for lighting calculations
-  project_uCameraPosition: Array,
+  project_uCameraPosition: Array
+};
 
+// 64 bit support
+const UNIFORMS_64 = {
+  project_uViewProjectionMatrixFP64: Array,
   project64_uViewProjectionMatrix: Array,
   project64_uScale: Number
 };
@@ -77,8 +77,10 @@ const DEPRECATED_UNIFORMS = {
   projectionScale: Number, // This is the mercator scale (2 ** zoom)
   viewportSize: Array,
   devicePixelRatio: Number,
-  cameraPos: Array,
+  cameraPos: Array
+};
 
+const DEPRECATED_UNIFORMS_64 = {
   projectionFP64: Array,
   projectionScaleFP64: Array
 };
@@ -97,6 +99,14 @@ test('project#getUniformsFromViewport#shader module style uniforms', t => {
 
   for (const uniform in UNIFORMS) {
     t.ok(uniforms[uniform] !== undefined, `Returned ${uniform}`);
+  }
+  for (const uniform in UNIFORMS_64) {
+    t.ok(uniforms[uniform] === undefined, `Should not return ${uniform}`);
+  }
+
+  uniforms = getUniformsFromViewport({viewport, fp64: true});
+  for (const uniform in UNIFORMS_64) {
+    t.ok(uniforms[uniform] !== undefined, `Return ${uniform}`);
   }
 
   uniforms = getUniformsFromViewport({
@@ -117,10 +127,17 @@ test('preoject#getUniformsFromViewport#deprecated uniforms', t => {
   for (const uniform in DEPRECATED_UNIFORMS) {
     t.ok(uniforms[uniform] !== undefined, `Returned deprecated ${uniform}`);
   }
+  for (const uniform in DEPRECATED_UNIFORMS_64) {
+    t.ok(uniforms[uniform] === undefined, `Should not return deprecated ${uniform}`);
+  }
+
+  uniforms = getUniformsFromViewport({viewport, fp64: true});
+  for (const uniform in DEPRECATED_UNIFORMS_64) {
+    t.ok(uniforms[uniform] !== undefined, `Return deprecated ${uniform}`);
+  }
 
   t.ok(uniforms.devicePixelRatio > 0, 'Returned devicePixelRatio');
-  t.ok((uniforms.projectionMatrix instanceof Float32Array) ||
-    (uniforms.projectionMatrix instanceof Matrix4), 'Returned projectionMatrix');
+  t.is(uniforms.projectionMatrix.length, 16, 'Returned projectionMatrix');
 
   uniforms = getUniformsFromViewport({
     viewport,


### PR DESCRIPTION
During profiling of an internal app, `setUniforms` and `fp64ifyMatrix4` stand out among the top most expensive operations. In reality, we do not have to generate the fp64 uniforms when using 32bit projection. 

Changes in this diff:
- Only generate fp64 viewport uniforms if `fp64` flag is on
- Remove duplicate call to `fp64ifyMatrix4(viewProjectionMatrix)`
- Remove unnecessary creation of new typed arrays
- Reduce small arrays generated during `fp64ify`

In terms of implementation, I do not think checking `fp64` is the right approach, as layers could use the `project64` module without the `fp64` flag. I suggest that in luma.gl, when a module specifies `dependencies`, its `getUniforms` callback should be able to access the uniforms generated by its dependencies. `project64` will then be able to leverage the `viewProjectionMatrix` generated by the `project` module.

Tested: test-node, test-browser, layer-browser