### PR TITLE
Add SolidPolygonLayer to experimental layers

### DIFF
--- a/examples/layer-browser/src/examples/experimental-layers.js
+++ b/examples/layer-browser/src/examples/experimental-layers.js
@@ -2,6 +2,7 @@ import {
   MeshLayer,
   PathOutlineLayer,
   PathMarkerLayer,
+  SolidPolygonLayer,
   Arrow2DGeometry,
   TextLayer
 } from 'deck.gl-layers';
@@ -9,6 +10,15 @@ import {
 import {COORDINATE_SYSTEM} from 'deck.gl';
 import {GL} from 'luma.gl';
 import dataSamples from '../immutable-data-samples';
+
+const LIGHT_SETTINGS = {
+  lightsPosition: [-122.45, 37.66, 8000, -122.0, 38.00, 8000],
+  ambientRatio: 0.3,
+  diffuseRatio: 0.6,
+  specularRatio: 0.4,
+  lightsStrength: [1, 0.0, 0.8, 0.0],
+  numberOfLights: 2
+};
 
 const arrowDataLngLat = [
   {position: [-122.4111557006836, 37.774879455566406], angle: 0},
@@ -105,6 +115,20 @@ const PathMarkerExampleMeter = {
   }
 };
 
+const SolidPolygonLayerExample = {
+  layer: SolidPolygonLayer,
+  getData: () => dataSamples.polygons,
+  props: {
+    getPolygon: f => f,
+    getColor: f => [200 + Math.random() * 55, 0, 0],
+    getElevation: f => Math.random() * 1000,
+    opacity: 0.8,
+    pickable: true,
+    lightSettings: LIGHT_SETTINGS,
+    elevationScale: 0.6
+  }
+};
+
 const TextLayerExample = {
   layer: TextLayer,
   getData: () => dataSamples.points.slice(0, 50),
@@ -129,6 +153,7 @@ export default {
     'PathOutlineLayer': PathOutlineExample,
     'PathMarkerLayer': PathMarkerExample,
     'PathMarkerLayer (Meter)': PathMarkerExampleMeter,
+    'New SolidPolygonLayer': SolidPolygonLayerExample,
     'TextLayer': TextLayerExample
   }
 };

--- a/src/experimental-layers/src/index.js
+++ b/src/experimental-layers/src/index.js
@@ -6,6 +6,8 @@ export {default as MeshLayer} from './mesh-layer/mesh-layer';
 export {default as PathMarkerLayer} from './path-marker-layer/path-marker-layer';
 export {default as PathOutlineLayer} from './path-outline-layer/path-outline-layer';
 
+export {default as SolidPolygonLayer} from './solid-polygon-layer/solid-polygon-layer';
+
 export {default as Arrow2DGeometry} from './path-marker-layer/arrow-2d-geometry';
 export {default as TextLayer} from './text-layer/text-layer';
 

--- a/src/experimental-layers/src/solid-polygon-layer/polygon-tesselator-extruded.js
+++ b/src/experimental-layers/src/solid-polygon-layer/polygon-tesselator-extruded.js
@@ -1,0 +1,359 @@
+// Copyright (c) 2015 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import * as Polygon from './polygon';
+import {experimental} from 'deck.gl';
+const {fp64ify, fillArray} = experimental;
+import earcut from 'earcut';
+
+function getPickingColor(index) {
+  return [
+    (index + 1) & 255,
+    ((index + 1) >> 8) & 255,
+    (((index + 1) >> 8) >> 8) & 255
+  ];
+}
+
+function arrayPush(array, values) {
+  const length = values.length;
+  let offset = array.length;
+
+  for (let index = 0; index < length; index++) {
+    array[offset++] = values[index];
+  }
+  return array;
+}
+
+function flatten(values, level, result = []) {
+  if (level > 1) {
+    values.forEach(v => flatten(v, level - 1, result));
+  } else {
+    arrayPush(result, values);
+  }
+  return result;
+}
+
+const DEFAULT_COLOR = [0, 0, 0, 255]; // Black
+
+export class PolygonTesselatorExtruded {
+
+  constructor({
+    polygons,
+    getHeight = x => 1000,
+    getColor = x => DEFAULT_COLOR,
+    wireframe = false,
+    fp64 = false
+  }) {
+    this.fp64 = fp64;
+
+    // Expensive operation, convert all polygons to arrays
+    polygons = polygons.map((complexPolygon, polygonIndex) => {
+      const height = getHeight(polygonIndex) || 0;
+      return Polygon.normalize(complexPolygon).map(
+        polygon => polygon.map(coord => [coord[0], coord[1], height])
+      );
+    });
+
+    const groupedVertices = polygons;
+    this.groupedVertices = polygons;
+    const pointCount = getPointCount(polygons);
+    this.pointCount = pointCount;
+    this.wireframe = wireframe;
+
+    this.attributes = {};
+
+    const positionsJS = calculatePositionsJS({groupedVertices, pointCount, wireframe});
+    Object.assign(this.attributes, {
+      positions: calculatePositions(positionsJS, this.fp64),
+      indices: calculateIndices({groupedVertices, wireframe}),
+      normals: calculateNormals({groupedVertices, pointCount, wireframe}),
+      // colors: calculateColors({groupedVertices, wireframe, getColor}),
+      pickingColors: calculatePickingColors({groupedVertices, pointCount, wireframe})
+    });
+  }
+
+  indices() {
+    return this.attributes.indices;
+  }
+
+  positions() {
+    return this.attributes.positions;
+  }
+
+  normals() {
+    return this.attributes.normals;
+  }
+
+  colors({getColor = x => DEFAULT_COLOR} = {}) {
+    const {groupedVertices, pointCount, wireframe} = this;
+    return calculateColors({groupedVertices, pointCount, wireframe, getColor});
+  }
+
+  pickingColors() {
+    return this.attributes.pickingColors;
+  }
+
+  // updateTriggers: {
+  //   positions: ['getHeight'],
+  //   colors: ['getColors']
+  //   pickingColors: 'none'
+  // }
+}
+
+// Count number of points in a list of complex polygons
+function getPointCount(polygons) {
+  return polygons.reduce((points, polygon) => points + Polygon.getVertexCount(polygon), 0);
+}
+
+function calculateIndices({groupedVertices, wireframe = false}) {
+  // adjust index offset for multiple polygons
+  const multiplier = wireframe ? 2 : 5;
+  const offsets = [];
+  groupedVertices.reduce((vertexIndex, vertices) => {
+    offsets.push(vertexIndex);
+    return vertexIndex + Polygon.getVertexCount(vertices) * multiplier;
+  }, 0);
+
+  const indices = groupedVertices.map((vertices, polygonIndex) =>
+    wireframe ?
+      // 1. get sequentially ordered indices of each polygons wireframe
+      // 2. offset them by the number of indices in previous polygons
+      calculateContourIndices(vertices, offsets[polygonIndex]) :
+      // 1. get triangulated indices for the internal areas
+      // 2. offset them by the number of indices in previous polygons
+      calculateSurfaceIndices(vertices, offsets[polygonIndex])
+  );
+
+  return new Uint32Array(flatten(indices, 2));
+}
+
+// Calculate a flat position array in JS - can be mapped to 32 or 64 bit typed arrays
+// Remarks:
+// * each top vertex is on 3 surfaces
+// * each bottom vertex is on 2 surfaces
+function calculatePositionsJS({groupedVertices, pointCount, wireframe = false}) {
+  const multiplier = wireframe ? 2 : 5;
+  const positions = new Float32Array(pointCount * 3 * multiplier);
+  let vertexIndex = 0;
+
+  groupedVertices.forEach(
+    vertices => {
+      const topVertices = flatten(vertices, 3);
+
+      const baseVertices = topVertices.slice(0);
+      let i = topVertices.length - 1;
+      while (i > 0) {
+        baseVertices[i] = 0;
+        i -= 3;
+      }
+      const len = topVertices.length;
+
+      if (wireframe) {
+        fillArray({target: positions, source: topVertices, start: vertexIndex});
+        fillArray({target: positions, source: baseVertices, start: vertexIndex + len});
+      } else {
+        fillArray({target: positions, source: topVertices, start: vertexIndex, count: 3});
+        fillArray({target: positions, source: baseVertices, start: vertexIndex + len * 3,
+          count: 2});
+      }
+      vertexIndex += len * multiplier;
+    }
+  );
+
+  return positions;
+}
+
+function calculatePositions(positionsJS, fp64) {
+  let positionLow;
+  if (fp64) {
+    // We only need x, y component
+    const vertexCount = positionsJS.length / 3;
+    positionLow = new Float32Array(vertexCount * 2);
+    for (let i = 0; i < vertexCount; i++) {
+      positionLow[i * 2 + 0] = fp64ify(positionsJS[i * 3 + 0])[1];
+      positionLow[i * 2 + 1] = fp64ify(positionsJS[i * 3 + 1])[1];
+    }
+
+  }
+  return {positions: positionsJS, positions64xyLow: positionLow};
+}
+
+function calculateNormals({groupedVertices, pointCount, wireframe}) {
+  const up = [0, 0, 1];
+  const multiplier = wireframe ? 2 : 5;
+
+  const normals = new Float32Array(pointCount * 3 * multiplier);
+  let vertexIndex = 0;
+
+  if (wireframe) {
+    return fillArray({target: normals, source: up, count: pointCount * multiplier});
+  }
+
+  groupedVertices.map((vertices, polygonIndex) => {
+    const vertexCount = Polygon.getVertexCount(vertices);
+
+    fillArray({target: normals, source: up, start: vertexIndex, count: vertexCount});
+    vertexIndex += vertexCount * 3;
+
+    const sideNormalsForward = [];
+    const sideNormalsBackward = [];
+
+    vertices.forEach(polygon => {
+      const sideNormals = calculateSideNormals(polygon);
+      const firstNormal = sideNormals.slice(0, 3);
+
+      arrayPush(sideNormalsForward, sideNormals);
+      arrayPush(sideNormalsForward, firstNormal);
+
+      arrayPush(sideNormalsBackward, firstNormal);
+      arrayPush(sideNormalsBackward, sideNormals);
+    });
+
+    fillArray({target: normals, start: vertexIndex, count: 2,
+      source: sideNormalsForward.concat(sideNormalsBackward)});
+    vertexIndex += vertexCount * 3 * 4;
+  });
+
+  return normals;
+}
+
+function calculateSideNormals(vertices) {
+  const normals = [];
+
+  let lastVertice = null;
+  for (const vertice of vertices) {
+    if (lastVertice) {
+      // vertex[i-1], vertex[i]
+      const n = getNormal(lastVertice, vertice);
+      arrayPush(normals, n);
+    }
+    lastVertice = vertice;
+  }
+
+  return normals;
+}
+
+function calculateColors({groupedVertices, pointCount, getColor, wireframe = false}) {
+  const multiplier = wireframe ? 2 : 5;
+  const colors = new Uint8ClampedArray(pointCount * 4 * multiplier);
+  let vertexIndex = 0;
+
+  groupedVertices.forEach((complexPolygon, polygonIndex) => {
+    const color = getColor(polygonIndex);
+    color[3] = Number.isFinite(color[3]) ? color[3] : 255;
+
+    const numVertices = Polygon.getVertexCount(complexPolygon);
+
+    fillArray({target: colors, source: color, start: vertexIndex, count: numVertices * multiplier});
+    vertexIndex += color.length * numVertices * multiplier;
+  });
+
+  return colors;
+}
+
+function calculatePickingColors({groupedVertices, pointCount, wireframe = false}) {
+  const multiplier = wireframe ? 2 : 5;
+  const colors = new Uint8ClampedArray(pointCount * 3 * multiplier);
+  let vertexIndex = 0;
+
+  groupedVertices.forEach((vertices, polygonIndex) => {
+    const numVertices = Polygon.getVertexCount(vertices);
+    const color = getPickingColor(polygonIndex);
+
+    fillArray({target: colors, source: color, start: vertexIndex, count: numVertices * multiplier});
+    vertexIndex += color.length * numVertices * multiplier;
+  });
+  return colors;
+}
+
+function calculateContourIndices(vertices, offset) {
+  const stride = Polygon.getVertexCount(vertices);
+  const indices = [];
+
+  vertices.forEach(polygon => {
+    indices.push(offset);
+    const numVertices = polygon.length;
+
+    // polygon top
+    // use vertex pairs for GL.LINES => [0, 1, 1, 2, 2, ..., n-1, n-1, 0]
+    for (let i = 1; i < numVertices - 1; i++) {
+      indices.push(i + offset, i + offset);
+    }
+    indices.push(offset);
+
+    // polygon sides
+    for (let i = 0; i < numVertices - 1; i++) {
+      indices.push(i + offset, i + stride + offset);
+    }
+
+    offset += numVertices;
+  });
+
+  return indices;
+}
+
+function drawSurfaceRectangle(targetArray, offset, stride) {
+  targetArray.push(
+    offset + stride,
+    offset + stride * 3,
+    offset + stride * 2 + 1,
+    offset + stride * 2 + 1,
+    offset + stride * 3,
+    offset + stride * 4 + 1
+  );
+}
+
+function calculateSurfaceIndices(vertices, offset) {
+  const stride = Polygon.getVertexCount(vertices);
+
+  let holes = null;
+  const holeCount = vertices.length - 1;
+
+  if (holeCount) {
+    holes = [];
+    let vertexIndex = 0;
+    for (let i = 0; i < holeCount; i++) {
+      vertexIndex += vertices[i].length;
+      holes[i] = vertexIndex;
+    }
+  }
+
+  const indices = earcut(flatten(vertices, 3), holes, 3).map(index => index + offset);
+
+  vertices.forEach(polygon => {
+    const numVertices = polygon.length;
+
+    // polygon sides
+    for (let i = 0; i < numVertices - 1; i++) {
+      drawSurfaceRectangle(indices, offset + i, stride);
+    }
+
+    offset += numVertices;
+  });
+
+  return indices;
+}
+
+// helpers
+
+// get normal vector of line segment
+function getNormal(p1, p2) {
+  return [p1[1] - p2[1], p2[0] - p1[0], 0];
+}

--- a/src/experimental-layers/src/solid-polygon-layer/polygon-tesselator.js
+++ b/src/experimental-layers/src/solid-polygon-layer/polygon-tesselator.js
@@ -1,0 +1,221 @@
+// Copyright (c) 2015 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Handles tesselation of polygons with holes
+// - 2D surfaces
+// - 2D outlines
+// - 3D surfaces (top and sides only)
+// - 3D wireframes (not yet)
+import * as Polygon from './polygon';
+import earcut from 'earcut';
+import {experimental} from 'deck.gl';
+const {fp64ify, flattenVertices, fillArray} = experimental;
+
+// Maybe deck.gl or luma.gl needs to export this
+function getPickingColor(index) {
+  return [
+    (index + 1) % 256,
+    Math.floor((index + 1) / 256) % 256,
+    Math.floor((index + 1) / 256 / 256) % 256
+  ];
+}
+
+const DEFAULT_COLOR = [0, 0, 0, 255]; // Black
+
+// This class is set up to allow querying one attribute at a time
+// the way the AttributeManager expects it
+export class PolygonTesselator {
+  constructor({polygons, fp64 = false}) {
+    // Normalize all polygons
+    this.polygons = polygons.map(polygon => Polygon.normalize(polygon));
+    // Count all polygon vertices
+    this.pointCount = getPointCount(this.polygons);
+    this.fp64 = fp64;
+  }
+
+  indices() {
+    const {polygons, indexCount} = this;
+    return calculateIndices({polygons, indexCount});
+  }
+
+  positions() {
+    const {polygons, pointCount} = this;
+    return calculatePositions({polygons, pointCount, fp64: this.fp64});
+  }
+
+  normals() {
+    const {polygons, pointCount} = this;
+    return calculateNormals({polygons, pointCount});
+  }
+
+  colors({getColor = x => DEFAULT_COLOR} = {}) {
+    const {polygons, pointCount} = this;
+    return calculateColors({polygons, pointCount, getColor});
+  }
+
+  pickingColors() {
+    const {polygons, pointCount} = this;
+    return calculatePickingColors({polygons, pointCount});
+  }
+
+  // getAttribute({size, accessor}) {
+  //   const {polygons, pointCount} = this;
+  //   return calculateAttribute({polygons, pointCount, size, accessor});
+  // }
+}
+
+// Count number of points in a list of complex polygons
+function getPointCount(polygons) {
+  return polygons.reduce((points, polygon) => points + Polygon.getVertexCount(polygon), 0);
+}
+
+// COunt number of triangles in a list of complex polygons
+function getTriangleCount(polygons) {
+  return polygons.reduce((triangles, polygon) => triangles + Polygon.getTriangleCount(polygon), 0);
+}
+
+// Returns the offsets of each complex polygon in the combined array of all polygons
+function getPolygonOffsets(polygons) {
+  const offsets = new Array(polygons.length + 1);
+  offsets[0] = 0;
+  let offset = 0;
+  polygons.forEach((polygon, i) => {
+    offset += Polygon.getVertexCount(polygon);
+    offsets[i + 1] = offset;
+  });
+  return offsets;
+}
+
+// Returns the offset of each hole polygon in the flattened array for that polygon
+function getHoleIndices(complexPolygon) {
+  let holeIndices = null;
+  if (complexPolygon.length > 1) {
+    let polygonStartIndex = 0;
+    holeIndices = [];
+    complexPolygon.forEach(polygon => {
+      polygonStartIndex += polygon.length;
+      holeIndices.push(polygonStartIndex);
+    });
+    // Last element points to end of the flat array, remove it
+    holeIndices.pop();
+  }
+  return holeIndices;
+}
+
+function calculateIndices({polygons, IndexType = Uint32Array}) {
+  // Calculate length of index array (3 * number of triangles)
+  const indexCount = 3 * getTriangleCount(polygons);
+  const offsets = getPolygonOffsets(polygons);
+
+  // Allocate the attribute
+  // TODO it's not the index count but the vertex count that must be checked
+  if (IndexType === Uint16Array && indexCount > 65535) {
+    throw new Error('Vertex count exceeds browser\'s limit');
+  }
+  const attribute = new IndexType(indexCount);
+
+  // 1. get triangulated indices for the internal areas
+  // 2. offset them by the number of indices in previous polygons
+  let i = 0;
+  polygons.forEach((polygon, polygonIndex) => {
+    for (const index of calculateSurfaceIndices(polygon)) {
+      attribute[i++] = index + offsets[polygonIndex];
+    }
+  });
+
+  return attribute;
+}
+
+/*
+ * Get vertex indices for drawing complexPolygon mesh
+ * @private
+ * @param {[Number,Number,Number][][]} complexPolygon
+ * @returns {[Number]} indices
+ */
+function calculateSurfaceIndices(complexPolygon) {
+  // Prepare an array of hole indices as expected by earcut
+  const holeIndices = getHoleIndices(complexPolygon);
+  // Flatten the polygon as expected by earcut
+  const verts = flattenVertices(complexPolygon);
+  // Let earcut triangulate the polygon
+  return earcut(verts, holeIndices, 3);
+}
+
+function calculatePositions({polygons, pointCount, fp64}) {
+  // Flatten out all the vertices of all the sub subPolygons
+  const attribute = new Float32Array(pointCount * 3);
+  let attributeLow;
+  if (fp64) {
+    // We only need x, y component
+    attributeLow = new Float32Array(pointCount * 2);
+  }
+  let i = 0;
+  let j = 0;
+  for (const polygon of polygons) {
+    Polygon.forEachVertex(polygon, vertex => { // eslint-disable-line
+      const x = vertex[0];
+      const y = vertex[1];
+      const z = vertex[2] || 0;
+      attribute[i++] = x;
+      attribute[i++] = y;
+      attribute[i++] = z;
+      if (fp64) {
+        attributeLow[j++] = fp64ify(x)[1];
+        attributeLow[j++] = fp64ify(y)[1];
+      }
+    });
+  }
+  return {positions: attribute, positions64xyLow: attributeLow};
+}
+
+function calculateNormals({polygons, pointCount}) {
+  // TODO - use generic vertex attribute?
+  const attribute = new Float32Array(pointCount * 3);
+  // normals is not used in flat polygon shader
+  // fillArray({target: attribute, source: [0, 0, 1], start: 0, count: pointCount});
+  return attribute;
+}
+
+function calculateColors({polygons, pointCount, getColor}) {
+  const attribute = new Uint8ClampedArray(pointCount * 4);
+  let i = 0;
+  polygons.forEach((complexPolygon, polygonIndex) => {
+    // Calculate polygon color
+    const color = getColor(polygonIndex);
+    color[3] = Number.isFinite(color[3]) ? color[3] : 255;
+
+    const vertexCount = Polygon.getVertexCount(complexPolygon);
+    fillArray({target: attribute, source: color, start: i, count: vertexCount});
+    i += color.length * vertexCount;
+  });
+  return attribute;
+}
+
+function calculatePickingColors({polygons, pointCount}) {
+  const attribute = new Uint8ClampedArray(pointCount * 3);
+  let i = 0;
+  polygons.forEach((complexPolygon, polygonIndex) => {
+    const color = getPickingColor(polygonIndex);
+    const vertexCount = Polygon.getVertexCount(complexPolygon);
+    fillArray({target: attribute, source: color, start: i, count: vertexCount});
+    i += color.length * vertexCount;
+  });
+  return attribute;
+}

--- a/src/experimental-layers/src/solid-polygon-layer/polygon.js
+++ b/src/experimental-layers/src/solid-polygon-layer/polygon.js
@@ -1,0 +1,88 @@
+// Copyright (c) 2015 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Basic polygon support
+//
+// Handles simple and complex polygons
+// Simple polygons are arrays of vertices, implicitly "closed"
+// Complex polygons are arrays of simple polygons, with the first polygon
+// representing the outer hull and other polygons representing holes
+
+/**
+ * Check if this is a non-nested polygon (i.e. the first element of the first element is a number)
+ * @param {Array} polygon - either a complex or simple polygon
+ * @return {Boolean} - true if the polygon is a simple polygon (i.e. not an array of polygons)
+ */
+export function isSimple(polygon) {
+  return polygon.length >= 1 &&
+    polygon[0].length >= 2 &&
+    Number.isFinite(polygon[0][0]);
+}
+
+/**
+ * Normalize to ensure that all polygons in a list are complex - simplifies processing
+ * @param {Array} polygon - either a complex or a simple polygon
+ * @param {Object} opts
+ * @param {Object} opts.dimensions - if 3, the coords will be padded with 0's if needed
+ * @return {Array} - returns a complex polygons
+ */
+export function normalize(polygon, {dimensions = 3} = {}) {
+  return isSimple(polygon) ? [polygon] : polygon;
+}
+
+/**
+ * Check if this is a non-nested polygon (i.e. the first element of the first element is a number)
+ * @param {Array} polygon - either a complex or simple polygon
+ * @return {Boolean} - true if the polygon is a simple polygon (i.e. not an array of polygons)
+ */
+export function getVertexCount(polygon) {
+  return isSimple(polygon) ?
+    polygon.length :
+    polygon.reduce((length, simplePolygon) => length + simplePolygon.length, 0);
+}
+
+// Return number of triangles needed to tesselate the polygon
+export function getTriangleCount(polygon) {
+  let triangleCount = 0;
+  let first = true;
+  for (const simplePolygon of normalize(polygon)) {
+    const size = simplePolygon.length;
+    if (first) {
+      triangleCount += size >= 3 ? size - 2 : 0;
+    } else {
+      triangleCount += size + 1;
+    }
+    first = false;
+  }
+  return triangleCount;
+}
+
+export function forEachVertex(polygon, visitor) {
+  if (isSimple(polygon)) {
+    polygon.forEach(visitor);
+    return;
+  }
+
+  let vertexIndex = 0;
+  polygon.forEach(simplePolygon => {
+    simplePolygon.forEach((v, i, p) => visitor(v, vertexIndex, polygon));
+    vertexIndex++;
+  });
+}

--- a/src/experimental-layers/src/solid-polygon-layer/solid-polygon-layer-fragment.glsl.js
+++ b/src/experimental-layers/src/solid-polygon-layer/solid-polygon-layer-fragment.glsl.js
@@ -18,22 +18,24 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import test from 'tape-catch';
+export default `\
+#define SHADER_NAME solid-polygon-layer-fragment-shader
 
-import {
-  MeshLayer, PathMarkerLayer, PathOutlineLayer,
-  Arrow2DGeometry, SolidPolygonLayer,
-  outline
-} from 'deck.gl-layers';
+#ifdef GL_ES
+precision highp float;
+#endif
 
-test('Top-level imports', t => {
-  t.ok(MeshLayer, 'MeshLayer symbol imported');
-  t.ok(PathMarkerLayer, 'PathMarkerLayer symbol imported');
-  t.ok(PathOutlineLayer, 'PathOutlineLayer symbol imported');
-  t.ok(SolidPolygonLayer, 'SolidPolygonLayer symbol imported');
-  t.ok(Arrow2DGeometry, 'Arrow2DGeometry symbol imported');
-  t.ok(outline, 'outline symbol imported');
-  t.end();
-});
+// PICKING
+// uniform bool pickingEnabled;
+varying vec4 vColor;
 
-import './polygon-tesselation.spec';
+void main(void) {
+  gl_FragColor = vColor;
+
+  // use highlight color if this fragment belongs to the selected object.
+  gl_FragColor = picking_filterHighlightColor(gl_FragColor);
+
+  // use picking color if rendering to picking FBO.
+  gl_FragColor = picking_filterPickingColor(gl_FragColor);
+}
+`;

--- a/src/experimental-layers/src/solid-polygon-layer/solid-polygon-layer-vertex-64.glsl.js
+++ b/src/experimental-layers/src/solid-polygon-layer/solid-polygon-layer-vertex-64.glsl.js
@@ -1,0 +1,70 @@
+// Copyright (c) 2015 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+export default `\
+#define SHADER_NAME solid-polygon-layer-vertex-shader-64
+
+attribute vec3 positions;
+attribute vec2 positions64xyLow;
+attribute vec3 normals;
+attribute vec4 colors;
+attribute vec3 pickingColors;
+
+uniform float extruded;
+uniform float elevationScale;
+uniform float opacity;
+uniform vec3 pixelsPerUnit;
+
+varying vec4 vColor;
+
+void main(void) {
+  vec4 positions64xy = vec4(positions.x, positions64xyLow.x, positions.y, positions64xyLow.y);
+
+  vec2 projected_coord_xy[2];
+  project_position_fp64(positions64xy, projected_coord_xy);
+
+  vec2 vertex_pos_modelspace[4];
+  vertex_pos_modelspace[0] = projected_coord_xy[0];
+  vertex_pos_modelspace[1] = projected_coord_xy[1];
+  vertex_pos_modelspace[2] = vec2(project_scale(positions.z * elevationScale), 0.0);
+  vertex_pos_modelspace[3] = vec2(1.0, 0.0);
+
+  gl_Position = project_to_clipspace_fp64(vertex_pos_modelspace);
+
+  vec4 position_worldspace = vec4(
+    vertex_pos_modelspace[0].x, vertex_pos_modelspace[1].x,
+    vertex_pos_modelspace[2].x, vertex_pos_modelspace[3].x);
+
+  float lightWeight = 1.0;
+
+  if (extruded > 0.5) {
+    lightWeight = getLightWeight(
+      position_worldspace.xyz, // the w component is always 1.0
+      normalize(normals * pixelsPerUnit)
+    );
+  }
+
+  vec3 lightWeightedColor = lightWeight * colors.rgb;
+  vColor = vec4(lightWeightedColor, colors.a * opacity) / 255.0;
+
+  // Set color to be rendered to picking fbo (also used to check for selection highlight).
+  picking_setPickingColor(pickingColors);
+}
+`;

--- a/src/experimental-layers/src/solid-polygon-layer/solid-polygon-layer-vertex.glsl.js
+++ b/src/experimental-layers/src/solid-polygon-layer/solid-polygon-layer-vertex.glsl.js
@@ -1,0 +1,67 @@
+// Copyright (c) 2015 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+export default `\
+#define SHADER_NAME solid-polygon-layer-vertex-shader
+
+attribute vec3 positions;
+attribute vec3 normals;
+attribute vec4 colors;
+attribute vec3 pickingColors;
+
+uniform float extruded;
+uniform float elevationScale;
+uniform float opacity;
+uniform vec3 pixelsPerUnit;
+
+varying vec4 vColor;
+
+void main(void) {
+  
+  vec4 position_worldspace = vec4(project_position(
+    vec3(positions.x, positions.y, positions.z * elevationScale)),
+    1.0
+  );
+  gl_Position = project_to_clipspace(position_worldspace);
+
+  float lightWeight = 1.0;
+  
+  if (extruded > 0.5) {
+    // Here, the input parameters should be
+    // position_worldspace.xyz / position_worldspace.w.
+    // However, this calculation generates all zeros on
+    // MacBook Pro with Intel Iris Pro GPUs for unclear reasons.
+    // (see https://github.com/uber/deck.gl/issues/559)
+    // Since the w component is always 1.0 in our shaders,
+    // we decided to just provide xyz component of position_worldspace
+    // to the getLightWeight() function
+    lightWeight = getLightWeight(
+      position_worldspace.xyz,
+      normalize(normals * pixelsPerUnit)
+    );
+  }
+
+  vec3 lightWeightedColor = lightWeight * colors.rgb;
+  vColor = vec4(lightWeightedColor, colors.a * opacity) / 255.0;
+
+  // Set color to be rendered to picking fbo (also used to check for selection highlight).
+  picking_setPickingColor(pickingColors);
+}
+`;

--- a/src/experimental-layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/src/experimental-layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -1,0 +1,211 @@
+// Copyright (c) 2015 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import {COORDINATE_SYSTEM, Layer, experimental} from 'deck.gl';
+const {enable64bitSupport, get} = experimental;
+import {GL, Model, Geometry} from 'luma.gl';
+import {compareProps} from 'deck.gl/dist/core/lib/props';
+
+// Polygon geometry generation is managed by the polygon tesselator
+import {PolygonTesselator} from './polygon-tesselator';
+import {PolygonTesselatorExtruded} from './polygon-tesselator-extruded';
+
+import vs from './solid-polygon-layer-vertex.glsl';
+import vs64 from './solid-polygon-layer-vertex-64.glsl';
+import fs from './solid-polygon-layer-fragment.glsl';
+
+const defaultProps = {
+  // Whether to extrude
+  extruded: false,
+  // Whether to draw a GL.LINES wireframe of the polygon
+  wireframe: false,
+  fp64: false,
+
+  // elevation multiplier
+  elevationScale: 1,
+
+  // Accessor for polygon geometry
+  getPolygon: f => get(f, 'polygon') || get(f, 'geometry.coordinates'),
+  // Accessor for extrusion height
+  getElevation: f => get(f, 'elevation') || get(f, 'properties.height') || 0,
+  // Accessor for color
+  getColor: f => get(f, 'color') || get(f, 'properties.color'),
+
+  // Optional settings for 'lighting' shader module
+  lightSettings: {
+    lightsPosition: [-122.45, 37.75, 8000, -122.0, 38.00, 5000],
+    ambientRatio: 0.05,
+    diffuseRatio: 0.6,
+    specularRatio: 0.8,
+    lightsStrength: [2.0, 0.0, 0.0, 0.0],
+    numberOfLights: 2
+  }
+};
+
+export default class SolidPolygonLayer extends Layer {
+  getShaders() {
+    return enable64bitSupport(this.props) ?
+      {vs: vs64, fs, modules: ['project64', 'lighting', 'picking']} :
+      {vs, fs, modules: ['lighting', 'picking']}; // 'project' module added by default.
+  }
+
+  initializeState() {
+    const {gl} = this.context;
+    this.setState({
+      model: this._getModel(gl),
+      numInstances: 0,
+      IndexType: gl.getExtension('OES_element_index_uint') ? Uint32Array : Uint16Array
+    });
+
+    const {attributeManager} = this.state;
+    const noAlloc = true;
+    /* eslint-disable max-len */
+    attributeManager.add({
+      indices: {size: 1, isIndexed: true, update: this.calculateIndices, noAlloc},
+      positions: {size: 3, accessor: 'getElevation', update: this.calculatePositions, noAlloc},
+      normals: {size: 3, update: this.calculateNormals, noAlloc},
+      colors: {size: 4, type: GL.UNSIGNED_BYTE, accessor: 'getColor', update: this.calculateColors, noAlloc},
+      pickingColors: {size: 3, type: GL.UNSIGNED_BYTE, update: this.calculatePickingColors, noAlloc}
+    });
+    /* eslint-enable max-len */
+  }
+
+  updateAttribute({props, oldProps, changeFlags}) {
+    if (props.fp64 !== oldProps.fp64) {
+      const {attributeManager} = this.state;
+      attributeManager.invalidateAll();
+
+      if (props.fp64 && props.coordinateSystem === COORDINATE_SYSTEM.LNGLAT) {
+        attributeManager.add({
+          positions64xyLow: {size: 2, update: this.calculatePositionsLow}
+        });
+      } else {
+        attributeManager.remove([
+          'positions64xyLow'
+        ]);
+      }
+    }
+  }
+
+  draw({uniforms}) {
+    const {extruded, lightSettings, elevationScale} = this.props;
+    const {viewport} = this.context;
+
+    this.state.model.render(Object.assign({}, uniforms, {
+      extruded: extruded ? 1.0 : 0.0,
+      elevationScale,
+      pixelsPerUnit: viewport.getDistanceScales().pixelsPerDegree
+    },
+    lightSettings));
+  }
+
+  updateState({props, oldProps, changeFlags}) {
+    super.updateState({props, oldProps, changeFlags});
+
+    const regenerateModel = this.updateGeometry({props, oldProps, changeFlags});
+
+    if (regenerateModel) {
+      const {gl} = this.context;
+      this.setState({model: this._getModel(gl)});
+    }
+    this.updateAttribute({props, oldProps, changeFlags});
+  }
+
+  updateGeometry({props, oldProps, changeFlags}) {
+    const geometryConfigChanged = props.extruded !== oldProps.extruded ||
+      props.wireframe !== oldProps.wireframe || props.fp64 !== oldProps.fp64 ||
+      (changeFlags.updateTriggersChanged && (
+        changeFlags.updateTriggersChanged.all ||
+        changeFlags.updateTriggersChanged.getPolygon));
+
+    // check if updateTriggers.getElevation has been triggered
+    const getElevationTriggered = changeFlags.updateTriggersChanged &&
+      compareProps({
+        oldProps: oldProps.updateTriggers.getElevation || {},
+        newProps: props.updateTriggers.getElevation || {},
+        triggerName: 'getElevation'
+      });
+
+    // When the geometry config  or the data is changed,
+    // tessellator needs to be invoked
+    if (changeFlags.dataChanged || geometryConfigChanged || getElevationTriggered) {
+      const {getPolygon, extruded, wireframe, getElevation} = props;
+
+      // TODO - avoid creating a temporary array here: let the tesselator iterate
+      const polygons = props.data.map(getPolygon);
+
+      this.setState({
+        polygonTesselator: !extruded ?
+          new PolygonTesselator({polygons, fp64: this.props.fp64}) :
+          new PolygonTesselatorExtruded({polygons, wireframe,
+            getHeight: polygonIndex => getElevation(this.props.data[polygonIndex]),
+            fp64: this.props.fp64
+          })
+      });
+
+      this.state.attributeManager.invalidateAll();
+    }
+
+    return geometryConfigChanged;
+  }
+
+  _getModel(gl) {
+    return new Model(gl, Object.assign({}, this.getShaders(), {
+      id: this.props.id,
+      geometry: new Geometry({
+        drawMode: this.props.wireframe ? GL.LINES : GL.TRIANGLES,
+        attributes: {}
+      }),
+      vertexCount: 0,
+      isIndexed: true,
+      shaderCache: this.context.shaderCache
+    }));
+  }
+
+  calculateIndices(attribute) {
+    attribute.value = this.state.polygonTesselator.indices();
+    attribute.target = GL.ELEMENT_ARRAY_BUFFER;
+    this.state.model.setVertexCount(attribute.value.length / attribute.size);
+  }
+
+  calculatePositions(attribute) {
+    attribute.value = this.state.polygonTesselator.positions().positions;
+  }
+  calculatePositionsLow(attribute) {
+    attribute.value = this.state.polygonTesselator.positions().positions64xyLow;
+  }
+  calculateNormals(attribute) {
+    attribute.value = this.state.polygonTesselator.normals();
+  }
+
+  calculateColors(attribute) {
+    attribute.value = this.state.polygonTesselator.colors({
+      getColor: polygonIndex => this.props.getColor(this.props.data[polygonIndex])
+    });
+  }
+
+  // Override the default picking colors calculation
+  calculatePickingColors(attribute) {
+    attribute.value = this.state.polygonTesselator.pickingColors();
+  }
+}
+
+SolidPolygonLayer.layerName = 'SolidPolygonLayer';
+SolidPolygonLayer.defaultProps = defaultProps;

--- a/src/experimental-layers/test/polygon-tesselation.spec.js
+++ b/src/experimental-layers/test/polygon-tesselation.spec.js
@@ -1,0 +1,131 @@
+// Copyright (c) 2015 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import test from 'tape-catch';
+
+import * as Polygon from 'deck.gl-layers/solid-polygon-layer/polygon';
+import {PolygonTesselator} from 'deck.gl-layers/solid-polygon-layer/polygon-tesselator';
+import {PolygonTesselatorExtruded}
+  from 'deck.gl-layers/solid-polygon-layer/polygon-tesselator-extruded';
+
+const POLYGONS = [
+  [],
+  [[1, 1]],
+  [[1, 1], [1, 1], [1, 1]],
+  [[[1, 1]]],
+  [[[1, 1], [1, 1], [1, 1]]]
+];
+
+const TEST_DATA = [
+  {
+    title: 'Plain array',
+    polygons: POLYGONS
+  }
+];
+
+const TEST_CASES = [
+  {
+    title: 'Tesselation(flat)',
+    TesselatorClass: PolygonTesselator,
+    params: {}
+  },
+  {
+    title: 'Tesselation(extruded)',
+    TesselatorClass: PolygonTesselatorExtruded,
+    params: {extruded: true}
+  },
+  {
+    title: 'Tesselation(wireframe)',
+    TesselatorClass: PolygonTesselatorExtruded,
+    params: {extruded: true, wireframe: true}
+  },
+  {
+    title: 'Tesselation(flat,fp64)',
+    TesselatorClass: PolygonTesselator,
+    params: {fp64: true}
+  },
+  {
+    title: 'Tesselation(extruded,fp64)',
+    TesselatorClass: PolygonTesselatorExtruded,
+    params: {extruded: true, fp64: true}
+  },
+  {
+    title: 'Tesselation(wireframe,fp64)',
+    TesselatorClass: PolygonTesselatorExtruded,
+    params: {extruded: true, wireframe: true, fp64: true}
+  }
+];
+
+test('polygon#imports', t => {
+  t.ok(typeof Polygon.normalize === 'function', 'Polygon.normalize imported');
+  t.ok(typeof Polygon.getVertexCount === 'function', 'Polygon.getVertexCount imported');
+  t.ok(typeof Polygon.getTriangleCount === 'function', 'Polygon.getTriangleCount imported');
+  t.ok(typeof Polygon.forEachVertex === 'function', 'Polygon.forEachVertex imported');
+  t.end();
+});
+
+test('polygon#functions', t => {
+  for (const polygon of POLYGONS) {
+    t.ok(Array.isArray(Polygon.normalize(polygon)), 'Polygon.normalize');
+    t.ok(Number.isFinite(Polygon.getTriangleCount(polygon)), 'Polygon.getTriangleCount');
+    t.ok(Number.isFinite(Polygon.getVertexCount(polygon)), 'Polygon.getVertexCount');
+  }
+
+  t.end();
+});
+
+test('polygonTesselator#imports', t => {
+  t.ok(typeof PolygonTesselator === 'function', 'PolygonTesselator imported');
+  t.ok(typeof PolygonTesselatorExtruded === 'function', 'PolygonTesselatorExtruded imported');
+  t.end();
+});
+
+test('PolygonTesselator#constructor', t => {
+  TEST_DATA.forEach(testData => {
+
+    t.comment(`Polygon data: ${testData.title}`);
+
+    TEST_CASES.forEach(testCase => {
+      t.comment(`  ${testCase.title}`);
+      const tesselator = new testCase.TesselatorClass(Object.assign({
+        polygons: testData.polygons
+      }, testCase.params));
+      t.ok(tesselator, 'PolygonTesselator created');
+
+      t.ok(ArrayBuffer.isView(tesselator.indices()),
+        'PolygonTesselator.indices');
+      t.ok(ArrayBuffer.isView(tesselator.positions().positions),
+        'PolygonTesselator.positions');
+      t.ok(ArrayBuffer.isView(tesselator.colors()),
+        'PolygonTesselator.colors');
+
+      if (testCase.params.fp64) {
+        t.ok(ArrayBuffer.isView(tesselator.positions().positions64xyLow),
+          'PolygonTesselator.positions64xyLow');
+      }
+      if (testCase.params.extruded) {
+        t.ok(ArrayBuffer.isView(tesselator.normals()),
+          'PolygonTesselator.normals');
+      }
+    });
+  });
+
+  t.end();
+});

--- a/test/bench/core-layers.bench.js
+++ b/test/bench/core-layers.bench.js
@@ -31,21 +31,7 @@ import {
 import {testInitializeLayer} from 'deck.gl/test/test-utils';
 
 import SolidPolygonLayer from 'deck.gl/core-layers/solid-polygon-layer/solid-polygon-layer';
-import {PolygonTesselator} from 'deck.gl/core-layers/solid-polygon-layer/polygon-tesselator';
-import {PolygonTesselatorExtruded}
-  from 'deck.gl/core-layers/solid-polygon-layer/polygon-tesselator-extruded';
-
-const polygons = data.choropleths.features.map(f => f.geometry.coordinates);
-
-function testTesselator(tesselator) {
-  return {
-    indices: tesselator.indices(),
-    positions: tesselator.positions(),
-    normals: tesselator.normals(),
-    colors: tesselator.colors(),
-    pickingColors: tesselator.pickingColors()
-  };
-}
+import {SolidPolygonLayer as SolidPolygonLayer2} from 'deck.gl/experimental-layers/src';
 
 // add tests
 export default function coreLayersBench(suite) {
@@ -86,6 +72,7 @@ export default function coreLayersBench(suite) {
       const layer = new PathLayer({data: data.lines});
       testInitializeLayer({layer});
     })
+
     .add('SolidPolygonLayer#initialize (flat)', () => {
       const layer = new SolidPolygonLayer({data: data.choropleths.features});
       testInitializeLayer({layer});
@@ -102,6 +89,55 @@ export default function coreLayersBench(suite) {
       });
       testInitializeLayer({layer});
     })
+    .add('SolidPolygonLayer#initialize (flat,fp64)', () => {
+      const layer = new SolidPolygonLayer({data: data.choropleths.features, fp64: true});
+      testInitializeLayer({layer});
+    })
+    .add('SolidPolygonLayer#initialize (extruded,fp64)', () => {
+      const layer = new SolidPolygonLayer({data: data.choropleths.features,
+        extruded: true, fp64: true
+      });
+      testInitializeLayer({layer});
+    })
+    .add('SolidPolygonLayer#initialize (wireframe,fp64)', () => {
+      const layer = new SolidPolygonLayer({data: data.choropleths.features,
+        extruded: true, wireframe: true, fp64: true
+      });
+      testInitializeLayer({layer});
+    })
+
+    .add('SolidPolygonLayer2#initialize (flat)', () => {
+      const layer = new SolidPolygonLayer2({data: data.choropleths.features});
+      testInitializeLayer({layer});
+    })
+    .add('SolidPolygonLayer2#initialize (extruded)', () => {
+      const layer = new SolidPolygonLayer2({data: data.choropleths.features,
+        extruded: true
+      });
+      testInitializeLayer({layer});
+    })
+    .add('SolidPolygonLayer2#initialize (wireframe)', () => {
+      const layer = new SolidPolygonLayer2({data: data.choropleths.features,
+        extruded: true, wireframe: true
+      });
+      testInitializeLayer({layer});
+    })
+    .add('SolidPolygonLayer2#initialize (flat,fp64)', () => {
+      const layer = new SolidPolygonLayer2({data: data.choropleths.features, fp64: true});
+      testInitializeLayer({layer});
+    })
+    .add('SolidPolygonLayer2#initialize (extruded,fp64)', () => {
+      const layer = new SolidPolygonLayer2({data: data.choropleths.features,
+        extruded: true, fp64: true
+      });
+      testInitializeLayer({layer});
+    })
+    .add('SolidPolygonLayer2#initialize (wireframe,fp64)', () => {
+      const layer = new SolidPolygonLayer2({data: data.choropleths.features,
+        extruded: true, wireframe: true, fp64: true
+      });
+      testInitializeLayer({layer});
+    })
 
     .group('LAYER CONSTRUCTION (NOTE: 3x REDUCED from 250K/s due to getOwnProperty)')
     .add('ScatterplotLayer#construct', () => {
@@ -115,20 +151,6 @@ export default function coreLayersBench(suite) {
     })
     .add('SolidPolygonLayer#construct', () => {
       return new PolygonLayer({data: data.choropleths.features});
-    })
-
-    .group('TESSELATOR')
-    .add('polygonTesselator#flat', () => {
-      const tesselator = new PolygonTesselator({polygons});
-      testTesselator(tesselator);
-    })
-    .add('polygonTesselator#extruded', () => {
-      const tesselator = new PolygonTesselatorExtruded({polygons});
-      testTesselator(tesselator);
-    })
-    .add('polygonTesselator#wireframe', () => {
-      const tesselator = new PolygonTesselatorExtruded({polygons, wireframe: true});
-      testTesselator(tesselator);
     })
 
     ;

--- a/test/bench/index.js
+++ b/test/bench/index.js
@@ -27,6 +27,7 @@ import viewportBench from './viewport.bench';
 import colorBench from './color.bench';
 import pickLayersBench from './pick-layers.bench';
 import utilsBench from './utils.bench';
+import tesselationBench from './tesselation.bench';
 
 const suite = new Bench();
 
@@ -37,6 +38,7 @@ layerBench(suite);
 viewportBench(suite);
 colorBench(suite);
 utilsBench(suite);
+tesselationBench(suite);
 
 // Run the suite
 suite.run();

--- a/test/bench/tesselation.bench.js
+++ b/test/bench/tesselation.bench.js
@@ -1,0 +1,54 @@
+import * as data from 'deck.gl/test/data';
+
+import {PolygonTesselator} from 'deck.gl/core-layers/solid-polygon-layer/polygon-tesselator';
+import {PolygonTesselatorExtruded}
+  from 'deck.gl/core-layers/solid-polygon-layer/polygon-tesselator-extruded';
+
+const polygons = data.choropleths.features.map(f => f.geometry.coordinates);
+
+function testTesselator(tesselator) {
+  return {
+    indices: tesselator.indices(),
+    positions: tesselator.positions(),
+    normals: tesselator.normals(),
+    colors: tesselator.colors(),
+    pickingColors: tesselator.pickingColors()
+  };
+}
+
+export default function tesselationBench(suite) {
+  return suite
+
+    .group('TESSELATOR')
+    .add('polygonTesselator#flat', () => {
+      const tesselator = new PolygonTesselator({polygons});
+      testTesselator(tesselator);
+    })
+    .add('polygonTesselator#extruded', () => {
+      const tesselator = new PolygonTesselatorExtruded({polygons,
+        getHeight: () => 100});
+      testTesselator(tesselator);
+    })
+    .add('polygonTesselator#wireframe', () => {
+      const tesselator = new PolygonTesselatorExtruded({polygons,
+        getHeight: () => 100, wireframe: true});
+      testTesselator(tesselator);
+    })
+
+    .add('polygonTesselator#flat - fp64', () => {
+      const tesselator = new PolygonTesselator({polygons, fp64: true});
+      testTesselator(tesselator);
+    })
+    .add('polygonTesselator#extruded - fp64', () => {
+      const tesselator = new PolygonTesselatorExtruded({polygons,
+        getHeight: () => 100, fp64: true});
+      testTesselator(tesselator);
+    })
+    .add('polygonTesselator#wireframe - fp64', () => {
+      const tesselator = new PolygonTesselatorExtruded({polygons,
+        getHeight: () => 100, wireframe: true, fp64: true});
+      testTesselator(tesselator);
+    })
+
+    ;
+}

--- a/test/index.js
+++ b/test/index.js
@@ -25,3 +25,6 @@ import './src/deprecated-layers';
 
 // React test cases currently only work in browser
 // import './src/react';
+
+// deck.gl-layers
+import '../src/experimental-layers/test';

--- a/test/node.js
+++ b/test/node.js
@@ -26,6 +26,8 @@ const path = require('path');
 const moduleAlias = require('module-alias');
 moduleAlias.addAlias('deck.gl/test', path.resolve('./test'));
 moduleAlias.addAlias('deck.gl', path.resolve('./src'));
+moduleAlias.addAlias('deck.gl/dist', path.resolve('./src'));
+moduleAlias.addAlias('deck.gl-layers', path.resolve('./src/experimental-layers/src'));
 
 require('babel-polyfill');
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -77,7 +77,9 @@ const TEST_BROWSER_CONFIG = {
   resolve: {
     alias: {
       'deck.gl/test': resolve('./test'),
-      'deck.gl': resolve('./src')
+      'deck.gl/dist': resolve('./src'),
+      'deck.gl': resolve('./src'),
+      'deck.gl-layers': resolve('./src/experimental-layers/src')
     }
   },
 


### PR DESCRIPTION
Per request of https://github.com/uber/deck.gl/pull/1224
- Copy `solid-polygon-layer` to `experimental-layers`
- Add example in layer-browser
- Add benchmark tests
- Include `experimental-layers` test in standard tests