### PR TITLE
Use Object.prototype to speed up default prop setting

### DIFF
--- a/examples/layer-browser/src/components/layer-controls.js
+++ b/examples/layer-browser/src/components/layer-controls.js
@@ -129,13 +129,24 @@ export default class LayerControls extends PureComponent {
     return null;
   }
 
+  // Get all inherited property keys
+  _getAllKeys(object) {
+    const keys = [];
+    for (const key in object) {
+      keys.push(key);
+    }
+    return keys;
+  }
+
   render() {
     const {title, settings, propTypes = {}} = this.props;
 
     return (
       <div className="layer-controls">
         {title && <h4>{title}</h4>}
-        {Object.keys(settings).map(key => this._renderSetting(key, settings[key], propTypes[key]))}
+        {this._getAllKeys(settings).map(
+          key => this._renderSetting(key, settings[key], propTypes[key])
+        )}
       </div>
     );
   }

--- a/src/core/lib/layer.js
+++ b/src/core/lib/layer.js
@@ -70,7 +70,7 @@ const defaultProps = {
 let counter = 0;
 
 export default class Layer {
-  constructor(props) {
+  constructor(props = {}) {
     // Merges incoming props with defaults and freezes them.
     this.props = createProps(this, props);
 

--- a/src/core/lib/layer.js
+++ b/src/core/lib/layer.js
@@ -22,18 +22,16 @@
 import {COORDINATE_SYSTEM, LIFECYCLE} from './constants';
 import AttributeManager from './attribute-manager';
 import Stats from './stats';
-import {getDefaultProps, diffProps} from './props';
 import {count} from '../utils/count';
 import log from '../utils/log';
+import {createProps, EMPTY_ARRAY} from '../lifecycle/create-props';
+import {getDefaultProps, diffProps} from './props';
 import {applyPropOverrides, removeLayerInSeer} from './seer-integration';
 import {GL, withParameters} from 'luma.gl';
 import assert from 'assert';
 
 const LOG_PRIORITY_UPDATE = 1;
-
-const EMPTY_ARRAY = [];
-const EMPTY_PROPS = {};
-Object.freeze(EMPTY_PROPS);
+const EMPTY_PROPS = Object.freeze({});
 const noop = () => {};
 
 const defaultProps = {
@@ -73,8 +71,8 @@ let counter = 0;
 
 export default class Layer {
   constructor(props) {
-    // Call a helper function to merge the incoming props with defaults and freeze them.
-    this.props = this._normalizeProps(props);
+    // Merges incoming props with defaults and freezes them.
+    this.props = createProps(this, props);
 
     // Define all members before layer is sealed
     this.id = this.props.id; // The layer's id, used for matching with layers from last render cycle

--- a/src/core/lib/layer.js
+++ b/src/core/lib/layer.js
@@ -667,9 +667,13 @@ ${flags.viewportChanged ? 'viewport' : ''}\
     // If sublayer has static defaultProps member, getDefaultProps will return it
     const mergedDefaultProps = getDefaultProps(this);
     // Merge supplied props with pre-merged default props
-    const id = props.id;
-    delete props.id;
-    const newProps = Object.create(mergedDefaultProps);
+    const newProps = Object.create(mergedDefaultProps, {
+      // id: {
+      //   configurable: true,
+      //   writeable: true,
+      //   value: props.id || this.constructor.layerName
+      // }
+    });
     props = Object.assign(newProps, props);
 
     // Accept null as data - otherwise apps and layers need to add ugly checks

--- a/src/core/lib/layer.js
+++ b/src/core/lib/layer.js
@@ -665,13 +665,7 @@ ${flags.viewportChanged ? 'viewport' : ''}\
     // If sublayer has static defaultProps member, getDefaultProps will return it
     const mergedDefaultProps = getDefaultProps(this);
     // Merge supplied props with pre-merged default props
-    const newProps = Object.create(mergedDefaultProps, {
-      // id: {
-      //   configurable: true,
-      //   writeable: true,
-      //   value: props.id || this.constructor.layerName
-      // }
-    });
+    const newProps = Object.create(mergedDefaultProps, {});
     props = Object.assign(newProps, props);
 
     // Accept null as data - otherwise apps and layers need to add ugly checks

--- a/src/core/lib/layer.js
+++ b/src/core/lib/layer.js
@@ -667,7 +667,11 @@ ${flags.viewportChanged ? 'viewport' : ''}\
     // If sublayer has static defaultProps member, getDefaultProps will return it
     const mergedDefaultProps = getDefaultProps(this);
     // Merge supplied props with pre-merged default props
-    props = Object.assign({}, mergedDefaultProps, props);
+    const id = props.id;
+    delete props.id;
+    const newProps = Object.create(mergedDefaultProps);
+    props = Object.assign(newProps, props);
+
     // Accept null as data - otherwise apps and layers need to add ugly checks
     // Use constant fallback so that data change is not triggered
     props.data = props.data || EMPTY_ARRAY;

--- a/src/core/lib/props.js
+++ b/src/core/lib/props.js
@@ -195,7 +195,7 @@ export function mergeDefaultProps(object, objectNameKey = 'layerName') {
   // Use the object's constructor name as default id prop.
   // Note that constructor names are substituted during minification and may not be "human readable"
   let mergedDefaultProps = {
-    id: objectName || object.constructor.name
+    // id: objectName || object.constructor.name
   };
 
   // Reverse shadowing
@@ -209,6 +209,7 @@ export function mergeDefaultProps(object, objectNameKey = 'layerName') {
     object = Object.getPrototypeOf(object);
   }
 
+  delete mergedDefaultProps.id;
   Object.freeze(mergedDefaultProps);
 
   // Store for quick lookup

--- a/src/core/lib/props.js
+++ b/src/core/lib/props.js
@@ -1,4 +1,3 @@
-import log from '../utils/log';
 import assert from 'assert';
 
 // Returns an object with "change flags", either false or strings indicating reason for change
@@ -63,7 +62,7 @@ export function compareProps({
   // Test if new props different from old props
   for (const key in oldProps) {
     if (!(key in ignoreProps)) {
-      if (!newProps.hasOwnProperty(key)) {
+      if (!(key in newProps)) {
         return `${triggerName}.${key} dropped: ${oldProps[key]} -> undefined`;
       }
 
@@ -90,7 +89,7 @@ export function compareProps({
   // Test if any new props have been added
   for (const key in newProps) {
     if (!(key in ignoreProps)) {
-      if (!oldProps.hasOwnProperty(key)) {
+      if (!(key in oldProps)) {
         return `${triggerName}.${key} added: undefined -> ${newProps[key]}`;
       }
     }
@@ -163,58 +162,4 @@ function diffUpdateTrigger(props, oldProps, triggerName) {
     triggerName
   });
   return diffReason;
-}
-
-// Constructors have their super class constructors as prototypes
-function getOwnProperty(object, prop) {
-  return Object.prototype.hasOwnProperty.call(object, prop) && object[prop];
-}
-
-/*
- * Return merged default props stored on layers constructor, create them if needed
- */
-export function getDefaultProps(layer) {
-  // TODO - getOwnProperty is very slow, reduces layer construction speed 3x
-  const mergedDefaultProps = getOwnProperty(layer.constructor, 'mergedDefaultProps');
-  if (mergedDefaultProps) {
-    return mergedDefaultProps;
-  }
-  return mergeDefaultProps(layer);
-}
-
-/*
- * Walk a prototype chain and merge all default props from any 'defaultProps' objects
- */
-export function mergeDefaultProps(object, objectNameKey = 'layerName') {
-  const subClassConstructor = object.constructor;
-  const objectName = getOwnProperty(subClassConstructor, objectNameKey);
-  if (!objectName) {
-    log.once(0, `${object.constructor.name} does not specify a ${objectNameKey}`);
-  }
-
-  // Use the object's constructor name as default id prop.
-  // Note that constructor names are substituted during minification and may not be "human readable"
-  let mergedDefaultProps = {
-    // id: objectName || object.constructor.name
-  };
-
-  // Reverse shadowing
-  // TODO - Rewrite to stop when mergedDefaultProps is available on parent?
-  while (object) {
-    const objectDefaultProps = getOwnProperty(object.constructor, 'defaultProps');
-    Object.freeze(objectDefaultProps);
-    if (objectDefaultProps) {
-      mergedDefaultProps = Object.assign({}, objectDefaultProps, mergedDefaultProps);
-    }
-    object = Object.getPrototypeOf(object);
-  }
-
-  delete mergedDefaultProps.id;
-  Object.freeze(mergedDefaultProps);
-
-  // Store for quick lookup
-  subClassConstructor.mergedDefaultProps = mergedDefaultProps;
-
-  assert(mergeDefaultProps);
-  return mergedDefaultProps;
 }

--- a/src/core/lifecycle/create-props.js
+++ b/src/core/lifecycle/create-props.js
@@ -58,7 +58,6 @@ function getLayerName(layerClass) {
 function getDefaultProps(layerClass) {
   const props = getOwnProperty(layerClass, '_props');
   if (props) {
-    assert(props);
     return props;
   }
 

--- a/src/core/lifecycle/create-props.js
+++ b/src/core/lifecycle/create-props.js
@@ -64,7 +64,7 @@ function getDefaultProps(layerClass) {
 
   const parent = layerClass.prototype;
   const parentClass = Object.getPrototypeOf(layerClass);
-  const parentProps = parent && getDefaultProps(parentClass) || null;
+  const parentProps = (parent && getDefaultProps(parentClass)) || null;
 
   // Parse propTypes from Layer.defaultProps
   const defaultProps = getOwnProperty(layerClass, 'defaultProps') || {};

--- a/src/core/lifecycle/create-props.js
+++ b/src/core/lifecycle/create-props.js
@@ -1,0 +1,99 @@
+import {applyPropOverrides} from '../lib/seer-integration';
+import log from '../utils/log';
+import assert from 'assert';
+
+export const EMPTY_ARRAY = Object.freeze([]);
+
+// Create a property object
+export function createProps(layer, props) {
+  // Get default prop object (a prototype chain for now)
+  const {defaultProps} = getDefaultProps(layer.constructor);
+
+  // Create a new prop object with the default props as prototype
+  const newProps = Object.create(defaultProps, {
+    _layer: {
+      enumerable: false,
+      value: layer
+    },
+    _asyncProps: {
+      enumerable: false,
+      value: {}
+    }
+  });
+
+  // Extract any async props
+  // props = setAsyncProps(newProps, props, ASYNC_PROPS);
+
+  // "Copy" all sync props
+  Object.assign(newProps, props);
+  newProps.data = props.data || EMPTY_ARRAY;
+
+  // SEER: Apply any overrides from the seer debug extension if it is active
+  applyPropOverrides(props);
+
+  // Props must be immutable
+  Object.freeze(newProps);
+
+  return newProps;
+}
+
+// Helper methods
+
+// Constructors have their super class constructors as prototypes
+function getOwnProperty(object, prop) {
+  return Object.prototype.hasOwnProperty.call(object, prop) && object[prop];
+}
+
+function getLayerName(layerClass) {
+  const layerName = getOwnProperty(layerClass, 'layerName');
+  if (!layerName) {
+    log.once(0, `Layer ${layerClass.name} does not specify a ${layerName}`);
+  }
+  return layerName || layerClass.name;
+}
+
+// ALT 1: Layer Prop Object Implementation
+
+// Create a new Prop object if needed
+function getDefaultProps(layerClass) {
+  const props = getOwnProperty(layerClass, '_props');
+  if (props) {
+    assert(props);
+    return props;
+  }
+
+  const parent = layerClass.prototype;
+  const parentClass = Object.getPrototypeOf(layerClass);
+  const parentProps = parent && getDefaultProps(parentClass) || null;
+
+  // Parse propTypes from Layer.defaultProps
+  const defaultProps = getOwnProperty(layerClass, 'defaultProps') || {};
+
+  // Create any necessary property descriptors and create the default prop object
+  // Assign merged default props
+  const myDefaultProps = Object.create(null);
+  Object.assign(myDefaultProps, parentProps && parentProps.defaultProps, defaultProps);
+
+  createPropDescriptors(myDefaultProps, layerClass);
+
+  // Store the props
+  layerClass._props = {
+    defaultProps: myDefaultProps
+  };
+
+  return layerClass._props;
+}
+
+function createPropDescriptors(props, layerClass) {
+  const descriptors = {};
+
+  delete props.id;
+  Object.assign(descriptors, {
+    id: {
+      configurable: false,
+      writable: true,
+      value: getLayerName(layerClass)
+    }
+  });
+  Object.defineProperties(props, descriptors);
+}

--- a/test/bench/core-layers.bench.js
+++ b/test/bench/core-layers.bench.js
@@ -31,6 +31,20 @@ import {SolidPolygonLayer as SolidPolygonLayer2} from 'deck.gl/experimental-laye
 // add tests
 export default function coreLayersBench(suite) {
   return suite
+    .group('LAYER CONSTRUCTION')
+    .add('ScatterplotLayer#construct', () => {
+      return new ScatterplotLayer({data: data.points});
+    })
+    .add('GeoJsonLayer#construct', () => {
+      return new GeoJsonLayer({data: data.choropleths});
+    })
+    .add('PolygonLayer#construct', () => {
+      return new PolygonLayer({data: data.choropleths.features});
+    })
+    .add('SolidPolygonLayer#construct', () => {
+      return new PolygonLayer({data: data.choropleths.features});
+    })
+
     .group('COMPOSITE LAYER INITIALIZATION')
     .add('GeoJsonLayer#initialize', () => {
       const layer = new GeoJsonLayer({data: data.choropleths});
@@ -148,18 +162,5 @@ export default function coreLayersBench(suite) {
         fp64: true
       });
       testInitializeLayer({layer});
-    })
-    .group('LAYER CONSTRUCTION (NOTE: 3x REDUCED from 250K/s due to getOwnProperty)')
-    .add('ScatterplotLayer#construct', () => {
-      return new ScatterplotLayer({data: data.points});
-    })
-    .add('GeoJsonLayer#construct', () => {
-      return new GeoJsonLayer({data: data.choropleths});
-    })
-    .add('PolygonLayer#construct', () => {
-      return new PolygonLayer({data: data.choropleths.features});
-    })
-    .add('SolidPolygonLayer#construct', () => {
-      return new PolygonLayer({data: data.choropleths.features});
     });
 }

--- a/test/rendering-test/test-rendering.js
+++ b/test/rendering-test/test-rendering.js
@@ -121,7 +121,7 @@ class RenderingTest extends Component {
       return;
     }
     // Mark current test as running
-    this.state.runningTests[name] = true;
+    this.state.runningTests[name] = true; // eslint-disable-line
 
     referenceImage.onload = () => {
       resultImage.onload = () => {

--- a/test/src/core/lib/props.spec.js
+++ b/test/src/core/lib/props.spec.js
@@ -1,6 +1,6 @@
 import test from 'tape-catch';
 
-import {mergeDefaultProps, compareProps} from 'deck.gl/core/lib/props';
+import {compareProps} from 'deck.gl/core/lib/props';
 import {createProps} from 'deck.gl/core/lifecycle/create-props';
 import {Vector2} from 'luma.gl';
 

--- a/test/src/core/lib/props.spec.js
+++ b/test/src/core/lib/props.spec.js
@@ -1,6 +1,7 @@
 import test from 'tape-catch';
 
 import {mergeDefaultProps, compareProps} from 'deck.gl/core/lib/props';
+import {createProps} from 'deck.gl/core/lifecycle/create-props';
 import {Vector2} from 'luma.gl';
 
 const SAME = 'equal';
@@ -159,14 +160,14 @@ test('compareProps#tests', t => {
   t.end();
 });
 
-test('mergeDefaultProps', t => {
+test('createProps', t => {
   class A {}
-  A.defaultProps = {a: 1};
+  A.defaultProps = {a: 1, data: []};
 
   class B extends A {}
   B.defaultProps = {b: 2};
 
-  const mergedProps = mergeDefaultProps(new B());
+  const mergedProps = createProps(new B(), {});
 
   t.equal(mergedProps.a, 1, 'base class props merged');
   t.equal(mergedProps.b, 2, 'sub class props merged');


### PR DESCRIPTION
I made this change on the 6.0-dev branch. I'm a little worried that this could cause some side effects, but hard to ignore the perf boost, so I am proposing it for 5.1:

LAYER CONSTRUCTION BENCH | MASTER | THIS PR |
| --- | --- | --- |
| ScatterplotLayer#construct: | 78k iterations/s | 532k iterations/s |
| GeoJsonLayer#construct | 55k iterations/s | 521k iterations/s | 
| PolygonLayer#construct | 51k iterations/s | 460k iterations/s |
| SolidPolygonLayer#construct | 55k iterations/s | 471k iterations/s | 
