### PR TITLE
Fix test-dist

### DIFF
--- a/test/node-dist.js
+++ b/test/node-dist.js
@@ -26,6 +26,7 @@ const path = require('path');
 const moduleAlias = require('module-alias');
 moduleAlias.addAlias('deck.gl/test', path.resolve('./test'));
 moduleAlias.addAlias('deck.gl', path.resolve('./dist'));
+moduleAlias.addAlias('deck.gl-layers', path.resolve('./src/experimental-layers/src'));
 
 require('babel-polyfill');
 


### PR DESCRIPTION
`publish` scripts are failing as they can't find `deck.gl-layers` module. Do not include these tests in `test-dist`.

Verified running `test-dist`.