### PR TITLE
Add more screenshots in Whats New

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -2,14 +2,12 @@
 
 Release date: TBD, target Q1-Q2, 2018
 
-
-## Experimental Features
-
 ### Prop Types
 
-It is now possible for deck.gl layers to specify type information for each supported property. Prop types will be used to validate property values during development, optimize property comparisons when layers are updated, and are also a foundation for planned features such as property transitions/animations and asynchronous properties.
+deck.gl layers can now specify additional type information about properties. When provided, these [prop types](docs/advanced/prop-types.md) will be used to speed up property comparisons in production and to validate `Layer` property values during development, to help catch programming errors. (Prop types will also serve as a foundation for future features such as property transitions/animations and asynchronous properties). Naturally, the core deck.gl layers have been updated with prop type definitions.
 
-> For layer writers: use of prop types is optional, and deck.gl layers will automatically try to deduce type information based on the default value in the `defaultProps` object for any properties that lack type information.
+> For layer writers: use of prop types is optional, and deck.gl layers will automatically deduce partial prop type information for any properties that lack type information, as long as a default value is specified in the `defaultProps` object.
+
 
 # deck.gl v5.1
 
@@ -35,7 +33,7 @@ Release date: Feb 16, 2018
 
 ### Layer Transitions
 
-Many layers now support smooth visual transitions of e.g. positions and colors of layer elements, animating the update of the layers element to match a new data set. The animations are done on the GPU and can thus support very large data sets. Use the new [`transitions`](/docs/layer-catalog/layer.md) prop on the `Layer` class to specify transition duration, easing function and callbacks.
+Many layers now support smooth visual transitions of e.g. positions and colors of layer elements, animating the update of the layers element to match a new data set. The animations are done on the GPU and can thus support very large number of elements. Use the new [`transitions`](/docs/layer-catalog/layer.md) prop on the `Layer` class to specify things like *transition duration*, *easing function* and *callbacks*.
 
 > Transitions are only supported on WebGL2-capable browsers such as Chrome and Firefox. The `transitions` prop will simply be ignored on WebGL1 browsers.
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -7,8 +7,9 @@ Release date: TBD, target Q1-Q2, 2018
 
 ### Prop Types
 
-It is now possible to provide additional type information when declaring the `defaultProps` object for deck.gl layers, and deck.gl layers will automatically try to deduce type information based on the default value for any properties that lack type information. Prop types can be used to validate property values during development, and are also a foundation for planned features such as property transitions/animations and asynchronous properties.
+It is now possible for deck.gl layers to specify type information for each supported property. Prop types will be used to validate property values during development, optimize property comparisons when layers are updated, and are also a foundation for planned features such as property transitions/animations and asynchronous properties.
 
+> For layer writers: use of prop types is optional, and deck.gl layers will automatically try to deduce type information based on the default value in the `defaultProps` object for any properties that lack type information.
 
 # deck.gl v5.1
 
@@ -30,36 +31,56 @@ Release date: Feb 16, 2018
 </table>
 
 
-## Layer Class
+## Layer Improvements
 
 ### Layer Transitions
 
-Smooth visual transitions of layer elements, animating the update of the layers element to match a new data set, interpolating positions and colors on the GPU. Use the new `transitions` prop on the `Layer` class to specify transition duration, easing function and callbacks. Note: Transitions are only available on WebGL2-capable browsers.
+Many layers now support smooth visual transitions of e.g. positions and colors of layer elements, animating the update of the layers element to match a new data set. The animations are done on the GPU and can thus support very large data sets. Use the new [`transitions`](/docs/layer-catalog/layer.md) prop on the `Layer` class to specify transition duration, easing function and callbacks.
 
-### Layer Optimizations
-
-**Multiple Prop Objects** - Layer class constructors are faster and can now accept multiple property objects. The property objects will be merged as if with `Object.assign`, with later objects taking precedence over earlier objects: `new Layer({prop1: ...}, {prop2: ...});`. This can further improve performance in cases when using many layers with lots of property object composition.
+> Transitions are only supported on WebGL2-capable browsers such as Chrome and Firefox. The `transitions` prop will simply be ignored on WebGL1 browsers.
 
 
-## React Integration
+## React Improvements
 
 ### Use JSX to render deck.gl Layers
 
-It is now possible to use JSX syntax to create (or "render") deck.gl layers. There are no performance advantages to using JSX syntax but some users feel that this results in a more natural, React-like coding style. There are limitations (deck.gl layers are **not** React components), for more information see [Using deck.gl with React](/docs/get-started/using-with-react.md).
+It is now possible to use JSX syntax to create (or "render") deck.gl layers. Many React users feel that this results in a more natural coding style.
 ```jsx
   <DeckGL {...viewport}>
     <LineLayer data={data} />
   <DeckGL />
 ```
 
+> There are limitations (deck.gl layers are **not** React components), for more information see [Using deck.gl with React](/docs/get-started/using-with-react.md).
+
+
 # deck.gl v5
 
 Release date: Dec 21, 2017
 
+<table style="border: 0;" align="center">
+  <tbody>
+    <tr>
+      <td>
+        <img height=150 src="https://raw.github.com/uber-common/deck.gl-data/master/images/whats-new/object-highlighting.gif" />
+        <p><i>GPU-based Highlighting</i></p>
+      </td>
+      <td>
+        <img height=150 src="https://raw.github.com/uber-common/deck.gl-data/master/images/whats-new/path-dash.png" />
+        <p><i>Dashes in GeoJson</i></p>
+      </td>
+      <td>
+        <img height=150 src="https://raw.github.com/uber-common/deck.gl-data/master/images/whats-new/react-16.png" />
+        <p><i>React 16 Support</i></p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
 <p align="center">
   <div>
     <img height=150 src="https://raw.github.com/uber-common/deck.gl-data/master/images/whats-new/object-highlighting.gif" />
-    <p><i>GPU-based Highlighting</i></p>
+    <p><i></i></p>
   </div>
 </p>
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -77,13 +77,6 @@ Release date: Dec 21, 2017
   </tbody>
 </table>
 
-<p align="center">
-  <div>
-    <img height=150 src="https://raw.github.com/uber-common/deck.gl-data/master/images/whats-new/object-highlighting.gif" />
-    <p><i></i></p>
-  </div>
-</p>
-
 
 All new additions to the official deck.gl 5.0 API are listed here. Note that in addition to the official new features in this release, deck.gl 5.0 also contains a number of significant under the hoods changes to prepare for new features and optimizations. Some of these are available as experimental APIs, see below.
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -158,6 +158,22 @@ As usual, deck.gl 5.0 contains a number of experimental features, e.g. "multi vi
 
 Release date: July 27th, 2017
 
+<table style="border: 0;" align="center">
+  <tbody>
+    <tr>
+      <td>
+        <img height=150 src="https://raw.github.com/uber-common/deck.gl-data/master/images/whats-new/webgl2.jpg" />
+        <p><i>WebGL 2</i></p>
+      </td>
+      <td>
+        <img height=150 src="https://raw.github.com/uber-common/deck.gl-data/master/images/whats-new/seer.png" />
+        <p><i>Seer Extension</i></p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+
 ## WebGL2 Support (provided by luma.gl v4)
 
 deck.gl v4.1 is based on luma.gl v4, a major release that adds full WebGL2 support as well as powerful features like WebGL state management and an improve GLSL shader module system. On all browsers that supports WebGL2 (e.g. recent Chrome and Firefox browsers), deck.gl will obtain WebGL2 context and utilize WebGL2 functionalities. To know more about WebGL2, please check [here](https://www.khronos.org/registry/webgl/specs/latest/2.0/).

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -66,7 +66,7 @@ Release date: Dec 21, 2017
         <p><i>GPU-based Highlighting</i></p>
       </td>
       <td>
-        <img height=150 src="https://raw.github.com/uber-common/deck.gl-data/master/images/whats-new/path-dash.png" />
+        <img height=150 src="https://raw.github.com/uber-common/deck.gl-data/master/images/whats-new/path-dashes.png" />
         <p><i>Dashes in GeoJson</i></p>
       </td>
       <td>


### PR DESCRIPTION
To see how this will look, click the **view** button on `whats-new.md` below, and check the images for the last three releases

<img width="329" alt="screen shot 2018-02-07 at 6 17 14 pm" src="https://user-images.githubusercontent.com/7025232/35952091-2693ea64-0c33-11e8-993e-1f29554474fa.png">

I am using tables because I can't seem to be able to control styling on github HTML, if someone is better at this. I welcome a follow up diff to improve formatting.