### PR TITLE
Fix `log.warn` usage

### DIFF
--- a/src/core/lib/layer-manager.js
+++ b/src/core/lib/layer-manager.js
@@ -502,7 +502,7 @@ export default class LayerManager {
     const oldLayerMap = {};
     for (const oldLayer of oldLayers) {
       if (oldLayerMap[oldLayer.id]) {
-        log.warn(0, `Multiple old layers with same id ${layerName(oldLayer)}`);
+        log.warn(`Multiple old layers with same id ${layerName(oldLayer)}`);
       } else {
         oldLayerMap[oldLayer.id] = oldLayer;
       }
@@ -533,7 +533,7 @@ export default class LayerManager {
       // Given a new coming layer, find its matching old layer (if any)
       const oldLayer = oldLayerMap[newLayer.id];
       if (oldLayer === null) { // null, rather than undefined, means this id was originally there
-        log.warn(0, `Multiple new layers with same id ${layerName(newLayer)}`);
+        log.warn(`Multiple new layers with same id ${layerName(newLayer)}`);
       }
       // Remove the old layer from candidates, as it has been matched with this layer
       oldLayerMap[newLayer.id] = null;
@@ -556,7 +556,7 @@ export default class LayerManager {
         sublayers = newLayer.isComposite && newLayer.getSubLayers();
         // End layer lifecycle method: render sublayers
       } catch (err) {
-        log.warn(0, `error during matching of ${layerName(newLayer)}`, err);
+        log.warn(`error during matching of ${layerName(newLayer)}`, err);
         error = error || err; // Record first exception
       }
 
@@ -594,7 +594,7 @@ export default class LayerManager {
       layer._initialize();
       layer.lifecycle = LIFECYCLE.INITIALIZED;
     } catch (err) {
-      log.warn(0, `error while initializing ${layerName(layer)}\n`, err);
+      log.warn(`error while initializing ${layerName(layer)}\n`, err);
       error = error || err;
       // TODO - what should the lifecycle state be here? LIFECYCLE.INITIALIZATION_FAILED?
     }
@@ -633,7 +633,7 @@ export default class LayerManager {
     try {
       layer._update();
     } catch (err) {
-      log.warn(0, `error during update of ${layerName(layer)}`, err);
+      log.warn(`error during update of ${layerName(layer)}`, err);
       // Save first error
       error = err;
     }
@@ -650,7 +650,7 @@ export default class LayerManager {
     try {
       layer._finalize();
     } catch (err) {
-      log.warn(0, `error during finalization of ${layerName(layer)}`, err);
+      log.warn(`error during finalization of ${layerName(layer)}`, err);
       error = err;
     }
     layer.lifecycle = LIFECYCLE.FINALIZED;
@@ -665,7 +665,7 @@ export default class LayerManager {
   _validateEventHandling() {
     if (this.onLayerClick || this.onLayerHover) {
       if (this.layers.length && !this.layers.some(layer => layer.props.pickable)) {
-        log.warn(1,
+        log.warn(
           'You have supplied a top-level input event handler (e.g. `onLayerClick`), ' +
           'but none of your layers have set the `pickable` flag.'
         );

--- a/src/core/lib/layer-manager.js
+++ b/src/core/lib/layer-manager.js
@@ -502,7 +502,7 @@ export default class LayerManager {
     const oldLayerMap = {};
     for (const oldLayer of oldLayers) {
       if (oldLayerMap[oldLayer.id]) {
-        log.warn(`Multiple old layers with same id ${layerName(oldLayer)}`);
+        log.warn(0, `Multiple old layers with same id ${layerName(oldLayer)}`);
       } else {
         oldLayerMap[oldLayer.id] = oldLayer;
       }
@@ -533,7 +533,7 @@ export default class LayerManager {
       // Given a new coming layer, find its matching old layer (if any)
       const oldLayer = oldLayerMap[newLayer.id];
       if (oldLayer === null) { // null, rather than undefined, means this id was originally there
-        log.warn(`Multiple new layers with same id ${layerName(newLayer)}`);
+        log.warn(0, `Multiple new layers with same id ${layerName(newLayer)}`);
       }
       // Remove the old layer from candidates, as it has been matched with this layer
       oldLayerMap[newLayer.id] = null;
@@ -556,7 +556,7 @@ export default class LayerManager {
         sublayers = newLayer.isComposite && newLayer.getSubLayers();
         // End layer lifecycle method: render sublayers
       } catch (err) {
-        log.warn(`error during matching of ${layerName(newLayer)}`, err);
+        log.warn(0, `error during matching of ${layerName(newLayer)}`, err);
         error = error || err; // Record first exception
       }
 
@@ -594,7 +594,7 @@ export default class LayerManager {
       layer._initialize();
       layer.lifecycle = LIFECYCLE.INITIALIZED;
     } catch (err) {
-      log.warn(`error while initializing ${layerName(layer)}\n`, err);
+      log.warn(0, `error while initializing ${layerName(layer)}\n`, err);
       error = error || err;
       // TODO - what should the lifecycle state be here? LIFECYCLE.INITIALIZATION_FAILED?
     }
@@ -633,7 +633,7 @@ export default class LayerManager {
     try {
       layer._update();
     } catch (err) {
-      log.warn(`error during update of ${layerName(layer)}`, err);
+      log.warn(0, `error during update of ${layerName(layer)}`, err);
       // Save first error
       error = err;
     }
@@ -650,7 +650,7 @@ export default class LayerManager {
     try {
       layer._finalize();
     } catch (err) {
-      log.warn(`error during finalization of ${layerName(layer)}`, err);
+      log.warn(0, `error during finalization of ${layerName(layer)}`, err);
       error = err;
     }
     layer.lifecycle = LIFECYCLE.FINALIZED;

--- a/src/core/lib/pick-layers.js
+++ b/src/core/lib/pick-layers.js
@@ -391,7 +391,7 @@ export function getClosestFromPickingBuffer(gl, {
       const pickedObjectIndex = pickedLayer.decodePickingColor(pickedColor);
       return {pickedColor, pickedLayer, pickedObjectIndex};
     }
-    log.error(0, 'Picked non-existent layer. Is picking buffer corrupt?');
+    log.error('Picked non-existent layer. Is picking buffer corrupt?');
   }
 
   return NO_PICKED_OBJECT;
@@ -423,7 +423,7 @@ function getUniquesFromPickingBuffer(gl, {pickedColors, layers}) {
               pickedObjectIndex: pickedLayer.decodePickingColor(pickedColor)
             });
           } else {
-            log.error(0, 'Picked non-existent layer. Is picking buffer corrupt?');
+            log.error('Picked non-existent layer. Is picking buffer corrupt?');
           }
         }
       }

--- a/src/core/utils/log.js
+++ b/src/core/utils/log.js
@@ -45,19 +45,19 @@ function once(priority, arg, ...args) {
   }
 }
 
-function warn(priority, arg, ...args) {
-  if (priority <= log.priority && !cache[arg]) {
+function warn(arg, ...args) {
+  if (!cache[arg]) {
     console.warn(`deck.gl: ${arg}`, ...args);
     cache[arg] = true;
   }
 }
 
-function error(priority, arg, ...args) {
+function error(arg, ...args) {
   console.error(`deck.gl: ${arg}`, ...args);
 }
 
 function deprecated(oldUsage, newUsage) {
-  log.warn(0, `deck.gl: \`${oldUsage}\` is deprecated and will be removed \
+  log.warn(`deck.gl: \`${oldUsage}\` is deprecated and will be removed \
 in a later version. Use \`${newUsage}\` instead`);
 }
 

--- a/src/core/viewports/viewport.js
+++ b/src/core/viewports/viewport.js
@@ -412,7 +412,7 @@ export default class Viewport {
 
     this.pixelUnprojectionMatrix = mat4_invert(createMat4(), this.pixelProjectionMatrix);
     if (!this.pixelUnprojectionMatrix) {
-      log.warn(0, 'Pixel project matrix not invertible');
+      log.warn('Pixel project matrix not invertible');
       // throw new Error('Pixel project matrix not invertible');
     }
   }

--- a/src/core/viewports/viewport.js
+++ b/src/core/viewports/viewport.js
@@ -412,7 +412,7 @@ export default class Viewport {
 
     this.pixelUnprojectionMatrix = mat4_invert(createMat4(), this.pixelProjectionMatrix);
     if (!this.pixelUnprojectionMatrix) {
-      log.warn('Pixel project matrix not invertible');
+      log.warn(0, 'Pixel project matrix not invertible');
       // throw new Error('Pixel project matrix not invertible');
     }
   }


### PR DESCRIPTION
Some calls to `log.warn` are not supplying the `priority` argument, which makes the message always invisible.