### PR TITLE
Fix wrong image links in website

### DIFF
--- a/docs/advanced/64-bits.md
+++ b/docs/advanced/64-bits.md
@@ -6,7 +6,7 @@ in GPU shaders using emulated 64-bit floating points. 64-bit shaders are used in
 
 <div align="center">
   <div>
-    <img src="https://github.com/uber/deck.gl/blob/5.1-release/website/src/static/images/demo-mandelbrot.gif" />
+    <img src="/website/src/static/images/demo-mandelbrot.gif" />
     <p><i>32-bit vs 64-bit Mandelbrot Set Zoom</i></p>
   </div>
 </div>

--- a/docs/layers/grid-cell-layer.md
+++ b/docs/layers/grid-cell-layer.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img height="300" src="/demo/src/static/images/grid-layer.gif" />
+  <img height="300" src="/website/src/static/images/grid-layer.gif" />
 </div>
 
 <p class="badges">

--- a/docs/layers/grid-layer.md
+++ b/docs/layers/grid-layer.md
@@ -57,7 +57,7 @@ Color scale domain, default is set to the range of point counts in each cell.
 
 ##### `colorRange` (Array, optional)
 
-- Default: <img src="/demo/src/static/images/colorbrewer_YlOrRd_6.png"/></a>
+- Default: <img src="/website/src/static/images/colorbrewer_YlOrRd_6.png"/></a>
 
 Color ranges as an array of colors formatted as `[255, 255, 255]`. Default is
 [colorbrewer](http://colorbrewer2.org/#type=sequential&scheme=YlOrRd&n=6) `6-class YlOrRd`.

--- a/docs/layers/hexagon-cell-layer.md
+++ b/docs/layers/hexagon-cell-layer.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img height="300" src="/demo/src/static/images/hexagon-cell-layer.png" />
+  <img height="300" src="/website/src/static/images/hexagon-cell-layer.png" />
 </div>
 
 <p class="badges">

--- a/docs/layers/hexagon-layer.md
+++ b/docs/layers/hexagon-layer.md
@@ -73,7 +73,7 @@ to number of counts by passing in an arbitrary color domain. This property is ex
 
 ##### `colorRange` (Array, optional)
 
-- Default: <img src="/demo/src/static/images/colorbrewer_YlOrRd_6.png"/></a>
+- Default: <img src="/website/src/static/images/colorbrewer_YlOrRd_6.png"/></a>
 
 Hexagon color ranges as an array of colors formatted as `[[255, 255, 255, 255]]`. Default is
 [colorbrewer](http://colorbrewer2.org/#type=sequential&scheme=YlOrRd&n=6) `6-class YlOrRd`.

--- a/website/src/components/markdown-page.js
+++ b/website/src/components/markdown-page.js
@@ -70,7 +70,7 @@ function renderMarkdown(content) {
   return marked(content, {renderer})
     // Since some images are embedded as html, it won't be processed by
     // the renderer image override. So hard replace it globally.
-    .replace(/\/demo\/src\/static\/images/g, 'images');
+    .replace(/\/website\/src\/static\/images/g, 'images');
 }
 
 export default class MarkdownPage extends PureComponent {


### PR DESCRIPTION
#### Background
Md docs in website has wrong image links, need make the image showing correctly for both website and github repo
<!-- For all the PRs -->
#### Change List
- Change image link in 64-bits.md to the right one
- Change "demo" in image path to "website" which is our current folder name
