### PR TITLE
Fix pickingSelectedColor, fix mesh-layer regression

### DIFF
--- a/dev-docs/RFCs/v5.0/auto-highlighting-rfc.md
+++ b/dev-docs/RFCs/v5.0/auto-highlighting-rfc.md
@@ -34,9 +34,9 @@ Layer props:
 
 1. **pickable** {Boolean, default: false} : Indicates whether deck.gl performs picking [**Existing**]
 
-2. **highlightedObjectIndex** {Int: default: -1} : [**Proposed**] - If set, the object (if any) at that index will be shown as selected. If the value doesn’t point to valid index, no object is selected.
+2. **highlightedObjectIndex** {Int: default: null} : [**Proposed**] - If set, the object (if any) at that index will be shown as selected. If the value doesn’t point to valid index, no object is selected.
 
-3. **autoHighlight** {Boolean, default: false} : [**Proposed**] for now, this is a boolean value, indicating that deck.gl will automatically track the hovered over object. Note: This could be extended in future to specify ‘hover’ , ‘click’ etc events, for different types of tracking. **highlightedObjectIndex** prop takes precedence when both **highlightedObjectIndex** and **autoHighlight** are set to valid values.
+3. **autoHighlight** {Boolean, default: false} : [**Proposed**] for now, this is a boolean value, indicating that deck.gl will automatically track the hovered over object. Note: This could be extended in future to specify ‘hover’ , ‘click’ etc events, for different types of tracking. **highlightedObjectIndex** prop takes precedence when both **highlightedObjectIndex** and **autoHighlight** are set to valid values. To disable **highlightedObjectIndex** set it to `null`.
 
 4. **highlightColor **{vec4: default: transparent light-blue color [0, 0, 128, 128]} : [**Proposed**] - This indicates which color should be used to display the selected object, if any.
 

--- a/src/core/lib/draw-layers.js
+++ b/src/core/lib/draw-layers.js
@@ -288,8 +288,10 @@ function getObjectHighlightParameters(layer) {
 
   // Update picking module settings if highlightedObjectIndex is set.
   // This will overwrite any settings from auto highlighting.
-  if (layer.props.highlightedObjectIndex >= 0) {
-    const pickingSelectedColor = layer.encodePickingColor(layer.props.highlightedObjectIndex);
+  if (Number.isInteger(layer.props.highlightedObjectIndex)) {
+    const pickingSelectedColor = layer.props.highlightedObjectIndex >= 0
+      ? layer.encodePickingColor(layer.props.highlightedObjectIndex)
+      : null;
 
     return {
       pickingSelectedColor

--- a/src/core/lib/layer.js
+++ b/src/core/lib/layer.js
@@ -64,7 +64,7 @@ const defaultProps = {
   getPolygonOffset: ({layerIndex}) => [0, -layerIndex * 100],
 
   // Selection/Highlighting
-  highlightedObjectIndex: -1,
+  highlightedObjectIndex: null,
   autoHighlight: false,
   highlightColor: [0, 0, 128, 128]
 };

--- a/src/experimental-layers/src/mesh-layer/mesh-layer.js
+++ b/src/experimental-layers/src/mesh-layer/mesh-layer.js
@@ -208,9 +208,9 @@ export default class MeshLayer extends Layer {
     let i = 0;
     for (const point of data) {
       const position = getPosition(point);
-      value[i++] = position[0];
-      value[i++] = position[1];
-      value[i++] = position[2] || 0;
+      value[i] = position[0];
+      value[i + 1] = position[1];
+      value[i + 2] = position[2] || 0;
       i += size;
     }
   }


### PR DESCRIPTION
- Fix highlighting when `highlightedObjectIndex` is used, set its default value to `null` which disables the feature. When set to a non null value, corresponding instance will be highlighted. Any invalid index value doesn't highlight any object.
- Fix a regression in `mesh-layer`.

Verified with `layer-browser`.
