### PR TITLE
Add VR support to point-cloud-laz example

### DIFF
--- a/examples/point-cloud-laz/README.md
+++ b/examples/point-cloud-laz/README.md
@@ -1,18 +1,18 @@
 ## VR Capability
 This example can be viewed in VR-capable devices. 
 It uses deck.gl's multi-viewport, the WebVR API and [WebVR Polyfill](https://github.com/immersive-web/webvr-polyfill) library.
-#### Working
-`_initVRDisplay()` setups the `vrDisplay` and sets `vrEnabled` to true if a VR display is connected.
+### Working
+The `_initVRDisplay()` function setups the `VRDisplay` and sets `vrEnabled` to true if a VR display is connected.
 In case a VR display is not detected, the default Orbit Controller along with the Orbit Viewport will be used.
 However, a stereoscopic view can still be viewed without an actual VR device.
 
-#### Rendering Viewports
+### Rendering Viewports
 For stereoscopic rendering, two default viewports are used for Side-by-Side display.
 
 The WebVR API provides [`VRFrameData`](https://developer.mozilla.org/en-US/docs/Web/API/VRFrameData) constructed by the `VRDisplay.getFrameData` function. This frame data is essential for obtaining the `viewMatrix` and `projectionMatrix` of both the left and right eye.
 The base deck.gl viewport can directly accept the view and projection matrices using the `DeckGL.viewports` property.
 
-#### Emulated VR Display
+### Emulated VR Display
 The ```EmulatedVRDisplay``` comes into picture when an actual VR hardware is not present.
 It provides a mock `VRFrameData` object which contains necessary matrices used for rendering the viewport.
 

--- a/examples/point-cloud-laz/README.md
+++ b/examples/point-cloud-laz/README.md
@@ -2,7 +2,7 @@
 This example can be viewed in VR-capable devices. 
 It uses deck.gl's multi-viewport, the WebVR API and [WebVR Polyfill](https://github.com/immersive-web/webvr-polyfill) library.
 ### Working
-The `_initVRDisplay()` function setups the `VRDisplay` and sets `vrEnabled` to true if a VR display is connected.
+The `_initVRDisplay()` method setups the `VRDisplay` and sets `vrEnabled` to true if a VR display is connected.
 
 In the absence of an actual VR device, the default Orbit Controller along with the Orbit Viewport will be used.
 However, a stereoscopic view can still be activated.
@@ -11,12 +11,11 @@ However, a stereoscopic view can still be activated.
 For stereoscopic rendering and Side-by-Side display, two default viewports are used.
 
 The WebVR API provides [`VRFrameData`](https://developer.mozilla.org/en-US/docs/Web/API/VRFrameData) constructed by the `VRDisplay.getFrameData` function. This frame data is essential for obtaining the `viewMatrix` and `projectionMatrix` of both the left and right eye.
-The base deck.gl viewport can directly accept the view and projection matrices using the `DeckGL.viewports` property.
+The base deck.gl viewport can directly accept these matrices using the `DeckGL.viewports` property.
 
 ### Emulated VR Display
 The ```EmulatedVRDisplay``` comes into picture when an actual VR hardware is not present.
 It provides a mock `VRFrameData` object which contains necessary matrices used for rendering the viewports.
 
-The `getFrameDataFromPose()` function accepts an emulated [`VRPose`](https://developer.mozilla.org/en-US/docs/Web/API/VRPose) object which contains the orientation and position. Thus, allowing manual control over the pose and finally, interaction in the viewports.
-
-  
+The `getFrameDataFromPose()` method accepts an emulated [`VRPose`](https://developer.mozilla.org/en-US/docs/Web/API/VRPose) object which contains the orientation and position. 
+Thus, allowing manual control over the pose and finally, interaction in the viewports.

--- a/examples/point-cloud-laz/README.md
+++ b/examples/point-cloud-laz/README.md
@@ -1,0 +1,21 @@
+## VR Capability
+This example can be viewed in VR-capable devices. 
+It uses deck.gl's multi-viewport, the WebVR API and [WebVR Polyfill](https://github.com/immersive-web/webvr-polyfill) library.
+#### Working
+`_initVRDisplay()` setups the `vrDisplay` and sets `vrEnabled` to true if a VR display is connected.
+In case a VR display is not detected, the default Orbit Controller along with the Orbit Viewport will be used.
+However, a stereoscopic view can still be viewed without an actual VR device.
+
+#### Rendering Viewports
+For stereoscopic rendering, two default viewports are used for Side-by-Side display.
+
+The WebVR API provides [`VRFrameData`](https://developer.mozilla.org/en-US/docs/Web/API/VRFrameData) constructed by the `VRDisplay.getFrameData` function. This frame data is essential for obtaining the `viewMatrix` and `projectionMatrix` of both the left and right eye.
+The base deck.gl viewport can directly accept the view and projection matrices using the `DeckGL.viewports` property.
+
+#### Emulated VR Display
+The ```EmulatedVRDisplay``` comes into picture when an actual VR hardware is not present.
+It provides a mock `VRFrameData` object which contains necessary matrices used for rendering the viewport.
+
+The `getFrameDataFromPose()` function accepts an emulated [`VRPose`](https://developer.mozilla.org/en-US/docs/Web/API/VRPose) object which contains the orientation and position. Thus, allowing manual control over the pose and finally, interaction in the viewports.
+
+  

--- a/examples/point-cloud-laz/README.md
+++ b/examples/point-cloud-laz/README.md
@@ -3,18 +3,19 @@ This example can be viewed in VR-capable devices.
 It uses deck.gl's multi-viewport, the WebVR API and [WebVR Polyfill](https://github.com/immersive-web/webvr-polyfill) library.
 ### Working
 The `_initVRDisplay()` function setups the `VRDisplay` and sets `vrEnabled` to true if a VR display is connected.
-In case a VR display is not detected, the default Orbit Controller along with the Orbit Viewport will be used.
-However, a stereoscopic view can still be viewed without an actual VR device.
+
+In the absence of an actual VR device, the default Orbit Controller along with the Orbit Viewport will be used.
+However, a stereoscopic view can still be activated.
 
 ### Rendering Viewports
-For stereoscopic rendering, two default viewports are used for Side-by-Side display.
+For stereoscopic rendering and Side-by-Side display, two default viewports are used.
 
 The WebVR API provides [`VRFrameData`](https://developer.mozilla.org/en-US/docs/Web/API/VRFrameData) constructed by the `VRDisplay.getFrameData` function. This frame data is essential for obtaining the `viewMatrix` and `projectionMatrix` of both the left and right eye.
 The base deck.gl viewport can directly accept the view and projection matrices using the `DeckGL.viewports` property.
 
 ### Emulated VR Display
 The ```EmulatedVRDisplay``` comes into picture when an actual VR hardware is not present.
-It provides a mock `VRFrameData` object which contains necessary matrices used for rendering the viewport.
+It provides a mock `VRFrameData` object which contains necessary matrices used for rendering the viewports.
 
 The `getFrameDataFromPose()` function accepts an emulated [`VRPose`](https://developer.mozilla.org/en-US/docs/Web/API/VRPose) object which contains the orientation and position. Thus, allowing manual control over the pose and finally, interaction in the viewports.
 

--- a/examples/point-cloud-laz/app.js
+++ b/examples/point-cloud-laz/app.js
@@ -1,13 +1,16 @@
-/* global document, window,*/
+/* global document, window, navigator */
 /* eslint-disable no-console */
 import React, {PureComponent} from 'react';
 import {render} from 'react-dom';
-import DeckGL, {COORDINATE_SYSTEM, PointCloudLayer, experimental} from 'deck.gl';
+import DeckGL, {COORDINATE_SYSTEM, PointCloudLayer, experimental, Viewport} from 'deck.gl';
 const {OrbitController} = experimental;
 
 import {setParameters} from 'luma.gl';
 
 import {loadLazFile, parseLazData} from './utils/laslaz-loader';
+
+import WebVRPolyfill from 'webvr-polyfill';
+import EmulatedVRDisplay from './vr/emulated-vr-display';
 
 const DATA_REPO = 'https://raw.githubusercontent.com/uber-common/deck.gl-data/master';
 const FILE_PATH = 'examples/point-cloud-laz/indoor.laz';
@@ -65,6 +68,12 @@ class Example extends PureComponent {
         fov: 30,
         minDistance: 0.5,
         maxDistance: 3
+      },
+      vrDisplay: new EmulatedVRDisplay(),
+      vrEnabled: false,
+      emulatedPose: {
+        orientation: [0, 0, 0, 1],
+        position: [0, 0, 0]
       }
     };
   }
@@ -92,7 +101,7 @@ class Example extends PureComponent {
         this.setState({points, progress});
       });
     });
-
+    this._initVRDisplay();
     window.requestAnimationFrame(this._onUpdate);
   }
 
@@ -124,8 +133,29 @@ class Example extends PureComponent {
   }
 
   _onUpdate() {
-    const {rotating, viewport} = this.state;
+    const {vrEnabled} = this.state;
 
+    if (vrEnabled) {
+      const {vrDisplay, emulatedPose} = this.state;
+      // animate camera in Z-axis
+      // this can be removed after we have a VRController for EmulatedVRDisplay
+      if (vrDisplay.isEmulated) {
+        const {position} = emulatedPose;
+        position[2] += position[2] < 0.5 ? 0.001 : -0.5;
+        this.setState({
+          emulatedPose: {
+            ...emulatedPose,
+            ...position
+          }
+        });
+      }
+
+      this.forceUpdate(); // explicitly refresh state; removing this breaks frame update in VR
+      window.requestAnimationFrame(this._onUpdate);
+      return;
+    }
+
+    const {rotating, viewport} = this.state;
     // note: when finished dragging, _onUpdate will not resume by default
     // to resume rotating, explicitly call _onUpdate or requestAnimationFrame
     if (!rotating) {
@@ -142,7 +172,7 @@ class Example extends PureComponent {
     window.requestAnimationFrame(this._onUpdate);
   }
 
-  _renderLazPointCloudLayer() {
+  _renderLazPointCloudLayer(useSmallRadius = false) {
     const {points} = this.state;
     if (!points || points.length === 0) {
       return null;
@@ -155,12 +185,75 @@ class Example extends PureComponent {
       getPosition: d => d.position,
       getNormal: d => [0, 0.5, 0.2],
       getColor: d => [255, 255, 255, 128],
-      radiusPixels: 1
+      radiusPixels: useSmallRadius ? 0.5 : 1
+    });
+  }
+
+  _initVRDisplay() {
+    const polyfill = new WebVRPolyfill({  // eslint-disable-line no-unused-vars
+      PROVIDE_MOBILE_VRDISPLAY: true
+    });
+
+    if (navigator && navigator.getVRDisplays) {
+      navigator.getVRDisplays().then(displays => {
+        const vrDisplay = displays.find(d => d.isConnected);
+        if (vrDisplay) {
+          this.setState({vrDisplay, vrEnabled: true});
+        }
+      });
+    }
+  }
+
+  _renderViewports() {
+    const {width, height, vrDisplay, emulatedPose} = this.state;
+    const frameData = vrDisplay.isEmulated ? {} : new window.VRFrameData();
+    const gotFrameData = vrDisplay.isEmulated
+      ? vrDisplay.getFrameDataFromPose(frameData, emulatedPose)
+      : vrDisplay.getFrameData(frameData);
+    if (gotFrameData) {
+      return [
+        new Viewport({
+          x: 0,
+          width: width / 2,
+          height,
+          viewMatrix: frameData.leftViewMatrix,
+          projectionMatrix: frameData.leftProjectionMatrix
+        }),
+        new Viewport({
+          x: width / 2,
+          width: width / 2,
+          height,
+          viewMatrix: frameData.rightViewMatrix,
+          projectionMatrix: frameData.rightProjectionMatrix
+        })
+      ];
+    }
+    return new Viewport({width, height});
+  }
+
+  _toggleDisplayMode() {
+    const {vrEnabled} = this.state;
+
+    this.setState({
+      vrEnabled: !vrEnabled
     });
   }
 
   _renderDeckGLCanvas() {
-    const {width, height, viewport} = this.state;
+    const {width, height, viewport, vrEnabled} = this.state;
+
+    if (vrEnabled) {
+      return (
+        <DeckGL
+          width={width}
+          height={height}
+          viewports={this._renderViewports()}
+          layers={[this._renderLazPointCloudLayer(true)]}
+          onWebGLInitialized={this._onInitialized}
+        />
+      );
+    }
+
     const canvasProps = {width, height, ...viewport};
     const glViewport = OrbitController.getViewport(canvasProps);
 
@@ -204,6 +297,30 @@ class Example extends PureComponent {
             </div>
           ) : (
             <div>Data source: kaarta.com</div>
+          )}
+        </div>
+        <div
+          style={{
+            position: 'absolute',
+            right: '8px',
+            bottom: '8px',
+            color: '#FFF',
+            fontSize: '15px'
+          }}
+        >
+          {this.state.vrEnabled ? (
+            <div>
+              {this.state.vrDisplay.isEmulated ? (
+                <a onClick={this._toggleDisplayMode.bind(this)}>Exit stereoscopic view.</a>
+              ) : (
+                <br />
+              )}
+            </div>
+          ) : (
+            <div>
+              <div>No VR Device found.</div>
+              <a onClick={this._toggleDisplayMode.bind(this)}>Enter stereoscopic view.</a>
+            </div>
           )}
         </div>
       </div>

--- a/examples/point-cloud-laz/app.js
+++ b/examples/point-cloud-laz/app.js
@@ -190,9 +190,11 @@ class Example extends PureComponent {
   }
 
   _initVRDisplay() {
-    const polyfill = new WebVRPolyfill({  // eslint-disable-line no-unused-vars
+    /* eslint-disable no-unused-vars */
+    const polyfill = new WebVRPolyfill({
       PROVIDE_MOBILE_VRDISPLAY: true
     });
+    /* eslint-disable no-unused-vars */
 
     if (navigator && navigator.getVRDisplays) {
       navigator.getVRDisplays().then(displays => {

--- a/examples/point-cloud-laz/package.json
+++ b/examples/point-cloud-laz/package.json
@@ -15,7 +15,9 @@
     "gl-matrix": "^2.3.2",
     "is-little-endian": "0.0.0",
     "react": "^16.2.0",
-    "react-dom": "^16.2.0"
+    "react-dom": "^16.2.0",
+    "webvr-polyfill": "^0.10.2",
+    "gl-mat4": "^1.1.4"
   },
   "devDependencies": {
     "buble-loader": "^0.4.1",

--- a/examples/point-cloud-laz/vr/emulated-vr-display.js
+++ b/examples/point-cloud-laz/vr/emulated-vr-display.js
@@ -1,0 +1,174 @@
+/* global window */
+import {Matrix4} from 'math.gl';
+import {perspectiveFromFieldOfView, fromRotationTranslation} from 'gl-mat4';
+
+const DEGREES_TO_RADIANS = Math.PI / 180;
+const EYE_DISTANCE = 0.03;
+const FOV_DEGREES_Y = 40;
+const FOV_DEGREES_X_MIN = 40;
+const FOV_DEGREES_X_MAX = 40;
+const DEFAULT_ORIENTATION = [0, 0, 0, 1];
+const DEFAULT_POSITION = [0, 0, 0];
+
+export default class EmulatedVRDisplay {
+  constructor() {
+    this.depthFar = 1000;
+    this.depthNear = 0.1;
+    this.layers = [];
+    this.isEmulated = true;
+
+    this.leftEyeParameters = {
+      offset: [-EYE_DISTANCE / 2, 0, 0],
+      fieldOfView: {
+        downDegrees: FOV_DEGREES_Y,
+        leftDegrees: FOV_DEGREES_X_MAX,
+        rightDegrees: FOV_DEGREES_X_MIN,
+        upDegrees: FOV_DEGREES_Y
+      }
+    };
+    this.rightEyeParameters = {
+      offset: [EYE_DISTANCE / 2, 0, 0],
+      fieldOfView: {
+        downDegrees: FOV_DEGREES_Y,
+        leftDegrees: FOV_DEGREES_X_MIN,
+        rightDegrees: FOV_DEGREES_X_MAX,
+        upDegrees: FOV_DEGREES_Y
+      }
+    };
+    this.poseMatrix = new Matrix4();
+  }
+
+  getEyeParameters(whichEye) {
+    const viewport = this._getViewportSize();
+
+    if (whichEye === 'right') {
+      return {...this.rightEyeParameters, ...viewport};
+    }
+    return {...this.leftEyeParameters, ...viewport};
+  }
+
+  getFrameData(vrFrameData) {
+    if (!vrFrameData) {
+      throw new Error('must supply a frameData object');
+    }
+
+    const timestamp = Date.now();
+
+    const leftProjectionMatrix = new Matrix4();
+    const rightProjectionMatrix = new Matrix4();
+    const leftViewMatrix = new Matrix4();
+    const rightViewMatrix = new Matrix4();
+
+    perspectiveFromFieldOfView(
+      leftProjectionMatrix,
+      this.leftEyeParameters.fieldOfView,
+      this.depthNear,
+      this.depthFar
+    );
+    perspectiveFromFieldOfView(
+      rightProjectionMatrix,
+      this.rightEyeParameters.fieldOfView,
+      this.depthNear,
+      this.depthFar
+    );
+
+    leftViewMatrix.translate(this.leftEyeParameters.offset);
+    rightViewMatrix.translate(this.rightEyeParameters.offset);
+
+    leftViewMatrix.invert();
+    rightViewMatrix.invert();
+
+    Object.assign(vrFrameData, {
+      timestamp,
+      leftProjectionMatrix,
+      rightProjectionMatrix,
+      leftViewMatrix,
+      rightViewMatrix
+    });
+
+    return true;
+  }
+
+  getFrameDataFromPose(vrFrameData, pose) {
+    if (!vrFrameData) {
+      throw new Error('must supply a frameData object');
+    }
+
+    if (!pose) {
+      throw new Error('must supply a pose object');
+    }
+
+    const timestamp = pose.timestamp || Date.now();
+
+    const leftProjectionMatrix = new Matrix4();
+    const rightProjectionMatrix = new Matrix4();
+    const leftViewMatrix = new Matrix4();
+    const rightViewMatrix = new Matrix4();
+
+    perspectiveFromFieldOfView(
+      leftProjectionMatrix,
+      this.leftEyeParameters.fieldOfView,
+      this.depthNear,
+      this.depthFar
+    );
+    perspectiveFromFieldOfView(
+      rightProjectionMatrix,
+      this.rightEyeParameters.fieldOfView,
+      this.depthNear,
+      this.depthFar
+    );
+
+    const orientation = pose.orientation || DEFAULT_ORIENTATION;
+    const position = pose.position || DEFAULT_POSITION;
+
+    fromRotationTranslation(leftViewMatrix, orientation, position);
+    fromRotationTranslation(rightViewMatrix, orientation, position);
+
+    leftViewMatrix.translate(this.leftEyeParameters.offset);
+    rightViewMatrix.translate(this.rightEyeParameters.offset);
+
+    leftViewMatrix.invert();
+    rightViewMatrix.invert();
+
+    Object.assign(vrFrameData, {
+      pose,
+      timestamp,
+      leftProjectionMatrix,
+      rightProjectionMatrix,
+      leftViewMatrix,
+      rightViewMatrix
+    });
+
+    return true;
+  }
+
+  requestPresent({source}) {
+    this.layers.push(source);
+    return Promise.resolve();
+  }
+
+  exitPresent() {
+    this.layers.length = 0;
+    return Promise.resolve();
+  }
+
+  submitFrame() {}
+
+  _getViewportSize() {
+    return {
+      renderWidth: window.innerWidth / 2,
+      renderHeight: window.innerHeight
+    };
+  }
+
+  _getEyeMatrix({offset, fieldOfView}) {
+    const matrix = new Matrix4();
+    // rotate
+    const gazeDir = -(fieldOfView.leftDegrees - fieldOfView.rightDegrees) * DEGREES_TO_RADIANS;
+    matrix.rotateZ(gazeDir);
+    // offset
+    matrix.translate(offset);
+
+    return matrix;
+  }
+}


### PR DESCRIPTION
If VR device is connected, it automatically switches to stereoscopic view, fallbacks to single Orbit Viewport otherwise.
A stereoscopic view can still be switched on a desktop by clicking "Enter stereoscopic view.".