### PR TITLE
More precise offset projection

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "mjolnir.js": ">=0.1.0",
     "prop-types": "^15.6.0",
     "seer": "^0.2.3",
-    "viewport-mercator-project": "^5.0.0-alpha.1"
+    "viewport-mercator-project": "^5.0.0-alpha.2"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",

--- a/src/core/shaderlib/check-legacy-uniforms.js
+++ b/src/core/shaderlib/check-legacy-uniforms.js
@@ -13,7 +13,7 @@ const legacyUniforms = [
   {old: 'mat4 modelMatrix', new: 'project_uModelMatrix'},
   {old: 'mat4 viewMatrix'},
   {old: 'mat4 projectionMatrix', new: 'project_uViewProjectionMatrix'},
-  {old: 'vec3 projectionPixelsPerUnit', new: 'project_uPixelsPerUnit'},
+  {old: 'vec3 projectionPixelsPerUnit', new: 'project_uPixelsPerMeter'},
   {old: 'float projectionScale', new: 'project_uScale'},
   {old: 'vec2 viewportSize', new: 'project_uViewportSize'},
   {old: 'float devicePixelRatio', new: 'project_uDevicePixelRatio'},

--- a/src/core/shaderlib/project/project.glsl.js
+++ b/src/core/shaderlib/project/project.glsl.js
@@ -75,7 +75,7 @@ vec3 project_normal(vec3 vector) {
   return normalize(vector * project_uPixelsPerMeter);
 }
 
-vec4 project_offset(vec4 offset) {
+vec4 project_offset_(vec4 offset) {
   vec3 pixelsPerUnit = project_uPixelsPerUnit + project_uPixelsPerUnit2 * offset.y;
   return vec4(offset.xyz * pixelsPerUnit, offset.w);
 }
@@ -104,13 +104,13 @@ vec4 project_position(vec4 position) {
   }
 
   if (project_uCoordinateSystem == COORDINATE_SYSTEM_LNGLAT_OFFSETS) {
-    return project_offset(position);
+    return project_offset_(position);
   }
 
   // METER_OFFSETS or IDENTITY
   // Apply model matrix
   vec4 position_modelspace = project_uModelMatrix * position;
-  return project_offset(position_modelspace);
+  return project_offset_(position_modelspace);
 }
 
 vec3 project_position(vec3 position) {

--- a/src/core/viewports/viewport.js
+++ b/src/core/viewports/viewport.js
@@ -303,7 +303,15 @@ export default class Viewport {
     return false;
   }
 
-  getDistanceScales() {
+  getDistanceScales(coordinateOrigin) {
+    if (coordinateOrigin) {
+      return getDistanceScales({
+        longitude: coordinateOrigin[0],
+        latitude: coordinateOrigin[1],
+        scale: this.scale,
+        highPrecision: true
+      });
+    }
     return this.distanceScales;
   }
 

--- a/src/core/viewports/viewport.js
+++ b/src/core/viewports/viewport.js
@@ -303,7 +303,7 @@ export default class Viewport {
     return false;
   }
 
-  getDistanceScales(coordinateOrigin) {
+  getDistanceScales(coordinateOrigin = null) {
     if (coordinateOrigin) {
       return getDistanceScales({
         longitude: coordinateOrigin[0],


### PR DESCRIPTION
Use new scaling factors from https://github.com/uber-common/viewport-mercator-project/blob/master/docs/get-started/offset-accuracy.md

Test data - 60km x 60km grid centered at SF
![precision-00](https://user-images.githubusercontent.com/2059298/34234929-222998fe-e5a3-11e7-8f90-d58cbcdd850a.jpg)

- grey - fp64 LNGLAT mode
- red - METER_OFFSETS mode
- blue - LNGLAT_OFFSETS mode

zoom=13, before: 
![precision-01](https://user-images.githubusercontent.com/2059298/34234940-2c675cb6-e5a3-11e7-9a95-5c7a408246d4.jpg)

After:
![precision-02](https://user-images.githubusercontent.com/2059298/34234947-34af494c-e5a3-11e7-83b8-34c291736110.jpg)
