### PR TITLE
Fix Picking Module object highlighting

### DIFF
--- a/src/core/lib/draw-layers.js
+++ b/src/core/lib/draw-layers.js
@@ -237,8 +237,6 @@ function drawLayerInViewport({gl, layer, layerIndex, drawPickingColors, glViewpo
   });
 
   if (drawPickingColors) {
-    // TODO - Disable during picking
-
     Object.assign(layerParameters, {
       blendColor: [0, 0, 0, (layerIndex + 1) / 255]
     });
@@ -246,12 +244,10 @@ function drawLayerInViewport({gl, layer, layerIndex, drawPickingColors, glViewpo
     Object.assign(moduleParameters, getObjectHighlightParameters(layer));
   }
 
-  withParameters(gl, layerParameters, () => {
-    layer.drawLayer({
-      moduleParameters,
-      uniforms,
-      parameters: layerParameters
-    });
+  layer.drawLayer({
+    moduleParameters,
+    uniforms,
+    parameters: layerParameters
   });
 }
 

--- a/src/core/lib/draw-layers.js
+++ b/src/core/lib/draw-layers.js
@@ -238,11 +238,12 @@ function drawLayerInViewport({gl, layer, layerIndex, drawPickingColors, glViewpo
 
   if (drawPickingColors) {
     // TODO - Disable during picking
-    Object.assign(moduleParameters, getPickingModuleParameters(layer));
 
     Object.assign(layerParameters, {
       blendColor: [0, 0, 0, (layerIndex + 1) / 255]
     });
+  } else {
+    Object.assign(moduleParameters, getObjectHighlightParameters(layer));
   }
 
   withParameters(gl, layerParameters, () => {
@@ -281,7 +282,7 @@ function getViewportFromDescriptor(viewportOrDescriptor) {
  * Returns the picking color of currenlty selected object of the given 'layer'.
  * @return {Array} - the picking color or null if layers selected object is invalid.
  */
-function getPickingModuleParameters(layer) {
+function getObjectHighlightParameters(layer) {
   // TODO - inefficient to update settings every render?
   // TODO: Add warning if 'highlightedObjectIndex' is > numberOfInstances of the model.
 


### PR DESCRIPTION
- Object highlighting uniforms should be set during drawing mode.
- Rename `getPickingModuleParameters` -> `getObjectHighlightParameters`

Fixes #1229 

Verified with layer-browser (`picking`, `selectedObjectIndex` and `autoHighlight`)