### PR TITLE
OrbitController pure-js support

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -56,6 +56,7 @@ import {default as OrbitViewport} from './viewports/orbit-viewport';
 // Experimental Pure JS (non-React) bindings
 import {default as DeckGLJS} from './pure-js/deck-js';
 import {default as MapControllerJS} from './pure-js/map-controller-js';
+import {default as OrbitControllerJS} from './pure-js/orbit-controller-js';
 
 // Experimental Effects (non-React) bindings
 import {default as EffectManager} from './experimental/lib/effect-manager';
@@ -105,6 +106,7 @@ export const experimental = {
 
   DeckGLJS,
   MapControllerJS,
+  OrbitControllerJS,
 
   EffectManager,
   Effect,

--- a/src/core/pure-js/orbit-controller-js.js
+++ b/src/core/pure-js/orbit-controller-js.js
@@ -1,0 +1,118 @@
+import PropTypes from 'prop-types';
+import OrbitViewport from '../viewports/orbit-viewport';
+import OrbitState from '../controllers/orbit-state';
+import ViewportControls from '../controllers/viewport-controls';
+import {EventManager} from 'mjolnir.js';
+
+const PREFIX = '-webkit-';
+
+const CURSOR = {
+  GRABBING: `${PREFIX}grabbing`,
+  GRAB: `${PREFIX}grab`,
+  POINTER: 'pointer'
+};
+
+const propTypes = {
+  /* Viewport properties */
+  lookAt: PropTypes.arrayOf(PropTypes.number), // target position
+  distance: PropTypes.number, // distance from camera to the target
+  rotationX: PropTypes.number, // rotation around X axis
+  rotationY: PropTypes.number, // rotation around Y axis
+  translationX: PropTypes.number, // translation x in screen space
+  translationY: PropTypes.number, // translation y in screen space
+  zoom: PropTypes.number, // scale in screen space
+  minZoom: PropTypes.number,
+  maxZoom: PropTypes.number,
+  fov: PropTypes.number, // field of view
+  near: PropTypes.number,
+  far: PropTypes.number,
+  width: PropTypes.number.isRequired, // viewport width in pixels
+  height: PropTypes.number.isRequired, // viewport height in pixels
+
+  /* Model properties */
+  bounds: PropTypes.object, // bounds in the shape of {minX, minY, minZ, maxX, maxY, maxZ}
+
+  /* Callbacks */
+  onViewportChange: PropTypes.func.isRequired,
+
+  /** Accessor that returns a cursor style to show interactive state */
+  getCursor: PropTypes.func,
+
+  /* Controls */
+  orbitControls: PropTypes.object
+};
+
+const getDefaultCursor = ({isDragging}) => isDragging ? CURSOR.GRABBING : CURSOR.GRAB;
+
+const defaultProps = {
+  lookAt: [0, 0, 0],
+  rotationX: 0,
+  rotationY: 0,
+  translationX: 0,
+  translationY: 0,
+  distance: 10,
+  zoom: 1,
+  minZoom: 0,
+  maxZoom: Infinity,
+  fov: 50,
+  near: 1,
+  far: 1000,
+  getCursor: getDefaultCursor
+};
+
+/*
+ * Maps mouse interaction to a deck.gl Viewport
+ */
+export default class OrbitControllerJS {
+
+  // Returns a deck.gl Viewport instance, to be used with the DeckGL component
+  static getViewport(viewport) {
+    return new OrbitViewport(viewport);
+  }
+
+  constructor(props) {
+    props = Object.assign({}, defaultProps, props);
+
+    this.props = props;
+
+    this.state = {
+      // Whether the cursor is down
+      isDragging: false
+    };
+
+    this.canvas = props.canvas;
+
+    const eventManager = new EventManager(this.canvas);
+
+    this._eventManager = eventManager;
+
+    this._controls = props.orbitControls || new ViewportControls(OrbitState);
+    this._controls.setOptions(Object.assign({}, this.props, {
+      onStateChange: this._onInteractiveStateChange.bind(this),
+      eventManager
+    }));
+  }
+
+  setProps(props) {
+    props = Object.assign({}, this.props, props);
+    this.props = props;
+
+    this._controls.setOptions(props);
+  }
+
+  finalize() {
+    this._eventManager.destroy();
+  }
+
+  _onInteractiveStateChange({isDragging = false}) {
+    if (isDragging !== this.state.isDragging) {
+      this.state.isDragging = isDragging;
+      const {getCursor} = this.props;
+      this.canvas.style.cursor = getCursor(this.state);
+    }
+  }
+}
+
+OrbitControllerJS.displayName = 'OrbitController';
+OrbitControllerJS.propTypes = propTypes;
+OrbitControllerJS.defaultProps = defaultProps;

--- a/src/react/experimental/orbit-controller.js
+++ b/src/react/experimental/orbit-controller.js
@@ -1,56 +1,8 @@
-import React, {createElement} from 'react';
-import PropTypes from 'prop-types';
+import {PureComponent, createElement} from 'react';
+import OrbitControllerJS from '../../core/pure-js/orbit-controller-js';
 import OrbitViewport from '../../core/viewports/orbit-viewport';
-import OrbitState from '../../core/controllers/orbit-state';
-import ViewportControls from '../../core/controllers/viewport-controls';
-import {EventManager} from 'mjolnir.js';
 
-const propTypes = {
-  /* Viewport properties */
-  lookAt: PropTypes.arrayOf(PropTypes.number), // target position
-  distance: PropTypes.number, // distance from camera to the target
-  rotationX: PropTypes.number, // rotation around X axis
-  rotationY: PropTypes.number, // rotation around Y axis
-  translationX: PropTypes.number, // translation x in screen space
-  translationY: PropTypes.number, // translation y in screen space
-  zoom: PropTypes.number, // scale in screen space
-  minZoom: PropTypes.number,
-  maxZoom: PropTypes.number,
-  fov: PropTypes.number, // field of view
-  near: PropTypes.number,
-  far: PropTypes.number,
-  width: PropTypes.number.isRequired, // viewport width in pixels
-  height: PropTypes.number.isRequired, // viewport height in pixels
-
-  /* Model properties */
-  bounds: PropTypes.object, // bounds in the shape of {minX, minY, minZ, maxX, maxY, maxZ}
-
-  /* Callbacks */
-  onViewportChange: PropTypes.func.isRequired,
-
-  /* Controls */
-  orbitControls: PropTypes.object
-};
-
-const defaultProps = {
-  lookAt: [0, 0, 0],
-  rotationX: 0,
-  rotationY: 0,
-  translationX: 0,
-  translationY: 0,
-  distance: 10,
-  zoom: 1,
-  minZoom: 0,
-  maxZoom: Infinity,
-  fov: 50,
-  near: 1,
-  far: 1000
-};
-
-/*
- * Maps mouse interaction to a deck.gl Viewport
- */
-export default class OrbitController extends React.Component {
+export default class OrbitController extends PureComponent {
 
   // Returns a deck.gl Viewport instance, to be used with the DeckGL component
   static getViewport(viewport) {
@@ -59,48 +11,25 @@ export default class OrbitController extends React.Component {
 
   constructor(props) {
     super(props);
-
-    this.state = {
-      // Whether the cursor is down
-      isDragging: false
-    };
-
-    this._orbitControls = props.orbitControls || new ViewportControls(OrbitState);
+    this.controller = null;
   }
 
   componentDidMount() {
     const {eventCanvas} = this.refs;
-
-    const eventManager = new EventManager(eventCanvas);
-    this._eventManager = eventManager;
-
-    this._orbitControls.setOptions(Object.assign({}, this.props, {
-      onStateChange: this._onInteractiveStateChange.bind(this),
-      eventManager
-    }));
+    this.controller = new OrbitControllerJS(Object.assign({}, this.props, {canvas: eventCanvas}));
   }
 
   componentWillUpdate(nextProps) {
-    this._orbitControls.setOptions(nextProps);
+    this.controller.setProps(nextProps);
   }
 
   componentWillUnmount() {
-    if (this._eventManager) {
-      // Must destroy because hammer adds event listeners to window
-      this._eventManager.destroy();
-    }
-  }
-
-  _onInteractiveStateChange({isDragging = false}) {
-    if (isDragging !== this.state.isDragging) {
-      this.setState({isDragging});
-    }
+    this.controller.finalize();
   }
 
   render() {
     const {width, height} = this.props;
 
-    // Create canvas style with right size
     const eventCanvasStyle = {
       width,
       height,
@@ -109,12 +38,16 @@ export default class OrbitController extends React.Component {
 
     return (
       createElement('div', {
+        key: 'map-controls',
         ref: 'eventCanvas',
         style: eventCanvasStyle
-      }, this.props.children)
+      },
+        this.props.children
+      )
     );
   }
 }
 
-OrbitController.propTypes = propTypes;
-OrbitController.defaultProps = defaultProps;
+OrbitController.displayName = 'OrbitController';
+OrbitController.propTypes = OrbitControllerJS.propTypes;
+OrbitController.defaultProps = OrbitControllerJS.defaultProps;


### PR DESCRIPTION
Pretty much mirrors `MapControllerJS` and `MapController`. There's room for code reuse in follow up refactors.

Tested: node, browser, examples/plot, examples/point-cloud-laz