### PR TITLE
Fix test harness exit code on failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,8 +73,6 @@
     "benchmark": "^2.1.3",
     "brfs-babel": "^1.0.0",
     "coveralls": "^2.13.0",
-    "deck.gl": ">=5.2.0-alpha.2",
-    "deck.gl-test-utils": ">=5.2.0-alpha.3",
     "eslint": "^4.13.1",
     "eslint-config-prettier": "^2.9.0",
     "eslint-config-uber-es2015": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "test-node": "node test/start.js test",
     "test-dist": "node test/start.js test-dist",
     "test-render": "node test/start.js render",
-    "test-render-react": "node test/start.js render-react",
+    "test-render-react": "node test/start.js render",
     "test-browser": "webpack-dev-server --env.test --progress --hot --open",
     "test-render-browser": "webpack-dev-server --env.render --progress --hot --open",
     "bench": "node test/start.js bench",

--- a/src/test-utils/package.json
+++ b/src/test-utils/package.json
@@ -62,7 +62,6 @@
     "eslint-config-uber-jsx": "^3.0.0",
     "eslint-plugin-react": "~6.7.0",
     "file-loader": "^0.10.1",
-    "gl": "^4.0.3",
     "immutable": "^3.8.1",
     "jsdom": "^9.11.0",
     "module-alias": "^2.0.0",

--- a/src/test-utils/src/drivers/render-test-driver.js
+++ b/src/test-utils/src/drivers/render-test-driver.js
@@ -57,7 +57,7 @@ export default class RenderTestDriver extends BrowserDriver {
       .catch(error => {
         this._done(false, error);
         // Leave browser running so that user can inspect image
-        return Promise.all([this.stopServer()]).then(_ => this.exitProcess());
+        return Promise.all([this.stopServer()]);
       });
   }
 

--- a/src/test-utils/src/drivers/render-test-driver.js
+++ b/src/test-utils/src/drivers/render-test-driver.js
@@ -49,25 +49,25 @@ export default class RenderTestDriver extends BrowserDriver {
           throw new Error(`Illegal response "${resultString}" returned from Chrome test script`);
         }
         if (!result.success) {
-          throw new Error(`Rendering test failed on ${result.failedTest}`);
+          throw new Error(result.failedTest);
         }
         this._done(result.success);
         this.exit();
       })
       .catch(error => {
-        this.console.error(addColor(error, COLOR.BRIGHT_RED));
-        this._done(false);
-        this.exit();
+        this._done(false, error);
+        // Leave browser running so that user can inspect image
+        return Promise.all([this.stopServer()]).then(_ => this.exitProcess());
       });
   }
 
-  _done(success) {
+  _done(success, error) {
     this.setShellStatus(success);
     const elapsed = ((Date.now() - this.time) / 1000).toFixed(1);
     this.console.log(
       success
         ? addColor(`Rendering test successfully completed in ${elapsed}s!`, COLOR.BRIGHT_GREEN)
-        : addColor('Rendering test failed!', COLOR.BRIGHT_RED)
+        : addColor(`Rendering test failed: ${error.message}`, COLOR.BRIGHT_RED)
     );
   }
 }

--- a/src/test-utils/src/render-test.js
+++ b/src/test-utils/src/render-test.js
@@ -59,6 +59,7 @@ export default class RenderTest {
 
   run() {
     this.passed = true;
+    this.failedTest = null;
     this.sceneRenderer.run();
   }
 
@@ -72,6 +73,7 @@ export default class RenderTest {
 
     const passed = percentage >= this.testPassThreshold;
     this.passed = this.passed && passed;
+    this.failedTest = this.failedTest || (this.passed ? null : name);
 
     return {
       name,
@@ -122,11 +124,14 @@ export default class RenderTest {
 
   // Node test driver (puppeteer) may not have had time to expose the function
   // if the test suite is short. If not available, wait a second and try again
-  _reportToTestDriver(firstTime = false) {
+  _reportToTestDriver() {
     if (window.renderTestComplete) {
-      window.renderTestComplete(JSON.stringify(this.passed));
+      const result = {success: this.passed, failedTest: this.failedTest || ''};
+      const resultString = JSON.stringify(result);
+      window.renderTestComplete(resultString);
     } else {
-      window.setTimeout(this._reportToTestDriver.bind(this, false), 1000);
+      console.warn('renderTestComplete not exposed, waiting 1 second'); // eslint-disable-line
+      window.setTimeout(this._reportToTestDriver.bind(this), 1000);
     }
   }
 }

--- a/test/render/test-cases.js
+++ b/test/render/test-cases.js
@@ -596,7 +596,7 @@ export const TEST_CASES = [
         id: 'screengrid-lnglat',
         data: dataSamples.points,
         getPosition: d => d.COORDINATES,
-        cellSizePixels: 30,
+        cellSizePixels: 40,
         minColor: [0, 0, 80, 0],
         maxColor: [100, 255, 0, 128],
         pickable: false

--- a/test/render/test-cases.js
+++ b/test/render/test-cases.js
@@ -596,7 +596,7 @@ export const TEST_CASES = [
         id: 'screengrid-lnglat',
         data: dataSamples.points,
         getPosition: d => d.COORDINATES,
-        cellSizePixels: 40,
+        cellSizePixels: 30,
         minColor: [0, 0, 80, 0],
         maxColor: [100, 255, 0, 128],
         pickable: false

--- a/test/start.js
+++ b/test/start.js
@@ -3,6 +3,8 @@
 // Enables ES2015 import/export in Node.js
 require('reify');
 
+require('../aliases');
+
 /* global process */
 const path = require('path');
 const moduleAlias = require('module-alias');
@@ -34,13 +36,11 @@ switch (mode) {
     break;
 
   case 'bench':
-    require('../aliases');
     require('luma.gl/headless');
     require('./bench/index'); // Run the benchmarks
     break;
 
   case 'test-ci':
-    require('../aliases');
     require('luma.gl/headless');
     // Run a smaller selection of the tests (avoid overwhelming Travis CI)
     require('./src/imports-spec');
@@ -57,7 +57,6 @@ switch (mode) {
     break;
 
   case 'test-dist':
-    require('../aliases');
     // Load deck.gl itself from the dist folder
     moduleAlias.addAlias('deck.gl', path.resolve('./dist'));
     require('luma.gl/headless');
@@ -66,7 +65,6 @@ switch (mode) {
 
   case 'test':
   default:
-    require('../aliases');
     require('luma.gl/headless');
     require('./src/index'); // Run the tests
     break;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1437,25 +1437,6 @@ decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
-deck.gl-test-utils@>=5.2.0-alpha.3:
-  version "5.2.0-alpha.4"
-  resolved "https://registry.yarnpkg.com/deck.gl-test-utils/-/deck.gl-test-utils-5.2.0-alpha.4.tgz#46f789c0238388d2db501d7bc3bf17fbc74afb92"
-
-deck.gl@>=5.2.0-alpha.2:
-  version "5.2.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/deck.gl/-/deck.gl-5.2.0-alpha.2.tgz#ff05754844339e1e8794ef56c9bc664d924d74a4"
-  dependencies:
-    d3-hexbin "^0.2.1"
-    earcut "^2.0.6"
-    lodash.flattendeep "^4.4.0"
-    luma.gl ">=5.2.0-alpha.3"
-    math.gl "^1.0.0"
-    mjolnir.js "^1.0.0"
-    probe.gl ">=1.0.0-alpha.2"
-    prop-types "^15.6.0"
-    seer "^0.2.4"
-    viewport-mercator-project "^5.0.0"
-
 decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
@@ -4161,7 +4142,7 @@ private@^0.1.6, private@^0.1.7:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
 
-probe.gl@>=1.0.0-alpha.2, probe.gl@>=1.0.0-alpha.3:
+probe.gl@>=1.0.0-alpha.3:
   version "1.0.0-alpha.3"
   resolved "https://registry.yarnpkg.com/probe.gl/-/probe.gl-1.0.0-alpha.3.tgz#2338b20a371e76dfd1ab4a7dc0e03ae908566c90"
   dependencies:


### PR DESCRIPTION
#### Background
For #1423
#### Change List
- Removes "circular" install of deck.gl, instead using alias to run from source, per discussion.
- Fixes passing of correct return status from Browser to Node.
- Also returns name of failing test.

