### PR TITLE
Reorder layer methods into public/private API. 

### DIFF
--- a/src/core/lib/layer.js
+++ b/src/core/lib/layer.js
@@ -142,6 +142,16 @@ export default class Layer {
     return this.props.pickable && this.props.visible;
   }
 
+  // Use iteration (the only required capability on data) to get first element
+  // deprecated
+  getFirstObject() {
+    const {data} = this.props;
+    for (const object of data) {
+      return object;
+    }
+    return null;
+  }
+
   // PROJECTION METHODS
 
   /**


### PR DESCRIPTION
This PR just reorders methods.

* The `dataUrl` diff makes some clever changes to the `Layer` class and I'd like to get this cleanup in place first to keep next PR clean.
* This split will also helps when reviewing future additions to the Layer API.