### PR TITLE
Improve perf of picking with large `pickingRadius`

### DIFF
--- a/src/core/lib/pick-layers.js
+++ b/src/core/lib/pick-layers.js
@@ -339,7 +339,7 @@ function callLayerPickingCallbacks(infos, mode) {
  * Pick at a specified pixel with a tolerance radius
  * Returns the closest object to the pixel in shape `{pickedColor, pickedLayer, pickedObjectIndex}`
  */
-function getClosestFromPickingBuffer(gl, {
+export function getClosestFromPickingBuffer(gl, {
   pickedColors,
   layers,
   deviceX,

--- a/test/bench/index.js
+++ b/test/bench/index.js
@@ -25,10 +25,12 @@ import coreLayersBench from './core-layers.bench';
 import layerBench from './layer.bench';
 import viewportBench from './viewport.bench';
 import colorBench from './color.bench';
+import pickLayersBench from './pick-layers.bench';
 
 const suite = new Bench();
 
 // add tests
+pickLayersBench(suite);
 coreLayersBench(suite);
 layerBench(suite);
 viewportBench(suite);

--- a/test/bench/pick-layers.bench.js
+++ b/test/bench/pick-layers.bench.js
@@ -1,0 +1,74 @@
+import {Layer} from 'deck.gl/core';
+import {getClosestFromPickingBuffer} from 'deck.gl/core/lib/pick-layers';
+
+const SAMPLE_LAYERS = [new Layer()];
+const OBJECT_COLOR = [0, 10, 20, 1];
+const NULL_COLOR = [0, 0, 0, 0];
+
+const TEST_CASES = [
+  {
+    title: 'Solid',
+    data: generateSampleData({
+      pickingRadius: 10,
+      getColor: () => OBJECT_COLOR
+    })
+  },
+  {
+    title: 'Circle',
+    data: generateSampleData({
+      pickingRadius: 10,
+      getColor: (x, y) => (10 - x) * (10 - x) + (10 - y) * (10 - y) < 25 ? OBJECT_COLOR : NULL_COLOR
+    })
+  },
+  {
+    title: 'Triangle',
+    data: generateSampleData({
+      pickingRadius: 10,
+      getColor: (x, y) => x + y <= 10 ? OBJECT_COLOR : NULL_COLOR
+    })
+  },
+  {
+    title: 'Solid - Big',
+    data: generateSampleData({
+      pickingRadius: 50,
+      getColor: () => OBJECT_COLOR
+    })
+  }
+];
+
+export default function pickLayersBench(bench) {
+
+  return TEST_CASES.reduce(
+    (b, testCase) => {
+      return b.add(testCase.title, () => getClosestFromPickingBuffer(null, testCase.data));
+    },
+    bench.group('getClosestFromPickingBuffer')
+  );
+
+}
+
+function generateSampleData({pickingRadius, getColor}) {
+  const width = pickingRadius * 2;
+  const height = pickingRadius * 2;
+  const pixels = new Uint8Array(width * height * 4);
+
+  let i = 0;
+  for (let row = 0; row < height; row++) {
+    for (let col = 0; col < width; col++) {
+      const color = getColor(col, row);
+      pixels[i++] = color[0];
+      pixels[i++] = color[1];
+      pixels[i++] = color[2];
+      pixels[i++] = color[3];
+    }
+  }
+
+  return {
+    pickedColors: pixels,
+    layers: SAMPLE_LAYERS,
+    deviceX: pickingRadius,
+    deviceY: pickingRadius,
+    deviceRadius: pickingRadius,
+    deviceRect: {x: 0, y: 0, width, height}
+  };
+}

--- a/test/bench/pick-layers.bench.js
+++ b/test/bench/pick-layers.bench.js
@@ -14,6 +14,7 @@ const TEST_CASES = [
     })
   },
   {
+    // radius 5 circle centered in 20x20 rect.
     title: 'Circle',
     data: generateSampleData({
       pickingRadius: 10,
@@ -21,6 +22,7 @@ const TEST_CASES = [
     })
   },
   {
+    // half of rect on top left
     title: 'Triangle',
     data: generateSampleData({
       pickingRadius: 10,
@@ -38,13 +40,13 @@ const TEST_CASES = [
 
 export default function pickLayersBench(bench) {
 
-  return TEST_CASES.reduce(
-    (b, testCase) => {
-      return b.add(testCase.title, () => getClosestFromPickingBuffer(null, testCase.data));
-    },
-    bench.group('getClosestFromPickingBuffer')
-  );
+  bench = bench.group('getClosestFromPickingBuffer');
 
+  TEST_CASES.forEach(testCase => {
+    bench = bench.add(testCase.title, () => getClosestFromPickingBuffer(null, testCase.data));
+  });
+
+  return bench;
 }
 
 function generateSampleData({pickingRadius, getColor}) {


### PR DESCRIPTION
- Avoid decoding picking color and generating info objects during the traversal
- Skip entire rows

Before:

| Test | Result |
| ---- | ------ |
| Solid | 56.8k iterations/s (0.18s) |
| Circle | 95.2k iterations/s (0.10s) |
| Triangle | 147k iterations/s (0.68s) |
| Solid - Big | 5.00k iterations/s (0.20s) |

After:

| Test | Result |
| ---- | ------ |
| Solid | 826k iterations/s (0.12s) |
| Circle | 1.04M iterations/s (0.96s) |
| Triangle | 820k iterations/s (0.12s) |
| Solid - Big | 64.5k iterations/s (0.15s) |

Tested: node, browser, layer-browser