### PR TITLE
[Website] Render nested categories in side bar

### DIFF
--- a/website/contents/pages.js
+++ b/website/contents/pages.js
@@ -8,16 +8,19 @@ function getCodeUrl(pathname) {
 // mapping from file path in source to generated page url
 export const markdownFiles = {};
 
-function generatePath(tree, parentPath = '') {
+function generatePath(tree, parentPath = '', depth = 0) {
   if (Array.isArray(tree)) {
-    tree.forEach(branch => generatePath(branch, parentPath));
+    tree.forEach(branch => generatePath(branch, parentPath, depth));
+    return tree;
   }
+
+  tree.depth = depth;
   if (tree.name) {
     tree.path = tree.name.match(/(GeoJson|3D|API|([A-Z]|^)[a-z'0-9]+|\d+)/g)
       .join('-').toLowerCase().replace(/[^\w-]/g, '');
   }
   if (tree.children) {
-    generatePath(tree.children, `${parentPath}/${tree.path}`);
+    generatePath(tree.children, `${parentPath}/${tree.path}`, depth + 1);
   }
   if (typeof tree.content === 'string') {
     const i = tree.content.indexOf('docs/');

--- a/website/src/components/table-of-contents.js
+++ b/website/src/components/table-of-contents.js
@@ -2,20 +2,37 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {Link} from 'react-router';
 
+const ITEM_HEIGHT = 40;
+const INDENT_BASE = 16;
+const INDENT_INC = 12;
+
+function getContentHeight(page) {
+  let height = 0;
+  if (page.children) {
+    page.children.forEach(child => {
+      height += getContentHeight(child);
+    });
+  }
+  return height + ITEM_HEIGHT;
+}
+
 export default class TableOfContents extends Component {
 
   _renderPage(parentRoute, page, i) {
     const {children, name, expanded} = page;
     const path = `${parentRoute}/${page.path}`;
+    const indent = INDENT_BASE + page.depth * INDENT_INC;
 
-    if (children) {
+    if (children && page.depth === 0) {
+      const maxHeight = getContentHeight(page) - ITEM_HEIGHT;
+
       return (
         <div key={`page-${i}`}>
           <Link className={`list-header ${expanded ? 'expanded' : ''}`}
             activeClassName="active" key={`group-header${i}`} to={path}>
             {name}
           </Link>
-          <div className="subpages" style={{maxHeight: `${40 * children.length}px`}}>
+          <div className="subpages" style={{maxHeight}}>
             <ul key={`group-list${i}`} >
               {children.map(this._renderPage.bind(this, path))}
             </ul>
@@ -24,18 +41,33 @@ export default class TableOfContents extends Component {
       );
     }
 
+    if (children) {
+      return (
+        <div key={`page-${i}`}>
+          <h4 style={{paddingLeft: indent}}>{name}</h4>
+          <ul key={`group-list${i}`} >
+            {children.map(this._renderPage.bind(this, path))}
+          </ul>
+        </div>
+      );
+    }
+
+    const tag = page.tag && <span className="badge">{page.tag}</span>;
+
     if (page.external) {
       // is external link
       return (
         <li key={`page-${i}`}>
-          <a className="link" href={page.external} target="_blank" >{page.name}</a>
+          <a className="link" style={{paddingLeft: indent}} href={page.external} target="_blank" >{page.name}</a>
+          {tag}
         </li>
       );
     }
 
     return (
       <li key={`page-${i}`}>
-        <Link className="link" to={path} activeClassName="active">{page.name}</Link>
+        <Link className="link" style={{paddingLeft: indent}} to={path} activeClassName="active">{page.name}</Link>
+        {tag}
       </li>
     );
   }

--- a/website/src/components/table-of-contents.js
+++ b/website/src/components/table-of-contents.js
@@ -6,15 +6,10 @@ const ITEM_HEIGHT = 40;
 const INDENT_BASE = 16;
 const INDENT_INC = 12;
 
-function getContentHeight(page) {
-  let height = 0;
-  if (page.children) {
-    page.children.forEach(child => {
-      height += getContentHeight(child);
-    });
-  }
-  return height + ITEM_HEIGHT;
-}
+const getContentHeight = (page) =>
+  page.children ?
+    page.children.reduce((height, child) => height + getContentHeight(child), ITEM_HEIGHT) :
+    ITEM_HEIGHT;
 
 export default class TableOfContents extends Component {
 

--- a/website/src/stylesheets/_gallery.scss
+++ b/website/src/stylesheets/_gallery.scss
@@ -11,7 +11,9 @@
   height: 100%;
 }
 .toc {
-  width: 240px;
+  min-width: 240px;
+  max-width: 320px;
+  width: 30vw;
   height: 100%;
   background: #fff;
   overflow-y: auto;
@@ -31,13 +33,21 @@
   }
   li {
     list-style: none;
-    line-height: 40px;
   }
   a {
-    display: block;
+    display: inline-block;
   }
-  .link {
-    padding-left: 28px;
+  .badge {
+    display: inline-block;
+    background: $white-40;
+    color: $white;
+    font-size: smaller;
+    padding: 0 4px;
+    border-radius: 4px;
+    margin: 0 -40px 0 6px;
+  }
+  .link, h4 {
+    line-height: 40px;
     color: $black-20;
     background: transparent;
     border-style: solid;
@@ -62,6 +72,7 @@
     letter-spacing: 2px;
     padding: 24px 0 8px 24px;
     color: $white-40;
+    display: block;
   }
   .list-header:not(.active):not(.expanded):before {
     content: '+';


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/1470

#### Change List
- Support sub headers in table of contents
- Support badges
- Render wider side bar in large window

<img width="305" alt="screen shot 2018-02-27 at 4 38 23 pm" src="https://user-images.githubusercontent.com/2059298/36763622-a39bc982-1bdd-11e8-82f2-551d65c6ec72.png">
