### PR TITLE
Fix layer browser disappearing controls

### DIFF
--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -172,6 +172,15 @@ export default class App extends PureComponent {
     return new Layer(layerProps);
   }
 
+  // Flatten layer props
+  _getLayerSettings(props) {
+    const settings = {};
+    for (const key in props) {
+      settings[key] = props[key];
+    }
+    return settings;
+  }
+
   /* eslint-disable max-depth */
   _renderExamples() {
     let index = 1;
@@ -187,7 +196,7 @@ export default class App extends PureComponent {
           const layer = this._renderExampleLayer(example, settings, index++);
 
           if (typeof settings !== 'object') {
-            activeExamples[exampleName] = layer.props;
+            activeExamples[exampleName] = this._getLayerSettings(layer.props);
           }
 
           layers.push(layer);


### PR DESCRIPTION
#### Background
In the layer browser app, changing any layer prop will cause some other prop controls to disappear.

This bug started after https://github.com/uber/deck.gl/pull/1336 when we switched to using chained object prototypes for merging props. Upon updating layer settings, the layer browser uses spread operator to update the props object, and loses its `__proto__` in the process.

#### Change List
- Manually flatten layer props to a plain object
