### PR TITLE
Fix quantize scale

### DIFF
--- a/src/core/utils/scale-utils.js
+++ b/src/core/utils/scale-utils.js
@@ -18,6 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+import log from './log';
+
 // Linear scale maps continuous domain to continuous range
 export function linearScale(domain, range, value) {
   return (value - domain[0]) / (domain[1] - domain[0]) * (range[1] - range[0]) + range[0];
@@ -28,6 +30,7 @@ export function linearScale(domain, range, value) {
 export function quantizeScale(domain, range, value) {
   const domainRange = domain[1] - domain[0];
   if (domainRange <= 0) {
+    log.warn('quantizeScale: invalid domain, returning range[0]');
     return range[0];
   }
   const step = domainRange / range.length;

--- a/src/core/utils/scale-utils.js
+++ b/src/core/utils/scale-utils.js
@@ -26,7 +26,11 @@ export function linearScale(domain, range, value) {
 // Quantize scale is similar to linear scales,
 // except it uses a discrete rather than continuous range
 export function quantizeScale(domain, range, value) {
-  const step = (domain[1] - domain[0]) / range.length;
+  const domainRange = domain[1] - domain[0];
+  if (domainRange <= 0) {
+    return range[0];
+  }
+  const step = domainRange / range.length;
   const idx = Math.floor((value - domain[0]) / step);
   const clampIdx = Math.max(Math.min(idx, range.length - 1), 0);
 
@@ -35,13 +39,7 @@ export function quantizeScale(domain, range, value) {
 
 // return a quantize scale function
 export function getQuantizeScale(domain, range) {
-  return value => {
-    const step = (domain[1] - domain[0]) / range.length;
-    const idx = Math.floor((value - domain[0]) / step);
-    const clampIdx = Math.max(Math.min(idx, range.length - 1), 0);
-
-    return range[clampIdx];
-  };
+  return value => quantizeScale(domain, range, value);
 }
 
 // return a linear scale funciton

--- a/test/src/core/utils/index.js
+++ b/test/src/core/utils/index.js
@@ -20,3 +20,4 @@
 
 import './positions.spec';
 import './memoize.spec';
+import './scale-utils.spec';

--- a/test/src/core/utils/scale-utils.spec.js
+++ b/test/src/core/utils/scale-utils.spec.js
@@ -1,0 +1,40 @@
+import test from 'tape-catch';
+import {quantizeScale} from 'deck.gl/core/utils/scale-utils';
+
+const RANGE = [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000];
+const QUANTIZE_SCALE_TEST_CASES = [
+  {
+    title: 'multi-value-domain',
+    domain: [1, 10],
+    range: RANGE,
+    value: 5,
+    result: 500
+  },
+  {
+    title: 'single-value-domain',
+    domain: [1, 1],
+    range: RANGE,
+    value: 1,
+    result: RANGE[0]
+  },
+  {
+    title: 'negative-value-domain',
+    domain: [10, 1],
+    range: RANGE,
+    value: 1,
+    result: RANGE[0]
+  }
+];
+
+test('scale-utils#import', t => {
+  t.ok(quantizeScale, 'quantizeScale imported OK');
+  t.end();
+});
+
+test('scale-utils#quantizeScale', t => {
+  for (const tc of QUANTIZE_SCALE_TEST_CASES) {
+    const result = quantizeScale(tc.domain, tc.range, tc.value);
+    t.deepEqual(result, tc.result, `quantizeScale ${tc.title} returned expected value`);
+  }
+  t.end();
+});


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #1536
<!-- For other PRs without open issue -->
#### Background
This bug is easier to reproduce with screen-grid layers, as when you zoom-in, you might endup with just one grid, where domain will have same min and max values. Also reproducible with Grid and Hex layers, if user provides domain with same min max value.
#### Change List
- Fix quantizeScale
- Add unit test
