### PR TITLE
JSAPI: Avoid importing PropTypes in the JavaScript API

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -165,5 +165,8 @@ export const experimental = {
 
   enable64bitSupport,
   fp64ify,
-  fp64LowPart
+  fp64LowPart,
+
+  // DEPRECATED experimantal exports
+  DeckGLJS: Deck
 };

--- a/src/core/lib/deck.js
+++ b/src/core/lib/deck.js
@@ -25,35 +25,36 @@ import Effect from '../experimental/lib/effect';
 import {EventManager} from 'mjolnir.js';
 import {GL, AnimationLoop, createGLContext, setParameters} from 'luma.gl';
 
-import PropTypes from 'prop-types';
 import assert from 'assert';
 /* global document */
 
 function noop() {}
 
-const propTypes = {
-  id: PropTypes.string,
-  width: PropTypes.number.isRequired,
-  height: PropTypes.number.isRequired,
-  layers: PropTypes.array, // Array can contain falsy values
-  views: PropTypes.array, // Array can contain falsy values
-  viewState: PropTypes.object,
-  effects: PropTypes.arrayOf(PropTypes.instanceOf(Effect)),
-  layerFilter: PropTypes.func,
-  glOptions: PropTypes.object,
-  gl: PropTypes.object,
-  pickingRadius: PropTypes.number,
-  onWebGLInitialized: PropTypes.func,
-  onBeforeRender: PropTypes.func,
-  onAfterRender: PropTypes.func,
-  onLayerClick: PropTypes.func,
-  onLayerHover: PropTypes.func,
-  useDevicePixels: PropTypes.bool,
+function getPropTypes(PropTypes) {
+  return {
+    id: PropTypes.string,
+    width: PropTypes.number.isRequired,
+    height: PropTypes.number.isRequired,
+    layers: PropTypes.array, // Array can contain falsy values
+    views: PropTypes.array, // Array can contain falsy values
+    viewState: PropTypes.object,
+    effects: PropTypes.arrayOf(PropTypes.instanceOf(Effect)),
+    layerFilter: PropTypes.func,
+    glOptions: PropTypes.object,
+    gl: PropTypes.object,
+    pickingRadius: PropTypes.number,
+    onWebGLInitialized: PropTypes.func,
+    onBeforeRender: PropTypes.func,
+    onAfterRender: PropTypes.func,
+    onLayerClick: PropTypes.func,
+    onLayerHover: PropTypes.func,
+    useDevicePixels: PropTypes.bool,
 
-  // Debug settings
-  debug: PropTypes.bool,
-  drawPickingColors: PropTypes.bool
-};
+    // Debug settings
+    debug: PropTypes.bool,
+    drawPickingColors: PropTypes.bool
+  };
+}
 
 const defaultProps = {
   id: 'deckgl-overlay',
@@ -63,6 +64,8 @@ const defaultProps = {
   gl: null,
   layers: [],
   effects: [],
+  views: null,
+
   onWebGLInitialized: noop,
   onBeforeRender: noop,
   onAfterRender: noop,
@@ -74,7 +77,6 @@ const defaultProps = {
   drawPickingColors: false
 };
 
-// TODO - should this class be joined with `LayerManager`?
 export default class Deck {
   constructor(props) {
     props = Object.assign({}, defaultProps, props);
@@ -263,5 +265,6 @@ export default class Deck {
   }
 }
 
-Deck.propTypes = propTypes;
+Deck.displayName = 'Deck';
+Deck.getPropTypes = getPropTypes;
 Deck.defaultProps = defaultProps;

--- a/src/core/pure-js/map-controller-js.js
+++ b/src/core/pure-js/map-controller-js.js
@@ -1,8 +1,6 @@
-import PropTypes from 'prop-types';
-
-import {EventManager} from 'mjolnir.js';
 import MapControls from '../controllers/map-controls';
 import {MAPBOX_LIMITS} from '../controllers/map-state';
+import {EventManager} from 'mjolnir.js';
 
 const PREFIX = '-webkit-';
 
@@ -12,50 +10,52 @@ const CURSOR = {
   POINTER: 'pointer'
 };
 
-const propTypes = {
-  width: PropTypes.number.isRequired /** The width of the map. */,
-  height: PropTypes.number.isRequired /** The height of the map. */,
-  longitude: PropTypes.number.isRequired /** The longitude of the center of the map. */,
-  latitude: PropTypes.number.isRequired /** The latitude of the center of the map. */,
-  zoom: PropTypes.number.isRequired /** The tile zoom level of the map. */,
-  bearing: PropTypes.number /** Specify the bearing of the viewport */,
-  pitch: PropTypes.number /** Specify the pitch of the viewport */,
-  // Note: Non-public API, see https://github.com/mapbox/mapbox-gl-js/issues/1137
-  altitude: PropTypes.number /** Altitude of the viewport camera. Default 1.5 "screen heights" */,
-
-  /** Viewport constraints */
-  maxZoom: PropTypes.number, // Max zoom level
-  minZoom: PropTypes.number, // Min zoom level
-  maxPitch: PropTypes.number, // Max pitch in degrees
-  minPitch: PropTypes.number, // Min pitch in degrees
-
-  /**
-   * `onViewportChange` callback is fired when the user interacted with the
-   * map. The object passed to the callback contains viewport properties
-   * such as `longitude`, `latitude`, `zoom` etc.
-   */
-  onViewportChange: PropTypes.func,
-
-  /** Enables control event handling */
-  scrollZoom: PropTypes.bool, // Scroll to zoom
-  dragPan: PropTypes.bool, // Drag to pan
-  dragRotate: PropTypes.bool, // Drag to rotate
-  doubleClickZoom: PropTypes.bool, // Double click to zoom
-  touchZoomRotate: PropTypes.bool, // Pinch to zoom / rotate
-
-  /** Accessor that returns a cursor style to show interactive state */
-  getCursor: PropTypes.func,
-
-  // A map control instance to replace the default map controls
-  // The object must expose one property: `events` as an array of subscribed
-  // event names; and two methods: `setState(state)` and `handle(event)`
-  controls: PropTypes.shape({
-    events: PropTypes.arrayOf(PropTypes.string),
-    handleEvent: PropTypes.func
-  })
-};
-
 const getDefaultCursor = ({isDragging}) => (isDragging ? CURSOR.GRABBING : CURSOR.GRAB);
+
+function getPropTypes(PropTypes) {
+  return {
+    width: PropTypes.number.isRequired /** The width of the map. */,
+    height: PropTypes.number.isRequired /** The height of the map. */,
+    longitude: PropTypes.number.isRequired /** The longitude of the center of the map. */,
+    latitude: PropTypes.number.isRequired /** The latitude of the center of the map. */,
+    zoom: PropTypes.number.isRequired /** The tile zoom level of the map. */,
+    bearing: PropTypes.number /** Specify the bearing of the viewport */,
+    pitch: PropTypes.number /** Specify the pitch of the viewport */,
+    // Note: Non-public API, see https://github.com/mapbox/mapbox-gl-js/issues/1137
+    altitude: PropTypes.number /** Altitude of the viewport camera. Default 1.5 "screen heights" */,
+
+    /** Viewport constraints */
+    maxZoom: PropTypes.number, // Max zoom level
+    minZoom: PropTypes.number, // Min zoom level
+    maxPitch: PropTypes.number, // Max pitch in degrees
+    minPitch: PropTypes.number, // Min pitch in degrees
+
+    /**
+     * `onViewportChange` callback is fired when the user interacted with the
+     * map. The object passed to the callback contains viewport properties
+     * such as `longitude`, `latitude`, `zoom` etc.
+     */
+    onViewportChange: PropTypes.func,
+
+    /** Enables control event handling */
+    scrollZoom: PropTypes.bool, // Scroll to zoom
+    dragPan: PropTypes.bool, // Drag to pan
+    dragRotate: PropTypes.bool, // Drag to rotate
+    doubleClickZoom: PropTypes.bool, // Double click to zoom
+    touchZoomRotate: PropTypes.bool, // Pinch to zoom / rotate
+
+    /** Accessor that returns a cursor style to show interactive state */
+    getCursor: PropTypes.func,
+
+    // A map control instance to replace the default map controls
+    // The object must expose one property: `events` as an array of subscribed
+    // event names; and two methods: `setState(state)` and `handle(event)`
+    controls: PropTypes.shape({
+      events: PropTypes.arrayOf(PropTypes.string),
+      handleEvent: PropTypes.func
+    })
+  };
+}
 
 const defaultProps = Object.assign({}, MAPBOX_LIMITS, {
   onViewportChange: null,
@@ -114,5 +114,5 @@ export default class MapControllerJS {
 }
 
 MapControllerJS.displayName = 'MapController';
-MapControllerJS.propTypes = propTypes;
 MapControllerJS.defaultProps = defaultProps;
+MapControllerJS.getPropTypes = getPropTypes;

--- a/src/core/pure-js/orbit-controller-js.js
+++ b/src/core/pure-js/orbit-controller-js.js
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import OrbitViewport from '../viewports/orbit-viewport';
 import OrbitState from '../controllers/orbit-state';
 import ViewportControls from '../controllers/viewport-controls';
@@ -12,37 +11,39 @@ const CURSOR = {
   POINTER: 'pointer'
 };
 
-const propTypes = {
-  /* Viewport properties */
-  lookAt: PropTypes.arrayOf(PropTypes.number), // target position
-  distance: PropTypes.number, // distance from camera to the target
-  rotationX: PropTypes.number, // rotation around X axis
-  rotationY: PropTypes.number, // rotation around Y axis
-  translationX: PropTypes.number, // translation x in screen space
-  translationY: PropTypes.number, // translation y in screen space
-  zoom: PropTypes.number, // scale in screen space
-  minZoom: PropTypes.number,
-  maxZoom: PropTypes.number,
-  fov: PropTypes.number, // field of view
-  near: PropTypes.number,
-  far: PropTypes.number,
-  width: PropTypes.number.isRequired, // viewport width in pixels
-  height: PropTypes.number.isRequired, // viewport height in pixels
-
-  /* Model properties */
-  bounds: PropTypes.object, // bounds in the shape of {minX, minY, minZ, maxX, maxY, maxZ}
-
-  /* Callbacks */
-  onViewportChange: PropTypes.func.isRequired,
-
-  /** Accessor that returns a cursor style to show interactive state */
-  getCursor: PropTypes.func,
-
-  /* Controls */
-  orbitControls: PropTypes.object
-};
-
 const getDefaultCursor = ({isDragging}) => (isDragging ? CURSOR.GRABBING : CURSOR.GRAB);
+
+function getPropTypes(PropTypes) {
+  return {
+    /* Viewport properties */
+    lookAt: PropTypes.arrayOf(PropTypes.number), // target position
+    distance: PropTypes.number, // distance from camera to the target
+    rotationX: PropTypes.number, // rotation around X axis
+    rotationY: PropTypes.number, // rotation around Y axis
+    translationX: PropTypes.number, // translation x in screen space
+    translationY: PropTypes.number, // translation y in screen space
+    zoom: PropTypes.number, // scale in screen space
+    minZoom: PropTypes.number,
+    maxZoom: PropTypes.number,
+    fov: PropTypes.number, // field of view
+    near: PropTypes.number,
+    far: PropTypes.number,
+    width: PropTypes.number.isRequired, // viewport width in pixels
+    height: PropTypes.number.isRequired, // viewport height in pixels
+
+    /* Model properties */
+    bounds: PropTypes.object, // bounds in the shape of {minX, minY, minZ, maxX, maxY, maxZ}
+
+    /* Callbacks */
+    onViewportChange: PropTypes.func.isRequired,
+
+    /** Accessor that returns a cursor style to show interactive state */
+    getCursor: PropTypes.func,
+
+    /* Controls */
+    orbitControls: PropTypes.object
+  };
+}
 
 const defaultProps = {
   lookAt: [0, 0, 0],
@@ -115,5 +116,5 @@ export default class OrbitControllerJS {
 }
 
 OrbitControllerJS.displayName = 'OrbitController';
-OrbitControllerJS.propTypes = propTypes;
 OrbitControllerJS.defaultProps = defaultProps;
+OrbitControllerJS.getPropTypes = getPropTypes;

--- a/src/react/src/deckgl.js
+++ b/src/react/src/deckgl.js
@@ -25,7 +25,7 @@ import {inheritsFrom} from './utils/inherits-from';
 import {Layer, experimental} from '../../core';
 const {Deck, log} = experimental;
 
-const propTypes = Object.assign({}, Deck.propTypes, {
+const propTypes = Object.assign({}, Deck.getPropTypes(PropTypes), {
   viewports: PropTypes.array, // Deprecated
   viewport: PropTypes.object // Deprecated
 });

--- a/src/react/src/experimental/orbit-controller.js
+++ b/src/react/src/experimental/orbit-controller.js
@@ -1,6 +1,7 @@
 import {PureComponent, createElement} from 'react';
 import OrbitControllerJS from '../../../core/pure-js/orbit-controller-js';
 import OrbitViewport from '../../../core/viewports/orbit-viewport';
+import PropTypes from 'prop-types';
 
 export default class OrbitController extends PureComponent {
   // Returns a deck.gl Viewport instance, to be used with the DeckGL component
@@ -49,5 +50,5 @@ export default class OrbitController extends PureComponent {
 }
 
 OrbitController.displayName = 'OrbitController';
-OrbitController.propTypes = OrbitControllerJS.propTypes;
+OrbitController.propTypes = OrbitControllerJS.getPropTypes(PropTypes);
 OrbitController.defaultProps = OrbitControllerJS.defaultProps;

--- a/src/react/src/map-controller.js
+++ b/src/react/src/map-controller.js
@@ -1,5 +1,6 @@
 import {PureComponent, createElement} from 'react';
 import MapControllerJS from '../../core/pure-js/map-controller-js';
+import PropTypes from 'prop-types';
 
 export default class MapController extends PureComponent {
   constructor(props) {
@@ -43,5 +44,5 @@ export default class MapController extends PureComponent {
 }
 
 MapController.displayName = 'MapController';
-MapController.propTypes = MapControllerJS.propTypes;
+MapController.propTypes = MapControllerJS.getPropTypes(PropTypes);
 MapController.defaultProps = MapControllerJS.defaultProps;


### PR DESCRIPTION
But keep the prop definitions with the code that implements them.

Towards #1429