### PR TITLE
Examples start script

### DIFF
--- a/examples/3d-heatmap/package.json
+++ b/examples/3d-heatmap/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "start-local": "webpack-dev-server --env.local --progress --hot --port 3030 --open",
-    "start": "webpack-dev-server --progress --hot --port 3030 --open"
+    "start-local": "webpack-dev-server --env.local --progress --hot --open",
+    "start": "webpack-dev-server --progress --hot --open"
   },
   "dependencies": {
     "d3-request": "^1.0.5",

--- a/examples/arc/package.json
+++ b/examples/arc/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "start-local": "webpack-dev-server --env.local --progress --hot --port 3030 --open",
-    "start": "webpack-dev-server --progress --hot --port 3030 --open"
+    "start-local": "webpack-dev-server --env.local --progress --hot --open",
+    "start": "webpack-dev-server --progress --hot --open"
   },
   "dependencies": {
     "d3-request": "^1.0.5",

--- a/examples/experimental/js/with-mapbox-map/package.json
+++ b/examples/experimental/js/with-mapbox-map/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "start-local": "webpack-dev-server --env.local --progress --hot --port 3030 --open",
-    "start": "webpack-dev-server --progress --hot --port 3030 --open",
+    "start-local": "webpack-dev-server --env.local --progress --hot --open",
+    "start": "webpack-dev-server --progress --hot --open",
     "build": "NODE_ENV=production webpack --env.prod=true"
   },
   "dependencies": {

--- a/examples/experimental/viewport-transitions/package.json
+++ b/examples/experimental/viewport-transitions/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "start-local": "webpack-dev-server --env.local --progress --hot --port 3030 --open",
-    "start": "webpack-dev-server --progress --hot --port 3030 --open"
+    "start-local": "webpack-dev-server --env.local --progress --hot --open",
+    "start": "webpack-dev-server --progress --hot --open"
   },
   "dependencies": {
     "d3-request": "^1.0.5",

--- a/examples/geojson/package.json
+++ b/examples/geojson/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "start-local": "webpack-dev-server --env.local --progress --hot --port 3030 --open",
-    "start": "webpack-dev-server --progress --hot --port 3030 --open"
+    "start-local": "webpack-dev-server --env.local --progress --hot --open",
+    "start": "webpack-dev-server --progress --hot --open"
   },
   "dependencies": {
     "d3-request": "^1.0.5",

--- a/examples/graph/package.json
+++ b/examples/graph/package.json
@@ -1,7 +1,11 @@
 {
   "scripts": {
     "start-local": "webpack-dev-server --env.local --progress --hot --port 3030 --open",
-    "start": "webpack-dev-server --progress --hot --port 3030 --open"
+    "start": "webpack-dev-server --progress --hot --port 3030 --open",
+    "build-clean": "rm -rf dist && mkdir dist",
+    "build-copy": "cp index.html dist",
+    "build-script": "NODE_ENV=production webpack --env.prod=true",
+    "build": "npm run build-clean && npm run build-script && npm run build-copy"
   },
   "dependencies": {
     "d3-array": "^1.1.1",

--- a/examples/graph/package.json
+++ b/examples/graph/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "start-local": "webpack-dev-server --env.local --progress --hot --port 3030 --open",
-    "start": "webpack-dev-server --progress --hot --port 3030 --open",
+    "start-local": "webpack-dev-server --env.local --progress --hot --open",
+    "start": "webpack-dev-server --progress --hot --open",
     "build-clean": "rm -rf dist && mkdir dist",
     "build-copy": "cp index.html dist",
     "build-script": "NODE_ENV=production webpack --env.prod=true",

--- a/examples/graph/webpack.config.js
+++ b/examples/graph/webpack.config.js
@@ -10,6 +10,10 @@ const CONFIG = {
   },
 
   devtool: 'source-map',
+  output: {
+    path: resolve('./dist'),
+    filename: 'bundle.js'
+  },
 
   module: {
     rules: [

--- a/examples/icon/package.json
+++ b/examples/icon/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "start-local": "webpack-dev-server --env.local --progress --hot --port 3030 --open",
-    "start": "webpack-dev-server --progress --hot --port 3030 --open"
+    "start-local": "webpack-dev-server --env.local --progress --hot --open",
+    "start": "webpack-dev-server --progress --hot --open"
   },
   "dependencies": {
     "d3-request": "^1.0.5",

--- a/examples/line/package.json
+++ b/examples/line/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "start-local": "webpack-dev-server --env.local --progress --hot --port 3030 --open",
-    "start": "webpack-dev-server --progress --hot --port 3030 --open"
+    "start-local": "webpack-dev-server --env.local --progress --hot --open",
+    "start": "webpack-dev-server --progress --hot --open"
   },
   "dependencies": {
     "d3-request": "^1.0.5",

--- a/examples/plot/plot-layer/axes-layer.js
+++ b/examples/plot/plot-layer/axes-layer.js
@@ -105,12 +105,14 @@ export default class AxesLayer extends Layer {
     });
 
     this.setState(
-      Object.assign({
+      Object.assign(
+        {
           numInstances: 0,
           labels: null
         },
         this._getModels(gl)
-      ));
+      )
+    );
   }
 
   updateState({oldProps, props, changeFlags}) {

--- a/examples/point-cloud-ply/package.json
+++ b/examples/point-cloud-ply/package.json
@@ -4,7 +4,11 @@
   "license": "MIT",
   "scripts": {
     "start": "webpack-dev-server --progress --hot --open",
-    "start-local": "webpack-dev-server --env.local --progress --hot --open"
+    "start-local": "webpack-dev-server --env.local --progress --hot --open",
+    "build-clean": "rm -rf dist && mkdir dist",
+    "build-copy": "cp index.html dist",
+    "build-script": "NODE_ENV=production webpack --env.prod=true",
+    "build": "npm run build-clean && npm run build-script && npm run build-copy"
   },
   "dependencies": {
     "deck.gl": "5.0.0-beta.2",

--- a/examples/point-cloud-ply/webpack.config.js
+++ b/examples/point-cloud-ply/webpack.config.js
@@ -6,6 +6,10 @@ const CONFIG = {
     app: resolve('./app.js')
   },
   devtool: 'source-maps',
+  output: {
+    path: resolve('./dist'),
+    filename: 'bundle.js'
+  },
   module: {
     rules: [
       {

--- a/examples/react/hello-world-webpack2/package.json
+++ b/examples/react/hello-world-webpack2/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "start-local": "webpack-dev-server --env.local --progress --hot --port 3000 --open",
-    "start": "webpack-dev-server --progress --hot --port 3000 --open"
+    "start-local": "webpack-dev-server --env.local --progress --hot --open",
+    "start": "webpack-dev-server --progress --hot --open"
   },
   "dependencies": {
     "deck.gl": "^4.1.0",

--- a/examples/react/jsx-layers/package.json
+++ b/examples/react/jsx-layers/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "start-local": "webpack-dev-server --env.local --progress --hot --port 3000 --open",
-    "start": "webpack-dev-server --progress --hot --port 3000 --open"
+    "start-local": "webpack-dev-server --env.local --progress --hot --open",
+    "start": "webpack-dev-server --progress --hot --open"
   },
   "dependencies": {
     "deck.gl": "^4.1.0",

--- a/examples/scatterplot/package.json
+++ b/examples/scatterplot/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "start-local": "webpack-dev-server --env.local --progress --hot --port 3030 --open",
-    "start": "webpack-dev-server --progress --hot --port 3030 --open"
+    "start-local": "webpack-dev-server --env.local --progress --hot --open",
+    "start": "webpack-dev-server --progress --hot --open"
   },
   "dependencies": {
     "d3-request": "^1.0.5",

--- a/examples/screen-grid/package.json
+++ b/examples/screen-grid/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "start-local": "webpack-dev-server --env.local --progress --hot --port 3030 --open",
-    "start": "webpack-dev-server --progress --hot --port 3030 --open"
+    "start-local": "webpack-dev-server --env.local --progress --hot --open",
+    "start": "webpack-dev-server --progress --hot --open"
   },
   "dependencies": {
     "d3-request": "^1.0.5",

--- a/examples/svg-interoperability/package.json
+++ b/examples/svg-interoperability/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "license": "MIT",
   "scripts": {
-    "start": "webpack-dev-server --progress --hot --port 3000 --open",
+    "start": "webpack-dev-server --progress --hot --open",
     "start-local": "webpack-dev-server --env.local --progress --hot --open",
     "build-clean": "rm -rf dist && mkdir dist",
     "build-copy": "cp index.html dist",

--- a/examples/svg-interoperability/package.json
+++ b/examples/svg-interoperability/package.json
@@ -4,7 +4,11 @@
   "license": "MIT",
   "scripts": {
     "start": "webpack-dev-server --progress --hot --port 3000 --open",
-    "start-local": "webpack-dev-server --env.local --progress --hot --open"
+    "start-local": "webpack-dev-server --env.local --progress --hot --open",
+    "build-clean": "rm -rf dist && mkdir dist",
+    "build-copy": "cp index.html dist",
+    "build-script": "NODE_ENV=production webpack --env.prod=true",
+    "build": "npm run build-clean && npm run build-script && npm run build-copy"
   },
   "dependencies": {
     "deck.gl": "5.0.0-beta.2",

--- a/examples/svg-interoperability/webpack.config.js
+++ b/examples/svg-interoperability/webpack.config.js
@@ -10,6 +10,10 @@ const CONFIG = {
     app: resolve('./app.js')
   },
   devtool: 'source-maps',
+  output: {
+    path: resolve('./dist'),
+    filename: 'bundle.js'
+  },
   module: {
     rules: [
       {

--- a/examples/tagmap/package.json
+++ b/examples/tagmap/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "start-local": "webpack-dev-server --env.local --progress --hot --port 3030 --open",
-    "start": "webpack-dev-server --progress --hot --port 3030 --open",
+    "start-local": "webpack-dev-server --env.local --progress --hot --open",
+    "start": "webpack-dev-server --progress --hot --open",
     "build": "NODE_ENV=production webpack --env.prod=true"
   },
   "dependencies": {

--- a/examples/test/tree-shaking/package.json
+++ b/examples/test/tree-shaking/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "start": "webpack-dev-server --progress --hot --port 3000 --open",
+    "start": "webpack-dev-server --progress --hot --open",
     "build": "NODE_ENV=production webpack --env.prod=true --display-modules | awk '{print $3$4\"  \"$2}' | grep -v bytes | sort -n -r | head -50",
     "analyze": "NODE_ENV=production webpack --env.prod=true --json | webpack-bundle-size-analyzer"
   },

--- a/examples/text-layer/package.json
+++ b/examples/text-layer/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "start-local": "webpack-dev-server --env.local --progress --hot --port 3030 --open",
-    "start": "webpack-dev-server --progress --hot --port 3030 --open",
+    "start-local": "webpack-dev-server --env.local --progress --hot --open",
+    "start": "webpack-dev-server --progress --hot --open",
     "build": "NODE_ENV=production webpack --env.prod=true"
   },
   "dependencies": {

--- a/examples/trips/package.json
+++ b/examples/trips/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "start-local": "webpack-dev-server --env.local --progress --hot --port 3030 --open",
-    "start": "webpack-dev-server --progress --hot --port 3030 --open"
+    "start-local": "webpack-dev-server --env.local --progress --hot --open",
+    "start": "webpack-dev-server --progress --hot --open"
   },
   "dependencies": {
     "d3-request": "^1.0.5",


### PR DESCRIPTION
- Fix `plot` example to work when using `npm run start`, `state.models` is iterated using `for .. of` iterator so it should be an array , not a object. 
- Fix build script in few examples.

Verified running `plot` and `point-cloud-laz` example