### PR TITLE
Remove old Coordinate system props.

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -8,9 +8,9 @@ deck.gl 4.1 requires luma.gl as peer dependency, but 4.2 specifies it as a norma
 
 ### Layer Props
 
-Coordinate system related props have been renamed for clarity. The old props are still available but will generate a deprecation warning.
+Coordinate system related props have been renamed for clarity. The old props are no longer supported and will generate errors when used.
 
-| Layer            | Old Prop           | New Prop             | Comment |
+| Layer            | Removed Prop       | New Prop             | Comment |
 | ---              | ---                | ---                  | ---     |
 | Layer            | `projectionMode`   | `coordinateSystem`   | Any constant from `COORDINATE_SYSTEM`  |
 | Layer            | `projectionOrigin` | `coordinateOrigin`   | |

--- a/src/core/shaderlib/project/viewport-uniforms.js
+++ b/src/core/shaderlib/project/viewport-uniforms.js
@@ -144,12 +144,10 @@ export function getUniformsFromViewport({
   assert(viewport);
 
   if (projectionMode !== undefined) {
-    coordinateSystem = projectionMode;
-    log.deprecated('projectionMode', 'coordinateSystem');
+    log.removed('projectionMode', 'coordinateSystem');
   }
   if (positionOrigin !== undefined) {
-    coordinateOrigin = positionOrigin;
-    log.deprecated('positionOrigin', 'coordinateOrigin');
+    log.removed('positionOrigin', 'coordinateOrigin');
   }
 
   const coordinateZoom = viewport.zoom;

--- a/src/core/utils/log.js
+++ b/src/core/utils/log.js
@@ -57,8 +57,13 @@ function error(arg, ...args) {
 }
 
 function deprecated(oldUsage, newUsage) {
-  log.warn(`deck.gl: \`${oldUsage}\` is deprecated and will be removed \
+  log.warn(`\`${oldUsage}\` is deprecated and will be removed \
 in a later version. Use \`${newUsage}\` instead`);
+}
+
+function removed(oldUsage, newUsage) {
+  log.error(`\`${oldUsage}\` is no longer supported. Use \`${newUsage}\` instead,\
+ check our upgrade-guide.md for more details`);
 }
 
 // Logs a message with a time
@@ -139,6 +144,7 @@ log.timeEnd = timeEnd;
 log.warn = warn;
 log.error = error;
 log.deprecated = deprecated;
+log.removed = removed;
 log.group = group;
 log.groupEnd = groupEnd;
 


### PR DESCRIPTION
- Remove `projectionMode` and `projectionOrigin`, instead setting them to corresponding new props.
- As described in upgrade-guide there is a semantic change (y-direciton flipped) with new props, so remove and generate errors  (instead of warnings) when used.

Tested with `test-browser` and `layer-browser`.