### PR TITLE
Improve fp64ify perf

### DIFF
--- a/src/core-layers/arc-layer/arc-layer.js
+++ b/src/core-layers/arc-layer/arc-layer.js
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 import {COORDINATE_SYSTEM, Layer, experimental} from '../../core';
-const {fp64ify, enable64bitSupport} = experimental;
+const {fp64LowPart, enable64bitSupport} = experimental;
 
 import {GL, Model, Geometry} from 'luma.gl';
 
@@ -167,10 +167,10 @@ export default class ArcLayer extends Layer {
     for (const object of data) {
       const sourcePosition = getSourcePosition(object);
       const targetPosition = getTargetPosition(object);
-      value[i + 0] = fp64ify(sourcePosition[0])[1];
-      value[i + 1] = fp64ify(sourcePosition[1])[1];
-      value[i + 2] = fp64ify(targetPosition[0])[1];
-      value[i + 3] = fp64ify(targetPosition[1])[1];
+      value[i + 0] = fp64LowPart(sourcePosition[0]);
+      value[i + 1] = fp64LowPart(sourcePosition[1]);
+      value[i + 2] = fp64LowPart(targetPosition[0]);
+      value[i + 3] = fp64LowPart(targetPosition[1]);
       i += size;
     }
   }

--- a/src/core-layers/grid-cell-layer/grid-cell-layer.js
+++ b/src/core-layers/grid-cell-layer/grid-cell-layer.js
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 import {COORDINATE_SYSTEM, Layer, experimental} from '../../core';
-const {fp64ify, enable64bitSupport} = experimental;
+const {fp64LowPart, enable64bitSupport} = experimental;
 import {GL, Model, CubeGeometry} from 'luma.gl';
 
 import vs from './grid-cell-layer-vertex.glsl';
@@ -187,8 +187,8 @@ export default class GridCellLayer extends Layer {
     let i = 0;
     for (const point of data) {
       const position = getPosition(point);
-      value[i++] = fp64ify(position[0])[1];
-      value[i++] = fp64ify(position[1])[1];
+      value[i++] = fp64LowPart(position[0]);
+      value[i++] = fp64LowPart(position[1]);
     }
   }
 

--- a/src/core-layers/hexagon-cell-layer/hexagon-cell-layer.js
+++ b/src/core-layers/hexagon-cell-layer/hexagon-cell-layer.js
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 import {COORDINATE_SYSTEM, Layer, experimental} from '../../core';
-const {log, fp64ify, enable64bitSupport} = experimental;
+const {log, fp64LowPart, enable64bitSupport} = experimental;
 import {GL, Model, CylinderGeometry} from 'luma.gl';
 
 import vs from './hexagon-cell-layer-vertex.glsl';
@@ -242,8 +242,8 @@ export default class HexagonCellLayer extends Layer {
     let i = 0;
     for (const object of data) {
       const position = getCentroid(object);
-      value[i++] = fp64ify(position[0])[1];
-      value[i++] = fp64ify(position[1])[1];
+      value[i++] = fp64LowPart(position[0]);
+      value[i++] = fp64LowPart(position[1]);
     }
   }
 

--- a/src/core-layers/icon-layer/icon-layer.js
+++ b/src/core-layers/icon-layer/icon-layer.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 import {COORDINATE_SYSTEM, Layer, experimental} from '../../core';
-const {fp64ify, enable64bitSupport} = experimental;
+const {fp64LowPart, enable64bitSupport} = experimental;
 import {GL, Model, Geometry, Texture2D, loadTextures} from 'luma.gl';
 
 import vs from './icon-layer-vertex.glsl';
@@ -213,8 +213,8 @@ export default class IconLayer extends Layer {
     let i = 0;
     for (const point of data) {
       const position = getPosition(point);
-      value[i++] = fp64ify(position[0])[1];
-      value[i++] = fp64ify(position[1])[1];
+      value[i++] = fp64LowPart(position[0]);
+      value[i++] = fp64LowPart(position[1]);
     }
   }
 

--- a/src/core-layers/line-layer/line-layer.js
+++ b/src/core-layers/line-layer/line-layer.js
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 import {COORDINATE_SYSTEM, Layer, experimental} from '../../core';
-const {fp64ify, enable64bitSupport} = experimental;
+const {fp64LowPart, enable64bitSupport} = experimental;
 import {GL, Model, Geometry} from 'luma.gl';
 
 import vs from './line-layer-vertex.glsl';
@@ -167,10 +167,10 @@ export default class LineLayer extends Layer {
     for (const object of data) {
       const sourcePosition = getSourcePosition(object);
       const targetPosition = getTargetPosition(object);
-      value[i + 0] = fp64ify(sourcePosition[0])[1];
-      value[i + 1] = fp64ify(sourcePosition[1])[1];
-      value[i + 2] = fp64ify(targetPosition[0])[1];
-      value[i + 3] = fp64ify(targetPosition[1])[1];
+      value[i + 0] = fp64LowPart(sourcePosition[0]);
+      value[i + 1] = fp64LowPart(sourcePosition[1]);
+      value[i + 2] = fp64LowPart(targetPosition[0]);
+      value[i + 3] = fp64LowPart(targetPosition[1]);
       i += size;
     }
   }

--- a/src/core-layers/path-layer/path-layer.js
+++ b/src/core-layers/path-layer/path-layer.js
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 import {COORDINATE_SYSTEM, Layer, experimental} from '../../core';
-const {fp64ify, enable64bitSupport} = experimental;
+const {fp64LowPart, enable64bitSupport} = experimental;
 import {GL, Model, Geometry} from 'luma.gl';
 
 import vs from './path-layer-vertex.glsl';
@@ -269,10 +269,10 @@ export default class PathLayer extends Layer {
       for (let ptIndex = 0; ptIndex < numSegments; ptIndex++) {
         const startPoint = path[ptIndex];
         const endPoint = path[ptIndex + 1];
-        value[i++] = fp64ify(startPoint[0])[1];
-        value[i++] = fp64ify(startPoint[1])[1];
-        value[i++] = fp64ify(endPoint[0])[1];
-        value[i++] = fp64ify(endPoint[1])[1];
+        value[i++] = fp64LowPart(startPoint[0]);
+        value[i++] = fp64LowPart(startPoint[1]);
+        value[i++] = fp64LowPart(endPoint[0]);
+        value[i++] = fp64LowPart(endPoint[1]);
       }
     });
   }

--- a/src/core-layers/point-cloud-layer/point-cloud-layer.js
+++ b/src/core-layers/point-cloud-layer/point-cloud-layer.js
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 import {COORDINATE_SYSTEM, Layer, experimental} from '../../core';
-const {fp64ify, enable64bitSupport} = experimental;
+const {fp64LowPart, enable64bitSupport} = experimental;
 import {GL, Model, Geometry} from 'luma.gl';
 
 import vs from './point-cloud-layer-vertex.glsl';
@@ -162,8 +162,8 @@ export default class PointCloudLayer extends Layer {
     let i = 0;
     for (const point of data) {
       const position = getPosition(point);
-      value[i++] = fp64ify(position[0])[1];
-      value[i++] = fp64ify(position[1])[1];
+      value[i++] = fp64LowPart(position[0]);
+      value[i++] = fp64LowPart(position[1]);
     }
   }
 

--- a/src/core-layers/scatterplot-layer/scatterplot-layer.js
+++ b/src/core-layers/scatterplot-layer/scatterplot-layer.js
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 import {COORDINATE_SYSTEM, Layer, experimental} from '../../core';
-const {fp64ify, enable64bitSupport} = experimental;
+const {fp64LowPart, enable64bitSupport} = experimental;
 import {GL, Model, Geometry} from 'luma.gl';
 
 import vs from './scatterplot-layer-vertex.glsl';
@@ -152,8 +152,8 @@ export default class ScatterplotLayer extends Layer {
     let i = 0;
     for (const point of data) {
       const position = getPosition(point);
-      value[i++] = fp64ify(position[0])[1];
-      value[i++] = fp64ify(position[1])[1];
+      value[i++] = fp64LowPart(position[0]);
+      value[i++] = fp64LowPart(position[1]);
     }
   }
 

--- a/src/core-layers/solid-polygon-layer/polygon-tesselator-extruded.js
+++ b/src/core-layers/solid-polygon-layer/polygon-tesselator-extruded.js
@@ -20,7 +20,7 @@
 
 import * as Polygon from './polygon';
 import {experimental} from '../../core';
-const {fp64ify, fillArray} = experimental;
+const {fp64LowPart, fillArray} = experimental;
 import earcut from 'earcut';
 
 function getPickingColor(index) {
@@ -185,8 +185,8 @@ function calculatePositions(positionsJS, fp64) {
     const vertexCount = positionsJS.length / 3;
     positionLow = new Float32Array(vertexCount * 2);
     for (let i = 0; i < vertexCount; i++) {
-      positionLow[i * 2 + 0] = fp64ify(positionsJS[i * 3 + 0])[1];
-      positionLow[i * 2 + 1] = fp64ify(positionsJS[i * 3 + 1])[1];
+      positionLow[i * 2 + 0] = fp64LowPart(positionsJS[i * 3 + 0]);
+      positionLow[i * 2 + 1] = fp64LowPart(positionsJS[i * 3 + 1]);
     }
   }
   return {positions: positionsJS, positions64xyLow: positionLow};

--- a/src/core-layers/solid-polygon-layer/polygon-tesselator.js
+++ b/src/core-layers/solid-polygon-layer/polygon-tesselator.js
@@ -26,7 +26,7 @@
 import * as Polygon from './polygon';
 import earcut from 'earcut';
 import {experimental} from '../../core';
-const {fp64ify, flattenVertices, fillArray} = experimental;
+const {fp64LowPart, flattenVertices, fillArray} = experimental;
 
 // Maybe deck.gl or luma.gl needs to export this
 function getPickingColor(index) {
@@ -178,8 +178,8 @@ function calculatePositions({polygons, pointCount, fp64}) {
       attribute[i++] = y;
       attribute[i++] = z;
       if (fp64) {
-        attributeLow[j++] = fp64ify(x)[1];
-        attributeLow[j++] = fp64ify(y)[1];
+        attributeLow[j++] = fp64LowPart(x);
+        attributeLow[j++] = fp64LowPart(y);
       }
     });
   }

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -92,7 +92,7 @@ import {clamp} from './utils/scale-utils';
 import {flatten, countVertices, flattenVertices, fillArray} from './utils/flatten';
 // TODO - just expose as layer methods instead?
 import {enable64bitSupport} from './utils/fp64';
-import {fp64ify} from './utils/fp64';
+import {fp64ify, fp64LowPart} from './utils/fp64';
 
 export const experimental = {
   ViewportControls: Controller,
@@ -145,5 +145,6 @@ export const experimental = {
   fillArray,
 
   enable64bitSupport,
-  fp64ify
+  fp64ify,
+  fp64LowPart
 };

--- a/src/core/utils/fp64.js
+++ b/src/core/utils/fp64.js
@@ -28,6 +28,10 @@ export function fp64ify(a) {
   return [hiPart, loPart];
 }
 
+export function fp64LowPart(a) {
+  return a - Math.fround(a);
+}
+
 export function enable64bitSupport(props) {
   if (props.fp64) {
     if (props.coordinateSystem === COORDINATE_SYSTEM.LNGLAT) {

--- a/src/core/utils/fp64.js
+++ b/src/core/utils/fp64.js
@@ -22,6 +22,11 @@
 import log from './log';
 import {COORDINATE_SYSTEM} from '../lib/constants'; // TODO - utils should not import from lib
 
+/*
+ * Frequently used small math utils: bundlers, especially webpack,
+ * adds a thunk around every exported function that adds enough overhead to pull down performance.
+ * It may be worth it to also export these as part of an object.
+ */
 export function fp64ify(a) {
   const hiPart = Math.fround(a);
   const loPart = a - Math.fround(a);

--- a/src/experimental-layers/src/mesh-layer/mesh-layer.js
+++ b/src/experimental-layers/src/mesh-layer/mesh-layer.js
@@ -23,7 +23,7 @@
 // THE SOFTWARE.
 
 import {Layer, COORDINATE_SYSTEM, experimental} from 'deck.gl';
-const {fp64ify, enable64bitSupport} = experimental;
+const {fp64LowPart, enable64bitSupport} = experimental;
 import {GL, Model, Geometry, loadTextures, Texture2D} from 'luma.gl';
 import assert from 'assert';
 
@@ -218,8 +218,8 @@ export default class MeshLayer extends Layer {
     let i = 0;
     for (const point of data) {
       const position = getPosition(point);
-      value[i++] = fp64ify(position[0])[1];
-      value[i++] = fp64ify(position[1])[1];
+      value[i++] = fp64LowPart(position[0]);
+      value[i++] = fp64LowPart(position[1]);
     }
   }
 

--- a/src/experimental-layers/src/solid-polygon-layer/polygon-tesselator.js
+++ b/src/experimental-layers/src/solid-polygon-layer/polygon-tesselator.js
@@ -25,7 +25,7 @@
 // - 3D wireframes (not yet)
 import * as Polygon from './polygon';
 import {experimental} from 'deck.gl';
-const {fillArray, fp64ify} = experimental;
+const {fillArray, fp64LowPart} = experimental;
 
 // Maybe deck.gl or luma.gl needs to export this
 function getPickingColor(index) {
@@ -201,8 +201,8 @@ function updatePositions({
       positions[i * 3 + 1] = y;
       positions[i * 3 + 2] = z;
       if (fp64) {
-        xLow = fp64ify(x)[1];
-        yLow = fp64ify(y)[1];
+        xLow = fp64LowPart(x);
+        yLow = fp64LowPart(y);
         positions64xyLow[i * 2] = xLow;
         positions64xyLow[i * 2 + 1] = yLow;
       }

--- a/src/index.js
+++ b/src/index.js
@@ -129,7 +129,8 @@ const {
   fillArray,
 
   enable64bitSupport,
-  fp64ify
+  fp64ify,
+  fp64LowPart
 } = CoreExperimental;
 
 Object.assign(experimental, {
@@ -157,7 +158,8 @@ Object.assign(experimental, {
   fillArray,
 
   enable64bitSupport,
-  fp64ify
+  fp64ify,
+  fp64LowPart
 });
 
 //

--- a/test/bench/utils.bench.js
+++ b/test/bench/utils.bench.js
@@ -22,7 +22,7 @@
 
 import {experimental} from 'deck.gl';
 
-const {get} = experimental;
+const {get, fp64ify, fp64LowPart} = experimental;
 
 const POSITION = [-122.4, 37.8, 0];
 
@@ -36,5 +36,11 @@ export default function utilsBench(suite) {
     })
     .add('direct access#Array', () => {
       return POSITION[0];
+    })
+    .add('fp64#fp64ify.lowPart', () => {
+      return fp64ify(Math.PI)[1];
+    })
+    .add('fp64#fp64LowPart', () => {
+      return fp64LowPart(Math.PI);
     });
 }


### PR DESCRIPTION
Avoid creating intermediate arrays.

Node:

├─ fp64#fp64ify(x)[1]: 21.3M iterations/s (0.03s elapsed)
├─ fp64#fp64LowPart(x): 39.5M iterations/s (0.03s elapsed)

Browser:

├─ fp64#fp64ify(x)[1]: 30.6M iterations/s (0.04s elapsed)
├─ fp64#fp64LowPart(x): 43.9M iterations/s (0.03s elapsed)

Verified: layer-browser
  