### PR TITLE
[Doc] Fix of layer attribute typo

### DIFF
--- a/docs/get-started/using-layers.md
+++ b/docs/get-started/using-layers.md
@@ -41,7 +41,7 @@ The main concern when rendering more than one instance of a specific layer (say 
 ```js
 <DeckGL layers={[
   new ScatterplotLayer({id: 'big-points', data: ..., ...}),
-  new ScatterplotLayer({data: 'small-points', data: ..., ...}),
+  new ScatterplotLayer({id: 'small-points', data: ..., ...}),
 ]} />
 ```
 


### PR DESCRIPTION
Changed 'data' to 'id', otherwise the object would have the 'data' attribute twice and no id at all.