### PR TITLE
allow override position, left, top of deck.gl canvas

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -30,6 +30,9 @@ A new `DeckGL` prop `layerFilter` gives the application an opportunity to filter
 
 To reduce confusion, `DeckGL.queryObject` has been renamed to `DeckGL.pickObject` and `DeckGL.queryVisibleObjects` has been renamed to `DeckGL.pickObjects`. Old functions are still supported with deprecated warning, but will be removed in the next major version.
 
+### DeckGL: Allow overriding canvas component style
+
+Users can now override the canvas size, position and offset via the style prop passed to the DeckGL component.
 
 ## Layer Improvements
 

--- a/src/react/deckgl.js
+++ b/src/react/deckgl.js
@@ -127,7 +127,13 @@ export default class DeckGL extends React.Component {
       ref: c => (this.overlay = c),
       key: 'overlay',
       id,
-      style: Object.assign({}, style, {position: 'absolute', left: 0, top: 0, width, height})
+      style: Object.assign({}, style, {
+        position: style.position || 'absolute',
+        left: style.left || 0,
+        top: style.top || 0,
+        width,
+        height
+      })
     });
     children.push(deck);
 

--- a/src/react/deckgl.js
+++ b/src/react/deckgl.js
@@ -127,13 +127,7 @@ export default class DeckGL extends React.Component {
       ref: c => (this.overlay = c),
       key: 'overlay',
       id,
-      style: Object.assign({}, style, {
-        position: style.position || 'absolute',
-        left: style.left || 0,
-        top: style.top || 0,
-        width,
-        height
-      })
+      style: Object.assign({}, {position: 'absolute', left: 0, top: 0, width, height}, style)
     });
     children.push(deck);
 


### PR DESCRIPTION
not sure if it was done by design (due to picking issues?) but I need to use relative position and have deck.gl canvas resize with his parent node.