### PR TITLE
file read/write methods for Browser and Node

### DIFF
--- a/src/test-utils/luma.gl/io-basic/README.md
+++ b/src/test-utils/luma.gl/io-basic/README.md
@@ -1,0 +1,11 @@
+# luma.gl IO module
+
+This luma submodule contains basic IO functions for browser and node. that can be implemented without dependencies.
+
+## Remarks
+
+* The node.js implementation uses stackgl modules for DOM-less reading and writing of images (`get-pixels`, `save-pixels`, `ndarray` etc).
+* These Node.js dependencies are quite large so great care is taken not to add these to the application bundle. They are loaded dynamically using `module.require` (typically from `node_modules`), to avoid bundling them in browser bundles. If the application doesn't find the required modules at run-time, it will throw an exception.
+
+TBD:
+* These are not dependencies of luma.gl. They need to be installed by the app.

--- a/src/test-utils/luma.gl/io-basic/browser-compress-image.js
+++ b/src/test-utils/luma.gl/io-basic/browser-compress-image.js
@@ -1,0 +1,31 @@
+// Image loading/saving for browser
+/* global document, HTMLCanvasElement, Image */
+/* global Buffer */
+import assert from 'assert';
+
+/*
+ * Returns data bytes representing a compressed image in PNG or JPG format,
+ * This data can be saved using file system (f) methods or
+ * used in a request.
+ * @param {Image}  image - Image or Canvas
+ * @param {String} opt.type='png' - png, jpg or image/png, image/jpg are valid
+ * @param {String} opt.dataURI= - Whether to include a data URI header
+ */
+export function compressImage(image, type) {
+  if (image instanceof HTMLCanvasElement) {
+    const canvas = image;
+    return canvas.toDataURL(type);
+  }
+
+  assert(image instanceof Image, 'getImageData accepts image or canvas');
+  const canvas = document.createElement('canvas');
+  canvas.width = image.width;
+  canvas.height = image.height;
+  canvas.getContext('2d').drawImage(image, 0, 0);
+
+  // Get raw image data
+  const data = canvas.toDataURL(type || 'png').replace(/^data:image\/(png|jpg);base64,/, '');
+
+  // Dump data into stream and return
+  return new Buffer(data, 'base64');
+}

--- a/src/test-utils/luma.gl/io-basic/browser-read-file.js
+++ b/src/test-utils/luma.gl/io-basic/browser-read-file.js
@@ -1,0 +1,69 @@
+// A browser implementation of the Node.js `fs.readFile` method
+
+import assert from 'assert';
+
+const window = require('global/window');
+const File = window.File;
+
+/**
+ * File reader function for the browser, intentionally similar
+ * to node's fs.readFile API, however returns a Promise rather than
+ * callbacks
+ *
+ * @param {File|Blob} file  HTML File or Blob object to read as string
+ * @returns {Promise.string}  Resolves to a string containing file contents
+ */
+export function readFile(file) {
+  return new Promise((resolve, reject) => {
+    try {
+      assert(File, 'window.File not defined. Must run under browser.');
+      assert(file instanceof File, 'parameter must be a File object');
+
+      const reader = new window.FileReader();
+
+      reader.onerror = e => reject(new Error(getFileErrorMessage(e)));
+      reader.onabort = () => reject(new Error('Read operation was aborted.'));
+      reader.onload = () => resolve(reader.result);
+
+      reader.readAsText(file);
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+// NOTES ON ERROR HANDLING
+//
+// Prepared to externalize error message texts
+//
+// The weird thing about the FileReader API is that the error definitions
+// are only available on the error event instance that is passed to the
+// handler. Thus we need to create definitions that are avialble outside
+// the handler.
+//
+// https://developer.mozilla.org/en-US/docs/Web/API/FileReader
+//
+// Side Note: To complicate matters, there are also a DOMError string set on
+// filereader object (error property). Not clear how or if these map
+// to the event error codes. These strings are not currently used by this api.
+//
+// https://developer.mozilla.org/en-US/docs/Web/API/DOMError
+
+function getFileErrorMessage(e) {
+  // Map event's error codes to static error codes so that we can
+  // externalize error code to error message mapping
+  switch (e.target.error.code) {
+    case e.target.error.NOT_FOUND_ERR:
+      return 'File not found';
+    case e.target.error.NOT_READABLE_ERR:
+      return 'File not readable';
+    case e.target.error.ABORT_ERR:
+      return 'Aborted';
+    case e.target.error.SECURITY_ERR:
+      return 'File locked';
+    case e.target.error.ENCODING_ERR:
+      return 'File too long';
+    default:
+      return 'Read error';
+  }
+}

--- a/src/test-utils/luma.gl/io-basic/browser-request-file.js
+++ b/src/test-utils/luma.gl/io-basic/browser-request-file.js
@@ -1,0 +1,121 @@
+import {getPathPrefix} from './path-prefix';
+
+export function loadFile(url, opts) {
+  if (typeof url !== 'string' && !opts) {
+    // TODO - warn for deprecated mode
+    opts = url;
+    url = opts.url;
+  }
+  const pathPrefix = getPathPrefix();
+  opts.url = pathPrefix ? pathPrefix + url : url;
+  return requestFile(opts);
+}
+
+// Supports loading (requesting) assets with XHR (XmlHttpRequest)
+/* eslint-disable guard-for-in, complexity, no-try-catch */
+
+/* global XMLHttpRequest */
+function noop() {}
+
+const XHR_STATES = {
+  UNINITIALIZED: 0,
+  LOADING: 1,
+  LOADED: 2,
+  INTERACTIVE: 3,
+  COMPLETED: 4
+};
+
+class XHR {
+  constructor({
+    url,
+    path = null,
+    method = 'GET',
+    asynchronous = true,
+    noCache = false,
+    // body = null,
+    sendAsBinary = false,
+    responseType = false,
+    onProgress = noop,
+    onError = noop,
+    onAbort = noop,
+    onComplete = noop
+  }) {
+    this.url = path ? path.join(path, url) : url;
+    this.method = method;
+    this.async = asynchronous;
+    this.noCache = noCache;
+    this.sendAsBinary = sendAsBinary;
+    this.responseType = responseType;
+
+    this.req = new XMLHttpRequest();
+
+    this.req.onload = e => onComplete(e);
+    this.req.onerror = e => onError(e);
+    this.req.onabort = e => onAbort(e);
+    this.req.onprogress = e => {
+      if (e.lengthComputable) {
+        onProgress(e, Math.round(e.loaded / e.total * 100));
+      } else {
+        onProgress(e, -1);
+      }
+    };
+  }
+
+  setRequestHeader(header, value) {
+    this.req.setRequestHeader(header, value);
+    return this;
+  }
+
+  // /* eslint-disable max-statements */
+  sendAsync(body = this.body || null) {
+    return new Promise((resolve, reject) => {
+      try {
+        const {req, method, noCache, sendAsBinary, responseType} = this;
+
+        const url = noCache
+          ? this.url + (this.url.indexOf('?') >= 0 ? '&' : '?') + Date.now()
+          : this.url;
+
+        req.open(method, url, this.async);
+
+        if (responseType) {
+          req.responseType = responseType;
+        }
+
+        if (this.async) {
+          req.onreadystatechange = e => {
+            if (req.readyState === XHR_STATES.COMPLETED) {
+              if (req.status === 200) {
+                resolve(req.responseType ? req.response : req.responseText);
+              } else {
+                reject(new Error(`${req.status}: ${url}`));
+              }
+            }
+          };
+        }
+
+        if (sendAsBinary) {
+          req.sendAsBinary(body);
+        } else {
+          req.send(body);
+        }
+
+        if (!this.async) {
+          if (req.status === 200) {
+            resolve(req.responseType ? req.response : req.responseText);
+          } else {
+            reject(new Error(`${req.status}: ${url}`));
+          }
+        }
+      } catch (error) {
+        reject(error);
+      }
+    });
+  }
+  /* eslint-enable max-statements */
+}
+
+export function requestFile(opts) {
+  const xhr = new XHR(opts);
+  return xhr.sendAsync();
+}

--- a/src/test-utils/luma.gl/io-basic/browser-request-image.js
+++ b/src/test-utils/luma.gl/io-basic/browser-request-image.js
@@ -1,0 +1,24 @@
+import {getPathPrefix} from './path-prefix';
+/* global Image */
+
+/*
+ * Loads images asynchronously
+ * image.crossOrigin can be set via opts.crossOrigin, default to 'anonymous'
+ * returns a promise tracking the load
+ */
+export function loadImage(url, opts) {
+  const pathPrefix = getPathPrefix();
+  url = pathPrefix ? pathPrefix + url : url;
+
+  return new Promise((resolve, reject) => {
+    try {
+      const image = new Image();
+      image.onload = () => resolve(image);
+      image.onerror = () => reject(new Error(`Could not load image ${url}.`));
+      image.crossOrigin = (opts && opts.crossOrigin) || 'anonymous';
+      image.src = url;
+    } catch (error) {
+      reject(error);
+    }
+  });
+}

--- a/src/test-utils/luma.gl/io-basic/index.js
+++ b/src/test-utils/luma.gl/io-basic/index.js
@@ -1,0 +1,17 @@
+import {isBrowser} from '../utils/globals';
+export {setPathPrefix} from './set-path-prefix';
+
+// Call a require based helper to select platform to export
+if (isBrowser) {
+  module.exports.loadFile = require('browser-request-file');
+  module.exports.loadImage = require('browser-request-image');
+  module.exports.readFile = require('browser-read-file');
+} else {
+  const fs = module.require('fs');
+  // TODO - needs to be promisified...
+  module.exports.readFile = fs && fs.readFile;
+}
+
+export {loadFiles, loadImages} from './load-files';
+export {loadTextures, loadProgram} from './load-textures';
+export {loadModel, parseModel} from './json-loader';

--- a/src/test-utils/luma.gl/io-basic/json-loader.js
+++ b/src/test-utils/luma.gl/io-basic/json-loader.js
@@ -1,0 +1,39 @@
+import {loadFile} from './browser-load-file';
+import {Program} from '../webgl';
+import {Model} from '../core';
+import {Geometry} from '../geometry';
+
+// Loads a simple JSON format
+export function loadModel(gl, opts = {}) {
+  return loadFile(opts).then(([file]) => parseModel(gl, Object.assign({file}, opts)));
+}
+
+export function parseModel(gl, opts = {}) {
+  const {file, program = new Program(gl)} = opts;
+  const json = typeof file === 'string' ? parseJSON(file) : file;
+  // Remove any attributes so that we can create a geometry
+  // TODO - change format to put these in geometry sub object?
+  const attributes = {};
+  const modelOptions = {};
+  for (const key in json) {
+    const value = json[key];
+    if (Array.isArray(value)) {
+      attributes[key] = key === 'indices' ? new Uint16Array(value) : new Float32Array(value);
+    } else {
+      modelOptions[key] = value;
+    }
+  }
+
+  return new Model(
+    gl,
+    Object.assign({program, geometry: new Geometry({attributes})}, modelOptions, opts)
+  );
+}
+
+function parseJSON(file) {
+  try {
+    return JSON.parse(file);
+  } catch (error) {
+    throw new Error(`Failed to parse JSON: ${error}`);
+  }
+}

--- a/src/test-utils/luma.gl/io-basic/load-files.js
+++ b/src/test-utils/luma.gl/io-basic/load-files.js
@@ -1,0 +1,52 @@
+/* eslint-disable guard-for-in, complexity, no-try-catch */
+import assert from 'assert';
+import {loadFile} from './browser-load-file';
+import {loadImage} from './browser-load-image';
+
+function noop() {}
+
+/*
+ * Loads (Requests) multiple files asynchronously
+ */
+export function loadFiles(opts = {}) {
+  const {urls, onProgress = noop} = opts;
+  assert(urls.every(url => typeof url === 'string'), 'loadImages: {urls} must be array of strings');
+  let count = 0;
+  return Promise.all(
+    urls.map(url => {
+      const promise = loadFile(Object.assign({url}, opts));
+      promise.then(file =>
+        onProgress({
+          progress: ++count / urls.length,
+          count,
+          total: urls.length,
+          url
+        })
+      );
+      return promise;
+    })
+  );
+}
+
+/*
+ * Loads (requests) multiple images asynchronously
+ */
+export function loadImages(opts = {}) {
+  const {urls, onProgress = noop} = opts;
+  assert(urls.every(url => typeof url === 'string'), 'loadImages: {urls} must be array of strings');
+  let count = 0;
+  return Promise.all(
+    urls.map(url => {
+      const promise = loadImage(url, opts);
+      promise.then(file =>
+        onProgress({
+          progress: ++count / urls.length,
+          count,
+          total: urls.length,
+          url
+        })
+      );
+      return promise;
+    })
+  );
+}

--- a/src/test-utils/luma.gl/io-basic/load-texture.js
+++ b/src/test-utils/luma.gl/io-basic/load-texture.js
@@ -1,0 +1,39 @@
+import {loadFiles, loadImages} from './load-files';
+import {Program, Texture2D} from '../webgl';
+import assert from 'assert';
+
+function noop() {}
+
+export function loadTexture(gl, url, opts = {}) {
+  const {urls, onProgress = noop} = opts;
+  assert(typeof url === 'string', 'loadTexture: url must be string');
+
+  return loadImages(Object.assign({urls, onProgress}, opts)).then(images =>
+    images.map((img, i) => {
+      return new Texture2D(gl, Object.assign({id: urls[i]}, opts, {data: img}));
+    })
+  );
+}
+
+export function loadProgram(gl, opts = {}) {
+  const {vs, fs, onProgress = noop} = opts;
+  return loadFiles(Object.assign({urls: [vs, fs], onProgress}, opts)).then(
+    ([vsText, fsText]) => new Program(gl, Object.assign({vs: vsText, fs: fsText}, opts))
+  );
+}
+
+export function loadTextures(gl, opts = {}) {
+  const {urls, onProgress = noop} = opts;
+  assert(
+    urls.every(url => typeof url === 'string'),
+    'loadTextures: {urls} must be array of strings'
+  );
+
+  return loadImages(Object.assign({urls, onProgress}, opts)).then(images =>
+    images.map((img, i) => {
+      let params = Array.isArray(opts.parameters) ? opts.parameters[i] : opts.parameters;
+      params = params === undefined ? {} : params;
+      return new Texture2D(gl, Object.assign({id: urls[i]}, params, {data: img}));
+    })
+  );
+}

--- a/src/test-utils/luma.gl/io-basic/node-compress-image.js
+++ b/src/test-utils/luma.gl/io-basic/node-compress-image.js
@@ -1,0 +1,25 @@
+// Use stackgl modules for DOM-less reading and writing of images
+// NOTE: These are not dependencies of luma.gl.
+// They need to be imported by the app.
+
+/**
+ * Returns data bytes representing a compressed image in PNG or JPG format,
+ * This data can be saved using file system (f) methods or
+ * used in a request.
+ * @param {Image} image to save
+ * @param {String} type='png' - png, jpg or image/png, image/jpg are valid
+ * @param {String} opt.dataURI= - Whether to include a data URI header
+ * @return {*} bytes
+ */
+export function compressImage(image, type = 'png') {
+  const savePixels = module.require('save-pixels');
+  const ndarray = module.require('ndarray');
+  if (!savePixels || !ndarray) {
+    throw new Error('compressImage: save-pixels or ndarray not installed');
+  }
+
+  const pixels = ndarray(image.data, [image.width, image.height, 4], [4, image.width * 4, 1], 0);
+
+  // TODO - does this return stream?
+  return savePixels(pixels, type.replace('image/', ''));
+}

--- a/src/test-utils/luma.gl/io-basic/node-load-image.js
+++ b/src/test-utils/luma.gl/io-basic/node-load-image.js
@@ -1,0 +1,10 @@
+import {promisify} from '../../utils';
+
+export function loadImage(url) {
+  const getPixels = module.require('get-pixels');
+  if (!getPixels) {
+    throw new Error('loadImage: get-pixels not installed');
+  }
+
+  return promisify(getPixels)(url);
+}

--- a/src/test-utils/luma.gl/io-basic/path-prefix.js
+++ b/src/test-utils/luma.gl/io-basic/path-prefix.js
@@ -1,0 +1,12 @@
+let pathPrefix = '';
+
+/*
+ * Set a relative path prefix
+ */
+export function setPathPrefix(prefix) {
+  pathPrefix = prefix;
+}
+
+export function getPathPrefix() {
+  return pathPrefix;
+}

--- a/src/test-utils/luma.gl/io-extended/README.md
+++ b/src/test-utils/luma.gl/io-extended/README.md
@@ -1,0 +1,8 @@
+# extended-io
+
+A separate module that contains IO functions that requires dependencies that can signficantly increase the size of an application bundle.
+
+More advanced IO support that handles e.g.
+* stream support in browsers
+
+is being developed in this separate module.

--- a/src/test-utils/luma.gl/io-extended/browser-compress-image.js
+++ b/src/test-utils/luma.gl/io-extended/browser-compress-image.js
@@ -1,0 +1,35 @@
+// Image loading/saving for browser
+/* global document, HTMLCanvasElement, Image */
+
+/* global process, Buffer */
+import assert from 'assert';
+import through from 'through'; // Note: through adds stream support
+
+/*
+ * Returns data bytes representing a compressed image in PNG or JPG format,
+ * This data can be saved using file system (f) methods or
+ * used in a request.
+ * @param {Image}  image - Image or Canvas
+ * @param {String} opt.type='png' - png, jpg or image/png, image/jpg are valid
+ * @param {String} opt.dataURI= - Whether to include a data URI header
+ */
+export function compressImage(image, type) {
+  if (image instanceof HTMLCanvasElement) {
+    const canvas = image;
+    return canvas.toDataURL(type);
+  }
+
+  assert(image instanceof Image, 'getImageData accepts image or canvas');
+  const canvas = document.createElement('canvas');
+  canvas.width = image.width;
+  canvas.height = image.height;
+  canvas.getContext('2d').drawImage(image, 0, 0);
+
+  // Get raw image data
+  const data = canvas.toDataURL(type || 'png').replace(/^data:image\/(png|jpg);base64,/, '');
+
+  // Dump data into stream and return
+  const result = through();
+  process.nextTick(() => result.end(new Buffer(data, 'base64')));
+  return result;
+}

--- a/src/test-utils/luma.gl/io-extended/browser-write-file.js
+++ b/src/test-utils/luma.gl/io-extended/browser-write-file.js
@@ -1,0 +1,59 @@
+// A browser implementation of the Node.js `fs` module's `fs.writeFile` method.
+
+import {isBrowser} from '../../utils';
+
+// TODO hack - trick filesaver.js to skip loading under node
+/* global global*/
+const savedNavigatorExists = 'navigator' in global;
+const savedNavigator = global.navigator;
+if (!isBrowser) {
+  global.navigator = {userAgent: 'MSIE 9.'};
+}
+
+// Need to use `require` to ensure our modification of global code above happens first
+const saveAs = require('filesaver.js');
+
+if (!isBrowser) {
+  if (savedNavigatorExists) {
+    global.navigator = savedNavigator;
+  } else {
+    delete global.navigator;
+  }
+}
+// END hack
+
+const window = require('global/window');
+const Blob = window.Blob;
+
+/**
+ * File system write function for the browser, similar to Node's fs.writeFile
+ *
+ * Saves a file by downloading it with the given file name.
+ *
+ * @param {String} file - file name
+ * @param {String|Blob} data - data to be written to file
+ * @param {String|Object} options -
+ * @param {Function} callback - Standard node (err, data) callback
+ * @return {Promise} - promise, can be used instead of callback
+ */
+export function writeFile(file, data, options, callback = () => {}) {
+  // options is optional
+  if (callback === undefined && typeof options === 'function') {
+    options = undefined;
+    callback = options;
+  }
+  if (typeof data === 'string') {
+    data = new Blob(data);
+  }
+  return new Promise((resolve, reject) => {
+    let result;
+    try {
+      result = saveAs(data, file, options);
+    } catch (error) {
+      reject(error);
+      return callback(error, null);
+    }
+    resolve();
+    return callback(null, result);
+  });
+}

--- a/src/test-utils/luma.gl/io-extended/index.js
+++ b/src/test-utils/luma.gl/io-extended/index.js
@@ -1,0 +1,6 @@
+export * from './browser-image-io';
+
+export {loadFile} from './browser-request';
+
+import * as fs from './browser-fs';
+export {fs};

--- a/src/test-utils/luma.gl/io-extended/test/index.js
+++ b/src/test-utils/luma.gl/io-extended/test/index.js
@@ -1,0 +1,1 @@
+import './write-read-image.spec.js';

--- a/src/test-utils/luma.gl/io-extended/test/write-read-image.spec.js
+++ b/src/test-utils/luma.gl/io-extended/test/write-read-image.spec.js
@@ -1,0 +1,51 @@
+// import test from '../setup';
+// import {promisify, compressImage, loadImage} from '../../src';
+// import fs from 'fs';
+// import path from 'path';
+// import mkdirp from 'mkdirp';
+
+// const TEST_DIR = path.join(__dirname, '..', 'data');
+// const TEST_FILE = path.join(TEST_DIR, 'test.png');
+
+// const IMAGE = {
+//   width: 2,
+//   height: 3,
+//   data: new Uint8Array([
+//     255,
+//     0,
+//     0,
+//     255,
+//     0,
+//     255,
+//     255,
+//     255,
+//     0,
+//     0,
+//     255,
+//     255,
+//     255,
+//     255,
+//     0,
+//     255,
+//     0,
+//     255,
+//     0,
+//     255,
+//     255,
+//     0,
+//     255,
+//     255
+//   ])
+// };
+
+// Test that we can write and read an image, and that result is identical
+// test('io#write-read-image', async function(t) {
+//   await promisify(mkdirp)(TEST_DIR);
+//   const file = fs.createWriteStream(TEST_FILE);
+//   file.on('close', async function() {
+//     const result = await loadImage(TEST_FILE);
+//     t.same(result, IMAGE);
+//     t.end();
+//   });
+//   compressImage(IMAGE).pipe(file);
+// });

--- a/src/test-utils/luma.gl/test/index.js
+++ b/src/test-utils/luma.gl/test/index.js
@@ -1,0 +1,1 @@
+import './read-image.spec.js';

--- a/src/test-utils/luma.gl/test/read-image.spec.js
+++ b/src/test-utils/luma.gl/test/read-image.spec.js
@@ -1,0 +1,19 @@
+import '../../../src/headless';
+import {loadImage} from '../../../src/io';
+import test from '../../setup';
+
+/* eslint-disable quotes */
+const PNG_BITS = `\
+iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAFElEQVQIW2P8z\
+/D/PwMDAwMjjAEAQOwF/W1Dp54AAAAASUVORK5CYII=`;
+/* eslint-enable quotes */
+
+const DATA_URL = `data:image/png;base64,${PNG_BITS}`;
+
+test('io#read-image', t => {
+  loadImage(DATA_URL).then(image => {
+    t.equals(image.width, 2, 'width');
+    t.equals(image.height, 2, 'height');
+    t.end();
+  });
+});

--- a/src/test-utils/luma.gl/utils/globals.js
+++ b/src/test-utils/luma.gl/utils/globals.js
@@ -1,23 +1,3 @@
-// Copyright (c) 2015 - 2017 Uber Technologies, Inc.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-
 // Purpose: include this in your module to avoids adding dependencies on
 // micro modules like 'global' and 'is-browser';
 


### PR DESCRIPTION
The luma.gl I/O package was originally designed to support read / write of files and images using a single API across both browser and Node.js. 

Unfortunately this approach was abandoned, mainly due to issues with bundle size due to the big node dependencies. But with dynamic requires we can get the best of both worlds. 

This PR is the start of an effort to review the luma.gl IO package:
* It copies the luma.gl IO module
* Splits IO into a clearer file structure and modernizes the code

Next steps:
* IO code will be iterated on here as part of making the rendering tests / golden image support work under both browser and node
* And finally moved back to luma.gl.