### PR TITLE
Implement unified 32 and 64 bit project interface (PR 1/2)

### DIFF
--- a/docs/shader-modules/project32.md
+++ b/docs/shader-modules/project32.md
@@ -1,0 +1,22 @@
+# project32 (Shader Module)
+
+The `project32` shader module is an extension of the `project` shader module that adds some projection utilities.
+
+## GLSL Functions
+
+### project_position_to_clipspace
+
+32 bit implementation of the `project_position_to_clipspace` interface.
+
+`vec4 project_position_to_clipspace(vec3 position, vec2 position64xyLow, vec3 offset)`
+
+`vec4 project_position_to_clipspace(vec3 position, vec2 position64xyLow, vec3 offset, out vec4 worldPosition)`
+
+Parameters:
+- `position` - vertex position in the layer's coordinate system.
+- `position64xyLow` - always ignored
+- `offset` - meter offset from the coordinate
+- `worldPosition` - projected position in the world space
+
+Returns:
+Projected position in the clipspace.

--- a/docs/shader-modules/project64.md
+++ b/docs/shader-modules/project64.md
@@ -20,11 +20,31 @@ Uniform names are not considered part of the official API of shader modules and 
 ## GLSL Functions
 
 
+### project_position_to_clipspace
+
+64 bit implementation of the `project_position_to_clipspace` interface.
+
+`vec4 project_position_to_clipspace(vec3 position, vec2 position64xyLow, vec3 offset)`
+
+`vec4 project_position_to_clipspace(vec3 position, vec2 position64xyLow, vec3 offset, out vec4 worldPosition)`
+
+Parameters:
+- `position` - vertex position in the layer's coordinate system.
+- `position64xyLow` - low part of the vertex position's xy
+- `offset` - meter offset from the coordinate
+- `worldPosition` - projected position in the world space
+
+Returns:
+Projected position in the clipspace.
+
+
 ### project_position_fp64
 
 64 bit counterpart of the `project` modules `project_position`
 
 `void project_position_fp64(vec4 position_fp64, out vec2 out_val[2])`
+
+`void project_position_fp64(vec2 position, vec2 position64xyLow, out vec2 out_val[2])`
 
 
 ### project_to_clipspace_fp64

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -14,6 +14,13 @@ deck.gl layers can now specify additional type information about properties. Whe
 > For layer writers: use of prop types is optional, and deck.gl layers will automatically deduce partial prop type information for any properties that lack type information, as long as a default value is specified in the `defaultProps` object.
 
 
+### Unified 32-bit and 64-bit projection glsl functions
+
+A new common API for 32 and 64 bit projection. This interface is implemented in both the `project64` shader module and a new `project32` shader module. As a result, the same vertex shader can be used for both 32-bit and 64-bit projection depending on which module it includes as dependency.
+
+For all deck.gl users, this means reduced bundle size. For layer writers, this means greatly simplified fp64 handling and easier-to-maintain shader code. See [docs](docs/shader-modules/project32.md) for more details.
+
+
 # deck.gl v5.1
 
 Release date: Feb 16, 2018

--- a/src/core/shaderlib/project32/project32.js
+++ b/src/core/shaderlib/project32/project32.js
@@ -18,19 +18,27 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {registerShaderModules, setDefaultShaderModules} from 'luma.gl';
-import {fp32, fp64, picking} from 'luma.gl';
-import project from '../shaderlib/project/project';
-import project32 from '../shaderlib/project32/project32';
-import project64 from '../shaderlib/project64/project64';
-import lighting from '../shaderlib/lighting/lighting';
+import project from '../project/project';
 
-export function initializeShaderModules() {
-  registerShaderModules([fp32, fp64, project, project32, project64, lighting, picking]);
-
-  setDefaultShaderModules([project]);
+const vs = `
+vec4 project_position_to_clipspace(
+  vec3 position, vec2 position64xyLow, vec3 offset, out vec4 worldPosition
+) {
+  vec3 projectedPosition = project_position(position);
+  worldPosition = vec4(projectedPosition + offset, 1.0);
+  return project_to_clipspace(worldPosition);
 }
 
-initializeShaderModules();
+vec4 project_position_to_clipspace(
+  vec3 position, vec2 position64xyLow, vec3 offset
+) {
+  vec4 worldPosition;
+  return project_position_to_clipspace(position, position64xyLow, offset, worldPosition);
+}
+`;
 
-export {fp32, fp64, picking, project, project64, lighting};
+export default {
+  name: 'project32',
+  dependencies: [project],
+  vs
+};

--- a/src/core/shaderlib/project64/project64.glsl.js
+++ b/src/core/shaderlib/project64/project64.glsl.js
@@ -49,6 +49,14 @@ void project_position_fp64(vec4 position_fp64, out vec2 out_val[2]) {
   return;
 }
 
+void project_position_fp64(vec2 position, vec2 position64xyLow, out vec2 out_val[2]) {
+  vec4 position64xy = vec4(
+    position.x, position64xyLow.x,
+    position.y, position64xyLow.y);
+
+  project_position_fp64(position64xy, out_val);
+}
+
 vec4 project_to_clipspace_fp64(vec2 vertex_pos_modelspace[4]) {
   vec2 vertex_pos_clipspace[4];
   mat4_vec4_mul_fp64(project_uViewProjectionMatrixFP64, vertex_pos_modelspace,
@@ -59,5 +67,38 @@ vec4 project_to_clipspace_fp64(vec2 vertex_pos_modelspace[4]) {
     vertex_pos_clipspace[2].x,
     vertex_pos_clipspace[3].x
     );
+}
+
+vec4 project_position_to_clipspace(
+  vec3 position, vec2 position64xyLow, vec3 offset, out vec4 worldPosition
+) {
+  // This is the local offset to the instance position
+  vec2 offset64[4];
+  vec4_fp64(vec4(offset, 0.0), offset64);
+
+  float z = project_scale(position.z);
+
+  // Apply web mercator projection (depends on coordinate system imn use)
+  vec2 projectedPosition64xy[2];
+  project_position_fp64(position.xy, position64xyLow, projectedPosition64xy);
+
+  vec2 worldPosition64[4];
+  worldPosition64[0] = sum_fp64(offset64[0], projectedPosition64xy[0]);
+  worldPosition64[1] = sum_fp64(offset64[1], projectedPosition64xy[1]);
+  worldPosition64[2] = sum_fp64(offset64[2], vec2(z, 0.0));
+  worldPosition64[3] = vec2(1.0, 0.0);
+
+  worldPosition = vec4(projectedPosition64xy[0].x, projectedPosition64xy[1].x, z, 1.0);
+
+  return project_to_clipspace_fp64(worldPosition64);
+}
+
+vec4 project_position_to_clipspace(
+  vec3 position, vec2 position64xyLow, vec3 offset
+) {
+  vec4 worldPosition;
+  return project_position_to_clipspace(
+    position, position64xyLow, offset, worldPosition
+  );
 }
 `;

--- a/website/contents/pages.js
+++ b/website/contents/pages.js
@@ -351,6 +351,10 @@ export const docPages = generatePath([
             content: getDocUrl('shader-modules/project.md')
           },
           {
+            name: 'project32',
+            content: getDocUrl('shader-modules/project32.md')
+          },
+          {
             name: 'project64',
             content: getDocUrl('shader-modules/project64.md')
           },


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/1492

#### Change List
- Add shader module `project32`
- Implement `project_position_to_clipspace` interface in `project32` and `project64`
