### PR TITLE
[DISCUSSION] invalid triggerName in attribute-manager.invalidate()

### DIFF
--- a/src/core/lib/attribute-manager.js
+++ b/src/core/lib/attribute-manager.js
@@ -255,13 +255,14 @@ export default class AttributeManager {
         `invalidating non-existent trigger ${triggerName} for ${this.id}\n`;
       message += `Valid triggers: ${Object.keys(attributes).join(', ')}`;
       log.warn(message, invalidatedAttributes);
+    } else {
+      invalidatedAttributes.forEach(name => {
+        const attribute = attributes[name];
+        if (attribute) {
+          attribute.needsUpdate = true;
+        }
+      });
     }
-    invalidatedAttributes.forEach(name => {
-      const attribute = attributes[name];
-      if (attribute) {
-        attribute.needsUpdate = true;
-      }
-    });
     return invalidatedAttributes;
   }
 

--- a/test/src/core/lib/attribute-manager.spec.js
+++ b/test/src/core/lib/attribute-manager.spec.js
@@ -186,11 +186,6 @@ test('AttributeManager.invalidate', t => {
   t.ok(attributeManager.getAttributes()['colors'].needsUpdate,
     'invalidated attribute by accessor name');
 
-  t.throws(
-    () => attributeManager.invalidate('lineWidths'),
-    'throws on unmatched attribute name'
-  );
-
   t.end();
 });
 


### PR DESCRIPTION
I ran into this error that somehow the application is invalidating a triggerName that was not in the updateTriggers, which led to invalidatedAttributes = undefined, and we are calling undefined.forEach afterward.

However, from the test spec it seems we were expecting an exception thrown in this case. Is this by design? 

I would expect the application to continue working if a mismatched triggerName is provided.