### PR TITLE
Update shader module docs

### DIFF
--- a/docs/shader-modules/lighting.md
+++ b/docs/shader-modules/lighting.md
@@ -2,14 +2,57 @@
 
 The `lighting` module provides a way to light a vertex using world positions and world normals.
 
+## Usage
+
+```
+// geometry
+attribute vec3 positions;
+attribute vec3 normals;
+attribute vec3 colors;
+// passed to fragment shader
+varying vec4 vColor;
+
+void main() {
+  vec3 position_worldspace = project_position(positions);
+  gl_Position = project_to_clipspace(vec4(position_worldspace, 1.0));
+
+  float lightWeight = lighting_getLightWeight(
+    position_worldspace,
+    project_normal(normals)
+  );
+
+  vColor = vec4(lightWeight * colors, 1.0) / 255.0;
+}
+```
+
 
 ## getUniforms
 
-* `vec3 lightsPosition[16]`
-* `vec2 lightsStrength[16]`
-* `float ambientRatio`
-* `float diffuseRatio`
-* `float specularRatio`
+The `lighting` module extracts uniforms from the `lightSettings` prop on layers that support lighting. The `lightSettings` prop is experimental and subject to change as we continue to improve this module.
+
+`lightSettings` fields:
+
+- `numberOfLights` (Number) - The number of lights, default `1`. Max number of lights is `16`.
+- `lightsPosition` (Array) - The positions of lights specified as `[x, y, z]`, in a flattened array. The length should be `3 x numberOfLights`.
+- `lightsStrength` (Array) - The strength of lights specified as `[x, y]`, in a flattened array. The length should be `2 x numberOfLights`.
+- `coordinateSystem` (Number) - The coordinate system in which the light positions are specified. Default `COORDINATE_SYSTEM.LNGLAT`.
+- `coordinateOrigin` (Number) - The coordinate origin to which the light positions are specified. Default `[0, 0, 0]`.
+- `modelMatrix` (Number) - The transform matrix of the light positions. Default `null`.
+- `ambientRatio` (Number) - The ambient ratio of the lights. Default `0.05`.
+- `diffuseRatio` (Number) - The diffuse ratio of the lights. Default `0.6`.
+- `specularRatio` (Number) - The specular ratio of the lights. Default `0.8`.
+
+
+## GLSL Uniforms
+
+| Uniform | Type | Description |
+| --- | --- | --- |
+| lighting_lightPositions | vec3[N] | light positions in world positions |
+| lighting_lightStrengths | vec2[N] | light strengths |
+| lighting_ambientRatio | float | ambient ratio |
+| lighting_diffuseRatio | float | diffuse ratio |
+| lighting_specularRatio | float | specular ratio |
+| lighting_numberOfLights | float | number of lights |
 
 
 ## GLSL Functions

--- a/docs/shader-modules/project.md
+++ b/docs/shader-modules/project.md
@@ -48,7 +48,12 @@ The GLSL uniforms of the `project` module are quite central to shader code and a
 | project_uViewportSize | vec2 | size of viewport in pixels |
 | project_uDevicePixelRatio | float | device pixel ratio of current viewport (value depends on `useDevicePixels` prop) |
 | project_uFocalDistance | float | distance where "pixel sizes" are display in 1:1 ratio (modulo `devicePixelRatio`) |
-| project_uCameraPosition | float | position of camera in world space |
+| project_uCameraPosition | vec3 | position of camera in world space |
+| project_uCoordinateSystem | float | COORDINATE_SYSTEM enum |
+| project_uCenter | float | coordinate origin in world space |
+| project_uScale | float | Web Mercator scale (2^zoom) |
+| project_uPixelsPerMeter | vec3 | Web Mercator pixels per meter near the current viewport center |
+| project_uPixelsPerDegree | vec3 | Web Mercator pixels per degree near the current viewport center |
 
 
 ## GLSL Functions

--- a/docs/shader-modules/project.md
+++ b/docs/shader-modules/project.md
@@ -39,7 +39,7 @@ Provided by `Layer` props:
 
 ## GLSL Uniforms
 
-The GLSL uniforms of the `project` module are quite central to shader code and are often needed by other shader modules (in particular for lighting calculations, or screen space type calculations), so to avoid having duplicate uniforms, some `project` uniforms are considered documented and stable and can be used directly in other modules.
+Uniform names are not considered part of the official API of shader modules and can potentially change between minor releases, but are documented for applications that need this level of access. Use the module's public GLSL functions instead of directly accessing uniforms when possible.
 
 | Uniform | Type | Description |
 | --- | --- | --- |

--- a/docs/shader-modules/project64.md
+++ b/docs/shader-modules/project64.md
@@ -5,8 +5,15 @@ The `project64` shader module is an extension of the `project` shader module tha
 
 ## getUniforms
 
-For efficiency, the uniforms needed by `project64` are set by the `project` module (which is a dependency of `project64`). This is done since it is essentially the same calculations that are needed in both cases, so it would be wasteful to do it twice.
+The uniforms needed by `project64` are extracted from the `project` module uniforms `project_uViewProjectionMatrix` and `project_uScale`.
 
+
+## GLSL Uniforms
+
+| Uniform | Type | Description |
+| --- | --- | --- |
+| project_uViewProjectionMatrixFP64 | uniform vec2[16] | 64-bit view projection matrix |
+| project64_uScale | uniform vec2 | 64-bit Web Mercator scale |
 
 ## GLSL Functions
 

--- a/docs/shader-modules/project64.md
+++ b/docs/shader-modules/project64.md
@@ -10,6 +10,8 @@ The uniforms needed by `project64` are extracted from the `project` module unifo
 
 ## GLSL Uniforms
 
+Uniform names are not considered part of the official API of shader modules and can potentially change between minor releases, but are documented for applications that need this level of access. Use the module's public GLSL functions instead of directly accessing uniforms when possible.
+
 | Uniform | Type | Description |
 | --- | --- | --- |
 | project_uViewProjectionMatrixFP64 | uniform vec2[16] | 64-bit view projection matrix |

--- a/src/core/shaderlib/lighting/lighting.js
+++ b/src/core/shaderlib/lighting/lighting.js
@@ -31,7 +31,7 @@ export default {
   getUniforms,
   deprecations: [
     // Deprecated lighting functions
-    {type: 'function', old: 'getLightWeight', new: 'lighting_getLightWeight', deprecated: 1}
+    {type: 'function', old: 'getLightWeight', new: 'lighting_getLightWeight', deprecated: true}
   ]
 };
 

--- a/src/core/shaderlib/lighting/lighting.js
+++ b/src/core/shaderlib/lighting/lighting.js
@@ -28,7 +28,11 @@ export default {
   name: 'lighting',
   dependencies: [project],
   vs: lightingShader,
-  getUniforms
+  getUniforms,
+  deprecations: [
+    // Deprecated lighting functions
+    {type: 'function', old: 'getLightWeight', new: 'lighting_getLightWeight', deprecated: 1}
+  ]
 };
 
 const INITIAL_MODULE_OPTIONS = {};


### PR DESCRIPTION
- Update shader module docs
- Add deprecation warning for the old `getLightWeight` function