### PR TITLE
Modernize tests, remove deprecated test utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "luma.gl": "^5.1.2",
     "math.gl": "^1.0.0",
     "mjolnir.js": "^1.0.0",
-    "probe.gl": "^0.1.0",
+    "probe.gl": "^0.2.2",
     "prop-types": "^15.6.0",
     "seer": "^0.2.4",
     "viewport-mercator-project": "^5.0.0"

--- a/src/test-utils/package.json
+++ b/src/test-utils/package.json
@@ -48,7 +48,7 @@
     "canvas-to-blob": "0.0.0",
     "filesaver.js": "^0.2.0",
     "through": "^2.3.8",
-    "probe.gl": "^0.1.0"
+    "probe.gl": "^0.2.2"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",

--- a/src/test-utils/src/drivers/render-test-driver.js
+++ b/src/test-utils/src/drivers/render-test-driver.js
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 /* global process */
-import {NodeTestDriver} from 'probe.gl/test';
+import {BrowserDriver} from 'probe.gl/test';
 import {addColor, COLOR} from '../utils/colors';
 
 // DEFAULT config, intended to be overridden in the node script that calls us
@@ -34,8 +34,8 @@ const SERVER_CONFIG = {
   parameters: [`--env.${webpackEnv}`, '--progress']
 };
 
-export default class RenderTestDriver extends NodeTestDriver {
-  // TODO - move this method to probe.gl/NodeTestDriver
+export default class RenderTestDriver extends BrowserDriver {
+  // TODO - move this method to probe.gl/BrowserDriver
   waitForFunction(name) {
     return new Promise(resolve => {
       this.page.exposeFunction(name, resolve);

--- a/src/test-utils/src/index.js
+++ b/src/test-utils/src/index.js
@@ -6,16 +6,7 @@ export * from './luma.gl/gpgpu';
 export {testLayer} from './lifecycle-test';
 
 // Deprecated utilities for update tests (lifecycle tests)
-export {
-  testInitializeLayer,
-  testUpdateLayer,
-  testDrawLayer,
-  testLayerUpdates,
-  testSubLayerUpdateTriggers,
-  testCreateLayer,
-  testCreateEmptyLayer,
-  testNullLayer
-} from './lifecycle-test-deprecated';
+export {testInitializeLayer, testUpdateLayer, testDrawLayer} from './lifecycle-test-deprecated';
 
 // Basic utility for rendering multiple scenes (could go into "deck.gl/core")
 export {default as SceneRenderer} from './scene-renderer';

--- a/src/test-utils/src/lifecycle-test-deprecated.js
+++ b/src/test-utils/src/lifecycle-test-deprecated.js
@@ -18,13 +18,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {LayerManager, WebMercatorViewport} from 'deck.gl';
-import {makeSpy} from 'probe.gl/test';
+import {LayerManager} from 'deck.gl';
 import gl from './utils/setup-gl';
 
 export function testInitializeLayer({layer, viewport}) {
   const layerManager = new LayerManager(gl);
-  layerManager.setViewport(new WebMercatorViewport(100, 100));
 
   try {
     layerManager.setLayers([layer]);
@@ -37,7 +35,6 @@ export function testInitializeLayer({layer, viewport}) {
 
 export function testUpdateLayer({layer, viewport, newProps}) {
   const layerManager = new LayerManager(gl);
-  layerManager.setViewport(new WebMercatorViewport(100, 100));
 
   try {
     layerManager.setLayers([layer]);
@@ -51,7 +48,6 @@ export function testUpdateLayer({layer, viewport, newProps}) {
 
 export function testDrawLayer({layer, uniforms = {}}) {
   const layerManager = new LayerManager(gl);
-  layerManager.setViewport(new WebMercatorViewport(100, 100));
 
   try {
     layerManager.setLayers([layer]);
@@ -61,193 +57,4 @@ export function testDrawLayer({layer, uniforms = {}}) {
   }
 
   return null;
-}
-
-/**
- * Initialize a layer, test layer update
- * on a series of newProps, assert on the resulting layer
- *
- * Note: Updates are called sequentially. updateProps will be merged
- * with previous props
- *
- * @param {Function} t - test function
- * @param {Object} opt - test options
- * @param {Object} opt.LayerComponent - The layer component class
- * @param {Array} opt.testCases - A list of testCases
- * @param {Object} opt.testCases.INITIAL_PROPS - The initial prop to initialize the layer with
- * @param {Array} opt.testCases.UPDATES - The list of updates to update
- * @param {Object} opt.testCases.UPDATES.updateProps - updated props
- * @param {Function} opt.testCases.UPDATES.assert - callbacks with updated layer, and oldState
- */
-
-export function testLayerUpdates(t, {LayerComponent, testCases}) {
-  const layerManager = new LayerManager(gl);
-  layerManager.setViewport(new WebMercatorViewport(100, 100));
-
-  const newProps = Object.assign({}, testCases.INITIAL_PROPS);
-  const layer = new LayerComponent(newProps);
-
-  t.doesNotThrow(
-    () => layerManager.setLayers([layer]),
-    `initialization of ${LayerComponent.layerName} should not fail`
-  );
-
-  for (const {updateProps, assert} of testCases.UPDATES) {
-    // Add on new props every iteration
-    Object.assign(newProps, updateProps);
-
-    // copy old state before update
-    const oldState = Object.assign({}, layer.state);
-
-    const newLayer = layer.clone(newProps);
-    t.doesNotThrow(
-      () => layerManager.setLayers([newLayer]),
-      `update ${LayerComponent.layerName} should not fail`
-    );
-
-    // call draw layer
-    t.doesNotThrow(
-      () => layerManager.drawLayers(),
-      `draw ${LayerComponent.layerName} should not fail`
-    );
-
-    // assert on updated layer
-    assert(newLayer, oldState, t);
-  }
-}
-
-/**
- * Initialize a parent layer and its subLayer
- * update the parent layer a series of newProps, assert on the updated subLayer
- *
- * Note: Updates are called sequentially. updateProps will be merged
- * with previous props
- *
- * @param {Function} t - test function
- * @param {Object} opt - test options
- * @param {Object} opt.FunctionsToSpy - Functions that spied by makeSpy
- * @param {Object} opt.LayerComponent - The layer component class
- * @param {Array} opt.testCases - A list of testCases
- * @param {Object} opt.testCases.INITIAL_PROPS - The initial prop to initialize the layer with
- * @param {Array} opt.testCases.UPDATES - The list of updates to update
- * @param {Object} opt.testCases.UPDATES.updateProps - updated props
- * @param {Function} opt.testCases.UPDATES.assert - callbacks with updated layer, and oldState
- */
-
-export function testSubLayerUpdateTriggers(t, {FunctionsToSpy, LayerComponent, testCases}) {
-  const layerManager = new LayerManager(gl);
-  layerManager.setViewport(new WebMercatorViewport(100, 100));
-
-  const newProps = Object.assign({}, testCases.INITIAL_PROPS);
-
-  // initialize parent layer (generates and initializes)
-  const layer = new LayerComponent(newProps);
-  t.doesNotThrow(
-    () => layerManager.setLayers([layer]),
-    `initialization of ${LayerComponent.layerName} should not fail`
-  );
-
-  // Create a map of spies that the test case can inspect
-  const spies = FunctionsToSpy.reduce(
-    (accu, curr) =>
-      Object.assign(accu, {
-        [curr]: makeSpy(LayerComponent.prototype, curr)
-      }),
-    {}
-  );
-
-  for (const {updateProps, assert} of testCases.UPDATES) {
-    // Add on new props every iteration
-    Object.assign(newProps, updateProps);
-
-    const newLayer = layer.clone(newProps);
-    t.doesNotThrow(
-      () => layerManager.setLayers([newLayer]),
-      `update ${LayerComponent.layerName} should not fail`
-    );
-
-    // layer manager should handle match subLayer and tranfer state and props
-    // here we assume subLayer matches copy over the new props
-    // from a new subLayer
-    const subLayer = layer.getSubLayers()[0];
-
-    // assert on updated subLayer
-    assert(subLayer, spies, t);
-
-    // reset spies
-    Object.keys(spies).forEach(k => spies[k].reset());
-  }
-
-  /*
-  failures = testInitializeLayer({layer: subLayer});
-  t.ok(!failures, `initialize ${LayerComponent.layerName} subLayer should not fail`);
-  testCases.UPDATES.reduce((currentProps, {updateProps, assert}) => {
-    // merge updated Props with initialProps
-    const newProps = Object.assign({}, currentProps, updateProps);
-    // call update layer with new props
-    testUpdateLayer({layer, newProps});
-    testUpdateLayer({layer: subLayer, newProps: newSubLayer.props});
-    t.ok(!failures, `update ${LayerComponent.layerName} subLayer should not fail`);
-    return newProps;
-  }, testCases.INITIAL_PROPS);
-  */
-
-  // restore spies
-  Object.keys(spies).forEach(k => spies[k].restore());
-}
-
-export function testCreateLayer(t, LayerComponent, props = {}) {
-  let failures = false;
-  let layer = null;
-
-  try {
-    layer = new LayerComponent(
-      Object.assign(
-        {
-          id: `${LayerComponent.layerName}-0`
-        },
-        props
-      )
-    );
-
-    t.ok(layer instanceof LayerComponent, `${LayerComponent.layerName} created`);
-  } catch (error) {
-    failures = true;
-  }
-  t.ok(!failures, `creating ${LayerComponent.layerName} should not fail`);
-
-  return layer;
-}
-
-export function testCreateEmptyLayer(t, LayerComponent, props = {}) {
-  let failures = false;
-  try {
-    const emptyLayer = new LayerComponent(
-      Object.assign(
-        {
-          id: `empty${LayerComponent.layerName}`,
-          data: [],
-          pickable: true
-        },
-        props
-      )
-    );
-
-    t.ok(emptyLayer instanceof LayerComponent, `Empty ${LayerComponent.layerName} created`);
-  } catch (error) {
-    failures = true;
-  }
-  t.ok(!failures, `creating empty ${LayerComponent.layerName} should not fail`);
-}
-
-export function testNullLayer(t, LayerComponent) {
-  t.doesNotThrow(
-    () =>
-      new LayerComponent({
-        id: 'nullPathLayer',
-        data: null,
-        pickable: true
-      }),
-    `Null ${LayerComponent.layerName} did not throw exception`
-  );
 }

--- a/test/node-dist.js
+++ b/test/node-dist.js
@@ -20,6 +20,11 @@
 
 require('./node-aliases');
 
+// Registers an alias for this module
+const path = require('path');
+const moduleAlias = require('module-alias');
+moduleAlias.addAlias('deck.gl', path.resolve('./dist'));
+
 // Import headless luma support
 require('luma.gl/headless');
 

--- a/test/src/core-layers/core-layers.spec.js
+++ b/test/src/core-layers/core-layers.spec.js
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 /* eslint-disable func-style, no-console, max-len */
 import test from 'tape-catch';
+import {testLayer} from 'deck.gl-test-utils';
 
 import {
   ScatterplotLayer,
@@ -30,32 +31,35 @@ import {
   PathLayer
 } from 'deck.gl';
 
-import {
-  testCreateLayer,
-  testCreateEmptyLayer,
-  testNullLayer,
-  testLayerUpdates
-} from 'deck.gl-test-utils';
-
 import * as FIXTURES from 'deck.gl/test/data';
 
 const getPointPosition = d => d.COORDINATES;
 
 test('ScreenGridLayer#constructor', t => {
-  const LayerComponent = ScreenGridLayer;
   const data = FIXTURES.points;
 
-  const TEST_CASES = {
-    INITIAL_PROPS: {
-      data,
-      getPosition: getPointPosition
-    },
-    UPDATES: [
+  testLayer({
+    Layer: ScreenGridLayer,
+    testCases: [
+      {
+        title: 'Empty layer',
+        props: {id: 'empty'}
+      },
+      {
+        title: 'Null layer',
+        props: {id: 'null', data: null}
+      },
+      {
+        props: {
+          data,
+          getPosition: getPointPosition
+        }
+      },
       {
         updateProps: {
           cellSizePixels: 10
         },
-        assert: (layer, oldState) => {
+        assert({layer, oldState}) {
           t.ok(layer.state !== oldState, 'should update layer state');
           t.ok(layer.state.cellScale !== oldState.cellScale, 'should update cellScale');
           t.ok(
@@ -72,7 +76,7 @@ test('ScreenGridLayer#constructor', t => {
         updateProps: {
           minColor: [0, 0, 0, 255]
         },
-        assert: (layer, oldState) => {
+        assert({layer, oldState}) {
           t.ok(layer.state, 'should update layer state');
           t.deepEqual(
             layer.state.model.uniforms.minColor,
@@ -82,32 +86,37 @@ test('ScreenGridLayer#constructor', t => {
         }
       }
     ]
-  };
-
-  testCreateLayer(t, LayerComponent, {data, pickable: true});
-  testCreateEmptyLayer(t, LayerComponent);
-  testNullLayer(t, LayerComponent);
-  testLayerUpdates(t, {LayerComponent, testCases: TEST_CASES});
+  });
 
   t.end();
 });
 
 test('ScatterplotLayer#constructor', t => {
-  const LayerComponent = ScatterplotLayer;
   const data = FIXTURES.points;
 
-  const TEST_CASES = {
-    INITIAL_PROPS: {
-      data,
-      radiusScale: 5,
-      getPosition: getPointPosition
-    },
-    UPDATES: [
+  testLayer({
+    Layer: ScatterplotLayer,
+    testCases: [
+      {
+        title: 'Empty layer',
+        props: {id: 'empty'}
+      },
+      {
+        title: 'Null layer',
+        props: {id: 'null', data: null}
+      },
+      {
+        props: {
+          data,
+          radiusScale: 5,
+          getPosition: getPointPosition
+        }
+      },
       {
         updateProps: {
           radiusScale: 10
         },
-        assert: (layer, oldState) => {
+        assert({layer, oldState}) {
           t.ok(layer.state, 'should update layer state');
           t.ok(layer.state.model.uniforms.radiusScale === 10, 'should update radiusScale');
         }
@@ -116,7 +125,7 @@ test('ScatterplotLayer#constructor', t => {
         updateProps: {
           fp64: true
         },
-        assert: (layer, oldState) => {
+        assert({layer, oldState}) {
           t.ok(layer.state, 'should update layer state');
           t.ok(
             layer.getAttributeManager().attributes.instancePositions64xyLow,
@@ -125,92 +134,107 @@ test('ScatterplotLayer#constructor', t => {
         }
       }
     ]
-  };
-
-  testCreateLayer(t, LayerComponent, {data, pickable: true});
-  testCreateEmptyLayer(t, LayerComponent);
-  testNullLayer(t, LayerComponent);
-  testLayerUpdates(t, {LayerComponent, testCases: TEST_CASES});
+  });
 
   t.end();
 });
 
 test('ArcLayer#constructor', t => {
-  const LayerComponent = ArcLayer;
   const data = FIXTURES.routes;
 
-  const TEST_CASES = {
-    INITIAL_PROPS: {
-      data,
-      getSourcePosition: d => d.START,
-      getTargetPosition: d => d.END
-    },
-    UPDATES: [
+  testLayer({
+    Layer: ArcLayer,
+    testCases: [
+      {
+        title: 'Empty layer',
+        props: {id: 'empty'}
+      },
+      {
+        title: 'Null layer',
+        props: {id: 'null', data: null}
+      },
+      {
+        props: {
+          data,
+          getSourcePosition: d => d.START,
+          getTargetPosition: d => d.END
+        }
+      },
       {
         updateProps: {
           strokeWidth: 10
         },
-        assert: (layer, oldState) => {
+        assert({layer, oldState}) {
           t.ok(layer.state, 'should update layer state');
           t.ok(layer.state.model.uniforms.strokeWidth === 10, 'should update strokeWidth');
         }
       }
     ]
-  };
-
-  testCreateLayer(t, LayerComponent, {data, pickable: true});
-  testCreateEmptyLayer(t, LayerComponent);
-  testNullLayer(t, LayerComponent);
-  testLayerUpdates(t, {LayerComponent, testCases: TEST_CASES});
+  });
 
   t.end();
 });
 
 test('PointCloudLayer#constructor', t => {
-  const LayerComponent = PointCloudLayer;
   const data = FIXTURES.getPointCloud();
 
-  const TEST_CASES = {
-    INITIAL_PROPS: {
-      data
-    },
-    UPDATES: [
+  testLayer({
+    Layer: PointCloudLayer,
+    testCases: [
+      {
+        title: 'Empty layer',
+        props: {id: 'empty'}
+      },
+      {
+        title: 'Null layer',
+        props: {id: 'null', data: null}
+      },
+      {
+        props: {
+          data
+        }
+      },
       {
         updateProps: {
           radiusPixels: 10
         },
-        assert: (layer, oldState) => {
+        assert({layer, oldState}) {
           t.ok(layer.state, 'should update layer state');
           t.ok(layer.state.model.uniforms.radiusPixels === 10, 'should update strokeWidth');
         }
       }
     ]
-  };
-
-  testCreateLayer(t, LayerComponent, {data, pickable: true});
-  testCreateEmptyLayer(t, LayerComponent);
-  testNullLayer(t, LayerComponent);
-  testLayerUpdates(t, {LayerComponent, testCases: TEST_CASES});
+  });
 
   t.end();
 });
 
 test('LineLayer#constructor', t => {
-  const LayerComponent = LineLayer;
   const data = FIXTURES.routes;
 
-  const TEST_CASES = {
-    INITIAL_PROPS: {
-      data,
-      getSourcePosition: d => d.START,
-      getTargetPosition: d => d.END
-    },
-    UPDATES: [
+  testLayer({
+    Layer: LineLayer,
+    testCases: [
+      {
+        title: 'Empty layer',
+        props: {id: 'empty'}
+      },
+      {
+        title: 'Null layer',
+        props: {id: 'null', data: null}
+      },
+      {
+        props: {
+          data,
+          getSourcePosition: d => d.START,
+          getTargetPosition: d => d.END
+        }
+      },
       {
         updateProps: {
           strokeWidth: 10
         },
-        assert: (layer, oldState) => {
+        assert({layer, oldState}) {
           t.ok(layer.state, 'should update layer state');
           t.ok(layer.state.model.uniforms.strokeWidth === 10, 'should update strokeWidth');
         }
@@ -219,7 +243,7 @@ test('LineLayer#constructor', t => {
         updateProps: {
           fp64: true
         },
-        assert: (layer, oldState) => {
+        assert({layer, oldState}) {
           t.ok(layer.state, 'should update layer state');
           t.ok(
             layer.getAttributeManager().attributes.instanceSourceTargetPositions64xyLow,
@@ -228,32 +252,37 @@ test('LineLayer#constructor', t => {
         }
       }
     ]
-  };
-
-  testCreateLayer(t, LayerComponent, {data, pickable: true});
-  testCreateEmptyLayer(t, LayerComponent);
-  testNullLayer(t, LayerComponent);
-  testLayerUpdates(t, {LayerComponent, testCases: TEST_CASES});
+  });
 
   t.end();
 });
 
 test('IconLayer#constructor', t => {
-  const LayerComponent = IconLayer;
   const data = FIXTURES.points;
 
-  const TEST_CASES = {
-    INITIAL_PROPS: {
-      data,
-      sizeScale: 24,
-      getPosition: getPointPosition
-    },
-    UPDATES: [
+  testLayer({
+    Layer: IconLayer,
+    testCases: [
+      {
+        title: 'Empty layer',
+        props: {id: 'empty'}
+      },
+      {
+        title: 'Null layer',
+        props: {id: 'null', data: null}
+      },
+      {
+        props: {
+          data,
+          sizeScale: 24,
+          getPosition: getPointPosition
+        }
+      },
       {
         updateProps: {
           sizeScale: 10
         },
-        assert: (layer, oldState) => {
+        assert({layer, oldState}) {
           t.ok(layer.state, 'should update layer state');
         }
       },
@@ -261,7 +290,7 @@ test('IconLayer#constructor', t => {
         updateProps: {
           fp64: true
         },
-        assert: (layer, oldState) => {
+        assert({layer, oldState}) {
           t.ok(layer.state, 'should update layer state');
           t.ok(
             layer.getAttributeManager().attributes.instancePositions64xyLow,
@@ -270,30 +299,35 @@ test('IconLayer#constructor', t => {
         }
       }
     ]
-  };
-
-  testCreateLayer(t, LayerComponent, {data, pickable: true});
-  testCreateEmptyLayer(t, LayerComponent);
-  testNullLayer(t, LayerComponent);
-  testLayerUpdates(t, {LayerComponent, testCases: TEST_CASES});
+  });
 
   t.end();
 });
 
 test('PathLayer#constructor', t => {
-  const LayerComponent = PathLayer;
   const data = FIXTURES.zigzag;
 
-  const TEST_CASES = {
-    INITIAL_PROPS: {
-      data
-    },
-    UPDATES: [
+  testLayer({
+    Layer: PathLayer,
+    testCases: [
+      {
+        title: 'Empty layer',
+        props: {id: 'empty'}
+      },
+      {
+        title: 'Null layer',
+        props: {id: 'null', data: null}
+      },
+      {
+        props: {
+          data
+        }
+      },
       {
         updateProps: {
           widthMinPixels: 10
         },
-        assert: (layer, oldState) => {
+        assert({layer, oldState}) {
           t.ok(layer.state, 'should update layer state');
           t.ok(layer.state.model.uniforms.widthMinPixels === 10, 'should update strokeWidth');
         }
@@ -301,19 +335,14 @@ test('PathLayer#constructor', t => {
         //   updateProps: {
         //     fp64: true
         //   },
-        //   assert: (layer, oldState) => {
+        //   assert({layer, oldState}) {
         //     t.ok(layer.state, 'should update layer state');
         //     t.ok(layer.getAttributeManager().attributes.instanceStartEndPositions64xyLow,
         //       'should add instancePositions64xyLow');
         //   }
       }
     ]
-  };
-
-  testCreateLayer(t, LayerComponent, {data, pickable: true});
-  testCreateEmptyLayer(t, LayerComponent);
-  testNullLayer(t, LayerComponent);
-  testLayerUpdates(t, {LayerComponent, testCases: TEST_CASES});
+  });
 
   t.end();
 });

--- a/test/src/core-layers/geojson-layer.spec.js
+++ b/test/src/core-layers/geojson-layer.spec.js
@@ -19,57 +19,42 @@
 // THE SOFTWARE.
 
 import test from 'tape-catch';
-import * as FIXTURES from 'deck.gl/test/data';
-import {
-  testCreateLayer,
-  testCreateEmptyLayer,
-  testNullLayer,
-  testLayerUpdates
-} from 'deck.gl-test-utils';
+import {testLayer} from 'deck.gl-test-utils';
 
 import {GeoJsonLayer} from 'deck.gl';
 
-const LayerComponent = GeoJsonLayer;
+import * as FIXTURES from 'deck.gl/test/data';
 const data = FIXTURES.choropleths;
 
-test('GeoJsonLayer#constructor', t => {
-  testCreateLayer(t, LayerComponent, {data, pickable: true});
-  // testCreateLayer(t, LayerComponent, {data: FIXTURES.immutableChoropleths, pickable: true});
-  testCreateEmptyLayer(t, LayerComponent);
-  testNullLayer(t, LayerComponent);
-
-  t.end();
-});
-
-test('GeoJsonLayer#updates', t => {
-  const TEST_CASES = {
-    INITIAL_PROPS: {
-      data
-    },
-    UPDATES: [
+test('GeoJsonLayer#tests', t => {
+  testLayer({
+    Layer: GeoJsonLayer,
+    userData: t,
+    testCases: [
+      {props: {data: []}},
+      {props: {data: null}},
+      {props: {data}},
+      {props: {data, pickable: true}},
       {
-        updateProps: {
-          lineWidthScale: 3
+        props: {
+          data: Object.assign({}, data)
         },
-        assert: (layer, oldState) => {
+        assert({layer, oldState}) {
           t.ok(layer.state, 'should update layer state');
-          const subLayers = layer.renderLayers().filter(Boolean);
-          t.ok(subLayers.length === 2, 'should render 2 subLayers');
+          t.ok(layer.state.features !== oldState.features, 'should update features');
         }
       },
       {
         updateProps: {
-          data: Object.assign({}, data)
+          lineWidthScale: 3
         },
-        assert: (layer, oldState) => {
+        assert({layer, oldState}) {
           t.ok(layer.state, 'should update layer state');
-          t.ok(layer.state.features !== oldState.features, 'should update features');
+          const subLayers = layer.renderLayers().filter(Boolean);
+          t.equal(subLayers.length, 2, 'should render 2 subLayers');
         }
       }
     ]
-  };
-
-  testLayerUpdates(t, {LayerComponent, testCases: TEST_CASES});
-
+  });
   t.end();
 });

--- a/test/src/core-layers/grid-cell-layer.spec.js
+++ b/test/src/core-layers/grid-cell-layer.spec.js
@@ -19,82 +19,49 @@
 // THE SOFTWARE.
 
 import test from 'tape-catch';
-import {testInitializeLayer, testLayerUpdates} from 'deck.gl-test-utils';
+import {testLayer} from 'deck.gl-test-utils';
 
 import {GridCellLayer} from 'deck.gl';
 
 const GRID = [{position: [37, 122]}, {position: [37.1, 122.8]}];
 
-const TEST_CASES = {
-  // props to initialize layer with
-  INITIAL_PROPS: {
-    data: GRID
-  },
-  // list of update props to call and asserts on the resulting layer
-  UPDATES: [
-    {
-      updateProps: {
-        coverage: 0.8
+test('GridCellLayer#updates', t => {
+  testLayer({
+    Layer: GridCellLayer,
+    testCases: [
+      {props: []},
+      {props: null, pickable: true},
+      {
+        props: {
+          data: GRID
+        },
+        assert({layer}) {
+          t.equal(layer.props.cellSize, 1000, 'Use default radius if not specified');
+          t.equal(layer.props.coverage, 1, 'Use default angel if not specified');
+        }
       },
-      assert: (layer, oldState, t) => {
-        t.ok(layer.state, 'should update layer');
-      }
-    },
-    {
-      updateProps: {
-        fp64: true
+      {
+        updateProps: {
+          coverage: 0.8
+        },
+        assert({layer, oldState}) {
+          t.ok(layer.state, 'should update layer');
+        }
       },
-      assert: (layer, oldState, t) => {
-        t.ok(layer.state, 'should update layer');
-        t.ok(
-          layer.getAttributeManager().attributes.instancePositions64xyLow,
-          'should add instancePositions64xyLow'
-        );
+      {
+        updateProps: {
+          fp64: true
+        },
+        assert({layer, oldState}) {
+          t.ok(layer.state, 'should update layer');
+          t.ok(
+            layer.getAttributeManager().attributes.instancePositions64xyLow,
+            'should add instancePositions64xyLow'
+          );
+        }
       }
-    }
-  ]
-};
-
-test('GridCellLayer#constructor', t => {
-  let layer = new GridCellLayer({
-    id: 'emptyGridCellLayer',
-    data: [],
-    pickable: true
+    ]
   });
-  t.ok(layer instanceof GridCellLayer, 'Empty GridCellLayer created');
-
-  layer = new GridCellLayer({
-    data: GRID,
-    pickable: true
-  });
-  t.ok(layer instanceof GridCellLayer, 'GridCellLayer created');
-
-  testInitializeLayer({layer});
-  t.ok(layer.state.model, 'GridCellLayer has state');
-
-  t.doesNotThrow(
-    () =>
-      new GridCellLayer({
-        id: 'nullGridCellLayer',
-        data: null,
-        pickable: true
-      }),
-    'Null GridCellLayer did not throw exception'
-  );
-
-  layer = new GridCellLayer({
-    data: [],
-    pickable: true
-  });
-
-  t.equal(layer.props.cellSize, 1000, 'Use default radius if not specified');
-  t.equal(layer.props.coverage, 1, 'Use default angel if not specified');
-
-  t.end();
-});
-
-test('HexagonCellLayer#layerUpdate', t => {
-  testLayerUpdates({LayerComponent: GridCellLayer, testCases: TEST_CASES, t});
 
   t.end();
 });

--- a/test/src/core-layers/grid-layer.spec.js
+++ b/test/src/core-layers/grid-layer.spec.js
@@ -22,468 +22,13 @@ import {makeSpy} from 'probe.gl/test';
 
 import * as FIXTURES from 'deck.gl/test/data';
 
-import {
-  testCreateEmptyLayer,
-  testCreateLayer,
-  testInitializeLayer,
-  testLayerUpdates,
-  testNullLayer,
-  testSubLayerUpdateTriggers
-} from 'deck.gl-test-utils';
+import {testLayer, testInitializeLayer} from 'deck.gl-test-utils';
 
 import {GridLayer, GridCellLayer} from 'deck.gl';
 
 const getColorValue = points => points.length;
 const getElevationValue = points => points.length;
 const getPosition = d => d.COORDINATES;
-
-const TEST_CASES = {
-  // props to initialize layer with
-  INITIAL_PROPS: {
-    data: FIXTURES.points,
-    cellSize: 400,
-    getPosition,
-    pickable: true
-  },
-  // list of update props to call and asserts on the resulting layer
-  UPDATES: [
-    {
-      updateProps: {
-        cellSize: 800
-      },
-      assert: (layer, oldState, t) => {
-        t.ok(oldState.layerData !== layer.state.layerData, 'should update layer data');
-
-        t.ok(
-          oldState.sortedColorBins !== layer.state.sortedColorBins,
-          'should update sortedColorBins'
-        );
-
-        t.ok(
-          oldState.colorValueDomain !== layer.state.colorValueDomain,
-          'should update valueDomain'
-        );
-
-        t.ok(
-          oldState.colorScaleFunc !== layer.state.colorScaleFunc,
-          'should update colorScaleFunc'
-        );
-
-        t.ok(
-          oldState.sortedElevationBins !== layer.state.sortedElevationBins,
-          'should update sortedElevationBins'
-        );
-
-        t.ok(
-          oldState.elevationValueDomain !== layer.state.elevationValueDomain,
-          'should update elevationValueDomain'
-        );
-
-        t.ok(
-          oldState.elevationScaleFunc !== layer.state.elevationScaleFunc,
-          'should update elevationScaleFunc'
-        );
-      }
-    },
-    {
-      updateProps: {
-        getColorValue
-      },
-      assert: (layer, oldState, t) => {
-        t.ok(oldState.layerData === layer.state.layerData, 'should not update layer data');
-
-        t.ok(
-          oldState.sortedColorBins !== layer.state.sortedColorBins,
-          'should not update sortedColorBins'
-        );
-
-        t.ok(
-          oldState.sortedElevationBins === layer.state.sortedElevationBins,
-          'should update sortedElevationBins'
-        );
-
-        t.ok(
-          oldState.colorValueDomain !== layer.state.colorValueDomain,
-          'should re calculate colorValueDomain'
-        );
-
-        t.ok(
-          oldState.elevationValueDomain === layer.state.elevationValueDomain,
-          'should not update elevationValueDomain'
-        );
-
-        t.ok(
-          oldState.colorScaleFunc !== layer.state.colorScaleFunc,
-          'should update colorScaleFunc'
-        );
-
-        t.ok(
-          oldState.elevationScaleFunc === layer.state.elevationScaleFunc,
-          'should not update colorScaleFunc'
-        );
-      }
-    },
-    {
-      updateProps: {
-        upperPercentile: 90
-      },
-      assert: (layer, oldState, t) => {
-        t.ok(oldState.layerData === layer.state.layerData, 'should not update layer data');
-
-        t.ok(
-          oldState.sortedColorBins === layer.state.sortedColorBins,
-          'should not update sortedColorBins'
-        );
-
-        t.ok(
-          oldState.colorValueDomain !== layer.state.colorValueDomain,
-          'should re calculate colorValueDomain'
-        );
-
-        t.ok(
-          oldState.colorScaleFunc !== layer.state.colorScaleFunc,
-          'should update colorScaleFunc'
-        );
-
-        t.ok(
-          oldState.sortedElevationBins === layer.state.sortedElevationBins,
-          'should not update sortedElevationBins'
-        );
-
-        t.ok(
-          oldState.elevationValueDomain === layer.state.elevationValueDomain,
-          'should not update elevationValueDomain'
-        );
-
-        t.ok(
-          oldState.elevationScaleFunc === layer.state.elevationScaleFunc,
-          'should not update elevationScaleFunc'
-        );
-      }
-    },
-    {
-      updateProps: {
-        colorDomain: [0, 10]
-      },
-      assert: (layer, oldState, t) => {
-        t.ok(oldState.layerData === layer.state.layerData, 'should not update layer data');
-
-        t.ok(
-          oldState.sortedColorBins === layer.state.sortedColorBins,
-          'should not update sortedColorBins'
-        );
-
-        t.ok(
-          oldState.colorValueDomain === layer.state.colorValueDomain,
-          'should not re calculate colorValueDomain'
-        );
-
-        t.ok(
-          oldState.colorScaleFunc !== layer.state.colorScaleFunc,
-          'should update colorScaleFunc'
-        );
-
-        t.ok(
-          oldState.sortedElevationBins === layer.state.sortedElevationBins,
-          'should not update sortedElevationBins'
-        );
-
-        t.ok(
-          oldState.elevationValueDomain === layer.state.elevationValueDomain,
-          'should not update elevationValueDomain'
-        );
-
-        t.ok(
-          oldState.elevationScaleFunc === layer.state.elevationScaleFunc,
-          'should not update elevationScaleFunc'
-        );
-      }
-    },
-    {
-      updateProps: {
-        getElevationValue
-      },
-      assert: (layer, oldState, t) => {
-        t.ok(oldState.layerData === layer.state.layerData, 'should not update layer data');
-
-        t.ok(
-          oldState.sortedElevationBins !== layer.state.sortedElevationBins,
-          'should update sortedElevationBins'
-        );
-
-        t.ok(
-          oldState.elevationValueDomain !== layer.state.elevationValueDomain,
-          'should re calculate elevationValueDomain'
-        );
-
-        t.ok(
-          oldState.elevationScaleFunc !== layer.state.elevationScaleFunc,
-          'should update elevationScaleFunc'
-        );
-
-        t.ok(
-          oldState.sortedColorBins === layer.state.sortedColorBins,
-          'should not update sortedColorBins'
-        );
-
-        t.ok(
-          oldState.colorValueDomain === layer.state.colorValueDomain,
-          'should not re calculate colorValueDomain'
-        );
-
-        t.ok(
-          oldState.colorScaleFunc === layer.state.colorScaleFunc,
-          'should not update colorScaleFunc'
-        );
-      }
-    },
-    {
-      updateProps: {
-        elevationLowerPercentile: 1
-      },
-      assert: (layer, oldState, t) => {
-        t.ok(oldState.layerData === layer.state.layerData, 'should not update layer data');
-
-        t.ok(
-          oldState.sortedElevationBins === layer.state.sortedElevationBins,
-          'should not update sortedElevationBins'
-        );
-
-        t.ok(
-          oldState.elevationValueDomain !== layer.state.elevationValueDomain,
-          'should re calculate elevationValueDomain'
-        );
-
-        t.ok(
-          oldState.elevationScaleFunc !== layer.state.elevationScaleFunc,
-          'should update elevationScaleFunc'
-        );
-
-        t.ok(
-          oldState.sortedColorBins === layer.state.sortedColorBins,
-          'should not update sortedColorBins'
-        );
-
-        t.ok(
-          oldState.colorValueDomain === layer.state.colorValueDomain,
-          'should not re calculate colorValueDomain'
-        );
-
-        t.ok(
-          oldState.colorScaleFunc === layer.state.colorScaleFunc,
-          'should not update colorScaleFunc'
-        );
-      }
-    },
-    {
-      updateProps: {
-        elevationRange: [1, 10]
-      },
-      assert: (layer, oldState, t) => {
-        t.ok(oldState.layerData === layer.state.layerData, 'should not update layer data');
-
-        t.ok(
-          oldState.sortedElevationBins === layer.state.sortedElevationBins,
-          'should not update sortedElevationBins'
-        );
-
-        t.ok(
-          oldState.elevationValueDomain === layer.state.elevationValueDomain,
-          'should not re calculate elevationValueDomain'
-        );
-
-        t.ok(
-          oldState.elevationScaleFunc !== layer.state.elevationScaleFunc,
-          'should update elevationScaleFunc'
-        );
-
-        t.ok(
-          oldState.sortedColorBins === layer.state.sortedColorBins,
-          'should not update sortedColorBins'
-        );
-
-        t.ok(
-          oldState.colorValueDomain === layer.state.colorValueDomain,
-          'should not re calculate colorValueDomain'
-        );
-
-        t.ok(
-          oldState.colorScaleFunc === layer.state.colorScaleFunc,
-          'should not update colorScaleFunc'
-        );
-      }
-    }
-  ]
-};
-
-const SUBLAYER_TEST_CASES = {
-  // props to initialize layer with
-  INITIAL_PROPS: {
-    data: FIXTURES.points,
-    cellSize: 400,
-    getPosition
-  },
-  // list of update props to call and asserts on the resulting layer
-  UPDATES: [
-    {
-      updateProps: {
-        cellSize: 800
-      },
-      assert: (subLayer, spies, t) => {
-        t.ok(spies._onGetSublayerColor.called, 'update radius should call _onGetSublayerColor');
-        t.ok(
-          spies._onGetSublayerElevation.called,
-          'update radius should call _onGetSublayerElevation'
-        );
-      }
-    },
-    {
-      updateProps: {
-        opacity: 0.1
-      },
-      assert: (subLayer, spies, t) => {
-        t.ok(
-          !spies._onGetSublayerColor.called,
-          'update opacity should not call _onGetSublayerColor'
-        );
-        t.ok(
-          !spies._onGetSublayerElevation.called,
-          'update opacity  should not call _onGetSublayerElevation'
-        );
-      }
-    },
-    {
-      updateProps: {
-        getColorValue
-      },
-      assert: (subLayer, spies, t) => {
-        t.ok(
-          spies._onGetSublayerColor.called,
-          'update getColorValue should call _onGetSublayerColor'
-        );
-        t.ok(
-          !spies._onGetSublayerElevation.called,
-          'update getColorValue  should not call _onGetSublayerElevation'
-        );
-      }
-    },
-    {
-      updateProps: {
-        upperPercentile: 90
-      },
-      assert: (subLayer, spies, t) => {
-        t.ok(
-          spies._onGetSublayerColor.called,
-          'update upperPercentile should call _onGetSublayerColor'
-        );
-        t.ok(
-          !spies._onGetSublayerElevation.called,
-          'update upperPercentile should not call _onGetSublayerElevation'
-        );
-      }
-    },
-    {
-      updateProps: {
-        getElevationValue
-      },
-      assert: (subLayer, spies, t) => {
-        t.ok(
-          !spies._onGetSublayerColor.called,
-          'update getElevationValue should not call _onGetSublayerColor'
-        );
-        t.ok(
-          spies._onGetSublayerElevation.called,
-          'update getElevationValue should call _onGetSublayerElevation'
-        );
-      }
-    },
-    {
-      updateProps: {
-        elevationUpperPercentile: 99
-      },
-      assert: (subLayer, spies, t) => {
-        t.ok(
-          !spies._onGetSublayerColor.called,
-          'update elevationUpperPercentile should not call _onGetSublayerColor'
-        );
-        t.ok(
-          spies._onGetSublayerElevation.called,
-          'update elevationUpperPercentile should call _onGetSublayerElevation'
-        );
-      }
-    },
-    {
-      updateProps: {
-        elevationRange: [0, 100]
-      },
-      assert: (subLayer, spies, t) => {
-        t.ok(
-          !spies._onGetSublayerColor.called,
-          'update elevationRange should not call _onGetSublayerColor'
-        );
-        t.ok(
-          spies._onGetSublayerElevation.called,
-          'update elevationRange should call _onGetSublayerElevation'
-        );
-      }
-    }
-  ]
-};
-
-test('GridLayer#constructor', t => {
-  const LayerComponent = GridLayer;
-  const props = TEST_CASES.INITIAL_PROPS;
-
-  testCreateEmptyLayer(t, LayerComponent);
-  testNullLayer(t, LayerComponent);
-  const layer = testCreateLayer(t, LayerComponent, props);
-
-  testInitializeLayer({layer});
-
-  const {
-    layerData,
-    sortedColorBins,
-    sortedElevationBins,
-    colorValueDomain,
-    elevationValueDomain
-  } = layer.state;
-
-  t.ok(layerData.length > 0, 'GridLayer.state.layerDate calculated');
-  t.ok(sortedColorBins, 'GridLayer.state.sortedColorBins calculated');
-  t.ok(sortedElevationBins, 'GridLayer.state.sortedColorBins calculated');
-  t.ok(Array.isArray(colorValueDomain), 'GridLayer.state.valueDomain calculated');
-  t.ok(Array.isArray(elevationValueDomain), 'GridLayer.state.valueDomain calculated');
-
-  t.ok(
-    Array.isArray(sortedColorBins.sortedBins),
-    'GridLayer.state.sortedColorBins.sortedBins calculated'
-  );
-  t.ok(
-    Array.isArray(sortedElevationBins.sortedBins),
-    'GridLayer.state.sortedColorBins.sortedBins calculated'
-  );
-  t.ok(
-    Number.isFinite(sortedColorBins.maxCount),
-    'GridLayer.state.sortedColorBins.maxCount calculated'
-  );
-  t.ok(
-    Number.isFinite(sortedElevationBins.maxCount),
-    'GridLayer.state.sortedColorBins.maxCount calculated'
-  );
-
-  const firstSortedBin = sortedColorBins.sortedBins[0];
-  const binTocell = layerData.find(d => d.index === firstSortedBin.i);
-
-  t.ok(
-    sortedColorBins.binMap[binTocell.index] === firstSortedBin,
-    'Correct GridLayer.state.sortedColorBins.binMap created'
-  );
-
-  const subLayer = layer.renderLayers();
-  t.ok(subLayer instanceof GridCellLayer, 'GridCellLayer rendered');
-
-  t.end();
-});
 
 test('GridLayer#renderSubLayer', t => {
   makeSpy(GridLayer.prototype, '_onGetSublayerColor');
@@ -514,19 +59,467 @@ test('GridLayer#renderSubLayer', t => {
   t.end();
 });
 
-test('GridLayer#updateLayer', t => {
-  testLayerUpdates(t, {LayerComponent: GridLayer, testCases: TEST_CASES});
+test('GridLayer#updates', t => {
+  testLayer({
+    Layer: GridLayer,
+    testCases: [
+      {
+        props: {
+          data: FIXTURES.points,
+          cellSize: 400,
+          getPosition,
+          pickable: true
+        },
+        assert({layer}) {
+          const {
+            layerData,
+            sortedColorBins,
+            sortedElevationBins,
+            colorValueDomain,
+            elevationValueDomain
+          } = layer.state;
+
+          t.ok(layerData.length > 0, 'GridLayer.state.layerDate calculated');
+          t.ok(sortedColorBins, 'GridLayer.state.sortedColorBins calculated');
+          t.ok(sortedElevationBins, 'GridLayer.state.sortedColorBins calculated');
+          t.ok(Array.isArray(colorValueDomain), 'GridLayer.state.valueDomain calculated');
+          t.ok(Array.isArray(elevationValueDomain), 'GridLayer.state.valueDomain calculated');
+
+          t.ok(
+            Array.isArray(sortedColorBins.sortedBins),
+            'GridLayer.state.sortedColorBins.sortedBins calculated'
+          );
+          t.ok(
+            Array.isArray(sortedElevationBins.sortedBins),
+            'GridLayer.state.sortedColorBins.sortedBins calculated'
+          );
+          t.ok(
+            Number.isFinite(sortedColorBins.maxCount),
+            'GridLayer.state.sortedColorBins.maxCount calculated'
+          );
+          t.ok(
+            Number.isFinite(sortedElevationBins.maxCount),
+            'GridLayer.state.sortedColorBins.maxCount calculated'
+          );
+
+          const firstSortedBin = sortedColorBins.sortedBins[0];
+          const binTocell = layerData.find(d => d.index === firstSortedBin.i);
+
+          t.ok(
+            sortedColorBins.binMap[binTocell.index] === firstSortedBin,
+            'Correct GridLayer.state.sortedColorBins.binMap created'
+          );
+        }
+      },
+      {
+        updateProps: {
+          data: FIXTURES.points,
+          cellSize: 500,
+          getPosition,
+          pickable: true
+        },
+        spies: ['_onGetSublayerColor', '_onGetSublayerElevation'],
+        assert({layer, subLayer, spies}) {
+          t.ok(subLayer instanceof GridCellLayer, 'GridCellLayer rendered');
+
+          // should call attribute updater twice
+          // because test util calls both initialize and update layer
+          t.ok(spies._onGetSublayerColor.called, 'should call _onGetSublayerColor');
+          t.ok(spies._onGetSublayerElevation.called, 'should call _onGetSublayerElevation');
+          spies._onGetSublayerColor.restore();
+          spies._onGetSublayerElevation.restore();
+        }
+      },
+      {
+        updateProps: {
+          cellSize: 800
+        },
+        assert({layer, oldState}) {
+          t.ok(oldState.layerData !== layer.state.layerData, 'should update layer data');
+
+          t.ok(
+            oldState.sortedColorBins !== layer.state.sortedColorBins,
+            'should update sortedColorBins'
+          );
+
+          t.ok(
+            oldState.colorValueDomain !== layer.state.colorValueDomain,
+            'should update valueDomain'
+          );
+
+          t.ok(
+            oldState.colorScaleFunc !== layer.state.colorScaleFunc,
+            'should update colorScaleFunc'
+          );
+
+          t.ok(
+            oldState.sortedElevationBins !== layer.state.sortedElevationBins,
+            'should update sortedElevationBins'
+          );
+
+          t.ok(
+            oldState.elevationValueDomain !== layer.state.elevationValueDomain,
+            'should update elevationValueDomain'
+          );
+
+          t.ok(
+            oldState.elevationScaleFunc !== layer.state.elevationScaleFunc,
+            'should update elevationScaleFunc'
+          );
+        }
+      },
+      {
+        updateProps: {
+          getColorValue
+        },
+        assert({layer, oldState}) {
+          t.ok(oldState.layerData === layer.state.layerData, 'should not update layer data');
+
+          t.ok(
+            oldState.sortedColorBins !== layer.state.sortedColorBins,
+            'should not update sortedColorBins'
+          );
+
+          t.ok(
+            oldState.sortedElevationBins === layer.state.sortedElevationBins,
+            'should update sortedElevationBins'
+          );
+
+          t.ok(
+            oldState.colorValueDomain !== layer.state.colorValueDomain,
+            'should re calculate colorValueDomain'
+          );
+
+          t.ok(
+            oldState.elevationValueDomain === layer.state.elevationValueDomain,
+            'should not update elevationValueDomain'
+          );
+
+          t.ok(
+            oldState.colorScaleFunc !== layer.state.colorScaleFunc,
+            'should update colorScaleFunc'
+          );
+
+          t.ok(
+            oldState.elevationScaleFunc === layer.state.elevationScaleFunc,
+            'should not update colorScaleFunc'
+          );
+        }
+      },
+      {
+        updateProps: {
+          upperPercentile: 90
+        },
+        assert({layer, oldState}) {
+          t.ok(oldState.layerData === layer.state.layerData, 'should not update layer data');
+
+          t.ok(
+            oldState.sortedColorBins === layer.state.sortedColorBins,
+            'should not update sortedColorBins'
+          );
+
+          t.ok(
+            oldState.colorValueDomain !== layer.state.colorValueDomain,
+            'should re calculate colorValueDomain'
+          );
+
+          t.ok(
+            oldState.colorScaleFunc !== layer.state.colorScaleFunc,
+            'should update colorScaleFunc'
+          );
+
+          t.ok(
+            oldState.sortedElevationBins === layer.state.sortedElevationBins,
+            'should not update sortedElevationBins'
+          );
+
+          t.ok(
+            oldState.elevationValueDomain === layer.state.elevationValueDomain,
+            'should not update elevationValueDomain'
+          );
+
+          t.ok(
+            oldState.elevationScaleFunc === layer.state.elevationScaleFunc,
+            'should not update elevationScaleFunc'
+          );
+        }
+      },
+      {
+        updateProps: {
+          colorDomain: [0, 10]
+        },
+        assert({layer, oldState}) {
+          t.ok(oldState.layerData === layer.state.layerData, 'should not update layer data');
+
+          t.ok(
+            oldState.sortedColorBins === layer.state.sortedColorBins,
+            'should not update sortedColorBins'
+          );
+
+          t.ok(
+            oldState.colorValueDomain === layer.state.colorValueDomain,
+            'should not re calculate colorValueDomain'
+          );
+
+          t.ok(
+            oldState.colorScaleFunc !== layer.state.colorScaleFunc,
+            'should update colorScaleFunc'
+          );
+
+          t.ok(
+            oldState.sortedElevationBins === layer.state.sortedElevationBins,
+            'should not update sortedElevationBins'
+          );
+
+          t.ok(
+            oldState.elevationValueDomain === layer.state.elevationValueDomain,
+            'should not update elevationValueDomain'
+          );
+
+          t.ok(
+            oldState.elevationScaleFunc === layer.state.elevationScaleFunc,
+            'should not update elevationScaleFunc'
+          );
+        }
+      },
+      {
+        updateProps: {
+          getElevationValue
+        },
+        assert({layer, oldState}) {
+          t.ok(oldState.layerData === layer.state.layerData, 'should not update layer data');
+
+          t.ok(
+            oldState.sortedElevationBins !== layer.state.sortedElevationBins,
+            'should update sortedElevationBins'
+          );
+
+          t.ok(
+            oldState.elevationValueDomain !== layer.state.elevationValueDomain,
+            'should re calculate elevationValueDomain'
+          );
+
+          t.ok(
+            oldState.elevationScaleFunc !== layer.state.elevationScaleFunc,
+            'should update elevationScaleFunc'
+          );
+
+          t.ok(
+            oldState.sortedColorBins === layer.state.sortedColorBins,
+            'should not update sortedColorBins'
+          );
+
+          t.ok(
+            oldState.colorValueDomain === layer.state.colorValueDomain,
+            'should not re calculate colorValueDomain'
+          );
+
+          t.ok(
+            oldState.colorScaleFunc === layer.state.colorScaleFunc,
+            'should not update colorScaleFunc'
+          );
+        }
+      },
+      {
+        updateProps: {
+          elevationLowerPercentile: 1
+        },
+        assert({layer, oldState}) {
+          t.ok(oldState.layerData === layer.state.layerData, 'should not update layer data');
+
+          t.ok(
+            oldState.sortedElevationBins === layer.state.sortedElevationBins,
+            'should not update sortedElevationBins'
+          );
+
+          t.ok(
+            oldState.elevationValueDomain !== layer.state.elevationValueDomain,
+            'should re calculate elevationValueDomain'
+          );
+
+          t.ok(
+            oldState.elevationScaleFunc !== layer.state.elevationScaleFunc,
+            'should update elevationScaleFunc'
+          );
+
+          t.ok(
+            oldState.sortedColorBins === layer.state.sortedColorBins,
+            'should not update sortedColorBins'
+          );
+
+          t.ok(
+            oldState.colorValueDomain === layer.state.colorValueDomain,
+            'should not re calculate colorValueDomain'
+          );
+
+          t.ok(
+            oldState.colorScaleFunc === layer.state.colorScaleFunc,
+            'should not update colorScaleFunc'
+          );
+        }
+      },
+      {
+        updateProps: {
+          elevationRange: [1, 10]
+        },
+        assert({layer, oldState}) {
+          t.ok(oldState.layerData === layer.state.layerData, 'should not update layer data');
+
+          t.ok(
+            oldState.sortedElevationBins === layer.state.sortedElevationBins,
+            'should not update sortedElevationBins'
+          );
+
+          t.ok(
+            oldState.elevationValueDomain === layer.state.elevationValueDomain,
+            'should not re calculate elevationValueDomain'
+          );
+
+          t.ok(
+            oldState.elevationScaleFunc !== layer.state.elevationScaleFunc,
+            'should update elevationScaleFunc'
+          );
+
+          t.ok(
+            oldState.sortedColorBins === layer.state.sortedColorBins,
+            'should not update sortedColorBins'
+          );
+
+          t.ok(
+            oldState.colorValueDomain === layer.state.colorValueDomain,
+            'should not re calculate colorValueDomain'
+          );
+
+          t.ok(
+            oldState.colorScaleFunc === layer.state.colorScaleFunc,
+            'should not update colorScaleFunc'
+          );
+        }
+      }
+    ]
+  });
+
   t.end();
 });
 
 test('GridLayer#updateTriggers', t => {
   // setup spies
-  const FunctionsToSpy = ['_onGetSublayerColor', '_onGetSublayerElevation'];
+  const SPIES = ['_onGetSublayerColor', '_onGetSublayerElevation'];
 
-  testSubLayerUpdateTriggers(t, {
-    FunctionsToSpy,
-    LayerComponent: GridLayer,
-    testCases: SUBLAYER_TEST_CASES
+  testLayer({
+    Layer: GridLayer,
+    spies: SPIES,
+    testCases: [
+      {
+        props: {
+          data: FIXTURES.points,
+          cellSize: 400,
+          getPosition
+        }
+      },
+      {
+        updateProps: {
+          cellSize: 800
+        },
+        assert({subLayer, spies}) {
+          t.ok(spies._onGetSublayerColor.called, 'update radius should call _onGetSublayerColor');
+          t.ok(
+            spies._onGetSublayerElevation.called,
+            'update radius should call _onGetSublayerElevation'
+          );
+        }
+      },
+      {
+        updateProps: {
+          opacity: 0.1
+        },
+        assert({subLayer, spies}) {
+          t.ok(
+            !spies._onGetSublayerColor.called,
+            'update opacity should not call _onGetSublayerColor'
+          );
+          t.ok(
+            !spies._onGetSublayerElevation.called,
+            'update opacity  should not call _onGetSublayerElevation'
+          );
+        }
+      },
+      {
+        updateProps: {
+          getColorValue
+        },
+        assert({subLayer, spies}) {
+          t.ok(
+            spies._onGetSublayerColor.called,
+            'update getColorValue should call _onGetSublayerColor'
+          );
+          t.ok(
+            !spies._onGetSublayerElevation.called,
+            'update getColorValue  should not call _onGetSublayerElevation'
+          );
+        }
+      },
+      {
+        updateProps: {
+          upperPercentile: 90
+        },
+        assert({subLayer, spies}) {
+          t.ok(
+            spies._onGetSublayerColor.called,
+            'update upperPercentile should call _onGetSublayerColor'
+          );
+          t.ok(
+            !spies._onGetSublayerElevation.called,
+            'update upperPercentile should not call _onGetSublayerElevation'
+          );
+        }
+      },
+      {
+        updateProps: {
+          getElevationValue
+        },
+        assert({subLayer, spies}) {
+          t.ok(
+            !spies._onGetSublayerColor.called,
+            'update getElevationValue should not call _onGetSublayerColor'
+          );
+          t.ok(
+            spies._onGetSublayerElevation.called,
+            'update getElevationValue should call _onGetSublayerElevation'
+          );
+        }
+      },
+      {
+        updateProps: {
+          elevationUpperPercentile: 99
+        },
+        assert({subLayer, spies}) {
+          t.ok(
+            !spies._onGetSublayerColor.called,
+            'update elevationUpperPercentile should not call _onGetSublayerColor'
+          );
+          t.ok(
+            spies._onGetSublayerElevation.called,
+            'update elevationUpperPercentile should call _onGetSublayerElevation'
+          );
+        }
+      },
+      {
+        updateProps: {
+          elevationRange: [0, 100]
+        },
+        assert({subLayer, spies}) {
+          t.ok(
+            !spies._onGetSublayerColor.called,
+            'update elevationRange should not call _onGetSublayerColor'
+          );
+          t.ok(
+            spies._onGetSublayerElevation.called,
+            'update elevationRange should call _onGetSublayerElevation'
+          );
+        }
+      }
+    ]
   });
 
   t.end();

--- a/test/src/core-layers/hexagon-cell-layer.spec.js
+++ b/test/src/core-layers/hexagon-cell-layer.spec.js
@@ -19,110 +19,87 @@
 // THE SOFTWARE.
 
 import test from 'tape-catch';
-import {testInitializeLayer, testLayerUpdates, toLowPrecision} from 'deck.gl-test-utils';
+import {testLayer, toLowPrecision} from 'deck.gl-test-utils';
 
 import {HexagonCellLayer} from 'deck.gl';
 
 const HEXAGONS = [{centroid: [37, 122]}, {centroid: [37.1, 122.8]}];
 
-const TEST_CASES = {
-  // props to initialize layer with
-  INITIAL_PROPS: {
-    data: HEXAGONS
-  },
-  // list of update props to call and asserts on the resulting layer
-  UPDATES: [
-    {
-      updateProps: {
-        coverage: 0.8
+test('HexagonCellLayer#updates', t => {
+  testLayer({
+    Layer: HexagonCellLayer,
+    testCases: [
+      {
+        props: {
+          id: 'emptyHexagonCellLayer',
+          data: [],
+          pickable: true
+        }
       },
-      assert: (layer, oldState, t) => {
-        t.ok(layer.state, 'should update layer');
-      }
-    },
-    {
-      updateProps: {
-        fp64: true
+      {
+        props: {
+          id: 'nullHexagonLayer',
+          data: null,
+          pickable: true
+        }
       },
-      assert: (layer, oldState, t) => {
-        t.ok(layer.state, 'should update layer');
-        t.ok(
-          layer.getAttributeManager().attributes.instancePositions64xyLow,
-          'should add instancePositions64xyLow'
-        );
+      {
+        props: {
+          data: HEXAGONS,
+          pickable: true
+        },
+        assert({layer}) {
+          t.equal(layer.props.radius, 1000, 'Use default radius if not specified');
+          t.equal(layer.props.angle, 0, 'Use default angel if not specified');
+        }
+      },
+      {
+        updateProps: {
+          coverage: 0.8
+        },
+        assert({layer, oldState}) {
+          t.ok(layer.state, 'should update layer');
+        }
+      },
+      {
+        updateProps: {
+          fp64: true
+        },
+        assert({layer, oldState}) {
+          t.ok(layer.state, 'should update layer');
+          t.ok(
+            layer.getAttributeManager().attributes.instancePositions64xyLow,
+            'should add instancePositions64xyLow'
+          );
+        }
+      },
+      {
+        title: 'HexagonCellLayer#updateRadiusAngle',
+        props: {
+          data: [],
+          pickable: true,
+          hexagonVertices: [
+            [-122.3993347, 37.79178708],
+            [-122.4021036, 37.79398118],
+            [-122.4060099, 37.79308171],
+            [-122.4071472, 37.78998822],
+            [-122.4043784, 37.78779417],
+            [-122.4004722, 37.78869356]
+          ],
+          radius: 10,
+          angle: 10
+        },
+        assert({layer}) {
+          const {angle} = layer.updateRadiusAngle();
+          t.equal(
+            toLowPrecision(angle, 5),
+            1.8543,
+            'Use hexagonVertices instead of radius and angle if both provided'
+          );
+        }
       }
-    }
-  ]
-};
-
-test('HexagonCellLayer#constructor', t => {
-  let layer = new HexagonCellLayer({
-    id: 'emptyHexagonCellLayer',
-    data: [],
-    pickable: true
+    ]
   });
-  t.ok(layer instanceof HexagonCellLayer, 'Empty HexagonCellLayer created');
-
-  layer = new HexagonCellLayer({
-    data: HEXAGONS,
-    pickable: true
-  });
-  t.ok(layer instanceof HexagonCellLayer, 'HexagonCellLayer created');
-
-  testInitializeLayer({layer});
-  t.ok(layer.state.model, 'HexagonCellLayer has state');
-
-  t.doesNotThrow(
-    () =>
-      new HexagonCellLayer({
-        id: 'nullHexagonLayer',
-        data: null,
-        pickable: true
-      }),
-    'Null HexagonCellLayer did not throw exception'
-  );
-
-  layer = new HexagonCellLayer({
-    data: [],
-    pickable: true
-  });
-
-  t.equal(layer.props.radius, 1000, 'Use default radius if not specified');
-  t.equal(layer.props.angle, 0, 'Use default angel if not specified');
-
-  t.end();
-});
-
-test('HexagonCellLayer#layerUpdate', t => {
-  testLayerUpdates(t, {LayerComponent: HexagonCellLayer, testCases: TEST_CASES});
-
-  t.end();
-});
-
-test('HexagonCellLayer#updateRadiusAngle', t => {
-  const layer = new HexagonCellLayer({
-    data: [],
-    pickable: true,
-    hexagonVertices: [
-      [-122.3993347, 37.79178708],
-      [-122.4021036, 37.79398118],
-      [-122.4060099, 37.79308171],
-      [-122.4071472, 37.78998822],
-      [-122.4043784, 37.78779417],
-      [-122.4004722, 37.78869356]
-    ],
-    radius: 10,
-    angle: 10
-  });
-
-  testInitializeLayer({layer});
-
-  const {angle} = layer.updateRadiusAngle();
-  t.equal(
-    toLowPrecision(angle, 5),
-    1.8543,
-    'Use hexagonVertices instead of radius and angle if both provided'
-  );
 
   t.end();
 });

--- a/test/src/core-layers/hexagon-layer.spec.js
+++ b/test/src/core-layers/hexagon-layer.spec.js
@@ -48,7 +48,7 @@ test('HexagonLayer#updateLayer', t => {
       },
       {
         title: 'Update radius',
-        props: {
+        updateProps: {
           radius: 800
         },
         assert({layer, oldState, userData}) {
@@ -87,7 +87,7 @@ test('HexagonLayer#updateLayer', t => {
       },
       {
         title: 'Update getColorValue accessor',
-        props: {
+        updateProps: {
           getColorValue
         },
         assert({layer, oldState, userData}) {
@@ -126,7 +126,7 @@ test('HexagonLayer#updateLayer', t => {
       },
       {
         title: 'Update getColorValue accessor',
-        props: {
+        updateProps: {
           upperPercentile: 90
         },
         assert({layer, oldState, userData}) {
@@ -165,7 +165,7 @@ test('HexagonLayer#updateLayer', t => {
       },
       {
         title: 'Update colorDomain',
-        props: {
+        updateProps: {
           colorDomain: [0, 10]
         },
         assert({layer, oldState, userData}) {
@@ -204,7 +204,7 @@ test('HexagonLayer#updateLayer', t => {
       },
       {
         title: 'Update getElevationValue accessor',
-        props: {
+        updateProps: {
           getElevationValue
         },
         assert({layer, oldState, userData}) {
@@ -243,7 +243,7 @@ test('HexagonLayer#updateLayer', t => {
       },
       {
         title: 'Update elevation lower percentile',
-        props: {
+        updateProps: {
           elevationLowerPercentile: 1
         },
         assert({layer, oldState, userData}) {
@@ -282,7 +282,7 @@ test('HexagonLayer#updateLayer', t => {
       },
       {
         title: 'Update elevationRange accessor',
-        props: {
+        updateProps: {
           elevationRange: [1, 10]
         },
         assert({layer, oldState, userData}) {
@@ -326,11 +326,11 @@ test('HexagonLayer#updateLayer', t => {
 });
 
 test('HexagonLayer#updateTriggers', t => {
-  const functionsToSpy = ['_onGetSublayerColor', '_onGetSublayerElevation'];
+  const SPIES = ['_onGetSublayerColor', '_onGetSublayerElevation'];
 
   testLayer({
     Layer: HexagonLayer,
-    spies: functionsToSpy,
+    spies: SPIES,
     userData: t,
     testCases: [
       {
@@ -343,10 +343,9 @@ test('HexagonLayer#updateTriggers', t => {
       },
       {
         title: 'Update radius prop',
-        props: {
+        updateProps: {
           radius: 800
         },
-        spies: functionsToSpy,
         assert({subLayer, spies, userData}) {
           t.ok(spies._onGetSublayerColor.called, 'update radius should call _onGetSublayerColor');
           t.ok(
@@ -357,10 +356,9 @@ test('HexagonLayer#updateTriggers', t => {
       },
       {
         title: 'Update opacity prop',
-        props: {
+        updateProps: {
           opacity: 0.1
         },
-        spies: functionsToSpy,
         assert({subLayer, spies, userData}) {
           t.ok(
             !spies._onGetSublayerColor.called,
@@ -374,10 +372,9 @@ test('HexagonLayer#updateTriggers', t => {
       },
       {
         title: 'Update getColorValue prop',
-        props: {
+        updateProps: {
           getColorValue
         },
-        spies: functionsToSpy,
         assert({subLayer, spies, userData}) {
           t.ok(
             spies._onGetSublayerColor.called,
@@ -391,10 +388,9 @@ test('HexagonLayer#updateTriggers', t => {
       },
       {
         title: 'Update upperPercentile prop',
-        props: {
+        updateProps: {
           upperPercentile: 90
         },
-        spies: functionsToSpy,
         assert({subLayer, spies, userData}) {
           t.ok(
             spies._onGetSublayerColor.called,
@@ -408,10 +404,9 @@ test('HexagonLayer#updateTriggers', t => {
       },
       {
         title: 'Update getElevationValue prop',
-        props: {
+        updateProps: {
           getElevationValue
         },
-        spies: functionsToSpy,
         assert({subLayer, spies, userData}) {
           t.ok(
             !spies._onGetSublayerColor.called,
@@ -425,10 +420,9 @@ test('HexagonLayer#updateTriggers', t => {
       },
       {
         title: 'Update elevationUpperPercentile prop',
-        props: {
+        updateProps: {
           elevationUpperPercentile: 99
         },
-        spies: functionsToSpy,
         assert({subLayer, spies, userData}) {
           t.ok(
             !spies._onGetSublayerColor.called,
@@ -442,10 +436,9 @@ test('HexagonLayer#updateTriggers', t => {
       },
       {
         title: 'Update elevationRange prop',
-        props: {
+        updateProps: {
           elevationRange: [0, 100]
         },
-        spies: functionsToSpy,
         assert({subLayer, spies, userData}) {
           t.ok(
             !spies._onGetSublayerColor.called,

--- a/test/src/core-layers/index.js
+++ b/test/src/core-layers/index.js
@@ -23,7 +23,7 @@ import './core-layers.spec';
 import './polygon-layer.spec';
 import './geojson.spec';
 import './geojson-layer.spec';
-// import './grid-cell-layer.spec';
+import './grid-cell-layer.spec';
 import './grid-layer.spec';
 import './hexagon-cell-layer.spec';
 import './hexagon-layer.spec';

--- a/test/src/core-layers/polygon-layer.spec.js
+++ b/test/src/core-layers/polygon-layer.spec.js
@@ -19,33 +19,31 @@
 // THE SOFTWARE.
 
 import test from 'tape-catch';
-import * as FIXTURES from 'deck.gl/test/data';
-import {
-  testCreateLayer,
-  testCreateEmptyLayer,
-  testNullLayer,
-  testLayerUpdates
-} from 'deck.gl-test-utils';
+import {testLayer} from 'deck.gl-test-utils';
 
 import {PolygonLayer} from 'deck.gl';
 
-test('PolygonLayer#constructor', t => {
-  const LayerComponent = PolygonLayer;
-  const data = FIXTURES.polygons;
+import * as FIXTURES from 'deck.gl/test/data';
+const data = FIXTURES.polygons;
 
-  const TEST_CASES = {
-    INITIAL_PROPS: {
-      data,
-      getPolygon: f => f
-    },
-    UPDATES: [
+test('PolygonLayer#constructor', t => {
+  testLayer({
+    Layer: PolygonLayer,
+    testCases: [
+      {props: []},
+      {props: null},
+      {
+        props: {
+          data,
+          getPolygon: f => f
+        }
+      },
       {
         updateProps: {
           filled: false
         },
-        assert: (layer, oldState) => {
+        assert({layer, subLayers, oldState}) {
           t.ok(layer.state, 'should update layer state');
-          const subLayers = layer.renderLayers();
           t.ok(subLayers.length, 'subLayers rendered');
         }
       },
@@ -53,17 +51,12 @@ test('PolygonLayer#constructor', t => {
         updateProps: {
           data: data.slice(0, 10)
         },
-        assert: (layer, oldState) => {
+        assert({layer, oldState}) {
           t.ok(layer.state.paths.length !== oldState.paths.length, 'should update state.paths');
         }
       }
     ]
-  };
-
-  testCreateLayer(t, LayerComponent, {data, pickable: true});
-  testCreateEmptyLayer(t, LayerComponent);
-  testNullLayer(t, LayerComponent);
-  testLayerUpdates(t, {LayerComponent, testCases: TEST_CASES});
+  });
 
   t.end();
 });

--- a/test/src/core/lib/layer.spec.js
+++ b/test/src/core/lib/layer.spec.js
@@ -141,7 +141,7 @@ test('Layer#getNumInstances', t => {
 
 test('Layer#diffProps', t => {
   const layer = new SubLayer(LAYER_PROPS);
-  testInitializeLayer({layer});
+  t.doesNotThrow(() => testInitializeLayer({layer}), 'Layer initialized OK');
 
   layer.diffProps(Object.assign({}, LAYER_PROPS), LAYER_PROPS);
   t.false(layer.getChangeFlags().somethingChanged, 'same props');

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,10 +11,10 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
 
 accepts@~1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.4.tgz#86246758c7dd6d21a6474ff084a4740ec05eb21f"
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.5.tgz#eb777df6011723a3b14e8a72c0805c8e86746bd2"
   dependencies:
-    mime-types "~2.1.16"
+    mime-types "~2.1.18"
     negotiator "0.6.1"
 
 acorn-dynamic-import@^2.0.0:
@@ -47,9 +47,9 @@ acorn@^4.0.3, acorn@^4.0.4:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
-acorn@^5.0.0, acorn@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.2.1.tgz#317ac7821826c22c702d66189ab8359675f135d7"
+acorn@^5.0.0, acorn@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.0.tgz#1abb587fbf051f94e3de20e6b26ef910b1828298"
 
 agent-base@^4.1.0:
   version "4.2.0"
@@ -72,16 +72,7 @@ ajv@^4.7.0, ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.1.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.3.0.tgz#4414ff74a50879c208ee5fdc826e32c303549eda"
-  dependencies:
-    co "^4.6.0"
-    fast-deep-equal "^1.0.0"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.3.0"
-
-ajv@^5.2.3, ajv@^5.3.0:
+ajv@^5.1.0, ajv@^5.2.3, ajv@^5.3.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
   dependencies:
@@ -122,9 +113,9 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@^3.1.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
+ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   dependencies:
     color-convert "^1.9.0"
 
@@ -134,6 +125,13 @@ anymatch@^1.3.0:
   dependencies:
     micromatch "^2.1.5"
     normalize-path "^2.0.0"
+
+anymatch@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-2.0.0.tgz#bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb"
+  dependencies:
+    micromatch "^3.1.4"
+    normalize-path "^2.1.1"
 
 append-transform@^0.4.0:
   version "0.4.0"
@@ -157,8 +155,8 @@ are-we-there-yet@~1.1.2:
     readable-stream "^2.0.6"
 
 argparse@^1.0.7:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.9.tgz#73d83bc263f86e97f8cc4f6bae1b0e90a7d22c86"
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
   dependencies:
     sprintf-js "~1.0.2"
 
@@ -168,9 +166,17 @@ arr-diff@^2.0.0:
   dependencies:
     arr-flatten "^1.0.1"
 
-arr-flatten@^1.0.1:
+arr-diff@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
+
+arr-flatten@^1.0.1, arr-flatten@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
+
+arr-union@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
 
 array-equal@^1.0.0:
   version "1.0.0"
@@ -209,6 +215,10 @@ array-unique@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
 
+array-unique@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
+
 array.prototype.find@^2.0.1:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/array.prototype.find/-/array.prototype.find-2.0.4.tgz#556a5c5362c08648323ddaeb9de9d14bc1864c90"
@@ -225,8 +235,8 @@ asap@~2.0.3:
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
 asn1.js@^4.0.0:
-  version "4.9.2"
-  resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-4.9.2.tgz#8117ef4f7ed87cd8f89044b5bff97ac243a16c9a"
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-4.10.1.tgz#b9c2bf5805f1e64aadeed6df3a2bfafb5a73f5a0"
   dependencies:
     bn.js "^4.0.0"
     inherits "^2.0.1"
@@ -249,6 +259,10 @@ assert@^1.1.1:
   resolved "https://registry.yarnpkg.com/assert/-/assert-1.4.1.tgz#99912d591836b5a6f5b345c0f07eefc08fc65d91"
   dependencies:
     util "0.10.3"
+
+assign-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
 
 ast-types@~0.9.0:
   version "0.9.14"
@@ -275,6 +289,10 @@ async@^2.1.2, async@^2.5.0:
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+
+atob@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/atob/-/atob-2.0.3.tgz#19c7a760473774468f20b2d2d03372ad7d4cbf5d"
 
 aws-sign2@~0.6.0:
   version "0.6.0"
@@ -342,8 +360,8 @@ babel-core@^6.22.1, babel-core@^6.26.0, babel-core@^6.4.0:
     source-map "^0.5.6"
 
 babel-generator@^6.18.0, babel-generator@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.26.0.tgz#ac1ae20070b79f6e3ca1d3269613053774f20dc5"
+  version "6.26.1"
+  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.26.1.tgz#1844408d3b8f0d35a404ea7ac180f087a601bd90"
   dependencies:
     babel-messages "^6.23.0"
     babel-runtime "^6.26.0"
@@ -351,7 +369,7 @@ babel-generator@^6.18.0, babel-generator@^6.26.0:
     detect-indent "^4.0.0"
     jsesc "^1.3.0"
     lodash "^4.17.4"
-    source-map "^0.5.6"
+    source-map "^0.5.7"
     trim-right "^1.0.1"
 
 babel-helper-call-delegate@^6.24.1:
@@ -747,8 +765,20 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
 base64-js@^1.0.2:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.1.tgz#a91947da1f4a516ea38e5b4ec0ec3773675e0886"
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.3.tgz#fb13668233d9614cf5fb4bce95a9ba4096cdf801"
+
+base@^0.11.1:
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
+  dependencies:
+    cache-base "^1.0.1"
+    class-utils "^0.3.5"
+    component-emitter "^1.2.1"
+    define-property "^1.0.0"
+    isobject "^3.0.1"
+    mixin-deep "^1.2.0"
+    pascalcase "^0.1.1"
 
 batch@0.6.1:
   version "0.6.1"
@@ -772,8 +802,8 @@ big.js@^3.1.3:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
 
 binary-extensions@^1.0.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.10.0.tgz#9aeb9a6c5e88638aad171e167f5900abe24835d0"
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"
 
 bindings@^1.2.1:
   version "1.3.0"
@@ -844,8 +874,8 @@ boom@5.x.x:
     hoek "4.x.x"
 
 brace-expansion@^1.1.7:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
@@ -857,6 +887,23 @@ braces@^1.8.2:
     expand-range "^1.8.1"
     preserve "^0.2.0"
     repeat-element "^1.1.2"
+
+braces@^2.3.0, braces@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.1.tgz#7086c913b4e5a08dbe37ac0ee6a2500c4ba691bb"
+  dependencies:
+    arr-flatten "^1.1.0"
+    array-unique "^0.3.2"
+    define-property "^1.0.0"
+    extend-shallow "^2.0.1"
+    fill-range "^4.0.0"
+    isobject "^3.0.1"
+    kind-of "^6.0.2"
+    repeat-element "^1.1.2"
+    snapdragon "^0.8.1"
+    snapdragon-node "^2.0.1"
+    split-string "^3.0.2"
+    to-regex "^3.0.1"
 
 brfs-babel@^1.0.0:
   version "1.0.0"
@@ -916,11 +963,11 @@ browserify-sign@^4.0.0:
     inherits "^2.0.1"
     parse-asn1 "^5.0.0"
 
-browserify-zlib@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/browserify-zlib/-/browserify-zlib-0.1.4.tgz#bb35f8a519f600e0fa6b8485241c979d0141fb2d"
+browserify-zlib@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/browserify-zlib/-/browserify-zlib-0.2.0.tgz#2869459d9aa3be245fe8fe2ca1f46e2e7f54d73f"
   dependencies:
-    pako "~0.2.0"
+    pako "~1.0.5"
 
 buffer-indexof@^1.0.0:
   version "1.1.1"
@@ -949,6 +996,20 @@ builtin-status-codes@^3.0.0:
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
+
+cache-base@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
+  dependencies:
+    collection-visit "^1.0.0"
+    component-emitter "^1.2.1"
+    get-value "^2.0.6"
+    has-value "^1.0.0"
+    isobject "^3.0.1"
+    set-value "^2.0.0"
+    to-object-path "^0.3.0"
+    union-value "^1.0.0"
+    unset-value "^1.0.0"
 
 caching-transform@^1.0.0:
   version "1.0.1"
@@ -1013,18 +1074,18 @@ chalk@^1.1.1, chalk@^1.1.3:
     supports-color "^2.0.0"
 
 chalk@^2.0.0, chalk@^2.1.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.2.tgz#250dc96b07491bfd601e648d66ddf5f60c7a5c65"
   dependencies:
-    ansi-styles "^3.1.0"
+    ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
-    supports-color "^4.0.0"
+    supports-color "^5.3.0"
 
 chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
 
-chokidar@^1.6.0, chokidar@^1.6.1, chokidar@^1.7.0:
+chokidar@^1.6.1:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
   dependencies:
@@ -1036,6 +1097,24 @@ chokidar@^1.6.0, chokidar@^1.6.1, chokidar@^1.7.0:
     is-glob "^2.0.0"
     path-is-absolute "^1.0.0"
     readdirp "^2.0.0"
+  optionalDependencies:
+    fsevents "^1.0.0"
+
+chokidar@^2.0.0, chokidar@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.2.tgz#4dc65139eeb2714977735b6a35d06e97b494dfd7"
+  dependencies:
+    anymatch "^2.0.0"
+    async-each "^1.0.0"
+    braces "^2.3.0"
+    glob-parent "^3.1.0"
+    inherits "^2.0.1"
+    is-binary-path "^1.0.0"
+    is-glob "^4.0.0"
+    normalize-path "^2.1.1"
+    path-is-absolute "^1.0.0"
+    readdirp "^2.0.0"
+    upath "^1.0.0"
   optionalDependencies:
     fsevents "^1.0.0"
 
@@ -1053,6 +1132,15 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
 circular-json@^0.3.1:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
+
+class-utils@^0.3.5:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
+  dependencies:
+    arr-union "^3.1.0"
+    define-property "^0.2.5"
+    isobject "^3.0.0"
+    static-extend "^0.1.1"
 
 cli-cursor@^2.1.0:
   version "2.1.0"
@@ -1088,6 +1176,13 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
+collection-visit@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
+  dependencies:
+    map-visit "^1.0.0"
+    object-visit "^1.0.0"
+
 color-convert@^1.9.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.1.tgz#c1261107aeb2f294ebffec9ed9ecad529a6097ed"
@@ -1098,33 +1193,37 @@ color-name@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
 
-combined-stream@^1.0.5, combined-stream@~1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
+combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
   dependencies:
     delayed-stream "~1.0.0"
 
 commander@^2.11.0, commander@^2.9.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.14.1.tgz#2235123e37af8ca3c65df45b026dbd357b01b9aa"
 
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
 
-compressible@~2.0.11:
-  version "2.0.12"
-  resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.12.tgz#c59a5c99db76767e9876500e271ef63b3493bd66"
+component-emitter@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
+
+compressible@~2.0.13:
+  version "2.0.13"
+  resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.13.tgz#0d1020ab924b2fdb4d6279875c7d6daba6baa7a9"
   dependencies:
-    mime-db ">= 1.30.0 < 2"
+    mime-db ">= 1.33.0 < 2"
 
 compression@^1.5.2:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/compression/-/compression-1.7.1.tgz#eff2603efc2e22cf86f35d2eb93589f9875373db"
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/compression/-/compression-1.7.2.tgz#aaffbcd6aaf854b44ebb280353d5ad1651f59a69"
   dependencies:
     accepts "~1.3.4"
     bytes "3.0.0"
-    compressible "~2.0.11"
+    compressible "~2.0.13"
     debug "2.6.9"
     on-headers "~1.0.1"
     safe-buffer "5.1.1"
@@ -1134,7 +1233,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@1.6.0, concat-stream@^1.4.7, concat-stream@^1.6.0:
+concat-stream@1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
@@ -1142,9 +1241,17 @@ concat-stream@1.6.0, concat-stream@^1.4.7, concat-stream@^1.6.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
+concat-stream@^1.4.7, concat-stream@^1.6.0:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.1.tgz#261b8f518301f1d834e36342b9fea095d2620a26"
+  dependencies:
+    inherits "^2.0.3"
+    readable-stream "^2.2.2"
+    typedarray "^0.0.6"
+
 connect-history-api-fallback@^1.3.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.4.0.tgz#3db24f973f4b923b0e82f619ce0df02411ca623d"
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz#b06873934bc5e344fef611a196a6faae0aee015a"
 
 console-browserify@^1.1.0:
   version "1.1.0"
@@ -1173,8 +1280,8 @@ content-type@~1.0.4:
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
 
 convert-source-map@^1.3.0, convert-source-map@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
 
 cookie-signature@1.0.6:
   version "1.0.6"
@@ -1184,13 +1291,17 @@ cookie@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
 
+copy-descriptor@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
+
 core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
 core-js@^2.4.0, core-js@^2.5.0:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.1.tgz#ae6874dc66937789b80754ff5428df66819ca50b"
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -1293,8 +1404,8 @@ currently-unhandled@^0.4.1:
     array-find-index "^1.0.1"
 
 d3-format@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.2.0.tgz#6b480baa886885d4651dc248a8f4ac9da16db07a"
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.2.2.tgz#1a39c479c8a57fe5051b2e67a3bee27061a74e7a"
 
 d3-hexbin@^0.2.1:
   version "0.2.2"
@@ -1314,13 +1425,13 @@ debug-log@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
 
-debug@2.6.9, debug@^2.2.0, debug@^2.6.6, debug@^2.6.8:
+debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.6, debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.1, debug@^3.1.0:
+debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
@@ -1329,6 +1440,16 @@ debug@^3.0.1, debug@^3.1.0:
 decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+
+decode-uri-component@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
+
+decompress-response@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-3.3.0.tgz#80a4dd323748384bfa248083622aedec982adff3"
+  dependencies:
+    mimic-response "^1.0.0"
 
 deep-equal@^1.0.1, deep-equal@~1.0.1:
   version "1.0.1"
@@ -1354,6 +1475,25 @@ define-properties@^1.1.2:
   dependencies:
     foreach "^2.0.5"
     object-keys "^1.0.8"
+
+define-property@^0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-0.2.5.tgz#c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
+  dependencies:
+    is-descriptor "^0.1.0"
+
+define-property@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-1.0.0.tgz#769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6"
+  dependencies:
+    is-descriptor "^1.0.0"
+
+define-property@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-2.0.2.tgz#d459689e8d654ba77e02a817f8710d702cb16e9d"
+  dependencies:
+    is-descriptor "^1.0.2"
+    isobject "^3.0.1"
 
 defined@~1.0.0:
   version "1.0.0"
@@ -1390,9 +1530,13 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
 
-depd@1.1.1, depd@~1.1.1:
+depd@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.1.tgz#5783b4e1c459f06fa5ca27f991f3d06e7a310359"
+
+depd@~1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
 
 des.js@^1.0.0:
   version "1.0.0"
@@ -1411,9 +1555,9 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
-detect-libc@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.2.tgz#71ad5d204bf17a6a6ca8f450c61454066ef461e1"
+detect-libc@^1.0.2, detect-libc@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
 
 detect-node@^2.0.3:
   version "2.0.3"
@@ -1431,9 +1575,9 @@ dns-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/dns-equal/-/dns-equal-1.0.0.tgz#b39e7f1da6eb0a75ba9c17324b34753c47e0654d"
 
-dns-packet@^1.0.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-1.2.2.tgz#a8a26bec7646438963fc86e06f8f8b16d6c8bf7a"
+dns-packet@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-1.3.1.tgz#12aa426981075be500b910eedcd0b47dd7deda5a"
   dependencies:
     ip "^1.1.0"
     safe-buffer "^5.0.1"
@@ -1451,16 +1595,9 @@ doctrine@^1.2.2:
     esutils "^2.0.2"
     isarray "^1.0.0"
 
-doctrine@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.0.0.tgz#c73d8d2909d22291e1a007a395804da8b665fe63"
-  dependencies:
-    esutils "^2.0.2"
-    isarray "^1.0.0"
-
-doctrine@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.0.2.tgz#68f96ce8efc56cc42651f1faadb4f175273b0075"
+doctrine@^2.0.2, doctrine@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
   dependencies:
     esutils "^2.0.2"
 
@@ -1469,12 +1606,12 @@ dom-walk@^0.1.0:
   resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
 
 domain-browser@^1.1.1:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.1.7.tgz#867aa4b093faa05f1de08c06f4d7b21fdf8698bc"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
 
 earcut@^2.0.6:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/earcut/-/earcut-2.1.2.tgz#542add0ca3a7b713452720e1d053937d3daf3784"
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/earcut/-/earcut-2.1.3.tgz#ca579545f351941af7c3d0df49c9f7d34af99b0c"
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"
@@ -1503,8 +1640,8 @@ emojis-list@^2.0.0:
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
 
 encodeurl@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.1.tgz#79e3d58655346909fe6f0f45a5de68103b294d20"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
 
 encoding@^0.1.11:
   version "0.1.12"
@@ -1513,8 +1650,8 @@ encoding@^0.1.11:
     iconv-lite "~0.4.13"
 
 end-of-stream@^1.0.0, end-of-stream@^1.1.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.0.tgz#7a90d833efda6cfa6eac0f4949dbb0fad3a63206"
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
   dependencies:
     once "^1.4.0"
 
@@ -1528,10 +1665,10 @@ enhanced-resolve@^3.3.0:
     tapable "^0.2.7"
 
 errno@^0.1.3:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.4.tgz#b896e23a9e5e8ba33871fc996abd3635fc9a1c7d"
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.7.tgz#4684d71779ad39af177e3f007996f7c67c852618"
   dependencies:
-    prr "~0.0.0"
+    prr "~1.0.1"
 
 error-ex@^1.2.0:
   version "1.3.1"
@@ -1540,8 +1677,8 @@ error-ex@^1.2.0:
     is-arrayish "^0.2.1"
 
 es-abstract@^1.5.0, es-abstract@^1.7.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.9.0.tgz#690829a07cae36b222e7fd9b75c0d0573eb25227"
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.10.0.tgz#1ecb36c197842a00d8ee4c2dfd8646bb97d60864"
   dependencies:
     es-to-primitive "^1.1.1"
     function-bind "^1.1.1"
@@ -1576,15 +1713,15 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
 escodegen@^1.6.1:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.9.0.tgz#9811a2f265dc1cd3894420ee3717064b632b8852"
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.9.1.tgz#dbae17ef96c8e4bedb1356f4504fa4cc2f7cb7e2"
   dependencies:
     esprima "^3.1.3"
     estraverse "^4.2.0"
     esutils "^2.0.2"
     optionator "^0.8.1"
   optionalDependencies:
-    source-map "~0.5.6"
+    source-map "~0.6.1"
 
 eslint-config-prettier@^2.9.0:
   version "2.9.0"
@@ -1620,12 +1757,12 @@ eslint-plugin-react@^6.7.1:
     object.assign "^4.0.4"
 
 eslint-plugin-react@^7.5.1:
-  version "7.5.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.5.1.tgz#52e56e8d80c810de158859ef07b880d2f56ee30b"
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz#f606c719dbd8a1a2b3d25c16299813878cca0160"
   dependencies:
-    doctrine "^2.0.0"
+    doctrine "^2.0.2"
     has "^1.0.1"
-    jsx-ast-utils "^2.0.0"
+    jsx-ast-utils "^2.0.1"
     prop-types "^15.6.0"
 
 eslint-scope@^3.7.1:
@@ -1635,21 +1772,25 @@ eslint-scope@^3.7.1:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-visitor-keys@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
+
 eslint@^4.13.1:
-  version "4.13.1"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.13.1.tgz#0055e0014464c7eb7878caf549ef2941992b444f"
+  version "4.18.2"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.18.2.tgz#0f81267ad1012e7d2051e186a9004cc2267b8d45"
   dependencies:
     ajv "^5.3.0"
     babel-code-frame "^6.22.0"
     chalk "^2.1.0"
     concat-stream "^1.6.0"
     cross-spawn "^5.1.0"
-    debug "^3.0.1"
-    doctrine "^2.0.2"
+    debug "^3.1.0"
+    doctrine "^2.1.0"
     eslint-scope "^3.7.1"
+    eslint-visitor-keys "^1.0.0"
     espree "^3.5.2"
     esquery "^1.0.0"
-    estraverse "^4.2.0"
     esutils "^2.0.2"
     file-entry-cache "^2.0.0"
     functional-red-black-tree "^1.0.1"
@@ -1674,14 +1815,14 @@ eslint@^4.13.1:
     semver "^5.3.0"
     strip-ansi "^4.0.0"
     strip-json-comments "~2.0.1"
-    table "^4.0.1"
+    table "4.0.2"
     text-table "~0.2.0"
 
 espree@^3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.2.tgz#756ada8b979e9dcfcdb30aad8d1a9304a905e1ca"
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.4.tgz#b0f447187c8a8bed944b815a660bddf5deb5d1a7"
   dependencies:
-    acorn "^5.2.1"
+    acorn "^5.5.0"
     acorn-jsx "^3.0.0"
 
 esprima@^2.6.0:
@@ -1703,11 +1844,10 @@ esquery@^1.0.0:
     estraverse "^4.0.0"
 
 esrecurse@^4.1.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.0.tgz#fa9568d98d3823f9a41d91e902dcab9ea6e5b163"
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz#007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf"
   dependencies:
     estraverse "^4.1.0"
-    object-assign "^4.0.1"
 
 estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
@@ -1760,6 +1900,18 @@ expand-brackets@^0.1.4:
   dependencies:
     is-posix-bracket "^0.1.0"
 
+expand-brackets@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-2.1.4.tgz#b77735e315ce30f6b6eff0f83b04151a22449622"
+  dependencies:
+    debug "^2.3.3"
+    define-property "^0.2.5"
+    extend-shallow "^2.0.1"
+    posix-character-classes "^0.1.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
+
 expand-range@^1.8.1:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/expand-range/-/expand-range-1.8.2.tgz#a299effd335fe2721ebae8e257ec79644fc85337"
@@ -1770,7 +1922,7 @@ expand-template@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-1.1.0.tgz#e09efba977bf98f9ee0ed25abd0c692e02aec3fc"
 
-express@^4.13.3:
+express@^4.16.2:
   version "4.16.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.16.2.tgz#e35c6dfe2d64b7dca0a5cd4f21781be3299e076c"
   dependencies:
@@ -1805,6 +1957,19 @@ express@^4.13.3:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
+extend-shallow@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
+  dependencies:
+    is-extendable "^0.1.0"
+
+extend-shallow@^3.0.0, extend-shallow@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-3.0.2.tgz#26a71aaf073b39fb2127172746131c2704028db8"
+  dependencies:
+    assign-symbols "^1.0.0"
+    is-extendable "^1.0.1"
+
 extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
@@ -1823,6 +1988,19 @@ extglob@^0.3.1:
   dependencies:
     is-extglob "^1.0.0"
 
+extglob@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
+  dependencies:
+    array-unique "^0.3.2"
+    define-property "^1.0.0"
+    expand-brackets "^2.1.4"
+    extend-shallow "^2.0.1"
+    fragment-cache "^0.2.1"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
+
 extract-zip@^1.6.5:
   version "1.6.6"
   resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.6.6.tgz#1290ede8d20d0872b429fd3f351ca128ec5ef85c"
@@ -1832,13 +2010,17 @@ extract-zip@^1.6.5:
     mkdirp "0.5.0"
     yauzl "2.4.1"
 
-extsprintf@1.3.0, extsprintf@^1.2.0:
+extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
 
+extsprintf@^1.2.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
+
 fast-deep-equal@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
 
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
@@ -1905,6 +2087,15 @@ fill-range@^2.1.0:
     repeat-element "^1.1.2"
     repeat-string "^1.5.2"
 
+fill-range@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-number "^3.0.0"
+    repeat-string "^1.6.1"
+    to-regex-range "^2.1.0"
+
 finalhandler@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.0.tgz#ce0b6855b45853e791b2fcc680046d88253dd7f5"
@@ -1953,7 +2144,7 @@ for-each@~0.3.2:
   dependencies:
     is-function "~1.0.0"
 
-for-in@^1.0.1:
+for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
 
@@ -1987,35 +2178,41 @@ form-data@~2.1.1:
     mime-types "^2.1.12"
 
 form-data@~2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.1.tgz#6fb94fbd71885306d73d15cc497fe4cc4ecd44bf"
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
   dependencies:
     asynckit "^0.4.0"
-    combined-stream "^1.0.5"
+    combined-stream "1.0.6"
     mime-types "^2.1.12"
 
 forwarded@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
 
+fragment-cache@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
+  dependencies:
+    map-cache "^0.2.2"
+
 fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
 
 fs-readdir-recursive@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz#8cd1745c8b4f8a29c8caec392476921ba195f560"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz#e32fc030a2ccee44a6b5371308da54be0b397d27"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
 fsevents@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.1.2.tgz#3282b713fb3ad80ede0e9fcf4611b5aa6fc033f4"
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.1.3.tgz#11f82318f5fe7bb2cd22965a108e9306208216d8"
   dependencies:
     nan "^2.3.0"
-    node-pre-gyp "^0.6.36"
+    node-pre-gyp "^0.6.39"
 
 fstream-ignore@^1.0.5:
   version "1.0.5"
@@ -2034,7 +2231,7 @@ fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
     mkdirp ">=0.5 0"
     rimraf "2"
 
-function-bind@^1.0.2, function-bind@^1.1.0, function-bind@^1.1.1, function-bind@~1.1.0:
+function-bind@^1.0.2, function-bind@^1.1.1, function-bind@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
@@ -2081,6 +2278,10 @@ get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
 
+get-value@^2.0.3, get-value@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
+
 getpass@^0.1.1:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
@@ -2108,8 +2309,8 @@ gl-quat@^1.0.0:
     gl-vec4 "^1.0.0"
 
 gl-vec2@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/gl-vec2/-/gl-vec2-1.0.0.tgz#77fce6ae9612856d6c8b621cd261cd8281b9c637"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/gl-vec2/-/gl-vec2-1.2.0.tgz#b0af95d2a582e3ad818446a1800093fc60b8b212"
 
 gl-vec3@^1.0.3:
   version "1.0.3"
@@ -2143,6 +2344,13 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
+glob-parent@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
+  dependencies:
+    is-glob "^3.1.0"
+    path-dirname "^1.0.0"
+
 glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.2, glob@~7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
@@ -2162,8 +2370,8 @@ global@~4.3.0:
     process "~0.5.1"
 
 globals@^11.0.1:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-11.1.0.tgz#632644457f5f0e3ae711807183700ebf2e4633e4"
+  version "11.3.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.3.0.tgz#e04fdb7b9796d8adac9c8f64c14837b2313378b0"
 
 globals@^9.18.0:
   version "9.18.0"
@@ -2259,13 +2467,44 @@ has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
 
-has-flag@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
+has-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
 
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
+
+has-value@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/has-value/-/has-value-0.3.1.tgz#7b1f58bada62ca827ec0a2078025654845995e1f"
+  dependencies:
+    get-value "^2.0.3"
+    has-values "^0.1.4"
+    isobject "^2.0.0"
+
+has-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-value/-/has-value-1.0.0.tgz#18b281da585b1c5c51def24c930ed29a0be6b177"
+  dependencies:
+    get-value "^2.0.6"
+    has-values "^1.0.0"
+    isobject "^3.0.0"
+
+has-values@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/has-values/-/has-values-0.1.4.tgz#6d61de95d91dfca9b9a02089ad384bff8f62b771"
+
+has-values@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-values/-/has-values-1.0.0.tgz#95b0b63fec2146619a6fe57fe75628d5a39efe4f"
+  dependencies:
+    is-number "^3.0.0"
+    kind-of "^4.0.0"
 
 has@^1.0.1, has@~1.0.1:
   version "1.0.1"
@@ -2324,8 +2563,8 @@ hoek@2.x.x:
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
 hoek@4.x.x:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -2371,8 +2610,8 @@ http-errors@1.6.2, http-errors@~1.6.2:
     statuses ">= 1.3.1 < 2"
 
 http-parser-js@>=0.4.0:
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.4.9.tgz#ea1a04fb64adff0242e9974f297dd4c3cad271e1"
+  version "0.4.10"
+  resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.4.10.tgz#92c9c1374c35085f75db359ec56cc257cbb93fa4"
 
 http-proxy-middleware@~0.17.4:
   version "0.17.4"
@@ -2406,13 +2645,13 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-https-browserify@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-0.0.1.tgz#3f91365cabe60b77ed0ebba24b454e3e09d95a82"
+https-browserify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
 
 https-proxy-agent@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.1.1.tgz#a7ce4382a1ba8266ee848578778122d491260fd9"
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.0.tgz#7fbba856be8cd677986f42ebd3664f6317257887"
   dependencies:
     agent-base "^4.1.0"
     debug "^3.1.0"
@@ -2433,9 +2672,9 @@ immutable@^3.8.1:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
 
-import-local@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/import-local/-/import-local-0.1.1.tgz#b1179572aacdc11c6a91009fb430dbcab5f668a8"
+import-local@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/import-local/-/import-local-1.0.0.tgz#5e4ffdc03f4fe6c009c6729beb29631c2f8227bc"
   dependencies:
     pkg-dir "^2.0.0"
     resolve-cwd "^2.0.0"
@@ -2470,8 +2709,8 @@ inherits@2.0.1:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
 
 ini@~1.3.0:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
 
 inquirer@^3.0.6:
   version "3.3.0"
@@ -2499,12 +2738,12 @@ internal-ip@1.2.0:
     meow "^3.3.0"
 
 interpret@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.4.tgz#820cdd588b868ffb191a809506d6c9c8f212b1b0"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
 invariant@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.3.tgz#1a827dfde7dcbd7c323f0ca826be8fa7c5e9d688"
   dependencies:
     loose-envify "^1.0.0"
 
@@ -2516,9 +2755,21 @@ ip@^1.1.0, ip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
 
-ipaddr.js@1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.5.2.tgz#d4b505bde9946987ccf0fc58d9010ff9607e3fa0"
+ipaddr.js@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.6.0.tgz#e3fa357b773da619f26e95f049d055c72796f86b"
+
+is-accessor-descriptor@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
+  dependencies:
+    kind-of "^3.0.2"
+
+is-accessor-descriptor@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz#169c2f6d3df1f992618072365c9b0ea1f6878656"
+  dependencies:
+    kind-of "^6.0.0"
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -2544,9 +2795,37 @@ is-callable@^1.1.1, is-callable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
 
+is-data-descriptor@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
+  dependencies:
+    kind-of "^3.0.2"
+
+is-data-descriptor@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz#d84876321d0e7add03990406abbbbd36ba9268c7"
+  dependencies:
+    kind-of "^6.0.0"
+
 is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+
+is-descriptor@^0.1.0:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-0.1.6.tgz#366d8240dde487ca51823b1ab9f07a10a78251ca"
+  dependencies:
+    is-accessor-descriptor "^0.1.6"
+    is-data-descriptor "^0.1.4"
+    kind-of "^5.0.0"
+
+is-descriptor@^1.0.0, is-descriptor@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-1.0.2.tgz#3b159746a66604b04f8c81524ba365c5f14d86ec"
+  dependencies:
+    is-accessor-descriptor "^1.0.0"
+    is-data-descriptor "^1.0.0"
+    kind-of "^6.0.2"
 
 is-dotfile@^1.0.0:
   version "1.0.3"
@@ -2558,15 +2837,21 @@ is-equal-shallow@^0.1.3:
   dependencies:
     is-primitive "^2.0.0"
 
-is-extendable@^0.1.1:
+is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
+
+is-extendable@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-1.0.1.tgz#a7470f9e426733d81bd81e1155264e3a3507cab4"
+  dependencies:
+    is-plain-object "^2.0.4"
 
 is-extglob@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
 
-is-extglob@^2.1.0:
+is-extglob@^2.1.0, is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
 
@@ -2602,12 +2887,23 @@ is-glob@^3.1.0:
   dependencies:
     is-extglob "^2.1.0"
 
+is-glob@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.0.tgz#9521c76845cc2610a85203ddf080a958c2ffabc0"
+  dependencies:
+    is-extglob "^2.1.1"
+
+is-my-ip-valid@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz#7b351b8e8edd4d3995d4d066680e664d94696824"
+
 is-my-json-valid@^2.12.4:
-  version "2.16.1"
-  resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz#5a846777e2c2620d1e69104e5d3a03b1f6088f11"
+  version "2.17.2"
+  resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz#6b2103a288e94ef3de5cf15d29dd85fc4b78d65c"
   dependencies:
     generate-function "^2.0.0"
     generate-object-property "^1.1.0"
+    is-my-ip-valid "^1.0.0"
     jsonpointer "^4.0.0"
     xtend "^4.0.0"
 
@@ -2623,6 +2919,16 @@ is-number@^3.0.0:
   dependencies:
     kind-of "^3.0.2"
 
+is-number@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
+
+is-odd@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-odd/-/is-odd-2.0.0.tgz#7646624671fd7ea558ccd9a2795182f2958f1b24"
+  dependencies:
+    is-number "^4.0.0"
+
 is-path-cwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
@@ -2634,10 +2940,16 @@ is-path-in-cwd@^1.0.0:
     is-path-inside "^1.0.0"
 
 is-path-inside@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.0.tgz#fc06e5a1683fbda13de667aff717bbc10a48f37f"
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
   dependencies:
     path-is-inside "^1.0.1"
+
+is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
+  dependencies:
+    isobject "^3.0.1"
 
 is-posix-bracket@^0.1.0:
   version "0.1.1"
@@ -2662,10 +2974,8 @@ is-regex@^1.0.4:
     has "^1.0.1"
 
 is-resolvable@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.0.0.tgz#8df57c61ea2e3c501408d100fb013cf8d6e0cc62"
-  dependencies:
-    tryit "^1.0.1"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
 
 is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
@@ -2682,6 +2992,10 @@ is-typedarray@~1.0.0:
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+
+is-windows@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 
 is-wsl@^1.1.0:
   version "1.1.0"
@@ -2705,6 +3019,10 @@ isobject@^2.0.0:
   dependencies:
     isarray "1.0.0"
 
+isobject@^3.0.0, isobject@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
+
 isomorphic-fetch@^2.1.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
@@ -2716,9 +3034,9 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
-istanbul-lib-coverage@^1.1.0, istanbul-lib-coverage@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz#73bfb998885299415c93d38a3e9adf784a77a9da"
+istanbul-lib-coverage@^1.1.0, istanbul-lib-coverage@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.2.tgz#4113c8ff6b7a40a1ef7350b01016331f63afde14"
 
 istanbul-lib-hook@^1.0.6:
   version "1.1.0"
@@ -2727,39 +3045,39 @@ istanbul-lib-hook@^1.0.6:
     append-transform "^0.4.0"
 
 istanbul-lib-instrument@^1.7.1, istanbul-lib-instrument@^1.7.5:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.1.tgz#250b30b3531e5d3251299fdd64b0b2c9db6b558e"
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.2.tgz#84905bf47f7e0b401d6b840da7bad67086b4aab6"
   dependencies:
     babel-generator "^6.18.0"
     babel-template "^6.16.0"
     babel-traverse "^6.18.0"
     babel-types "^6.18.0"
     babylon "^6.18.0"
-    istanbul-lib-coverage "^1.1.1"
+    istanbul-lib-coverage "^1.1.2"
     semver "^5.3.0"
 
 istanbul-lib-report@^1.1.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.2.tgz#922be27c13b9511b979bd1587359f69798c1d425"
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.3.tgz#2df12188c0fa77990c0d2176d2d0ba3394188259"
   dependencies:
-    istanbul-lib-coverage "^1.1.1"
+    istanbul-lib-coverage "^1.1.2"
     mkdirp "^0.5.1"
     path-parse "^1.0.5"
     supports-color "^3.1.2"
 
 istanbul-lib-source-maps@^1.2.0:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.2.tgz#750578602435f28a0c04ee6d7d9e0f2960e62c1c"
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz#20fb54b14e14b3fb6edb6aca3571fd2143db44e6"
   dependencies:
     debug "^3.1.0"
-    istanbul-lib-coverage "^1.1.1"
+    istanbul-lib-coverage "^1.1.2"
     mkdirp "^0.5.1"
     rimraf "^2.6.1"
     source-map "^0.5.3"
 
 istanbul-reports@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.1.3.tgz#3b9e1e8defb6d18b1d425da8e8b32c5a163f2d10"
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.1.4.tgz#5ccba5e22b7b5a5d91d5e0a830f89be334bf97bd"
   dependencies:
     handlebars "^4.0.3"
 
@@ -2775,8 +3093,8 @@ js-yaml@3.6.1:
     esprima "^2.6.0"
 
 js-yaml@^3.9.1:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.11.0.tgz#597c1a8bd57152f26d622ce4117851a51f5ebaef"
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -2872,7 +3190,7 @@ jsx-ast-utils@^1.3.4:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz#3867213e8dd79bf1e8f2300c0cfc1efb182c0df1"
 
-jsx-ast-utils@^2.0.0:
+jsx-ast-utils@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz#e801b1b39985e20fffc87b40e3748080e2dcac7f"
   dependencies:
@@ -2882,7 +3200,7 @@ killable@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.0.tgz#da8b84bd47de5395878f95d64d02f2449fe05e6b"
 
-kind-of@^3.0.2:
+kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
   dependencies:
@@ -2894,9 +3212,23 @@ kind-of@^4.0.0:
   dependencies:
     is-buffer "^1.1.5"
 
+kind-of@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
+
+kind-of@^6.0.0, kind-of@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
+
 lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
+
+lazy-cache@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-2.0.2.tgz#b9190a4f913354694840859f8a8f7084d8822264"
+  dependencies:
+    set-getter "^0.1.0"
 
 lcid@^1.0.0:
   version "1.0.0"
@@ -2958,16 +3290,16 @@ lodash.flattendeep@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
 
 lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.3.0:
-  version "4.17.4"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+  version "4.17.5"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
 log-driver@1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.5.tgz#7ae4ec257302fd790d557cb10c97100d857b0056"
 
 loglevel@^1.4.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.5.1.tgz#189078c94ab9053ee215a0acdbf24244ea0f6502"
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.1.tgz#e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -3007,13 +3339,23 @@ magic-string@~0.16.0:
   dependencies:
     vlq "^0.2.1"
 
+map-cache@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
+
 map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
+map-visit@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
+  dependencies:
+    object-visit "^1.0.0"
+
 math.gl@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/math.gl/-/math.gl-1.0.2.tgz#b714c0d0f68b787c90ba026dad38e104a3e004d9"
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/math.gl/-/math.gl-1.0.4.tgz#c43e177ebe85c4bf460668fe8b4cfba57813c469"
   dependencies:
     gl-mat4 "^1.1.4"
     gl-quat "^1.0.0"
@@ -3069,10 +3411,10 @@ merge-descriptors@1.0.1:
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
 
 merge-source-map@^1.0.2:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/merge-source-map/-/merge-source-map-1.0.4.tgz#a5de46538dae84d4114cc5ea02b4772a6346701f"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/merge-source-map/-/merge-source-map-1.1.0.tgz#2fdde7e6020939f70906a68f2d7ae685e4c8c646"
   dependencies:
-    source-map "^0.5.6"
+    source-map "^0.6.1"
 
 methods@~1.1.2:
   version "1.1.2"
@@ -3096,6 +3438,24 @@ micromatch@^2.1.5, micromatch@^2.3.11:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
+micromatch@^3.1.4:
+  version "3.1.9"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.9.tgz#15dc93175ae39e52e93087847096effc73efcf89"
+  dependencies:
+    arr-diff "^4.0.0"
+    array-unique "^0.3.2"
+    braces "^2.3.1"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    extglob "^2.0.4"
+    fragment-cache "^0.2.1"
+    kind-of "^6.0.2"
+    nanomatch "^1.2.9"
+    object.pick "^1.3.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
+
 miller-rabin@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
@@ -3103,27 +3463,31 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-"mime-db@>= 1.30.0 < 2":
-  version "1.31.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.31.0.tgz#a49cd8f3ebf3ed1a482b60561d9105ad40ca74cb"
+"mime-db@>= 1.33.0 < 2", mime-db@~1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
 
-mime-db@~1.30.0:
-  version "1.30.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
-
-mime-types@^2.1.12, mime-types@~2.1.15, mime-types@~2.1.16, mime-types@~2.1.17, mime-types@~2.1.7:
-  version "2.1.17"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
+mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.18, mime-types@~2.1.7:
+  version "2.1.18"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
   dependencies:
-    mime-db "~1.30.0"
+    mime-db "~1.33.0"
 
-mime@1.4.1, mime@^1.3.4:
+mime@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
 
+mime@^1.3.4, mime@^1.5.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
+
 mimic-fn@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
+
+mimic-response@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.0.tgz#df3d3652a73fded6b9b0b24146e6fd052353458e"
 
 min-document@^2.19.0:
   version "2.19.0"
@@ -3157,9 +3521,16 @@ minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
+mixin-deep@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe"
+  dependencies:
+    for-in "^1.0.2"
+    is-extendable "^1.0.1"
+
 mjolnir.js@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/mjolnir.js/-/mjolnir.js-1.0.0.tgz#881eaac896f2c2693bc39f5127b4fabe99ff56fb"
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mjolnir.js/-/mjolnir.js-1.0.1.tgz#0ce2389c18e8de00a402b3ff4b91aaee0b2a6dc6"
   dependencies:
     hammerjs "^2.0.8"
 
@@ -3176,8 +3547,8 @@ mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
     minimist "0.0.8"
 
 module-alias@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/module-alias/-/module-alias-2.0.2.tgz#6af6b3a638a4b5460ddd6bc7705ce7b4cb27c9a5"
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/module-alias/-/module-alias-2.0.6.tgz#abb2cfa07014f503514ad5061c6f03d79b591889"
 
 ms@2.0.0:
   version "2.0.0"
@@ -3188,19 +3559,36 @@ multicast-dns-service-types@^1.1.0:
   resolved "https://registry.yarnpkg.com/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz#899f11d9686e5e05cb91b35d5f0e63b773cfc901"
 
 multicast-dns@^6.0.1:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/multicast-dns/-/multicast-dns-6.1.1.tgz#6e7de86a570872ab17058adea7160bbeca814dde"
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/multicast-dns/-/multicast-dns-6.2.3.tgz#a0ec7bd9055c4282f790c3c82f4e28db3b31b229"
   dependencies:
-    dns-packet "^1.0.1"
-    thunky "^0.1.0"
+    dns-packet "^1.3.1"
+    thunky "^1.0.2"
 
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
 nan@^2.3.0, nan@^2.6.2:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.9.2.tgz#f564d75f5f8f36a6d9456cca7a6c4fe488ab7866"
+
+nanomatch@^1.2.9:
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.9.tgz#879f7150cb2dab7a471259066c104eee6e0fa7c2"
+  dependencies:
+    arr-diff "^4.0.0"
+    array-unique "^0.3.2"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    fragment-cache "^0.2.1"
+    is-odd "^2.0.0"
+    is-windows "^1.0.2"
+    kind-of "^6.0.2"
+    object.pick "^1.3.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -3210,9 +3598,13 @@ negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
-node-abi@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.1.2.tgz#4da6caceb6685fcd31e7dd1994ef6bb7d0a9c0b2"
+neo-async@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.5.0.tgz#76b1c823130cca26acfbaccc8fbaf0a2fa33b18f"
+
+node-abi@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.3.0.tgz#f3d554d6ac72a9ee16f0f4dc9548db7c08de4986"
   dependencies:
     semver "^5.4.1"
 
@@ -3223,9 +3615,9 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-node-forge@0.6.33:
-  version "0.6.33"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.6.33.tgz#463811879f573d45155ad6a9f43dc296e8e85ebc"
+node-forge@0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.1.tgz#9da611ea08982f4b94206b3beb4cc9665f20c300"
 
 node-gyp@^3.6.2:
   version "3.6.2"
@@ -3246,34 +3638,34 @@ node-gyp@^3.6.2:
     which "1"
 
 node-libs-browser@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.0.0.tgz#a3a59ec97024985b46e958379646f96c4b616646"
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.1.0.tgz#5f94263d404f6e44767d726901fff05478d600df"
   dependencies:
     assert "^1.1.1"
-    browserify-zlib "^0.1.4"
+    browserify-zlib "^0.2.0"
     buffer "^4.3.0"
     console-browserify "^1.1.0"
     constants-browserify "^1.0.0"
     crypto-browserify "^3.11.0"
     domain-browser "^1.1.1"
     events "^1.0.0"
-    https-browserify "0.0.1"
-    os-browserify "^0.2.0"
+    https-browserify "^1.0.0"
+    os-browserify "^0.3.0"
     path-browserify "0.0.0"
-    process "^0.11.0"
+    process "^0.11.10"
     punycode "^1.2.4"
     querystring-es3 "^0.2.0"
-    readable-stream "^2.0.5"
+    readable-stream "^2.3.3"
     stream-browserify "^2.0.1"
-    stream-http "^2.3.1"
-    string_decoder "^0.10.25"
-    timers-browserify "^2.0.2"
+    stream-http "^2.7.2"
+    string_decoder "^1.0.0"
+    timers-browserify "^2.0.4"
     tty-browserify "0.0.0"
     url "^0.11.0"
     util "^0.10.3"
     vm-browserify "0.0.4"
 
-node-pre-gyp@^0.6.36:
+node-pre-gyp@^0.6.39:
   version "0.6.39"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz#c00e96860b23c0e1420ac7befc5044e1d78d8649"
   dependencies:
@@ -3315,7 +3707,7 @@ normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
-normalize-path@^2.0.0, normalize-path@^2.0.1:
+normalize-path@^2.0.0, normalize-path@^2.0.1, normalize-path@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
   dependencies:
@@ -3384,21 +3776,36 @@ object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
+object-copy@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/object-copy/-/object-copy-0.1.0.tgz#7e7d858b781bd7c991a41ba975ed3812754e998c"
+  dependencies:
+    copy-descriptor "^0.1.0"
+    define-property "^0.2.5"
+    kind-of "^3.0.3"
+
 object-inspect@~1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.3.0.tgz#5b1eb8e6742e2ee83342a637034d844928ba2f6d"
 
-object-keys@^1.0.10, object-keys@^1.0.8:
+object-keys@^1.0.11, object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
 
+object-visit@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
+  dependencies:
+    isobject "^3.0.0"
+
 object.assign@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.0.4.tgz#b1c9cc044ef1b9fe63606fc141abbb32e14730cc"
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
   dependencies:
     define-properties "^1.1.2"
-    function-bind "^1.1.0"
-    object-keys "^1.0.10"
+    function-bind "^1.1.1"
+    has-symbols "^1.0.0"
+    object-keys "^1.0.11"
 
 object.omit@^2.0.0:
   version "2.0.1"
@@ -3406,6 +3813,12 @@ object.omit@^2.0.0:
   dependencies:
     for-own "^0.1.4"
     is-extendable "^0.1.1"
+
+object.pick@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/object.pick/-/object.pick-1.3.0.tgz#87a10ac4c1694bd2e1cbf53591a66141fb5dd747"
+  dependencies:
+    isobject "^3.0.1"
 
 obuf@^1.0.0, obuf@^1.1.1:
   version "1.1.1"
@@ -3434,8 +3847,8 @@ onetime@^2.0.0:
     mimic-fn "^1.0.0"
 
 opn@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/opn/-/opn-5.1.0.tgz#72ce2306a17dbea58ff1041853352b4a8fc77519"
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/opn/-/opn-5.2.0.tgz#71fdf934d6827d676cecbea1531f95d354641225"
   dependencies:
     is-wsl "^1.1.0"
 
@@ -3463,9 +3876,9 @@ original@>=0.0.5:
   dependencies:
     url-parse "1.0.x"
 
-os-browserify@^0.2.0:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.2.1.tgz#63fc4ccee5d2d7763d26bbf8601078e6c2e0044f"
+os-browserify@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
 
 os-homedir@^1.0.0, os-homedir@^1.0.1:
   version "1.0.2"
@@ -3486,8 +3899,8 @@ os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.2:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
 osenv@0, osenv@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.4.tgz#42fe6d5953df06c8064be6f176c3d05aaaa34644"
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
@@ -3505,8 +3918,10 @@ p-finally@^1.0.0:
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
 
 p-limit@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.1.0.tgz#b07ff2d9a5d88bec806035895a2bab66a27988bc"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.2.0.tgz#0e92b6bedcb59f022c13d0f1949dc82d15909f1c"
+  dependencies:
+    p-try "^1.0.0"
 
 p-locate@^2.0.0:
   version "2.0.0"
@@ -3518,9 +3933,13 @@ p-map@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
 
-pako@~0.2.0:
-  version "0.2.9"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
+p-try@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
+
+pako@~1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.6.tgz#0101211baa70c4bca4a0f63f2206e97b7dfaf258"
 
 parse-asn1@^5.0.0:
   version "5.1.0"
@@ -3555,9 +3974,17 @@ parseurl@~1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
 
+pascalcase@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
+
 path-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.0.tgz#a0b870729aae214005b7d5032ec2cbbb0fb4451a"
+
+path-dirname@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
 
 path-exists@^2.0.0:
   version "2.1.0"
@@ -3650,8 +4077,8 @@ pkg-dir@^2.0.0:
     find-up "^2.1.0"
 
 platform@^1.3.3:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.4.tgz#6f0fb17edaaa48f21442b3a975c063130f1c3ebd"
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.5.tgz#fb6958c696e07e2918d2eeda0f0bc9448d733444"
 
 pluralize@^7.0.0:
   version "7.0.0"
@@ -3665,6 +4092,10 @@ portfinder@^1.0.9:
     debug "^2.2.0"
     mkdirp "0.5.x"
 
+posix-character-classes@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
+
 pre-commit@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/pre-commit/-/pre-commit-1.2.2.tgz#dbcee0ee9de7235e57f79c56d7ce94641a69eec6"
@@ -3674,23 +4105,24 @@ pre-commit@^1.2.2:
     which "1.2.x"
 
 prebuild-install@^2.1.1:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-2.3.0.tgz#19481247df728b854ab57b187ce234211311b485"
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-2.5.1.tgz#0f234140a73760813657c413cdccdda58296b1da"
   dependencies:
+    detect-libc "^1.0.3"
     expand-template "^1.0.2"
     github-from-package "0.0.0"
     minimist "^1.2.0"
     mkdirp "^0.5.1"
-    node-abi "^2.1.1"
+    node-abi "^2.2.0"
     noop-logger "^0.1.1"
     npmlog "^4.0.1"
     os-homedir "^1.0.1"
-    pump "^1.0.1"
+    pump "^2.0.1"
     rc "^1.1.6"
-    simple-get "^1.4.2"
+    simple-get "^2.7.0"
     tar-fs "^1.13.0"
     tunnel-agent "^0.6.0"
-    xtend "4.0.1"
+    which-pm-runs "^1.0.0"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -3707,25 +4139,25 @@ prettier-check@^2.0.0:
     execa "^0.6.0"
 
 prettier@^1.9.2:
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.9.2.tgz#96bc2132f7a32338e6078aeb29727178c6335827"
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.11.1.tgz#61e43fc4cd44e68f2b0dfc2c38cd4bb0fccdcc75"
 
 private@^0.1.6, private@^0.1.7:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
 
-probe.gl@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/probe.gl/-/probe.gl-0.1.0.tgz#d7c838dd0055362bdc0f52d552334f477f53cf8e"
+probe.gl@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/probe.gl/-/probe.gl-0.2.2.tgz#a92de82ac6dd58aca02127618aad102b1657c5ab"
   dependencies:
     babel-runtime "^6.11.6"
     d3-format "^1.2.0"
 
-process-nextick-args@~1.0.6:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
+process-nextick-args@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
 
-process@^0.11.0:
+process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
 
@@ -3744,27 +4176,27 @@ promise@^7.1.1:
     asap "~2.0.3"
 
 prop-types@^15.6.0:
-  version "15.6.0"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
 proxy-addr@~2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.2.tgz#6571504f47bb988ec8180253f85dd7e14952bdec"
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.3.tgz#355f262505a621646b3130a728eb647e22055341"
   dependencies:
     forwarded "~0.1.2"
-    ipaddr.js "1.5.2"
+    ipaddr.js "1.6.0"
 
 proxy-from-env@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
 
-prr@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
+prr@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -3780,9 +4212,16 @@ public-encrypt@^4.0.0:
     parse-asn1 "^5.0.0"
     randombytes "^2.0.1"
 
-pump@^1.0.0, pump@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/pump/-/pump-1.0.2.tgz#3b3ee6512f94f0e575538c17995f9f16990a5d51"
+pump@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-1.0.3.tgz#5dfe8311c33bbf6fc18261f9f34702c47c08a954"
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
+pump@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-2.0.1.tgz#12399add6e4cf7526d973cbc8b5ce2e2908b3909"
   dependencies:
     end-of-stream "^1.1.0"
     once "^1.3.1"
@@ -3796,8 +4235,8 @@ punycode@^1.2.4, punycode@^1.4.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
 puppeteer@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.0.0.tgz#20f3bb6ad6c6778b4d1fb750e808a29fec0a88a4"
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.1.1.tgz#adbf25e49f5ef03443c10ab8e09a954ca0c7bfee"
   dependencies:
     debug "^2.6.8"
     extract-zip "^1.6.5"
@@ -3844,14 +4283,14 @@ randomatic@^1.1.3:
     kind-of "^4.0.0"
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.0.5.tgz#dc009a246b8d09a177b4b7a0ae77bc570f4b1b79"
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.0.6.tgz#d302c522948588848a8d300c932b44c24231da80"
   dependencies:
     safe-buffer "^5.1.0"
 
 randomfill@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/randomfill/-/randomfill-1.0.3.tgz#b96b7df587f01dd91726c418f30553b1418e3d62"
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/randomfill/-/randomfill-1.0.4.tgz#c92196fc86ab42be983f1bf31778224931d61458"
   dependencies:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
@@ -3874,8 +4313,8 @@ raw-loader@^0.5.1:
   resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-0.5.1.tgz#0c3d0beaed8a01c966d9787bf778281252a979aa"
 
 rc@^1.1.6, rc@^1.1.7:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.2.tgz#d8ce9cb57e8d64d9c7badd9876c7c34cbe3c7077"
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.5.tgz#275cd687f6e3b36cc756baa26dfee80a790301fd"
   dependencies:
     deep-extend "~0.4.0"
     ini "~1.3.0"
@@ -3924,14 +4363,14 @@ read-pkg@^1.0.0:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.6, readable-stream@^2.2.9:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
+readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.9, readable-stream@^2.3.3:
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.5.tgz#b4f85003a938cbb6ecbce2a124fb1012bd1a838d"
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
     isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
+    process-nextick-args "~2.0.0"
     safe-buffer "~5.1.1"
     string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
@@ -3961,8 +4400,8 @@ regenerator-runtime@^0.10.5:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
 regenerator-runtime@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 
 regenerator-transform@^0.10.0:
   version "0.10.1"
@@ -3977,6 +4416,13 @@ regex-cache@^0.4.2:
   resolved "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.4.tgz#75bdc58a2a1496cec48a12835bc54c8d562336dd"
   dependencies:
     is-equal-shallow "^0.1.3"
+
+regex-not@^1.0.0, regex-not@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
+  dependencies:
+    extend-shallow "^3.0.2"
+    safe-regex "^1.1.0"
 
 regexpu-core@^2.0.0:
   version "2.0.0"
@@ -4013,7 +4459,7 @@ repeat-element@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.2.tgz#ef089a178d1483baae4d93eb98b4f9e4e11d990a"
 
-repeat-string@^1.5.2:
+repeat-string@^1.5.2, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
 
@@ -4139,6 +4585,10 @@ resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
 
+resolve-url@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
+
 resolve@~1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.4.0.tgz#a75be01c53da25d934a98ebd0e4c4a7312f92a86"
@@ -4157,6 +4607,10 @@ resumer@~0.0.0:
   resolved "https://registry.yarnpkg.com/resumer/-/resumer-0.0.0.tgz#f1e8f461e4064ba39e82af3cdc2a8c893d076759"
   dependencies:
     through "~2.3.4"
+
+ret@~0.1.10:
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
 
 right-align@^0.1.1:
   version "0.1.3"
@@ -4197,6 +4651,12 @@ safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, s
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
+safe-regex@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
+  dependencies:
+    ret "~0.1.10"
+
 sax@^1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
@@ -4210,14 +4670,14 @@ select-hose@^2.0.0:
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
 
 selfsigned@^1.9.1:
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.1.tgz#bf8cb7b83256c4551e31347c6311778db99eec52"
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.2.tgz#b4449580d99929b65b10a48389301a6592088758"
   dependencies:
-    node-forge "0.6.33"
+    node-forge "0.7.1"
 
 "semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1:
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
 semver@~5.3.0:
   version "5.3.0"
@@ -4266,9 +4726,33 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
 
+set-getter@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/set-getter/-/set-getter-0.1.0.tgz#d769c182c9d5a51f409145f2fba82e5e86e80376"
+  dependencies:
+    to-object-path "^0.3.0"
+
 set-immediate-shim@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
+
+set-value@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-0.4.3.tgz#7db08f9d3d22dc7f78e53af3c3bf4666ecdfccf1"
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-extendable "^0.1.1"
+    is-plain-object "^2.0.1"
+    to-object-path "^0.3.0"
+
+set-value@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.0.tgz#71ae4a88f0feefbbf52d1ea604f3fb315ebb6274"
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-extendable "^0.1.1"
+    is-plain-object "^2.0.3"
+    split-string "^3.0.1"
 
 setimmediate@^1.0.4, setimmediate@^1.0.5:
   version "1.0.5"
@@ -4283,8 +4767,8 @@ setprototypeof@1.1.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
 
 sha.js@^2.4.0, sha.js@^2.4.8:
-  version "2.4.9"
-  resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.9.tgz#98f64880474b74f4a38b8da9d3c0f2d104633e7d"
+  version "2.4.10"
+  resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.10.tgz#b1fde5cd7d11a5626638a07c604ab909cfa31f9b"
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
@@ -4307,13 +4791,17 @@ signal-exit@^3.0.0, signal-exit@^3.0.1, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
-simple-get@^1.4.2:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-1.4.3.tgz#e9755eda407e96da40c5e5158c9ea37b33becbeb"
+simple-concat@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.0.tgz#7344cbb8b6e26fb27d66b2fc86f9f6d5997521c6"
+
+simple-get@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-2.7.0.tgz#ad37f926d08129237ff08c4f2edfd6f10e0380b5"
   dependencies:
+    decompress-response "^3.3.0"
     once "^1.3.1"
-    unzip-response "^1.0.0"
-    xtend "^4.0.0"
+    simple-concat "^1.0.0"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -4328,6 +4816,33 @@ slice-ansi@1.0.0:
 slide@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
+
+snapdragon-node@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
+  dependencies:
+    define-property "^1.0.0"
+    isobject "^3.0.0"
+    snapdragon-util "^3.0.1"
+
+snapdragon-util@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/snapdragon-util/-/snapdragon-util-3.0.1.tgz#f956479486f2acd79700693f6f7b805e45ab56e2"
+  dependencies:
+    kind-of "^3.2.0"
+
+snapdragon@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/snapdragon/-/snapdragon-0.8.1.tgz#e12b5487faded3e3dea0ac91e9400bf75b401370"
+  dependencies:
+    base "^0.11.1"
+    debug "^2.2.0"
+    define-property "^0.2.5"
+    extend-shallow "^2.0.1"
+    map-cache "^0.2.2"
+    source-map "^0.5.6"
+    source-map-resolve "^0.5.0"
+    use "^2.0.0"
 
 sntp@1.x.x:
   version "1.0.9"
@@ -4352,12 +4867,12 @@ sockjs-client@1.1.4:
     json3 "^3.3.2"
     url-parse "^1.1.8"
 
-sockjs@0.3.18:
-  version "0.3.18"
-  resolved "https://registry.yarnpkg.com/sockjs/-/sockjs-0.3.18.tgz#d9b289316ca7df77595ef299e075f0f937eb4207"
+sockjs@0.3.19:
+  version "0.3.19"
+  resolved "https://registry.yarnpkg.com/sockjs/-/sockjs-0.3.19.tgz#d976bbe800af7bd20ae08598d582393508993c0d"
   dependencies:
     faye-websocket "^0.10.0"
-    uuid "^2.0.2"
+    uuid "^3.0.1"
 
 source-list-map@^2.0.0:
   version "2.0.0"
@@ -4371,11 +4886,25 @@ source-map-loader@^0.2.1:
     loader-utils "~0.2.2"
     source-map "~0.6.1"
 
+source-map-resolve@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.1.tgz#7ad0f593f2281598e854df80f19aae4b92d7a11a"
+  dependencies:
+    atob "^2.0.0"
+    decode-uri-component "^0.2.0"
+    resolve-url "^0.2.1"
+    source-map-url "^0.4.0"
+    urix "^0.1.0"
+
 source-map-support@^0.4.15:
   version "0.4.18"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
   dependencies:
     source-map "^0.5.6"
+
+source-map-url@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
 
 source-map@^0.4.4:
   version "0.4.4"
@@ -4383,11 +4912,11 @@ source-map@^0.4.4:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.6:
+source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
-source-map@~0.6.1:
+source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
@@ -4409,19 +4938,27 @@ spawn-wrap@1.2.4:
     signal-exit "^2.0.0"
     which "^1.2.4"
 
-spdx-correct@~1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-1.0.2.tgz#4b3073d933ff51f3912f03ac5519498a4150db40"
+spdx-correct@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.0.0.tgz#05a5b4d7153a195bc92c3c425b69f3b2a9524c82"
   dependencies:
-    spdx-license-ids "^1.0.2"
+    spdx-expression-parse "^3.0.0"
+    spdx-license-ids "^3.0.0"
 
-spdx-expression-parse@~1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz#9bdf2f20e1f40ed447fbe273266191fced51626c"
+spdx-exceptions@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz#2c7ae61056c714a5b9b9b2b2af7d311ef5c78fe9"
 
-spdx-license-ids@^1.0.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
+spdx-expression-parse@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz#99e119b7a5da00e05491c9fa338b7904823b41d0"
+  dependencies:
+    spdx-exceptions "^2.1.0"
+    spdx-license-ids "^3.0.0"
+
+spdx-license-ids@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz#7a7cd28470cc6d3a1cfe6d66886f6bc430d3ac87"
 
 spdy-transport@^2.0.18:
   version "2.0.20"
@@ -4446,6 +4983,12 @@ spdy@^3.4.1:
     select-hose "^2.0.0"
     spdy-transport "^2.0.18"
 
+split-string@^3.0.1, split-string@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
+  dependencies:
+    extend-shallow "^3.0.0"
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -4464,6 +5007,13 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
+static-extend@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
+  dependencies:
+    define-property "^0.2.5"
+    object-copy "^0.1.0"
+
 "statuses@>= 1.3.1 < 2":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
@@ -4479,13 +5029,13 @@ stream-browserify@^2.0.1:
     inherits "~2.0.1"
     readable-stream "^2.0.2"
 
-stream-http@^2.3.1:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.7.2.tgz#40a050ec8dc3b53b33d9909415c02c0bf1abfbad"
+stream-http@^2.7.2:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.8.0.tgz#fd86546dac9b1c91aff8fc5d287b98fafb41bc10"
   dependencies:
     builtin-status-codes "^3.0.0"
     inherits "^2.0.1"
-    readable-stream "^2.2.6"
+    readable-stream "^2.3.3"
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
 
@@ -4512,15 +5062,15 @@ string.prototype.trim@~1.1.2:
     es-abstract "^1.5.0"
     function-bind "^1.0.2"
 
-string_decoder@^0.10.25, string_decoder@~0.10.x:
-  version "0.10.31"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
-
-string_decoder@~1.0.3:
+string_decoder@^1.0.0, string_decoder@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
   dependencies:
     safe-buffer "~5.1.0"
+
+string_decoder@~0.10.x:
+  version "0.10.31"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
 
 stringstream@~0.0.4, stringstream@~0.0.5:
   version "0.0.5"
@@ -4568,17 +5118,17 @@ supports-color@^3.1.0, supports-color@^3.1.2:
   dependencies:
     has-flag "^1.0.0"
 
-supports-color@^4.0.0, supports-color@^4.2.1:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
+supports-color@^5.1.0, supports-color@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.3.0.tgz#5b24ac15db80fa927cf5227a4a33fd3c4c7676c0"
   dependencies:
-    has-flag "^2.0.0"
+    has-flag "^3.0.0"
 
 symbol-tree@^3.2.1:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
-table@^4.0.1:
+table@4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/table/-/table-4.0.2.tgz#a33447375391e766ad34d3486e6e2aedc84d2e36"
   dependencies:
@@ -4644,8 +5194,8 @@ tar-pack@^3.4.0:
     uid-number "^0.0.6"
 
 tar-stream@^1.1.2:
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.5.4.tgz#36549cf04ed1aee9b2a30c0143252238daf94016"
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.5.5.tgz#5cad84779f45c83b1f2508d96b09d88c7218af55"
   dependencies:
     bl "^1.0.0"
     end-of-stream "^1.0.0"
@@ -4661,8 +5211,8 @@ tar@^2.0.0, tar@^2.2.1:
     inherits "2"
 
 test-exclude@^4.1.0, test-exclude@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.1.1.tgz#4d84964b0966b0087ecc334a2ce002d3d9341e26"
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.2.0.tgz#07e3613609a362c74516a717515e13322ab45b3c"
   dependencies:
     arrify "^1.0.1"
     micromatch "^2.3.11"
@@ -4692,17 +5242,17 @@ through@^2.3.6, through@~2.3.4, through@~2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
-thunky@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/thunky/-/thunky-0.1.0.tgz#bf30146824e2b6e67b0f2d7a4ac8beb26908684e"
+thunky@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.0.2.tgz#a862e018e3fb1ea2ec3fce5d55605cf57f247371"
 
 time-stamp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/time-stamp/-/time-stamp-2.0.0.tgz#95c6a44530e15ba8d6f4a3ecb8c3a3fac46da357"
 
-timers-browserify@^2.0.2:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.4.tgz#96ca53f4b794a5e7c0e1bd7cc88a372298fa01e6"
+timers-browserify@^2.0.4:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.6.tgz#241e76927d9ca05f4d959819022f5b3664b64bae"
   dependencies:
     setimmediate "^1.0.4"
 
@@ -4720,9 +5270,31 @@ to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
 
+to-object-path@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/to-object-path/-/to-object-path-0.3.0.tgz#297588b7b0e7e0ac08e04e672f85c1f4999e17af"
+  dependencies:
+    kind-of "^3.0.2"
+
+to-regex-range@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-2.1.1.tgz#7c80c17b9dfebe599e27367e0d4dd5590141db38"
+  dependencies:
+    is-number "^3.0.0"
+    repeat-string "^1.6.1"
+
+to-regex@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/to-regex/-/to-regex-3.0.2.tgz#13cfdd9b336552f30b51f33a8ae1b42a7a7599ce"
+  dependencies:
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    regex-not "^1.0.2"
+    safe-regex "^1.1.0"
+
 tough-cookie@^2.3.2, tough-cookie@~2.3.0, tough-cookie@~2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.4.tgz#ec60cee38ac675063ffc97a5c18970578ee83655"
   dependencies:
     punycode "^1.4.1"
 
@@ -4743,10 +5315,6 @@ trim-newlines@^1.0.0:
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
-
-tryit@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/tryit/-/tryit-1.0.3.tgz#393be730a9446fd1ead6da59a014308f36c289cb"
 
 tty-browserify@0.0.0:
   version "0.0.0"
@@ -4773,11 +5341,11 @@ type-check@~0.3.2:
     prelude-ls "~1.1.2"
 
 type-is@~1.6.15:
-  version "1.6.15"
-  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.15.tgz#cab10fb4909e441c82842eafe1ad646c81804410"
+  version "1.6.16"
+  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.16.tgz#f89ce341541c672b25ee7ae3c73dee3b2be50194"
   dependencies:
     media-typer "0.3.0"
-    mime-types "~2.1.15"
+    mime-types "~2.1.18"
 
 typedarray@^0.0.6:
   version "0.0.6"
@@ -4808,13 +5376,33 @@ ultron@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
 
+union-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
+  dependencies:
+    arr-union "^3.1.0"
+    get-value "^2.0.6"
+    is-extendable "^0.1.1"
+    set-value "^0.4.3"
+
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
 
-unzip-response@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-1.0.2.tgz#b984f0877fc0a89c2c773cc1ef7b5b232b5b06fe"
+unset-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unset-value/-/unset-value-1.0.0.tgz#8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559"
+  dependencies:
+    has-value "^0.3.1"
+    isobject "^3.0.0"
+
+upath@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-1.0.4.tgz#ee2321ba0a786c50973db043a50b7bcba822361d"
+
+urix@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
 
 url-parse@1.0.x:
   version "1.0.5"
@@ -4837,6 +5425,14 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
+use@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/use/-/use-2.0.2.tgz#ae28a0d72f93bf22422a18a2e379993112dec8e8"
+  dependencies:
+    define-property "^0.2.5"
+    isobject "^3.0.0"
+    lazy-cache "^2.0.2"
+
 user-home@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/user-home/-/user-home-1.1.1.tgz#2b5be23a32b63a7c9deb8d0f28d485724a3df190"
@@ -4855,13 +5451,9 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
 
-uuid@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
-
-uuid@^3.0.0, uuid@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
+uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
 
 v8flags@^2.1.1:
   version "2.1.1"
@@ -4870,11 +5462,11 @@ v8flags@^2.1.1:
     user-home "^1.1.1"
 
 validate-npm-package-license@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz#2804babe712ad3379459acfbe24746ab2c303fbc"
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz#81643bcbef1bdfecd4623793dc4648948ba98338"
   dependencies:
-    spdx-correct "~1.0.0"
-    spdx-expression-parse "~1.0.0"
+    spdx-correct "^3.0.0"
+    spdx-expression-parse "^3.0.0"
 
 vary@~1.1.2:
   version "1.1.2"
@@ -4889,8 +5481,8 @@ verror@1.10.0:
     extsprintf "^1.2.0"
 
 viewport-mercator-project@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/viewport-mercator-project/-/viewport-mercator-project-5.0.0.tgz#d18709dad652581108a6dd58f320409491d40982"
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/viewport-mercator-project/-/viewport-mercator-project-5.0.1.tgz#8f2fd1d265e9790577cb43449be708203966bc2d"
   dependencies:
     math.gl "^1.0.0"
 
@@ -4905,12 +5497,12 @@ vm-browserify@0.0.4:
     indexof "0.0.1"
 
 watchpack@^1.3.1:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.4.0.tgz#4a1472bcbb952bd0a9bb4036801f954dfb39faac"
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.5.0.tgz#231e783af830a22f8966f65c4c4bacc814072eed"
   dependencies:
-    async "^2.1.2"
-    chokidar "^1.7.0"
+    chokidar "^2.0.2"
     graceful-fs "^4.1.2"
+    neo-async "^2.5.0"
 
 wbuf@^1.1.0, wbuf@^1.7.2:
   version "1.7.2"
@@ -4930,32 +5522,32 @@ webidl-conversions@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
 
-webpack-dev-middleware@^1.11.0:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-1.12.0.tgz#d34efefb2edda7e1d3b5dbe07289513219651709"
+webpack-dev-middleware@1.12.2:
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz#f8fc1120ce3b4fc5680ceecb43d777966b21105e"
   dependencies:
     memory-fs "~0.4.1"
-    mime "^1.3.4"
+    mime "^1.5.0"
     path-is-absolute "^1.0.0"
     range-parser "^1.0.3"
     time-stamp "^2.0.0"
 
 webpack-dev-server@^2.4.0:
-  version "2.9.4"
-  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-2.9.4.tgz#7883e61759c6a4b33e9b19ec4037bd4ab61428d1"
+  version "2.11.2"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-2.11.2.tgz#1f4f4c78bf1895378f376815910812daf79a216f"
   dependencies:
     ansi-html "0.0.7"
     array-includes "^3.0.3"
     bonjour "^3.5.0"
-    chokidar "^1.6.0"
+    chokidar "^2.0.0"
     compression "^1.5.2"
     connect-history-api-fallback "^1.3.0"
     debug "^3.1.0"
     del "^3.0.0"
-    express "^4.13.3"
+    express "^4.16.2"
     html-entities "^1.2.0"
     http-proxy-middleware "~0.17.4"
-    import-local "^0.1.1"
+    import-local "^1.0.0"
     internal-ip "1.2.0"
     ip "^1.1.5"
     killable "^1.0.0"
@@ -4964,17 +5556,17 @@ webpack-dev-server@^2.4.0:
     portfinder "^1.0.9"
     selfsigned "^1.9.1"
     serve-index "^1.7.2"
-    sockjs "0.3.18"
+    sockjs "0.3.19"
     sockjs-client "1.1.4"
     spdy "^3.4.1"
-    strip-ansi "^3.0.1"
-    supports-color "^4.2.1"
-    webpack-dev-middleware "^1.11.0"
-    yargs "^6.6.0"
+    strip-ansi "^3.0.0"
+    supports-color "^5.1.0"
+    webpack-dev-middleware "1.12.2"
+    yargs "6.6.0"
 
 webpack-sources@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.0.2.tgz#d0148ec083b3b5ccef1035a6b3ec16442983b27a"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.1.0.tgz#a101ebae59d6507354d71d8013950a3a8b7a5a54"
   dependencies:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
@@ -5013,8 +5605,8 @@ websocket-driver@>=0.5.1:
     websocket-extensions ">=0.1.1"
 
 websocket-extensions@>=0.1.1:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.2.tgz#0e18781de629a18308ce1481650f67ffa2693a5d"
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
 
 whatwg-encoding@^1.0.1:
   version "1.0.3"
@@ -5036,6 +5628,10 @@ whatwg-url@^4.3.0:
 which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
+
+which-pm-runs@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb"
 
 which@1, which@^1.2.4, which@^1.2.9:
   version "1.3.0"
@@ -5108,7 +5704,7 @@ xml-name-validator@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
 
-xtend@4.0.1, "xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@~4.0.1:
+"xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 
@@ -5132,7 +5728,7 @@ yargs-parser@^5.0.0:
   dependencies:
     camelcase "^3.0.0"
 
-yargs@^6.0.0, yargs@^6.6.0:
+yargs@6.6.0, yargs@^6.0.0:
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-6.6.0.tgz#782ec21ef403345f830a808ca3d513af56065208"
   dependencies:


### PR DESCRIPTION
For #1423
#### Change List
- replace various lifecycle test utils with `testLayer`.
- update tests
- remove unused test utils
