### PR TITLE
Update README.md and package.json to reflect latest luma.gl

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ such as scatterplots, arcs, geometries defined in GeoJSON, etc...
 To learn how to use deck.gl through examples coming with the deck.gl repo,
 please clone the latest **release** branch.
 
-`git clone -b 4.1-release --single-branch https://github.com/uber/deck.gl.git`
+`git clone -b 5.1-release --single-branch https://github.com/uber/deck.gl.git`
 
 A very simple usage of deck.gl is showcased in the [hello-world examples](./examples),
 using both [webpack2](./examples/hello-world-webpack2) and

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "d3-hexbin": "^0.2.1",
     "earcut": "^2.0.6",
     "lodash.flattendeep": "^4.4.0",
-    "luma.gl": "^5.1.0",
+    "luma.gl": "^5.1.1",
     "math.gl": "^1.0.0",
     "mjolnir.js": "^1.0.0",
     "prop-types": "^15.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2993,7 +2993,7 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
-luma.gl@^5.1.0:
+luma.gl@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/luma.gl/-/luma.gl-5.1.1.tgz#dced444fb23f695303007074241176be8148bdda"
   dependencies:


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
<!-- For other PRs without open issue -->
#### Background
- When using Fusion to build deck.gl example, it installs 5.1.0 as a dependency which is missing a patch that fixes an import issue. The import issue will break Fusion build.
<!-- For all the PRs -->
#### Change List
- Update README.md to reflect latest release
- Update package.json to reflect latest luma.gl release
