### PR TITLE
Fix polygon normals in meter offset mode

### DIFF
--- a/docs/shader-modules/project.md
+++ b/docs/shader-modules/project.md
@@ -74,6 +74,13 @@ Projects positions (coordinates) to worldspace coordinates. The coordinates are 
 Projects sizes in meters to worldspace offsets. These offsets can be added directly to values returned by `project_position`.
 
 
+### project_normal
+
+`vec3 project_normal(vec3 vector)`
+
+Projects position deltas in the current coordinate system to worldspace normals.
+
+
 ### project_to_clipspace
 
 Projects world space coordinates to clipspace, which can be assigned to `gl_Position` as the "return value" from the vertex shader.

--- a/src/core-layers/solid-polygon-layer/solid-polygon-layer-vertex-64.glsl.js
+++ b/src/core-layers/solid-polygon-layer/solid-polygon-layer-vertex-64.glsl.js
@@ -30,7 +30,6 @@ attribute vec3 pickingColors;
 uniform float extruded;
 uniform float elevationScale;
 uniform float opacity;
-uniform vec3 pixelsPerUnit;
 
 varying vec4 vColor;
 
@@ -57,7 +56,7 @@ void main(void) {
   if (extruded > 0.5) {
     lightWeight = getLightWeight(
       position_worldspace.xyz, // the w component is always 1.0
-      normalize(normals * pixelsPerUnit)
+      normalize(project_scale(normals))
     );
   }
 

--- a/src/core-layers/solid-polygon-layer/solid-polygon-layer-vertex-64.glsl.js
+++ b/src/core-layers/solid-polygon-layer/solid-polygon-layer-vertex-64.glsl.js
@@ -56,7 +56,7 @@ void main(void) {
   if (extruded > 0.5) {
     lightWeight = getLightWeight(
       position_worldspace.xyz, // the w component is always 1.0
-      normalize(project_scale(normals))
+      project_normal(normals)
     );
   }
 

--- a/src/core-layers/solid-polygon-layer/solid-polygon-layer-vertex.glsl.js
+++ b/src/core-layers/solid-polygon-layer/solid-polygon-layer-vertex.glsl.js
@@ -29,7 +29,6 @@ attribute vec3 pickingColors;
 uniform float extruded;
 uniform float elevationScale;
 uniform float opacity;
-uniform vec3 pixelsPerUnit;
 
 varying vec4 vColor;
 
@@ -54,7 +53,7 @@ void main(void) {
     // to the getLightWeight() function
     lightWeight = getLightWeight(
       position_worldspace.xyz,
-      normalize(normals * pixelsPerUnit)
+      normalize(project_scale(normals))
     );
   }
 

--- a/src/core-layers/solid-polygon-layer/solid-polygon-layer-vertex.glsl.js
+++ b/src/core-layers/solid-polygon-layer/solid-polygon-layer-vertex.glsl.js
@@ -53,7 +53,7 @@ void main(void) {
     // to the getLightWeight() function
     lightWeight = getLightWeight(
       position_worldspace.xyz,
-      normalize(project_scale(normals))
+      project_normal(normals)
     );
   }
 

--- a/src/core-layers/solid-polygon-layer/solid-polygon-layer.js
+++ b/src/core-layers/solid-polygon-layer/solid-polygon-layer.js
@@ -106,12 +106,10 @@ export default class SolidPolygonLayer extends Layer {
 
   draw({uniforms}) {
     const {extruded, lightSettings, elevationScale} = this.props;
-    const {viewport} = this.context;
 
     this.state.model.render(Object.assign({}, uniforms, {
       extruded: extruded ? 1.0 : 0.0,
-      elevationScale,
-      pixelsPerUnit: viewport.getDistanceScales().pixelsPerDegree
+      elevationScale
     },
     lightSettings));
   }

--- a/src/core/shaderlib/project/project.glsl.js
+++ b/src/core/shaderlib/project/project.glsl.js
@@ -27,6 +27,7 @@ const float COORDINATE_SYSTEM_METER_OFFSETS = 2.;
 uniform float project_uCoordinateSystem;
 uniform float project_uScale;
 uniform vec3 project_uPixelsPerUnit;
+uniform vec3 project_uPixelsPerDegree;
 uniform vec4 project_uCenter;
 uniform mat4 project_uModelMatrix;
 uniform mat4 project_uViewProjectionMatrix;
@@ -48,6 +49,9 @@ float project_scale(float meters) {
 }
 
 vec2 project_scale(vec2 meters) {
+  if (project_uCoordinateSystem == COORDINATE_SYSTEM_LNG_LAT) {
+    return meters * project_uPixelsPerDegree.xy;
+  }
   return meters * project_uPixelsPerUnit.xy;
 }
 

--- a/src/core/shaderlib/project/project.glsl.js
+++ b/src/core/shaderlib/project/project.glsl.js
@@ -62,13 +62,13 @@ vec4 project_scale(vec4 meters) {
 
 //
 // Projecting normal - transform deltas from current coordinate system to
-// normals in the model space
+// normals in the worldspace
 //
-vec3 project_normal(vec3 normal) {
+vec3 project_normal(vec3 vector) {
   if (project_uCoordinateSystem == COORDINATE_SYSTEM_LNG_LAT) {
-    return normalize(normal * project_uPixelsPerDegree);
+    return normalize(vector * project_uPixelsPerDegree);
   }
-  return normalize(normal * project_uPixelsPerUnit);
+  return normalize(vector * project_uPixelsPerUnit);
 }
 
 //

--- a/src/core/shaderlib/project/project.glsl.js
+++ b/src/core/shaderlib/project/project.glsl.js
@@ -49,9 +49,6 @@ float project_scale(float meters) {
 }
 
 vec2 project_scale(vec2 meters) {
-  if (project_uCoordinateSystem == COORDINATE_SYSTEM_LNG_LAT) {
-    return meters * project_uPixelsPerDegree.xy;
-  }
   return meters * project_uPixelsPerUnit.xy;
 }
 
@@ -61,6 +58,17 @@ vec3 project_scale(vec3 meters) {
 
 vec4 project_scale(vec4 meters) {
   return vec4(project_scale(meters.xyz), meters.w);
+}
+
+//
+// Projecting normal - transform deltas from current coordinate system to
+// normals in the model space
+//
+vec3 project_normal(vec3 normal) {
+  if (project_uCoordinateSystem == COORDINATE_SYSTEM_LNG_LAT) {
+    return normalize(normal * project_uPixelsPerDegree);
+  }
+  return normalize(normal * project_uPixelsPerUnit);
 }
 
 //

--- a/src/core/shaderlib/project/viewport-uniforms.js
+++ b/src/core/shaderlib/project/viewport-uniforms.js
@@ -183,6 +183,7 @@ export function getUniformsFromViewport({
     // Distance at which screen pixels are projected
     project_uFocalDistance: viewport.focalDistance || 1,
     project_uPixelsPerUnit: distanceScales.pixelsPerMeter,
+    project_uPixelsPerDegree: distanceScales.pixelsPerDegree,
     project_uScale: viewport.scale, // This is the mercator scale (2 ** zoom)
 
     project_uModelMatrix: glModelMatrix,


### PR DESCRIPTION
Polygon layer needs to project normals (either lng_lat delta or meters delta depending on the coordinate system) into the world space. The existing code assumes that the layer is always in LNG_LAT mode.