### PR TITLE
Remove container support from core layers

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -8,13 +8,19 @@ As always, for information on deprecations and how to update your code in respon
 
 > TODO - Add a row of small square GIFs/PNGs of Viewport Transitions, Automatic Highlighting, Dashed Lines, Multiple Viewports. Would be really nice with a screenshot (or GIF) of Seer.
 
-
 ## DeckGL: Viewport Transitions
 
 A major new feature is support for Viewport Transitions.
 
 > TODO - Add more extensive description. This is our major official feature after all...
 
+## DeckGL: Performance Boost
+
+Immutable support is dropped.
+
+Layer initialization, rendering and picking performance are improved.
+
+> TODO - Add more description
 
 ## DeckGL: Control over DevicePixelRatio
 

--- a/src/core-layers/scatterplot-layer/scatterplot-layer.js
+++ b/src/core-layers/scatterplot-layer/scatterplot-layer.js
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 import {COORDINATE_SYSTEM, Layer, experimental} from '../../core';
-const {fp64ify, enable64bitSupport, get} = experimental;
+const {fp64ify, enable64bitSupport} = experimental;
 import {GL, Model, Geometry} from 'luma.gl';
 
 import vs from './scatterplot-layer-vertex.glsl';
@@ -131,9 +131,9 @@ export default class ScatterplotLayer extends Layer {
     let i = 0;
     for (const point of data) {
       const position = getPosition(point);
-      value[i++] = get(position, 0);
-      value[i++] = get(position, 1);
-      value[i++] = get(position, 2) || 0;
+      value[i++] = position[0];
+      value[i++] = position[1];
+      value[i++] = position[2] || 0;
     }
   }
 
@@ -143,8 +143,8 @@ export default class ScatterplotLayer extends Layer {
     let i = 0;
     for (const point of data) {
       const position = getPosition(point);
-      value[i++] = fp64ify(get(position, 0))[1];
-      value[i++] = fp64ify(get(position, 1))[1];
+      value[i++] = fp64ify(position[0])[1];
+      value[i++] = fp64ify(position[1])[1];
     }
   }
 
@@ -164,10 +164,10 @@ export default class ScatterplotLayer extends Layer {
     let i = 0;
     for (const point of data) {
       const color = getColor(point) || DEFAULT_COLOR;
-      value[i++] = get(color, 0);
-      value[i++] = get(color, 1);
-      value[i++] = get(color, 2);
-      value[i++] = isNaN(get(color, 3)) ? 255 : get(color, 3);
+      value[i++] = color[0];
+      value[i++] = color[1];
+      value[i++] = color[2];
+      value[i++] = isNaN(color[3]) ? 255 : color[3];
     }
   }
 }

--- a/src/core-layers/solid-polygon-layer/polygon.js
+++ b/src/core-layers/solid-polygon-layer/polygon.js
@@ -18,9 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {experimental} from '../../core';
-const {get, count} = experimental;
-
 // Basic polygon support
 //
 // Handles simple and complex polygons
@@ -34,9 +31,9 @@ const {get, count} = experimental;
  * @return {Boolean} - true if the polygon is a simple polygon (i.e. not an array of polygons)
  */
 export function isSimple(polygon) {
-  return count(polygon) >= 1 &&
-    count(get(polygon, 0)) >= 2 &&
-    Number.isFinite(get(get(polygon, 0), 0));
+  return polygon.length >= 1 &&
+    polygon[0].length >= 2 &&
+    Number.isFinite(polygon[0][0]);
 }
 
 /**
@@ -57,8 +54,8 @@ export function normalize(polygon, {dimensions = 3} = {}) {
  */
 export function getVertexCount(polygon) {
   return isSimple(polygon) ?
-    count(polygon) :
-    polygon.reduce((length, simplePolygon) => length + count(simplePolygon), 0);
+    polygon.length :
+    polygon.reduce((length, simplePolygon) => length + simplePolygon.length, 0);
 }
 
 // Return number of triangles needed to tesselate the polygon
@@ -66,7 +63,7 @@ export function getTriangleCount(polygon) {
   let triangleCount = 0;
   let first = true;
   for (const simplePolygon of normalize(polygon)) {
-    const size = count(simplePolygon);
+    const size = simplePolygon.length;
     if (first) {
       triangleCount += size >= 3 ? size - 2 : 0;
     } else {

--- a/src/experimental-layers/src/mesh-layer/mesh-layer.js
+++ b/src/experimental-layers/src/mesh-layer/mesh-layer.js
@@ -23,7 +23,7 @@
 // THE SOFTWARE.
 
 import {Layer, COORDINATE_SYSTEM, experimental} from 'deck.gl';
-const {fp64ify, enable64bitSupport, get} = experimental;
+const {fp64ify, enable64bitSupport} = experimental;
 import {GL, Model, Geometry, loadTextures, Texture2D} from 'luma.gl';
 import assert from 'assert';
 
@@ -201,9 +201,9 @@ export default class MeshLayer extends Layer {
     let i = 0;
     for (const point of data) {
       const position = getPosition(point);
-      value[i + 0] = get(position, 0);
-      value[i + 1] = get(position, 1);
-      value[i + 2] = get(position, 2) || 0;
+      value[i++] = position[0];
+      value[i++] = position[1];
+      value[i++] = position[2] || 0;
       i += size;
     }
   }
@@ -214,8 +214,8 @@ export default class MeshLayer extends Layer {
     let i = 0;
     for (const point of data) {
       const position = getPosition(point);
-      value[i++] = fp64ify(get(position, 0))[1];
-      value[i++] = fp64ify(get(position, 1))[1];
+      value[i++] = fp64ify(position[0])[1];
+      value[i++] = fp64ify(position[1])[1];
     }
   }
 
@@ -236,10 +236,10 @@ export default class MeshLayer extends Layer {
     let i = 0;
     for (const point of data) {
       const color = getColor(point) || DEFAULT_COLOR;
-      value[i++] = get(color, 0);
-      value[i++] = get(color, 1);
-      value[i++] = get(color, 2);
-      value[i++] = isNaN(get(color, 3)) ? 255 : get(color, 3);
+      value[i++] = color[0];
+      value[i++] = color[1];
+      value[i++] = color[2];
+      value[i++] = isNaN(color[3]) ? 255 : color[3];
     }
   }
 }

--- a/test/bench/utils.bench.js
+++ b/test/bench/utils.bench.js
@@ -19,24 +19,25 @@
 // THE SOFTWARE.
 
 /* eslint-disable no-console, no-invalid-this */
-import {Bench} from 'probe.gl';
 
-import coreLayersBench from './core-layers.bench';
-import layerBench from './layer.bench';
-import viewportBench from './viewport.bench';
-import colorBench from './color.bench';
-import pickLayersBench from './pick-layers.bench';
-import utilsBench from './utils.bench';
+import {
+  experimental
+} from 'deck.gl';
 
-const suite = new Bench();
+const {get} = experimental;
+
+const POSITION = [-122.4, 37.8, 0];
 
 // add tests
-pickLayersBench(suite);
-coreLayersBench(suite);
-layerBench(suite);
-viewportBench(suite);
-colorBench(suite);
-utilsBench(suite);
 
-// Run the suite
-suite.run();
+export default function utilsBench(suite) {
+  return suite
+    .group('UTILS')
+    .add('get#Array', () => {
+      return get(POSITION, 0);
+    })
+    .add('direct access#Array', () => {
+      return POSITION[0];
+    })
+    ;
+}

--- a/test/src/core-layers/geojson-layer.spec.js
+++ b/test/src/core-layers/geojson-layer.spec.js
@@ -35,7 +35,7 @@ const data = FIXTURES.choropleths;
 test('GeoJsonLayer#constructor', t => {
 
   testCreateLayer(t, LayerComponent, {data, pickable: true});
-  testCreateLayer(t, LayerComponent, {data: FIXTURES.immutableChoropleths, pickable: true});
+  // testCreateLayer(t, LayerComponent, {data: FIXTURES.immutableChoropleths, pickable: true});
   testCreateEmptyLayer(t, LayerComponent);
   testNullLayer(t, LayerComponent);
 

--- a/test/src/core-layers/polygon-tesselation.spec.js
+++ b/test/src/core-layers/polygon-tesselation.spec.js
@@ -52,11 +52,12 @@ test('polygon#functions', t => {
     t.ok(Number.isFinite(Polygon.getVertexCount(polygon)), 'Polygon.getVertexCount');
   }
 
-  for (const polygon of IMMUTABLE_POLYGONS) {
-    t.ok(Polygon.normalize(polygon), 'Polygon.normalize(immutable)');
-    t.ok(Number.isFinite(Polygon.getTriangleCount(polygon)), 'Polygon.getTriangleCount(immutable)');
-    t.ok(Number.isFinite(Polygon.getVertexCount(polygon)), 'Polygon.getVertexCount(immutable)');
-  }
+  // for (const polygon of IMMUTABLE_POLYGONS) {
+  //   t.ok(Polygon.normalize(polygon), 'Polygon.normalize(immutable)');
+  //   t.ok(Number.isFinite(Polygon.getTriangleCount(polygon)),
+  //     'Polygon.getTriangleCount(immutable)');
+  //   t.ok(Number.isFinite(Polygon.getVertexCount(polygon)), 'Polygon.getVertexCount(immutable)');
+  // }
   t.end();
 });
 
@@ -98,7 +99,7 @@ test('PolygonTesselatorExtruded#methods', t => {
   t.end();
 });
 
-test('PolygonTesselator#methods(immutable)', t => {
+test.skip('PolygonTesselator#methods(immutable)', t => {
   const tesselator = new PolygonTesselator({polygons: IMMUTABLE_POLYGONS});
   t.ok(tesselator instanceof PolygonTesselator, 'PolygonTesselator created');
   const indices = tesselator.indices();
@@ -110,7 +111,7 @@ test('PolygonTesselator#methods(immutable)', t => {
   t.end();
 });
 
-test('PolygonTesselatorExtruded#methods(immutable)', t => {
+test.skip('PolygonTesselatorExtruded#methods(immutable)', t => {
   const tesselator = new PolygonTesselatorExtruded({polygons: IMMUTABLE_POLYGONS});
   t.ok(tesselator instanceof PolygonTesselatorExtruded, 'PolygonTesselatorExtruded created');
   const indices = tesselator.indices();

--- a/test/src/core-layers/polygon-tesselation.spec.js
+++ b/test/src/core-layers/polygon-tesselation.spec.js
@@ -25,8 +25,6 @@ import {PolygonTesselator} from 'deck.gl/core-layers/solid-polygon-layer/polygon
 import {PolygonTesselatorExtruded}
   from 'deck.gl/core-layers/solid-polygon-layer/polygon-tesselator-extruded';
 
-import Immutable from 'immutable';
-
 const POLYGONS = [
   [],
   [[1, 1]],
@@ -34,8 +32,6 @@ const POLYGONS = [
   [[[1, 1]]],
   [[[1, 1], [1, 1], [1, 1]]]
 ];
-
-const IMMUTABLE_POLYGONS = Immutable.fromJS(POLYGONS);
 
 test('polygon#imports', t => {
   t.ok(typeof Polygon.normalize === 'function', 'Polygon.normalize imported');
@@ -52,12 +48,6 @@ test('polygon#functions', t => {
     t.ok(Number.isFinite(Polygon.getVertexCount(polygon)), 'Polygon.getVertexCount');
   }
 
-  // for (const polygon of IMMUTABLE_POLYGONS) {
-  //   t.ok(Polygon.normalize(polygon), 'Polygon.normalize(immutable)');
-  //   t.ok(Number.isFinite(Polygon.getTriangleCount(polygon)),
-  //     'Polygon.getTriangleCount(immutable)');
-  //   t.ok(Number.isFinite(Polygon.getVertexCount(polygon)), 'Polygon.getVertexCount(immutable)');
-  // }
   t.end();
 });
 
@@ -96,30 +86,5 @@ test('PolygonTesselatorExtruded#methods', t => {
   const positionsExtruded64xyLow = tesselatorExtruded64.positions().positions64xyLow;
   t.ok(ArrayBuffer.isView(positionsExtruded64xyLow), 'PolygonTesselatorExtruded.positions64xyLow');
 
-  t.end();
-});
-
-test.skip('PolygonTesselator#methods(immutable)', t => {
-  const tesselator = new PolygonTesselator({polygons: IMMUTABLE_POLYGONS});
-  t.ok(tesselator instanceof PolygonTesselator, 'PolygonTesselator created');
-  const indices = tesselator.indices();
-  t.ok(ArrayBuffer.isView(indices), 'PolygonTesselator.indices');
-  const positions = tesselator.positions().positions;
-  t.ok(ArrayBuffer.isView(positions), 'PolygonTesselator.positions');
-  const colors = tesselator.colors();
-  t.ok(ArrayBuffer.isView(colors), 'PolygonTesselator.colors');
-  t.end();
-});
-
-test.skip('PolygonTesselatorExtruded#methods(immutable)', t => {
-  const tesselator = new PolygonTesselatorExtruded({polygons: IMMUTABLE_POLYGONS});
-  t.ok(tesselator instanceof PolygonTesselatorExtruded, 'PolygonTesselatorExtruded created');
-  const indices = tesselator.indices();
-  t.ok(ArrayBuffer.isView(indices), 'PolygonTesselatorExtruded.indices');
-  const positions = tesselator.positions().positions;
-  t.ok(ArrayBuffer.isView(positions), 'PolygonTesselatorExtruded.positions');
-  const colors = tesselator.colors();
-  t.ok(ArrayBuffer.isView(colors), 'PolygonTesselatorExtruded.colors');
-  t.ok(ArrayBuffer.isView(tesselator.normals()), 'PolygonTesselatorExtruded.normals');
   t.end();
 });


### PR DESCRIPTION
[The `get` function](https://github.com/uber/deck.gl/blob/master/src/core/utils/get.js#L31) used for immutable/ES6 container support has a large perf hit, both due to the complexity of the operation, and the creation of a small new array of keys every time it is called. In ScatterplotLayer, `get` is called 7-9x per object.

deck.gl never fully supported immutable data - only ScatterplotLayer and PolygonLayer did. I think it's debatable what value this inconsistent feature brings to the table given its cost.

This PR demonstrates how much we gain by removing `get` usage from the ScatterplotLayer:

|      | Test | Result |
| --- | --- | --- |
| Before | ScatterplotLayer#initialize | 97.1 iterations/s (10.3ms) |
| After | ScatterplotLayer#initialize | 141 iterations/s (7.1ms) |