### PR TITLE
Remove lint and React warnings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,7 +11,8 @@
   "rules": {
     "guard-for-in": 0,
     "no-inline-comments": 0,
-    "camelcase": 0
+    "camelcase": 0,
+    "react/forbid-prop-types": 0
   }
 }
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,7 +4,7 @@ Interested in what is coming down the road? We are trying to make the deck.gl ro
 
 We currently are using four ways to share information about the direction of deck.gl.
 * **Roadmap Document** - (this document) A high-level summary of our current direction for future releases.
-* **RFCs** - We are now publishing our RFCs (Requests For Comments) for features in upcoming releases. RFCs are technical writeups that describe a proposed feature. RFCs are vailable [here](https://github.com/uber/deck.gl/tree/master/dev-docs/RFCs).
+* **RFCs** - We are now publishing our RFCs (Requests For Comments) for features in upcoming releases. RFCs are technical writeups that describe a proposed feature. RFCs are available [here](https://github.com/uber/deck.gl/tree/master/dev-docs/RFCs).
 * **Experimental exports** - We are making unfinished features available as experimental exports. This gives users a clear indication about what is coming and even allow early adopters a chance to play with and provide comments on these features.
 * **Blog** - We will of course continue to use the [vis.gl](vis.gl) blog to share information about what we are doing.
 

--- a/src/react/viewport-controller.js
+++ b/src/react/viewport-controller.js
@@ -1,4 +1,4 @@
-import {PureComponent, createElement} from 'react';
+import {Component, createElement} from 'react';
 import PropTypes from 'prop-types';
 
 import {EventManager} from 'mjolnir.js';
@@ -101,7 +101,7 @@ const defaultProps = Object.assign({}, TransitionManager.defaultProps, {
   getCursor: getDefaultCursor
 });
 
-export default class ViewportController extends PureComponent {
+export default class ViewportController extends Component {
   constructor(props) {
     super(props);
 


### PR DESCRIPTION
* Disable react linter warnings for `PropTypes.array` - type checking each element in arrays is too expensive.
* Remove React warning:
<img width="554" alt="screen shot 2017-12-22 at 2 15 35 pm" src="https://user-images.githubusercontent.com/7025232/34313795-c1fa7922-e722-11e7-81c0-d3046249faba.png">


