### PR TITLE
Improve point-cloud-laz example by skipping rendering until data loaded

### DIFF
--- a/examples/point-cloud-laz/app.js
+++ b/examples/point-cloud-laz/app.js
@@ -124,7 +124,7 @@ class Example extends PureComponent {
   }
 
   _onUpdate() {
-    const {rotating, viewport} = this.state;
+    const {rotating, viewport, progress} = this.state;
 
     // note: when finished dragging, _onUpdate will not resume by default
     // to resume rotating, explicitly call _onUpdate or requestAnimationFrame
@@ -132,13 +132,14 @@ class Example extends PureComponent {
       return;
     }
 
-    this.setState({
-      viewport: {
-        ...viewport,
-        rotationOrbit: viewport.rotationOrbit + 1
-      }
-    });
-
+    if (progress >= 1.0) {
+      this.setState({
+        viewport: {
+          ...viewport,
+          rotationOrbit: viewport.rotationOrbit + 1
+        }
+      });
+    }
     window.requestAnimationFrame(this._onUpdate);
   }
 

--- a/examples/point-cloud-laz/app.js
+++ b/examples/point-cloud-laz/app.js
@@ -143,8 +143,8 @@ class Example extends PureComponent {
   }
 
   _renderLazPointCloudLayer() {
-    const {points} = this.state;
-    if (!points || points.length === 0) {
+    const {points, progress} = this.state;
+    if (!points || points.length === 0 || progress < 1.0) {
       return null;
     }
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
<!-- For other PRs without open issue -->
#### Background
During the data loading time, point cloud layer should not be rendered

<!-- For all the PRs -->
#### Change List
- Skip rendering until data is fully loaded
