### PR TITLE
PRE-REVIEWED: Fold ViewportController into DeckGL

### DIFF
--- a/src/react/deckgl.js
+++ b/src/react/deckgl.js
@@ -27,7 +27,16 @@ const {Deck, log} = experimental;
 
 const propTypes = Object.assign({}, Deck.propTypes, {
   viewports: PropTypes.array, // Deprecated
-  viewport: PropTypes.object // Deprecated
+  viewport: PropTypes.object, // Deprecated
+
+  // Viewport props (TODO - should only support these on the react component)
+  longitude: PropTypes.number, // The longitude of the center of the map.
+  latitude: PropTypes.number, // The latitude of the center of the map.
+  zoom: PropTypes.number, // The tile zoom level of the map.
+  bearing: PropTypes.number, // Specify the bearing of the viewport
+  pitch: PropTypes.number, // Specify the pitch of the viewport
+  altitude: PropTypes.number, // Altitude of camera. Default 1.5 "screen heights"
+  position: PropTypes.array // Camera position for FirstPersonViewport
 });
 
 const defaultProps = Deck.defaultProps;
@@ -47,6 +56,16 @@ export default class DeckGL extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     this._updateFromProps(nextProps);
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    // TODO/ib - this needs to be moved into deck.js
+    if (this.deck.transitionManager) {
+      const transitionTriggered = this.deck.transitionManager.processViewportChange(nextProps);
+      // Skip this render to avoid jump during viewport transitions.
+      return !transitionTriggered;
+    }
+    return true;
   }
 
   componentWillUnmount() {
@@ -203,7 +222,7 @@ export default class DeckGL extends React.Component {
     });
     children.push(deck);
 
-    return createElement('div', {id: 'deckgl-wrapper'}, children);
+    return createElement('div', {id: 'deckgl-wrapper', style: {width, height}}, children);
   }
 }
 

--- a/src/react/deprecated/viewport-controller.js
+++ b/src/react/deprecated/viewport-controller.js
@@ -2,10 +2,15 @@ import {Component, createElement} from 'react';
 import PropTypes from 'prop-types';
 
 import {EventManager} from 'mjolnir.js';
-import {experimental} from '../core';
+import {experimental} from '../../core';
 const {ViewportControls, TransitionManager} = experimental;
 
-import CURSOR from './utils/cursors';
+const PREFIX = '-webkit-';
+const CURSOR = {
+  GRABBING: `${PREFIX}grabbing`,
+  GRAB: `${PREFIX}grab`,
+  POINTER: 'pointer'
+};
 
 const propTypes = {
   viewportState: PropTypes.func,

--- a/src/react/index.js
+++ b/src/react/index.js
@@ -20,10 +20,11 @@
 
 export {default as DeckGL} from './deckgl';
 export {default} from './deckgl';
+export {default as autobind} from './utils/autobind';
 
-// TODO - should react controllers be exported or just integrated into deck.gl API?
-export {default as ViewportController} from './viewport-controller';
+// TODO - React controllers should just be integrated into deck.gl API
 export {default as MapController} from './map-controller';
 export {default as OrbitController} from './experimental/orbit-controller';
 
-export {default as autobind} from './utils/autobind';
+// Deprecated exports
+export {default as ViewportController} from './deprecated/viewport-controller';


### PR DESCRIPTION
This PR leaves the old `ViewportController` as deprecated.

Note: Most of these changes were already reviewed once when parts of this were merged into 6.0-dev.