### PR TITLE
Property Copy Reduction

### DIFF
--- a/docs/api-reference/layer.md
+++ b/docs/api-reference/layer.md
@@ -18,9 +18,17 @@ Remarks:
 
 ## Constructor
 
-Parameters:
+```
+new Layer(...props);
+```
 
-- `props` - Layer properties.
+Parameters:
+- `props` (Object) - `Layer` properties.
+
+Notes:
+* More than one property object can be supplied.
+* Property objects will be merged with the same semantics as [Object.assign](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign), i.e. props in later objects will overwrite props earlier object.
+* Every layer specifies default values for all its props, and these values will be used internally if that prop is not specified by the application in the Layer constructor.
 
 ### Basic Properties
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -4,6 +4,10 @@
 
 WebGL2 feature: smooth attribute transition performed on GPU. Use the new `transitions` prop on the `Layer` class to specify transition duration, easing function and callbacks.
 
+## Layer Class
+
+* Layer class constructors can now take multiple property objects. The property objects will be merged, with later objects taking precedence over earlier objects: `new Layer({prop1: ...}, {prop2: ...});`
+
 
 # deck.gl v5
 

--- a/src/core/lib/layer.js
+++ b/src/core/lib/layer.js
@@ -70,9 +70,15 @@ const defaultProps = {
 let counter = 0;
 
 export default class Layer {
+<<<<<<< HEAD
   constructor(props = {}) {
     // Merges incoming props with defaults and freezes them.
     this.props = createProps(this, props);
+=======
+  constructor(...props) {
+    // Call a helper function to merge the incoming props with defaults and freeze them.
+    this.props = this._normalizeProps(props);
+>>>>>>> Allow multiple partial prop objects to be passed to layer
 
     // Define all members before layer is sealed
     this.id = this.props.id; // The layer's id, used for matching with layers from last render cycle
@@ -661,11 +667,11 @@ ${flags.viewportChanged ? 'viewport' : ''}\
   }
 
   // Helper for constructor, merges props with default props and freezes them
-  _normalizeProps(props) {
+  _normalizeProps(propObjectList) {
     // If sublayer has static defaultProps member, getDefaultProps will return it
     const mergedDefaultProps = getDefaultProps(this);
     // Merge supplied props with pre-merged default props
-    const newProps = Object.create(mergedDefaultProps, {});
+    const newProps = Object.create(mergedDefaultProps, ...propObjectList);
     props = Object.assign(newProps, props);
 
     // Accept null as data - otherwise apps and layers need to add ugly checks

--- a/src/core/lib/layer.js
+++ b/src/core/lib/layer.js
@@ -70,9 +70,14 @@ const defaultProps = {
 let counter = 0;
 
 export default class Layer {
-  constructor(...propObjects) {
+  // constructor(...propObjects)
+  constructor() {
     // Merges incoming props with defaults and freezes them.
-    this.props = createProps(this, propObjects);
+    // TODO switch to spread operator once we no longer transpile this code
+    // this.props = createProps.apply(propObjects);
+    /* eslint-disable prefer-spread */
+    this.props = createProps.apply(this, arguments);
+    /* eslint-enable prefer-spread */
 
     // Define all members before layer is sealed
     this.id = this.props.id; // The layer's id, used for matching with layers from last render cycle

--- a/src/core/lib/layer.js
+++ b/src/core/lib/layer.js
@@ -70,15 +70,9 @@ const defaultProps = {
 let counter = 0;
 
 export default class Layer {
-<<<<<<< HEAD
-  constructor(props = {}) {
+  constructor(...propObjects) {
     // Merges incoming props with defaults and freezes them.
-    this.props = createProps(this, props);
-=======
-  constructor(...props) {
-    // Call a helper function to merge the incoming props with defaults and freeze them.
-    this.props = this._normalizeProps(props);
->>>>>>> Allow multiple partial prop objects to be passed to layer
+    this.props = createProps(this, propObjects);
 
     // Define all members before layer is sealed
     this.id = this.props.id; // The layer's id, used for matching with layers from last render cycle

--- a/src/core/lifecycle/create-props.js
+++ b/src/core/lifecycle/create-props.js
@@ -4,7 +4,9 @@ import log from '../utils/log';
 export const EMPTY_ARRAY = Object.freeze([]);
 
 // Create a property object
-export function createProps(layer, propObjects = []) {
+export function createProps(propObjects = []) {
+  const layer = this; // eslint-disable-line
+
   // Get default prop object (a prototype chain for now)
   const {defaultProps} = getDefaultProps(layer.constructor);
 
@@ -21,7 +23,9 @@ export function createProps(layer, propObjects = []) {
   });
 
   // "Copy" all sync props
-  Object.assign(newProps, ...propObjects);
+  for (let i = 0; i < arguments.length; ++i) {
+    Object.assign(newProps, arguments[i]);
+  }
   newProps.data = newProps.data || EMPTY_ARRAY;
 
   // SEER: Apply any overrides from the seer debug extension if it is active

--- a/src/core/lifecycle/create-props.js
+++ b/src/core/lifecycle/create-props.js
@@ -4,7 +4,7 @@ import log from '../utils/log';
 export const EMPTY_ARRAY = Object.freeze([]);
 
 // Create a property object
-export function createProps(layer, props) {
+export function createProps(layer, propObjects = []) {
   // Get default prop object (a prototype chain for now)
   const {defaultProps} = getDefaultProps(layer.constructor);
 
@@ -20,15 +20,12 @@ export function createProps(layer, props) {
     }
   });
 
-  // Extract any async props
-  // props = setAsyncProps(newProps, props, ASYNC_PROPS);
-
   // "Copy" all sync props
-  Object.assign(newProps, props);
-  newProps.data = props.data || EMPTY_ARRAY;
+  Object.assign(newProps, ...propObjects);
+  newProps.data = newProps.data || EMPTY_ARRAY;
 
   // SEER: Apply any overrides from the seer debug extension if it is active
-  applyPropOverrides(props);
+  applyPropOverrides(newProps);
 
   // Props must be immutable
   Object.freeze(newProps);

--- a/test/bench/core-layers.bench.js
+++ b/test/bench/core-layers.bench.js
@@ -30,21 +30,9 @@ import {SolidPolygonLayer as SolidPolygonLayer2} from 'deck.gl/experimental-laye
 
 // add tests
 export default function coreLayersBench(suite) {
-  return suite
-    .group('LAYER CONSTRUCTION')
-    .add('ScatterplotLayer#construct', () => {
-      return new ScatterplotLayer({data: data.points});
-    })
-    .add('GeoJsonLayer#construct', () => {
-      return new GeoJsonLayer({data: data.choropleths});
-    })
-    .add('PolygonLayer#construct', () => {
-      return new PolygonLayer({data: data.choropleths.features});
-    })
-    .add('SolidPolygonLayer#construct', () => {
-      return new PolygonLayer({data: data.choropleths.features});
-    })
+  layerConstructionBench(suite);
 
+  return suite
     .group('COMPOSITE LAYER INITIALIZATION')
     .add('GeoJsonLayer#initialize', () => {
       const layer = new GeoJsonLayer({data: data.choropleths});
@@ -162,5 +150,86 @@ export default function coreLayersBench(suite) {
         fp64: true
       });
       testInitializeLayer({layer});
-    });
+    })
+    ;
+}
+
+
+const PROPS1 = {
+  // data: Special handling for null, see below
+  dataComparator: null,
+  updateTriggers: {}, // Update triggers: a core change detection mechanism in deck.gl
+  numInstances: undefined,
+
+  visible: true,
+  pickable: false,
+  opacity: 0.8,
+
+  onHover: () => {},
+  onClick: () => {},
+
+  coordinateSystem: 1,
+  coordinateOrigin: [0, 0, 0],
+
+  parameters: {},
+  uniforms: {},
+  framebuffer: null,
+
+  animation: null, // Passed prop animation functions to evaluate props
+
+  // Offset depth based on layer index to avoid z-fighting.
+  // Negative values pull layer towards the camera
+  // https://www.opengl.org/archives/resources/faq/technical/polygonoffset.htm
+  getPolygonOffset: ({layerIndex}) => [0, -layerIndex * 100],
+};
+
+const PROPS2 = {
+  // data: Special handling for null, see below
+  dataComparator2: null,
+  updateTriggers2: {}, // Update triggers: a core change detection mechanism in deck.gl
+  numInstances2: undefined,
+
+  visible2: true,
+  pickable2: false,
+  opacity2: 0.8,
+
+  coordinateSystem2: 1,
+  coordinateOrigin2: [0, 0, 0],
+
+  parameters2: {},
+  uniforms2: {},
+  framebuffer2: null,
+
+  animation2: null, // Passed prop animation functions to evaluate props
+};
+
+const PROPS3 = {
+  // Selection/Highlighting
+  highlightedObjectIndex: null,
+  autoHighlight: false,
+  highlightColor: [0, 0, 128, 128]
+};
+
+function layerConstructionBench(suite) {
+  suite
+    .group('LAYER CONSTRUCTION')
+    .add('ScatterplotLayer#construct', () => {
+      return new ScatterplotLayer({data: data.points});
+    })
+    .add('GeoJsonLayer#construct', () => {
+      return new GeoJsonLayer({data: data.choropleths});
+    })
+    .add('PolygonLayer#construct', () => {
+      return new PolygonLayer({data: data.choropleths.features});
+    })
+    .add('SolidPolygonLayer#construct', () => {
+      return new PolygonLayer({data: data.choropleths.features});
+    })
+    .add('ScatterplotLayer#construct(separate prop objects)', () => {
+      return new ScatterplotLayer(PROPS1, PROPS2, PROPS3);
+    })
+    .add('ScatterplotLayer#construct(precomposed prop objects)', () => {
+      return new ScatterplotLayer(Object.assign({}, PROPS1, PROPS2, PROPS3));
+    })
+    ;
 }

--- a/test/src/core/lib/layer.spec.js
+++ b/test/src/core/lib/layer.spec.js
@@ -52,6 +52,13 @@ const LAYER_CONSTRUCT_TEST_CASES = [
   {
     title: 'With data map',
     props: {id: 'testLayer', data: new Map([['a', 'a'], ['b', 'b'], ['c', 'c']])}
+  },
+];
+
+const LAYER_CONSTRUCT_MULTIPROP_TEST_CASES = [
+  {
+    title: 'With multiple prop objects',
+    props: [{data: {a: 'a', b: 'b', c: 'c'}}, {id: 'testLayer'}]
   }
 ];
 
@@ -82,9 +89,24 @@ SubLayer3.layerName = 'SubLayer2';
 
 test('Layer#constructor', t => {
   for (const tc of LAYER_CONSTRUCT_TEST_CASES) {
-    const layer = new Layer(tc.props);
+    const layer = Array.isArray(tc.props) ?
+      new Layer(...tc.props) :
+      new Layer(tc.props);
     t.ok(layer, `Layer created ${tc.title}`);
-    const expectedId = tc.props.id || tc.id;
+    const props = Array.isArray(tc.props) ? tc.props[0] : tc.props;
+    const expectedId = props.id || tc.id;
+    t.equal(layer.id, expectedId, 'Layer id set correctly');
+    t.ok(layer.props, 'Layer props not null');
+  }
+  t.end();
+});
+
+test('Layer#constructor(multi prop objects)', t => {
+  for (const tc of LAYER_CONSTRUCT_MULTIPROP_TEST_CASES) {
+    const layer = new Layer(...tc.props);
+    t.ok(layer, `Layer created ${tc.title}`);
+    const props = Object.assign({}, ...tc.props);
+    const expectedId = props.id || tc.id;
     t.equal(layer.id, expectedId, 'Layer id set correctly');
     t.ok(layer.props, 'Layer props not null');
   }

--- a/test/src/core/lib/layer.spec.js
+++ b/test/src/core/lib/layer.spec.js
@@ -52,7 +52,7 @@ const LAYER_CONSTRUCT_TEST_CASES = [
   {
     title: 'With data map',
     props: {id: 'testLayer', data: new Map([['a', 'a'], ['b', 'b'], ['c', 'c']])}
-  },
+  }
 ];
 
 const LAYER_CONSTRUCT_MULTIPROP_TEST_CASES = [
@@ -89,9 +89,7 @@ SubLayer3.layerName = 'SubLayer2';
 
 test('Layer#constructor', t => {
   for (const tc of LAYER_CONSTRUCT_TEST_CASES) {
-    const layer = Array.isArray(tc.props) ?
-      new Layer(...tc.props) :
-      new Layer(tc.props);
+    const layer = Array.isArray(tc.props) ? new Layer(...tc.props) : new Layer(tc.props);
     t.ok(layer, `Layer created ${tc.title}`);
     const props = Array.isArray(tc.props) ? tc.props[0] : tc.props;
     const expectedId = props.id || tc.id;

--- a/test/src/core/lib/props.spec.js
+++ b/test/src/core/lib/props.spec.js
@@ -167,7 +167,7 @@ test('createProps', t => {
   class B extends A {}
   B.defaultProps = {b: 2};
 
-  const mergedProps = createProps(new B());
+  const mergedProps = createProps.apply(new B(), []);
 
   t.equal(mergedProps.a, 1, 'base class props merged');
   t.equal(mergedProps.b, 2, 'sub class props merged');

--- a/test/src/core/lib/props.spec.js
+++ b/test/src/core/lib/props.spec.js
@@ -167,7 +167,7 @@ test('createProps', t => {
   class B extends A {}
   B.defaultProps = {b: 2};
 
-  const mergedProps = createProps(new B(), {});
+  const mergedProps = createProps(new B());
 
   t.equal(mergedProps.a, 1, 'base class props merged');
   t.equal(mergedProps.b, 2, 'sub class props merged');


### PR DESCRIPTION
This PR might be pushing micro performance optimization a little far so opening this for comment:

The problem: Complex apps often build large prop objects by "merging" smaller objects. Currently we have to merge these objects in the app, and then the layer merges again with the default props. With lots of layers and props in play, such copying can have a noticeable perf impact (see measurements in #1336 ). 

The idea in this PR: By allowing Layers to take multiple prop objects, we can let the layer do a single merge and save one round of copying and temp object creation, i.e:

```
new Layer({...commonProps, ...settingProps, ...layerProps});
```

```
new Layer(commonProps, this.getSublayerProps(...), {data: ...});
```

Obviously documentation needs to be updated, this PR is not final.