### PR TITLE
Wind demo: update using newest luma.gl TF API

### DIFF
--- a/examples/wind/src/layers/particle-layer/particle-layer-vertex.glsl.js
+++ b/examples/wind/src/layers/particle-layer/particle-layer-vertex.glsl.js
@@ -39,7 +39,7 @@ uniform vec4 elevationBounds;
 uniform vec2 elevationRange;
 uniform float zScale;
 
-// attribute vec3 positions;
+attribute vec3 positions;
 attribute vec4 posFrom;
 // attribute vec3 vertices;
 
@@ -67,7 +67,7 @@ void main(void) {
   vec2 pos = project_position(posFrom.xy);
   float elevation = project_scale((texel.w) * ELEVATION_SCALE);
 
-  vec3 extrudedPosition = vec3(pos.xy, elevation + 1.0);
+  vec3 extrudedPosition = vec3(pos.xy, elevation + 1.0) + positions;
   vec4 position_worldspace = vec4(extrudedPosition, 1.0);
   gl_Position = project_to_clipspace(position_worldspace);
   gl_PointSize = 3.5 * pixelRatio / 2.0;

--- a/examples/wind/src/layers/particle-layer/particle-layer.js
+++ b/examples/wind/src/layers/particle-layer/particle-layer.js
@@ -249,7 +249,6 @@ export default class ParticleLayer extends Layer {
       parameters: pixelStoreParameters
     });
 
-    modelTF.program.use();
     const {transformFeedback} = this.state;
 
     modelTF.setAttributes({
@@ -258,14 +257,13 @@ export default class ParticleLayer extends Layer {
 
     transformFeedback.bindBuffers(
       {
-        0: bufferTo
+        gl_Position: bufferTo
       },
       {
-        clear: true
+        clear: true,
+        varyingMap: modelTF.varyingMap
       }
     );
-
-    transformFeedback.begin(gl.POINTS);
 
     const uniforms = {
       bbox: [bbox.minLng, bbox.maxLng, bbox.minLat, bbox.maxLat],
@@ -283,9 +281,7 @@ export default class ParticleLayer extends Layer {
       [GL.RASTERIZER_DISCARD]: true
     };
 
-    modelTF.draw({uniforms, parameters});
-
-    transformFeedback.end();
+    modelTF.draw({uniforms, parameters, transformFeedback});
 
     if (flip > 0) {
       flip = -1;

--- a/examples/wind/src/layers/particle-layer/particle-layer.js
+++ b/examples/wind/src/layers/particle-layer/particle-layer.js
@@ -167,7 +167,7 @@ export default class ParticleLayer extends Layer {
     });
 
     model.setAttributes({
-      posFrom: bufferTo
+      posFrom: bufferTo.setDataLayout({size: 4, instanced: 1})
     });
 
     model.render(Object.assign({}, currentUniforms, uniforms));
@@ -252,12 +252,12 @@ export default class ParticleLayer extends Layer {
     const {transformFeedback} = this.state;
 
     modelTF.setAttributes({
-      posFrom: bufferFrom
+      posFrom: bufferFrom.setDataLayout({size: 4, instanced: 0})
     });
 
     transformFeedback.bindBuffers(
       {
-        gl_Position: bufferTo
+        gl_Position: bufferTo.setDataLayout({size: 4, instanced: 0})
       },
       {
         clear: true,
@@ -325,7 +325,7 @@ export default class ParticleLayer extends Layer {
     // This will be a grid of elements
     this.state.numInstances = nx * ny;
 
-    const positions3 = this.calculatePositions3({nx, ny});
+    const positions3 = new Float32Array([0, 0, 0]);
 
     return new Model(gl, {
       id: 'ParticleLayer-model',
@@ -334,11 +334,13 @@ export default class ParticleLayer extends Layer {
       geometry: new Geometry({
         id: this.props.id,
         drawMode: GL.POINTS,
+        vertexCount: 1,
         attributes: {
-          positions: {size: 3, type: GL.FLOAT, value: positions3},
-          vertices: {size: 3, type: GL.FLOAT, value: positions3}
+          positions: {size: 3, type: GL.FLOAT, value: positions3, instanced: 0}
         }
       }),
+      isInstanced: true,
+      instanceCount: this.state.numInstances,
       isIndexed: false
     });
   }


### PR DESCRIPTION
- REQUIRES luma.gl 5.1.0.
- Update wind demo to use newer luma.gl TransformFeedback API.
- Use instanced rendering for particle layer.

Verified running wind demo using latest luma.gl build.