### PR TITLE
Fix double model generation

### DIFF
--- a/src/core-layers/arc-layer/arc-layer.js
+++ b/src/core-layers/arc-layer/arc-layer.js
@@ -47,9 +47,6 @@ export default class ArcLayer extends Layer {
   }
 
   initializeState() {
-    const {gl} = this.context;
-    this.setState({model: this._getModel(gl)});
-
     const {attributeManager} = this.state;
 
     /* eslint-disable max-len */

--- a/src/core-layers/grid-cell-layer/grid-cell-layer.js
+++ b/src/core-layers/grid-cell-layer/grid-cell-layer.js
@@ -71,9 +71,6 @@ export default class GridCellLayer extends Layer {
   }
 
   initializeState() {
-    const {gl} = this.context;
-    this.setState({model: this._getModel(gl)});
-
     const {attributeManager} = this.state;
     /* eslint-disable max-len */
     attributeManager.addInstanced({

--- a/src/core-layers/hexagon-cell-layer/hexagon-cell-layer.js
+++ b/src/core-layers/hexagon-cell-layer/hexagon-cell-layer.js
@@ -90,8 +90,6 @@ export default class HexagonCellLayer extends Layer {
    * Essentially a deferred constructor
    */
   initializeState() {
-    const {gl} = this.context;
-    this.setState({model: this._getModel(gl)});
     const {attributeManager} = this.state;
     /* eslint-disable max-len */
     attributeManager.addInstanced({

--- a/src/core-layers/icon-layer/icon-layer.js
+++ b/src/core-layers/icon-layer/icon-layer.js
@@ -75,7 +75,6 @@ export default class IconLayer extends Layer {
 
   initializeState() {
     const {attributeManager} = this.state;
-    const {gl} = this.context;
 
     /* eslint-disable max-len */
     attributeManager.addInstanced({
@@ -102,8 +101,6 @@ export default class IconLayer extends Layer {
       instanceAngles: {size: 1, accessor: 'getAngle', update: this.calculateInstanceAngles}
     });
     /* eslint-enable max-len */
-
-    this.setState({model: this._getModel(gl)});
   }
 
   updateAttribute({props, oldProps, changeFlags}) {

--- a/src/core-layers/line-layer/line-layer.js
+++ b/src/core-layers/line-layer/line-layer.js
@@ -45,9 +45,6 @@ export default class LineLayer extends Layer {
   }
 
   initializeState() {
-    const {gl} = this.context;
-    this.setState({model: this._getModel(gl)});
-
     const {attributeManager} = this.state;
 
     /* eslint-disable max-len */

--- a/src/core-layers/path-layer/path-layer.js
+++ b/src/core-layers/path-layer/path-layer.js
@@ -61,9 +61,6 @@ export default class PathLayer extends Layer {
   }
 
   initializeState() {
-    const {gl} = this.context;
-    this.setState({model: this._getModel(gl)});
-
     const {attributeManager} = this.state;
     /* eslint-disable max-len */
     attributeManager.addInstanced({

--- a/src/core-layers/point-cloud-layer/point-cloud-layer.js
+++ b/src/core-layers/point-cloud-layer/point-cloud-layer.js
@@ -55,9 +55,6 @@ export default class PointCloudLayer extends Layer {
   }
 
   initializeState() {
-    const {gl} = this.context;
-    this.setState({model: this._getModel(gl)});
-
     /* eslint-disable max-len */
     this.state.attributeManager.addInstanced({
       instancePositions: {

--- a/src/core-layers/scatterplot-layer/scatterplot-layer.js
+++ b/src/core-layers/scatterplot-layer/scatterplot-layer.js
@@ -50,9 +50,6 @@ export default class ScatterplotLayer extends Layer {
   }
 
   initializeState() {
-    const {gl} = this.context;
-    this.setState({model: this._getModel(gl)});
-
     /* eslint-disable max-len */
     this.state.attributeManager.addInstanced({
       instancePositions: {

--- a/src/core-layers/solid-polygon-layer/solid-polygon-layer.js
+++ b/src/core-layers/solid-polygon-layer/solid-polygon-layer.js
@@ -69,7 +69,6 @@ export default class SolidPolygonLayer extends Layer {
   initializeState() {
     const {gl} = this.context;
     this.setState({
-      model: this._getModel(gl),
       numInstances: 0,
       IndexType: gl.getExtension('OES_element_index_uint') ? Uint32Array : Uint16Array
     });

--- a/src/core/lib/layer.js
+++ b/src/core/lib/layer.js
@@ -403,7 +403,7 @@ export default class Layer {
     // Call subclass lifecycle methods
     this.initializeState(this.context);
     // End subclass lifecycle methods
-    this._checkLegacyUniforms();
+    // this._checkLegacyUniforms();
 
     // initializeState callback tends to clear state
     this.setChangeFlags({dataChanged: true, propsChanged: true, viewportChanged: true});

--- a/src/experimental-layers/src/mesh-layer/mesh-layer.js
+++ b/src/experimental-layers/src/mesh-layer/mesh-layer.js
@@ -101,9 +101,6 @@ export default class MeshLayer extends Layer {
   }
 
   initializeState() {
-    const {gl} = this.context;
-    this.setState({model: this.getModel(gl)});
-
     const {attributeManager} = this.state;
     attributeManager.addInstanced({
       instancePositions: {

--- a/src/experimental-layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/src/experimental-layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -131,15 +131,10 @@ export default class SolidPolygonLayer extends Layer {
 
   initializeState() {
     const {gl} = this.context;
-    this.setState(
-      Object.assign(
-        {
-          numInstances: 0,
-          IndexType: gl.getExtension('OES_element_index_uint') ? Uint32Array : Uint16Array
-        },
-        this._getModels(gl)
-      )
-    );
+    this.setState({
+      numInstances: 0,
+      IndexType: gl.getExtension('OES_element_index_uint') ? Uint32Array : Uint16Array
+    });
 
     const {attributeManager} = this.state;
     const noAlloc = true;


### PR DESCRIPTION
In core layers, we call `_getModel` in `initializeState`, then immediately again in `updateState` because `props.fp64 !== oldProps.fp64` (oldProps is empty at initialization).