### PR TITLE
Fix Bezier-Curve layer rendering issues

### DIFF
--- a/examples/bezier/deckgl-overlay.js
+++ b/examples/bezier/deckgl-overlay.js
@@ -12,7 +12,9 @@ export default class DeckGLOverlay extends Component {
       left: -width / 2,
       top: -height / 2,
       right: width / 2,
-      bottom: height / 2
+      bottom: height / 2,
+      near: 0,
+      far: 100
     });
 
     const layers = [

--- a/src/experimental-layers/src/bezier-curve-layer/bezier-curve-layer-vertex.glsl.js
+++ b/src/experimental-layers/src/bezier-curve-layer/bezier-curve-layer-vertex.glsl.js
@@ -61,6 +61,7 @@ vec4 computeBezierCurve(vec4 source, vec4 target, vec4 controlPoint, float segme
   float a = mt2;
   float b = mt * segmentRatio * 2.0;
   float c = t2;
+  // TODO: if depth is not needed remove z computaitons.
   vec4 ret = vec4(
     a * source.x + b * controlPoint.x + c * target.x,
     a * source.y + b * controlPoint.y + c * target.y,

--- a/src/experimental-layers/src/bezier-curve-layer/bezier-curve-layer-vertex.glsl.js
+++ b/src/experimental-layers/src/bezier-curve-layer/bezier-curve-layer-vertex.glsl.js
@@ -90,7 +90,9 @@ void main(void) {
   vec4 nextP = computeBezierCurve(source, target, controlPoint, nextSegmentRatio);
 
   // extrude
-  vec2 offset = getExtrusionOffset(nextP.xy - p.xy, positions.y);
+  float direction = float(positions.y);
+  direction = mix(-1.0, 1.0, step(segmentIndex, 0.0)) *  direction;
+  vec2 offset = getExtrusionOffset(nextP.xy - p.xy, direction);
   gl_Position = p + vec4(offset, 0.0, 0.0);
 
   // Color

--- a/src/experimental-layers/src/bezier-curve-layer/bezier-curve-layer.js
+++ b/src/experimental-layers/src/bezier-curve-layer/bezier-curve-layer.js
@@ -25,7 +25,7 @@ import {GL, Model, Geometry} from 'luma.gl';
 import vs from './bezier-curve-layer-vertex.glsl';
 import fs from './bezier-curve-layer-fragment.glsl';
 
-const NUM_SEGMENTS = 80;
+const NUM_SEGMENTS = 40;
 const DEFAULT_COLOR = [0, 0, 0, 255];
 
 const defaultProps = {

--- a/src/experimental-layers/src/bezier-curve-layer/bezier-curve-layer.js
+++ b/src/experimental-layers/src/bezier-curve-layer/bezier-curve-layer.js
@@ -25,7 +25,7 @@ import {GL, Model, Geometry} from 'luma.gl';
 import vs from './bezier-curve-layer-vertex.glsl';
 import fs from './bezier-curve-layer-fragment.glsl';
 
-const NUM_SEGMENTS = 40;
+const NUM_SEGMENTS = 80;
 const DEFAULT_COLOR = [0, 0, 0, 255];
 
 const defaultProps = {


### PR DESCRIPTION
There were two different problems :
1. Triangle ordering was incorrect for the first instance.
2. Depending on number of segments, some of the vertices have wrong z, values.

I have included the fix for both, but lets discuss and finalize the changes.

**Before:**
<img width="539" alt="screen shot 2018-02-07 at 9 04 34 pm" src="https://user-images.githubusercontent.com/9502731/35957080-77ae02ca-0c4e-11e8-8f1a-6837a00a512b.png">
<img width="600" alt="screen shot 2018-02-07 at 9 04 20 pm" src="https://user-images.githubusercontent.com/9502731/35957083-7dac9704-0c4e-11e8-8b66-39e4ad581edd.png">

**After.**
<img width="572" alt="screen shot 2018-02-07 at 9 05 28 pm" src="https://user-images.githubusercontent.com/9502731/35957093-8dad797a-0c4e-11e8-8a46-79b636c7a7ec.png">
<img width="487" alt="screen shot 2018-02-07 at 9 05 47 pm" src="https://user-images.githubusercontent.com/9502731/35957097-92baa6a4-0c4e-11e8-8943-72faef2e475d.png">
