### PR TITLE
View constructors no longer rely on custom Viewport classes (PR 1)

### DIFF
--- a/examples/experimental/multi-viewport/app.js
+++ b/examples/experimental/multi-viewport/app.js
@@ -288,7 +288,9 @@ class Root extends Component {
       new ThirdPersonView({
         id: '3rd-person',
         y: '33.33%',
-        height: '33.33%'
+        height: '33.33%',
+        near: 0.1, // Distance of near clipping plane
+        far: 10000 // Distance of far clipping plane
       }),
       new MapView({
         id: 'basemap',

--- a/src/core/lib/deck.js
+++ b/src/core/lib/deck.js
@@ -103,8 +103,8 @@ export default class Deck {
     this._setLayerManagerProps(props);
 
     // TODO - unify setParameters/setOptions/setProps etc naming.
-    const {useDevicePixels} = props;
-    this.animationLoop.setViewParameters({useDevicePixels});
+    const {useDevicePixels, autoResizeDrawingBuffer} = props;
+    this.animationLoop.setViewParameters({useDevicePixels, autoResizeDrawingBuffer});
   }
 
   finalize() {
@@ -161,12 +161,13 @@ export default class Deck {
   }
 
   _createAnimationLoop(props) {
-    const {width, height, gl, glOptions, debug, useDevicePixels} = props;
+    const {width, height, gl, glOptions, debug, useDevicePixels, autoResizeDrawingBuffer} = props;
 
     return new AnimationLoop({
       width,
       height,
       useDevicePixels,
+      autoResizeDrawingBuffer,
       onCreateContext: opts =>
         gl || createGLContext(Object.assign({}, glOptions, {canvas: this.canvas, debug})),
       onInitialize: this._onRendererInitialized,

--- a/src/core/viewports/first-person-viewport.js
+++ b/src/core/viewports/first-person-viewport.js
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 
 import Viewport from './viewport';
+import log from '../utils/log';
 import {Matrix4, experimental} from 'math.gl';
 const {SphericalCoordinates} = experimental;
 
@@ -30,6 +31,8 @@ function getDirectionFromBearingAndPitch({bearing, pitch}) {
 
 export default class FirstPersonViewport extends Viewport {
   constructor(opts = {}) {
+    log.deprecated('FirstPersonViewport', 'FirstPersonView');
+
     // TODO - push direction handling into Matrix4.lookAt
     const {
       // view matrix arguments
@@ -58,5 +61,3 @@ export default class FirstPersonViewport extends Viewport {
     );
   }
 }
-
-FirstPersonViewport.displayName = 'FirstPersonViewport';

--- a/src/core/viewports/orbit-viewport.js
+++ b/src/core/viewports/orbit-viewport.js
@@ -1,4 +1,5 @@
 import Viewport from './viewport';
+// import log from '../utils/log';
 
 import {createMat4, transformVector} from '../utils/math-utils';
 
@@ -36,6 +37,8 @@ export default class OrbitViewport extends Viewport {
     far = 100, // Distance of far clipping plane
     zoom = 1
   }) {
+    // log.deprecated('OrbitViewport', 'OrbitView');
+
     const rotationMatrix = mat4_rotateX([], createMat4(), -rotationX / 180 * Math.PI);
     if (orbitAxis === 'Z') {
       mat4_rotateZ(rotationMatrix, rotationMatrix, -rotationOrbit / 180 * Math.PI);

--- a/src/core/viewports/orthographic-viewport.js
+++ b/src/core/viewports/orthographic-viewport.js
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 
 import Viewport from './viewport';
+import log from '../utils/log';
 import mat4_lookAt from 'gl-mat4/lookAt';
 import mat4_ortho from 'gl-mat4/ortho';
 
@@ -40,6 +41,8 @@ export default class OrthographicViewport extends Viewport {
     right = null, // Right bound of the frustum
     bottom = null // Bottom bound of the frustum
   }) {
+    log.deprecated('OrthgraphicViewport', 'OrthgraphicView');
+
     right = Number.isFinite(right) ? right : left + width;
     bottom = Number.isFinite(bottom) ? bottom : top + height;
     super({

--- a/src/core/viewports/perspective-viewport.js
+++ b/src/core/viewports/perspective-viewport.js
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 
 import Viewport from './viewport';
+import log from '../utils/log';
 import mat4_lookAt from 'gl-mat4/lookAt';
 import mat4_perspective from 'gl-mat4/perspective';
 
@@ -40,6 +41,8 @@ export default class PerspectiveViewport extends Viewport {
     // automatically calculated
     aspect = null // Aspect ratio (set to viewport widht/height)
   }) {
+    log.deprecated('PerspectiveViewport', 'PerspectiveView');
+
     const fovyRadians = fovy * DEGREES_TO_RADIANS;
     aspect = Number.isFinite(aspect) ? aspect : width / height;
     super({

--- a/src/core/viewports/third-person-viewport.js
+++ b/src/core/viewports/third-person-viewport.js
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 
 import Viewport from './viewport';
+import log from '../utils/log';
 import {Vector3, Matrix4, experimental} from 'math.gl';
 const {SphericalCoordinates} = experimental;
 
@@ -29,6 +30,8 @@ function getDirectionFromBearingAndPitch({bearing, pitch}) {
 
 export default class ThirdPersonViewport extends Viewport {
   constructor(opts) {
+    log.deprecated('ThirdPersonViewport', 'ThirdPersonView');
+
     const {bearing, pitch, position, up, zoom} = opts;
 
     const direction = getDirectionFromBearingAndPitch({
@@ -55,5 +58,3 @@ export default class ThirdPersonViewport extends Viewport {
     );
   }
 }
-
-ThirdPersonViewport.displayName = 'ThirdPersonViewport';

--- a/src/core/views/first-person-view.js
+++ b/src/core/views/first-person-view.js
@@ -1,12 +1,43 @@
 import View from './view';
-import FirstPersonViewport from '../viewports/first-person-viewport';
+import Viewport from '../viewports/viewport';
+import {Matrix4, experimental} from 'math.gl';
+const {SphericalCoordinates} = experimental;
+
+function getDirectionFromBearingAndPitch({bearing, pitch}) {
+  const spherical = new SphericalCoordinates({bearing, pitch});
+  const direction = spherical.toVector3().normalize();
+  return direction;
+}
 
 export default class FirstPersonView extends View {
-  constructor(props) {
-    super(
+  _getViewport(props) {
+    // TODO - push direction handling into Matrix4.lookAt
+    const {
+      // view matrix arguments
+      modelMatrix = null,
+      bearing,
+      up = [0, 0, 1] // Defines up direction, default positive z axis,
+    } = props.viewState;
+
+    // Always calculate direction from bearing and pitch
+    const dir = getDirectionFromBearingAndPitch({
+      bearing,
+      pitch: 89
+    });
+
+    // Direction is relative to model coordinates, of course
+    const center = modelMatrix ? modelMatrix.transformDirection(dir) : dir;
+
+    // Just the direction. All the positioning is done in viewport.js
+    const viewMatrix = new Matrix4().lookAt({eye: [0, 0, 0], center, up});
+
+    return new Viewport(
       Object.assign({}, props, {
-        type: FirstPersonViewport
+        zoom: null, // triggers meter level zoom
+        viewMatrix
       })
     );
   }
 }
+
+FirstPersonView.displayName = 'FirstPersonView';

--- a/src/core/views/map-view.js
+++ b/src/core/views/map-view.js
@@ -10,3 +10,5 @@ export default class MapView extends View {
     );
   }
 }
+
+MapView.displayName = 'MapView';

--- a/src/core/views/orbit-view.js
+++ b/src/core/views/orbit-view.js
@@ -10,3 +10,5 @@ export default class OrbitView extends View {
     );
   }
 }
+
+OrbitView.displayName = 'OrbitView';

--- a/src/core/views/orthographic-view.js
+++ b/src/core/views/orthographic-view.js
@@ -1,42 +1,44 @@
 import View from './view';
+import Viewport from '../viewports/viewport';
 
 import mat4_lookAt from 'gl-mat4/lookAt';
 import mat4_ortho from 'gl-mat4/ortho';
 
 export default class OrthographicView extends View {
-  constructor({
-    // view matrix arguments
-    eye, // Defines eye position
-    lookAt = [0, 0, 0], // Which point is camera looking at, default origin
-    up = [0, 1, 0] // Defines up direction, default positive y axis
-  }) {
-    super({
-      viewMatrix: mat4_lookAt([], eye, lookAt, up)
-    });
-  }
+  _getViewport({x, y, width, height, viewState}) {
+    const {
+      // view matrix arguments
+      eye = [0, 0, 1], // Defines eye position
+      lookAt = [0, 0, 0], // Which point is camera looking at, default origin
+      up = [0, 1, 0], // Defines up direction, default positive y axis
 
-  getMatrix({
-    // viewport arguments
-    width, // Width of viewport
-    height, // Height of viewport
-    // view matrix arguments
-    eye = [0, 0, 1], // Defines eye position, default unit distance along z axis
-    lookAt = [0, 0, 0], // Which point is camera looking at, default origin
-    up = [0, 1, 0], // Defines up direction, default positive y axis
-    // projection matrix arguments
-    near = 1, // Distance of near clipping plane
-    far = 100, // Distance of far clipping plane
-    left, // Left bound of the frustum
-    top, // Top bound of the frustum
-    // automatically calculated
-    right = null, // Right bound of the frustum
-    bottom = null // Bottom bound of the frustum
-  }) {
+      // projection matrix arguments
+      left, // Left bound of the frustum
+      top // Top bound of the frustum
+    } = viewState;
+
+    let {
+      // automatically calculated
+      right = null, // Right bound of the frustum
+      bottom = null // Bottom bound of the frustum
+    } = viewState;
+
+    const {
+      near = 1, // Distance of near clipping plane
+      far = 100 // Distance of far clipping plane
+    } = this.props;
+
     right = Number.isFinite(right) ? right : left + width;
     bottom = Number.isFinite(bottom) ? bottom : top + height;
-    return {
+    return new Viewport({
+      x,
+      y,
+      width,
+      height,
       viewMatrix: mat4_lookAt([], eye, lookAt, up),
       projectionMatrix: mat4_ortho([], left, right, bottom, top, near, far)
-    };
+    });
   }
 }
+
+OrthographicView.displayName = 'OrthographicView';

--- a/src/core/views/perspective-view.js
+++ b/src/core/views/perspective-view.js
@@ -1,16 +1,50 @@
 import View from './view';
+import Viewport from '../viewports/viewport';
 
 import mat4_lookAt from 'gl-mat4/lookAt';
+import mat4_perspective from 'gl-mat4/perspective';
+
+const DEGREES_TO_RADIANS = Math.PI / 180;
 
 export default class PerspectiveView extends View {
-  constructor({
-    // view matrix arguments
-    eye, // Defines eye position
-    lookAt = [0, 0, 0], // Which point is camera looking at, default origin
-    up = [0, 1, 0] // Defines up direction, default positive y axis
-  }) {
-    super({
-      viewMatrix: mat4_lookAt([], eye, lookAt, up)
+  _getViewport(props) {
+    const {
+      // viewport arguments
+      x,
+      y,
+      width, // Width of viewport
+      height, // Height of viewport
+
+      viewState
+    } = props;
+
+    const {
+      // view matrix arguments
+      eye, // Defines eye position
+      lookAt = [0, 0, 0], // Which point is camera looking at, default origin
+      up = [0, 1, 0], // Defines up direction, default positive y axis
+      // projection matrix arguments
+      fovy = 75, // Field of view covered by camera
+      near = 1, // Distance of near clipping plane
+      far = 100 // Distance of far clipping plane
+    } = viewState;
+
+    let {
+      // automatically calculated
+      aspect = null // Aspect ratio (set to viewport widht/height)
+    } = viewState;
+
+    const fovyRadians = fovy * DEGREES_TO_RADIANS;
+    aspect = Number.isFinite(aspect) ? aspect : width / height;
+    return new Viewport({
+      x,
+      y,
+      width,
+      height,
+      viewMatrix: mat4_lookAt([], eye, lookAt, up),
+      projectionMatrix: mat4_perspective([], fovyRadians, aspect, near, far)
     });
   }
 }
+
+PerspectiveView.displayName = 'PerspectiveView';

--- a/src/core/views/third-person-view.js
+++ b/src/core/views/third-person-view.js
@@ -1,12 +1,39 @@
 import View from './view';
-import ThirdPersonViewport from '../viewports/third-person-viewport';
+import Viewport from '../viewports/viewport';
+import {Vector3, Matrix4, experimental} from 'math.gl';
+const {SphericalCoordinates} = experimental;
+
+function getDirectionFromBearingAndPitch({bearing, pitch}) {
+  const spherical = new SphericalCoordinates({bearing, pitch});
+  return spherical.toVector3().normalize();
+}
 
 export default class ThirdPersonView extends View {
-  constructor(props) {
-    super(
+  _getViewport(props) {
+    const {bearing, pitch, position, up, zoom} = props.viewState;
+
+    const direction = getDirectionFromBearingAndPitch({
+      bearing,
+      pitch
+    });
+
+    const distance = zoom * 50;
+
+    // TODO somehow need to flip z to make it work
+    // check if the position offset is done in the base viewport
+    const eye = direction.scale(-distance).multiply(new Vector3(1, 1, -1));
+
+    const viewMatrix = new Matrix4().multiplyRight(
+      new Matrix4().lookAt({eye, center: position, up})
+    );
+
+    return new Viewport(
       Object.assign({}, props, {
-        type: ThirdPersonViewport
+        zoom: null, // triggers meter level zoom
+        viewMatrix
       })
     );
   }
 }
+
+ThirdPersonView.displayName = 'ThirdPersonView';


### PR DESCRIPTION
Another PR towards completing #1370.

Once this is in place we can potentially deprecate/remove most of the `Viewport` classes.