### PR TITLE
Add alpha for minColor to fix test

### DIFF
--- a/test/src/core-layers/core-layers.spec.js
+++ b/test/src/core-layers/core-layers.spec.js
@@ -70,11 +70,15 @@ test('ScreenGridLayer#constructor', t => {
       },
       {
         updateProps: {
-          minColor: [0, 0, 0]
+          minColor: [0, 0, 0, 1.0]
         },
         assert: (layer, oldState) => {
           t.ok(layer.state, 'should update layer state');
-          t.deepEqual(layer.state.model.uniforms.minColor, [0, 0, 0], 'should update minColor');
+          t.deepEqual(
+            layer.state.model.uniforms.minColor,
+            [0, 0, 0, 1.0],
+            'should update minColor'
+          );
         }
       }
     ]

--- a/test/src/core-layers/core-layers.spec.js
+++ b/test/src/core-layers/core-layers.spec.js
@@ -70,13 +70,13 @@ test('ScreenGridLayer#constructor', t => {
       },
       {
         updateProps: {
-          minColor: [0, 0, 0, 1.0]
+          minColor: [0, 0, 0, 255]
         },
         assert: (layer, oldState) => {
           t.ok(layer.state, 'should update layer state');
           t.deepEqual(
             layer.state.model.uniforms.minColor,
-            [0, 0, 0, 1.0],
+            [0, 0, 0, 255],
             'should update minColor'
           );
         }


### PR DESCRIPTION
#### Background
Test-browser failed after we fix the uniform bug(https://github.com/uber/luma.gl/pull/425)

<!-- For all the PRs -->
#### Change List
- Change the minColor uniform to match the size in glsl shader.
