### PR TITLE
Fix bug where HexagonLayer always rerenders

### DIFF
--- a/src/core-layers/hexagon-layer/hexagon-layer.js
+++ b/src/core-layers/hexagon-layer/hexagon-layer.js
@@ -125,10 +125,6 @@ export default class HexagonLayer extends CompositeLayer {
     };
   }
 
-  shouldUpdateState({changeFlags}) {
-    return changeFlags.somethingChanged;
-  }
-
   updateState({oldProps, props, changeFlags}) {
     const dimensionChanges = this.getDimensionChanges(oldProps, props);
 


### PR DESCRIPTION
To reproduce the bug: run layer browser, and set `luma.log.priority=2` in the console.