### PR TITLE
Add assert error messages

### DIFF
--- a/src/core/controllers/viewport-controls.js
+++ b/src/core/controllers/viewport-controls.js
@@ -41,7 +41,7 @@ export default class ViewportControls {
    * A class that handles events and updates mercator style viewport parameters
    */
   constructor(ViewportState, options = {}) {
-    assert(ViewportState);
+    assert(ViewportState, 'ViewportState constructor must be supplied');
     this.ViewportState = ViewportState;
     this.viewportState = null;
     this.viewportStateProps = null;

--- a/src/core/lib/layer-manager.js
+++ b/src/core/lib/layer-manager.js
@@ -586,7 +586,7 @@ export default class LayerManager {
 
   // Initializes a single layer, calling layer methods
   _initializeLayer(layer) {
-    assert(!layer.state);
+    assert(!layer.state, 'layer has already been initialized');
     log(LOG_PRIORITY_LIFECYCLE, `initializing ${layerName(layer)}`);
 
     let error = null;
@@ -599,7 +599,7 @@ export default class LayerManager {
       // TODO - what should the lifecycle state be here? LIFECYCLE.INITIALIZATION_FAILED?
     }
 
-    assert(layer.state);
+    assert(layer.state, 'layer state is missing after initialization');
 
     // Set back pointer (used in picking)
     layer.state.layer = layer;
@@ -642,8 +642,8 @@ export default class LayerManager {
 
   // Finalizes a single layer
   _finalizeLayer(layer) {
-    assert(layer.state);
-    assert(layer.lifecycle !== LIFECYCLE.AWAITING_FINALIZATION);
+    assert(layer.state, 'finalizing a layer that is not initialized');
+    assert(layer.lifecycle !== LIFECYCLE.AWAITING_FINALIZATION, 'layer is already finalizing');
     layer.lifecycle = LIFECYCLE.AWAITING_FINALIZATION;
     let error = null;
     this.setNeedsRedraw(`finalized ${layerName(layer)}`);

--- a/src/core/lib/layer.js
+++ b/src/core/lib/layer.js
@@ -316,7 +316,7 @@ export default class Layer {
    * @return {Array} - the decoded picking color
    */
   decodePickingColor(color) {
-    assert(color instanceof Uint8Array);
+    assert(color instanceof Uint8Array, 'color must be Uint8Array');
     const [i1, i2, i3] = color;
     // 1 was added to seperate from no selection
     const index = i1 + i2 * 256 + i3 * 65536 - 1;
@@ -382,9 +382,8 @@ export default class Layer {
   // Called by layer manager when a new layer is found
   /* eslint-disable max-statements */
   _initialize() {
-    assert(arguments.length === 0);
-    assert(this.context.gl);
-    assert(!this.state);
+    assert(this.context.gl, 'missing gl context');
+    assert(!this.state, 'layer has already been initialized');
 
     const attributeManager = new AttributeManager({id: this.props.id});
     // All instanced layers get instancePickingColors attribute by default
@@ -443,8 +442,6 @@ export default class Layer {
   // Called by layer manager
   // if this layer is new (not matched with an existing layer) oldProps will be empty object
   _update() {
-    assert(arguments.length === 0);
-
     // Call subclass lifecycle method
     const stateNeedsUpdate = this.needsUpdate();
     // End lifecycle method
@@ -489,7 +486,6 @@ export default class Layer {
   // Called by manager when layer is about to be disposed
   // Note: not guaranteed to be called on application shutdown
   _finalize() {
-    assert(arguments.length === 0);
     // Call subclass lifecycle method
     this.finalizeState(this.context);
     // End lifecycle method
@@ -676,7 +672,7 @@ ${flags.viewportChanged ? 'viewport' : ''}\
   // Called by layer manager to transfer state from an old layer
   _transferState(oldLayer) {
     const {state, internalState, props} = oldLayer;
-    assert(state && internalState);
+    assert(state && internalState, 'old layer missing state or internalState');
 
     // Move state
     state.layer = this;

--- a/src/core/lib/pick-layers.js
+++ b/src/core/lib/pick-layers.js
@@ -159,7 +159,7 @@ function drawAndSamplePickingBuffer(gl, {
   layerFilter,
   redrawReason
 }) {
-  assert(deviceRect);
+  assert(deviceRect, 'deviceRect is not supplied');
   assert((Number.isFinite(deviceRect.width) && deviceRect.width > 0), '`width` must be > 0');
   assert((Number.isFinite(deviceRect.height) && deviceRect.height > 0), '`height` must be > 0');
 
@@ -347,7 +347,7 @@ export function getClosestFromPickingBuffer(gl, {
   deviceRadius,
   deviceRect
 }) {
-  assert(pickedColors);
+  assert(pickedColors, 'pickedColors is not supplied');
 
   // Traverse all pixels in picking results and find the one closest to the supplied
   // [deviceX, deviceY]

--- a/src/core/lib/props.js
+++ b/src/core/lib/props.js
@@ -210,6 +210,5 @@ export function mergeDefaultProps(object, objectNameKey = 'layerName') {
   // Store for quick lookup
   subClassConstructor.mergedDefaultProps = mergedDefaultProps;
 
-  assert(mergeDefaultProps);
   return mergedDefaultProps;
 }

--- a/src/core/shaderlib/project/viewport-uniforms.js
+++ b/src/core/shaderlib/project/viewport-uniforms.js
@@ -141,7 +141,7 @@ export function getUniformsFromViewport({
   projectionMode,
   positionOrigin
 } = {}) {
-  assert(viewport);
+  assert(viewport, 'missing viewport');
 
   if (projectionMode !== undefined) {
     coordinateSystem = projectionMode;
@@ -153,7 +153,7 @@ export function getUniformsFromViewport({
   }
 
   const coordinateZoom = viewport.zoom;
-  assert(coordinateZoom >= 0);
+  assert(coordinateZoom >= 0, 'viewport zoom is negative');
 
   const {projectionCenter, viewProjectionMatrix, cameraPos} =
     calculateMatrixAndOffset({

--- a/src/core/viewports/viewport.js
+++ b/src/core/viewports/viewport.js
@@ -158,7 +158,7 @@ export default class Viewport {
     if (projectionMatrix) {
       this.projectionMatrix = projectionMatrix;
     } else {
-      assert(Number.isFinite(fovy));
+      assert(Number.isFinite(fovy), 'fovy is not a number');
       const DEGREES_TO_RADIANS = Math.PI / 180;
       const fovyRadians = fovy * DEGREES_TO_RADIANS;
       const aspect = this.width / this.height;


### PR DESCRIPTION
If message is not supplied, `assert` throws error `false === true` which is not helpful at all (especially with minified version).

It is debatable whether all of these `assert` usages are necessary.