### PR TITLE
Fix devicePixelRatio uniform

### DIFF
--- a/src/core/lib/draw-layers.js
+++ b/src/core/lib/draw-layers.js
@@ -213,7 +213,7 @@ function drawLayersInViewport(
         layer,
         layerIndex,
         drawPickingColors,
-        useDevicePixels,
+        pixelRatio,
         glViewport,
         parameters
       });
@@ -230,14 +230,14 @@ function drawLayerInViewport({
   layer,
   layerIndex,
   drawPickingColors,
-  useDevicePixels,
+  pixelRatio,
   glViewport,
   parameters
 }) {
   const moduleParameters = Object.assign({}, layer.props, {
     viewport: layer.context.viewport,
     pickingActive: drawPickingColors ? 1 : 0,
-    useDevicePixels
+    devicePixelRatio: pixelRatio
   });
 
   const uniforms = Object.assign({}, layer.context.uniforms, {layerIndex});

--- a/src/core/lib/draw-layers.js
+++ b/src/core/lib/draw-layers.js
@@ -208,7 +208,15 @@ function drawLayersInViewport(
         renderStats.visibleCount++;
       }
 
-      drawLayerInViewport({gl, layer, layerIndex, drawPickingColors, glViewport, parameters});
+      drawLayerInViewport({
+        gl,
+        layer,
+        layerIndex,
+        drawPickingColors,
+        useDevicePixels,
+        glViewport,
+        parameters
+      });
     }
   });
 
@@ -217,10 +225,19 @@ function drawLayersInViewport(
   logRenderStats({renderStats, pass, redrawReason});
 }
 
-function drawLayerInViewport({gl, layer, layerIndex, drawPickingColors, glViewport, parameters}) {
+function drawLayerInViewport({
+  gl,
+  layer,
+  layerIndex,
+  drawPickingColors,
+  useDevicePixels,
+  glViewport,
+  parameters
+}) {
   const moduleParameters = Object.assign({}, layer.props, {
     viewport: layer.context.viewport,
-    pickingActive: drawPickingColors ? 1 : 0
+    pickingActive: drawPickingColors ? 1 : 0,
+    useDevicePixels
   });
 
   const uniforms = Object.assign({}, layer.context.uniforms, {layerIndex});

--- a/src/core/shaderlib/project/viewport-uniforms.js
+++ b/src/core/shaderlib/project/viewport-uniforms.js
@@ -18,7 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-/* global window */
 import mat4_multiply from 'gl-mat4/multiply';
 import vec4_transformMat4 from 'gl-vec4/transformMat4';
 
@@ -111,7 +110,7 @@ function calculateMatrixAndOffset({
  */
 export function getUniformsFromViewport({
   viewport,
-  useDevicePixels,
+  devicePixelRatio = 1,
   modelMatrix = null,
   // Match Layer.defaultProps
   coordinateSystem = COORDINATE_SYSTEM.LNGLAT,
@@ -133,13 +132,13 @@ export function getUniformsFromViewport({
     {
       project_uModelMatrix: modelMatrix || IDENTITY_MATRIX
     },
-    getMemoizedViewportUniforms({viewport, useDevicePixels, coordinateSystem, coordinateOrigin})
+    getMemoizedViewportUniforms({viewport, devicePixelRatio, coordinateSystem, coordinateOrigin})
   );
 }
 
 function calculateViewportUniforms({
   viewport,
-  useDevicePixels,
+  devicePixelRatio,
   coordinateSystem,
   coordinateOrigin
 }) {
@@ -158,9 +157,6 @@ function calculateViewportUniforms({
   // Calculate projection pixels per unit
   const distanceScales = viewport.getDistanceScales();
 
-  // TODO - does this depend on useDevicePixels?
-  const devicePixelRatio =
-    useDevicePixels && typeof window !== 'undefined' ? window.devicePixelRatio : 1;
   const viewportSize = [viewport.width * devicePixelRatio, viewport.height * devicePixelRatio];
 
   const uniforms = {

--- a/src/core/shaderlib/project/viewport-uniforms.js
+++ b/src/core/shaderlib/project/viewport-uniforms.js
@@ -111,6 +111,7 @@ function calculateMatrixAndOffset({
  */
 export function getUniformsFromViewport({
   viewport,
+  useDevicePixels,
   modelMatrix = null,
   // Match Layer.defaultProps
   coordinateSystem = COORDINATE_SYSTEM.LNGLAT,
@@ -132,11 +133,16 @@ export function getUniformsFromViewport({
     {
       project_uModelMatrix: modelMatrix || IDENTITY_MATRIX
     },
-    getMemoizedViewportUniforms({viewport, coordinateSystem, coordinateOrigin})
+    getMemoizedViewportUniforms({viewport, useDevicePixels, coordinateSystem, coordinateOrigin})
   );
 }
 
-function calculateViewportUniforms({viewport, coordinateSystem, coordinateOrigin}) {
+function calculateViewportUniforms({
+  viewport,
+  useDevicePixels,
+  coordinateSystem,
+  coordinateOrigin
+}) {
   const coordinateZoom = viewport.zoom;
   assert(coordinateZoom >= 0);
 
@@ -153,7 +159,8 @@ function calculateViewportUniforms({viewport, coordinateSystem, coordinateOrigin
   const distanceScales = viewport.getDistanceScales();
 
   // TODO - does this depend on useDevicePixels?
-  const devicePixelRatio = (typeof window !== 'undefined' && window.devicePixelRatio) || 1;
+  const devicePixelRatio =
+    useDevicePixels && typeof window !== 'undefined' ? window.devicePixelRatio : 1;
   const viewportSize = [viewport.width * devicePixelRatio, viewport.height * devicePixelRatio];
 
   const uniforms = {


### PR DESCRIPTION
Set devicePixel related viewport uniform based on `useDevicePixels` flag.

Verified toggling `useDevicePixels` in layerBrowser and windDemo.