### PR TITLE
[FOR DISCUSSION] ScreenGridLayer: Add support for GPU based aggregation

### DIFF
--- a/examples/layer-browser/package.json
+++ b/examples/layer-browser/package.json
@@ -10,7 +10,7 @@
     "deck.gl": "^5.0.0",
     "deck.gl-layers": ">=0.0.2",
     "extrude-polyline": "^1.0.6",
-    "luma.gl": "^5.0.0",
+    "luma.gl": ">=5.2.0-alpha.3",
     "react": "^16.2.0",
     "react-autobind": "^1.0.6",
     "react-dom": "^16.2.0",

--- a/examples/layer-browser/src/data-samples.js
+++ b/examples/layer-browser/src/data-samples.js
@@ -136,9 +136,21 @@ export function getPoints100K() {
   return _points100K;
 }
 
+let _points500K = null;
+export function getPoints500K() {
+  _points500K = _points500K || pointGrid(5 * 1e5, [-122.6, 37.6, -122.2, 37.9]);
+  return _points500K;
+}
+
 let _points1M = null;
 export function getPoints1M() {
   _points1M = _points1M || pointGrid(1e6, [-122.6, 37.6, -122.2, 37.9]);
+  return _points1M;
+}
+
+let _points2M = null;
+export function getPoints2M() {
+  _points2M = _points2M || pointGrid(2 * 1e6, [-122.6, 37.6, -122.2, 37.9]);
   return _points1M;
 }
 

--- a/examples/layer-browser/src/examples/core-layers.js
+++ b/examples/layer-browser/src/examples/core-layers.js
@@ -414,6 +414,17 @@ const ScatterplotLayer64PerfExample = (id, getData) => ({
   }
 });
 
+const ScreenGridLayerPerfExample = (id, getData) => ({
+  layer: ScreenGridLayer,
+  getData,
+  props: {
+    id: `screengridLayerPerf-${id}`,
+    getPosition: d => d,
+    cellSizePixels: 40,
+    pickable: false
+  }
+});
+
 /* eslint-disable quote-props */
 export default {
   'Core Layers - LngLat': {
@@ -442,6 +453,10 @@ export default {
   },
 
   'Performance Tests': {
+    'ScreenGridLayer 500K': ScreenGridLayerPerfExample('500K', dataSamples.getPoints500K),
+    'ScreenGridLayer 1M': ScreenGridLayerPerfExample('1M', dataSamples.getPoints1M),
+    'ScreenGridLayer 2M': ScreenGridLayerPerfExample('1M', dataSamples.getPoints2M),
+    'ScreenGridLayer 10M': ScreenGridLayerPerfExample('10M', dataSamples.getPoints10M),
     'ScatterplotLayer 1M': ScatterplotLayerPerfExample('1M', dataSamples.getPoints1M),
     'ScatterplotLayer 10M': ScatterplotLayerPerfExample('10M', dataSamples.getPoints10M),
     'ScatterplotLayer64 100K': ScatterplotLayer64PerfExample('100K', dataSamples.getPoints100K),

--- a/examples/screen-grid/package.json
+++ b/examples/screen-grid/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "d3-request": "^1.0.5",
     "deck.gl": "^5.0.0",
-    "luma.gl": "^5.0.0",
+    "luma.gl": ">=5.2.0-alpha.3",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-map-gl": "^3.2.0"

--- a/src/core-layers/screen-grid-layer/screen-grid-layer.js
+++ b/src/core-layers/screen-grid-layer/screen-grid-layer.js
@@ -33,7 +33,7 @@ const LOG_LEVEL = 0;
 
 const defaultProps = {
   cellSizePixels: 100,
-  gpuAggregation: false,
+  gpuAggregation: true,
 
   colorDomain: null,
   colorRange: defaultColorRange,

--- a/src/core/experimental/utils/screen-grid-aggregator.js
+++ b/src/core/experimental/utils/screen-grid-aggregator.js
@@ -179,7 +179,7 @@ export default class ScreenGridAggregator {
       data: gridTexCoords
     });
 
-    if (opts.changeFlags.dataChanged || !this.positionBuffer) {
+    if (opts.changeFlags.dataChanged || !this.positionsBuffer) {
       // TODO: add support for weights
       if (this.positionsBuffer) {
         this.positionsBuffer.delete();

--- a/src/core/experimental/utils/screen-grid-aggregator.js
+++ b/src/core/experimental/utils/screen-grid-aggregator.js
@@ -1,0 +1,342 @@
+import {Buffer, Model, GL, Framebuffer, Texture2D, FEATURES, hasFeatures} from 'luma.gl';
+import log from '../../utils/log';
+import assert from 'assert';
+
+const LOG_LEVEL = 0;
+
+const AGGREGATE_TO_GRID_VS = `\
+attribute vec2 positions;
+uniform vec2 windowSize;
+uniform vec2 cellSize;
+uniform vec2 gridSize;
+void main(void) {
+
+  vec2 windowPos = project_position(positions);
+  windowPos = project_to_pixel(windowPos);
+
+  // Transform (0,0):windowSize -> (0, 0): gridSize
+  vec2 pos = floor(windowPos / cellSize);
+
+  // Transform (0,0):gridSize -> (-1, -1):(1,1)
+  pos = (pos * (2., 2.) / (gridSize)) - (1., 1.);
+
+  // Move to pixel center, pixel-size in screen sapce (2/gridSize) * 0.5 => 1/gridSize
+  vec2 offset = 1.0 / gridSize;
+  pos = pos + offset;
+
+  gl_Position = vec4(pos, 0.0, 1.0);
+}
+`;
+
+const AGGREGATE_TO_GRID_FS = `\
+#ifdef GL_ES
+precision highp float;
+#endif
+
+void main(void) {
+  gl_FragColor = vec4(1., 0, 0, 1.0);
+}
+`;
+
+const AGGREGATE_ALL_VS = `\
+attribute vec2 positions;
+attribute vec2 texCoords;
+varying vec2 vTextureCoord;
+void main(void) {
+  // Map each position to single pixel
+   gl_Position = vec4(-1.0, -1.0, 0.0, 1.0);
+
+  vTextureCoord = texCoords;
+}
+`;
+
+const AGGREGATE_ALL_FS = `\
+#ifdef GL_ES
+precision highp float;
+#endif
+
+varying vec2 vTextureCoord;
+uniform sampler2D uSampler;
+
+void main(void) {
+  vec4 textureColor = texture2D(uSampler, vec2(vTextureCoord.s, vTextureCoord.t));
+  gl_FragColor = vec4(textureColor.r, 0., 0., textureColor.r);
+}
+`;
+
+export default class ScreenGridAggregator {
+  static hasGPUSupport(gl) {
+    return hasFeatures(
+      gl,
+      FEATURES.BLEND_EQUATION_MINMAX,
+      FEATURES.COLOR_ATTACHMENT_RGBA32F,
+      FEATURES.TEXTURE_FILTER_LINEAR_FLOAT
+    );
+  }
+
+  constructor(gl, opts = {}) {
+    this.id = opts.id || 'screen-grid-aggregator';
+    this.shaderCache = opts.shaderCache || null;
+    this.gl = gl;
+    this._hasGPUSupport = hasFeatures(
+      this.gl,
+      FEATURES.BLEND_EQUATION_MINMAX,
+      FEATURES.COLOR_ATTACHMENT_RGBA32F,
+      FEATURES.TEXTURE_FILTER_LINEAR_FLOAT
+    );
+    if (this._hasGPUSupport) {
+      this._setupModels();
+    }
+  }
+
+  // Perform aggregation and retun the results
+  run(opts) {
+    if (this._hasGPUSupport && opts.useGPU) {
+      return this._runAggregationOnGPU(opts);
+    }
+    if (opts.useGPU) {
+      log.warn('ScreenGridAggregator: WebGL2 not supported, falling back to CPU');
+    }
+    return this._runAggregationOnCPU(opts);
+  }
+
+  // PRIVATE
+
+  _setupModels() {
+    const {gl, shaderCache} = this;
+
+    this.gridAggregationModel = new Model(gl, {
+      id: 'Gird-Aggregation-Model',
+      vs: AGGREGATE_TO_GRID_VS,
+      fs: AGGREGATE_TO_GRID_FS,
+      shaderCache,
+      vertexCount: 0,
+      drawMode: GL.POINTS
+    });
+    this.allAggregationModel = new Model(gl, {
+      id: 'All-Aggregation-Model',
+      vs: AGGREGATE_ALL_VS,
+      fs: AGGREGATE_ALL_FS,
+      shaderCache,
+      vertexCount: 0,
+      drawMode: GL.POINTS
+    });
+
+    this.gridAggregationFramebuffer = setupFramebuffer(gl, {id: 'GridAggregation'});
+    this.allAggregrationFramebuffer = setupFramebuffer(gl, {id: 'AllAggregation'});
+  }
+
+  _runAggregationOnGPU(opts) {
+    this._updateModels(opts);
+    this._runGridAggregation(opts);
+    return this._getAggregateData(opts);
+  }
+
+  _runAggregationOnCPU(opts) {
+    if (LOG_LEVEL > 0) {
+      console.log(`Aggregator: _runAggregationOnCPU`);
+    }
+
+    const {positions, weights, viewport, cellSize, gridSize} = opts;
+    const cellSizePixels = cellSize;
+    const [numCol, numRow] = gridSize;
+    const counts = new Array(numCol * numRow);
+
+    counts.fill(0);
+    let maxCount = 0;
+    let totalCount = 0;
+    for (let index = 0; index < weights.length; index++) {
+      const [x, y] = viewport.project([positions[index * 2], positions[index * 2 + 1]]);
+      const weight = weights ? weights[index] : 1;
+      assert(Number.isFinite(weight));
+      const colId = Math.floor(x / cellSizePixels[0]);
+      const rowId = Math.floor(y / cellSizePixels[1]);
+      if (colId >= 0 && colId < numCol && rowId >= 0 && rowId < numRow) {
+        const i = colId + rowId * numCol;
+        counts[i] += weight;
+        totalCount += weight;
+        if (counts[i] > maxCount) {
+          maxCount = counts[i];
+        }
+      }
+    }
+
+    return {counts, totalCount, maxCount};
+  }
+
+  _updateModels(opts) {
+    const {gl} = this;
+    const {positions, gridSize} = opts;
+
+    const gridPixels = new Float32Array(gridSize[0] * gridSize[1] * 2);
+    const gridTexCoords = new Float32Array(getTexCoordPerPixel(gridSize));
+    const gridPixelBuffer = new Buffer(gl, {
+      size: 2,
+      data: gridPixels
+    });
+    const gridTexCoordsBuffer = new Buffer(gl, {
+      size: 2,
+      data: gridTexCoords
+    });
+
+    if (opts.changeFlags.dataChanged || !this.positionBuffer) {
+      // TODO: add support for weights
+      if (this.positionsBuffer) {
+        this.positionsBuffer.delete();
+      }
+      this.positionsBuffer = new Buffer(gl, {size: 2, data: new Float32Array(positions)});
+      this.gridAggregationModel.setAttributes({
+        positions: this.positionsBuffer
+      });
+      this.gridAggregationModel.setVertexCount(positions.length / 2);
+    }
+
+    this.allAggregationModel.setAttributes({
+      positions: gridPixelBuffer,
+      texCoords: gridTexCoordsBuffer
+    });
+    this.allAggregationModel.setVertexCount(gridPixels.length / 2);
+
+    const framebufferSize = {width: gridSize[0], height: gridSize[1]};
+    this.gridAggregationFramebuffer.resize(framebufferSize);
+    this.allAggregrationFramebuffer.resize(framebufferSize);
+  }
+
+  _runGridAggregation(opts) {
+    if (LOG_LEVEL > 0) {
+      console.log(`Aggregator: _runAggregationOnGPU`);
+    }
+    const {gridSize, windowSize, cellSize, viewport} = opts;
+    const {
+      gl,
+      gridAggregationFramebuffer,
+      gridAggregationModel,
+      allAggregrationFramebuffer,
+      allAggregationModel
+    } = this;
+
+    gridAggregationFramebuffer.bind();
+    gl.viewport(0, 0, gridSize[0], gridSize[1]);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    gridAggregationModel.draw({
+      parameters: {
+        clearColor: [0, 0, 0, 0],
+        clearDepth: 0,
+        blend: true,
+        depthTest: false,
+        blendEquation: GL.FUNC_ADD,
+        blendFunc: [GL.ONE, GL.ONE]
+      },
+      moduleSettings: {
+        viewport
+      },
+      uniforms: {
+        windowSize,
+        cellSize,
+        gridSize
+      }
+    });
+    gridAggregationFramebuffer.unbind();
+
+    allAggregrationFramebuffer.bind();
+    gl.viewport(0, 0, gridSize[0], gridSize[1]);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    allAggregationModel.draw({
+      parameters: {
+        clearColor: [0, 0, 0, 0],
+        clearDepth: 0,
+        blend: true,
+        depthTest: false,
+        blendEquation: [GL.FUNC_ADD, GL.MAX],
+        blendFunc: [GL.ONE, GL.ONE],
+        viewport: [0, 0, 1, 1]
+      },
+      uniforms: {
+        uSampler: gridAggregationFramebuffer.texture
+      }
+    });
+    allAggregrationFramebuffer.unbind();
+  }
+
+  _getAggregateData(opts) {
+    const {gridSize, readData} = opts;
+
+    if (!readData) {
+      return {
+        uSamplerCount: this.gridAggregationFramebuffer.texture,
+        uSamplerMaxCount: this.allAggregrationFramebuffer.texture
+      };
+    }
+    if (LOG_LEVEL > 0) {
+      console.log(`Aggregator: readPixels on FB`);
+    }
+
+    const pixels = this.gridAggregationFramebuffer.readPixels({
+      width: gridSize[0],
+      height: gridSize[1],
+      format: GL.RGBA,
+      type: GL.FLOAT
+    });
+    const totalMaxCounts = this.allAggregrationFramebuffer.readPixels({
+      width: 1,
+      height: 1,
+      format: GL.RGBA,
+      type: GL.FLOAT
+    });
+
+    // TODO: use R32F & GL.RED for 'gridAggregationFramebuffer' texture to avoid this conversion.
+    // It needs some addtional support from luma.gl : https://github.com/uber/luma.gl/issues/429
+    const counts = [];
+    for (let index = 0; index < pixels.length; index += 4) {
+      counts.push(pixels[index]);
+    }
+    return {
+      counts,
+      totalCount: totalMaxCounts[0],
+      maxCount: totalMaxCounts[3]
+    };
+  }
+}
+
+// Helper methods.
+
+// Generates (s, t) tex coordinates for each point in the rect
+// s, t are in [0, 1] range
+function getTexCoordPerPixel(rectSize) {
+  assert(Number.isFinite(rectSize[0]) && Number.isFinite(rectSize[1]));
+  const points = [];
+  for (let i = 0; i < rectSize[0]; i++) {
+    for (let j = 0; j < rectSize[1]; j++) {
+      const s = i / rectSize[0];
+      const t = j / rectSize[1];
+      points.push(s);
+      points.push(t);
+    }
+  }
+  return points;
+}
+
+function setupFramebuffer(gl, opts) {
+  const {id} = opts;
+  const texture = new Texture2D(gl, {
+    data: null,
+    format: GL.RGBA32F,
+    type: GL.FLOAT,
+    border: 0,
+    mipmaps: false,
+    parameters: {
+      [GL.TEXTURE_MAG_FILTER]: GL.NEAREST,
+      [GL.TEXTURE_MIN_FILTER]: GL.NEAREST
+    },
+    dataFormat: GL.RGBA
+  });
+
+  const fb = new Framebuffer(gl, {
+    id,
+    attachments: {
+      [GL.COLOR_ATTACHMENT0]: texture
+    }
+  });
+
+  return fb;
+}

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -80,6 +80,7 @@ import {TRANSITION_EVENTS} from './lib/transition-manager';
 import {default as LinearInterpolator} from './transitions/linear-interpolator';
 import {default as ViewportFlyToInterpolator} from './transitions/viewport-fly-to-interpolator';
 
+import {default as ScreenGridAggregator} from './experimental/utils/screen-grid-aggregator';
 // INTERNAL EXPORTS
 
 import TransitionManager from './lib/transition-manager';
@@ -152,6 +153,7 @@ export const experimental = {
   getQuantizeScale,
   clamp,
   defaultColorRange,
+  ScreenGridAggregator,
 
   log,
 

--- a/src/core/shaderlib/project/project.glsl.js
+++ b/src/core/shaderlib/project/project.glsl.js
@@ -34,6 +34,7 @@ uniform vec3 project_uPixelsPerUnit2;
 uniform vec4 project_uCenter;
 uniform mat4 project_uModelMatrix;
 uniform mat4 project_uViewProjectionMatrix;
+uniform mat4 project_uPixelProjectionMatrix;
 uniform vec2 project_uViewportSize;
 uniform float project_uDevicePixelRatio;
 uniform float project_uFocalDistance;
@@ -143,4 +144,10 @@ vec4 project_pixel_to_clipspace(vec2 pixels) {
   vec2 offset = pixels / project_uViewportSize * project_uDevicePixelRatio;
   return vec4(offset * project_uFocalDistance, 0.0, 0.0);
 }
-`;
+
+vec2 project_to_pixel(vec2 pixels) {
+  vec4 pixPosition = vec4(pixels, 0., 1.);
+  vec4 result =  project_uPixelProjectionMatrix * pixPosition;
+  return result.xy/result.w;
+}
+ `;

--- a/src/core/shaderlib/project/viewport-uniforms.js
+++ b/src/core/shaderlib/project/viewport-uniforms.js
@@ -53,6 +53,7 @@ function calculateMatrixAndOffset({
   let {viewMatrix} = viewport;
   const {projectionMatrix} = viewport;
   let {viewProjectionMatrix} = viewport;
+  const {pixelProjectionMatrix} = viewport;
 
   let projectionCenter;
 
@@ -85,6 +86,7 @@ function calculateMatrixAndOffset({
       //   .multiplyRight(VECTOR_TO_POINT_MATRIX);
       viewProjectionMatrix = mat4_multiply([], projectionMatrix, viewMatrix);
       viewProjectionMatrix = mat4_multiply([], viewProjectionMatrix, VECTOR_TO_POINT_MATRIX);
+      // TODO: update pixelProjectionMatrix ?
       break;
 
     default:
@@ -94,6 +96,7 @@ function calculateMatrixAndOffset({
   return {
     viewMatrix,
     viewProjectionMatrix,
+    pixelProjectionMatrix,
     projectionCenter,
     cameraPos: viewport.cameraPosition
   };
@@ -145,7 +148,12 @@ function calculateViewportUniforms({
   const coordinateZoom = viewport.zoom;
   assert(coordinateZoom >= 0);
 
-  const {projectionCenter, viewProjectionMatrix, cameraPos} = calculateMatrixAndOffset({
+  const {
+    projectionCenter,
+    viewProjectionMatrix,
+    pixelProjectionMatrix,
+    cameraPos
+  } = calculateMatrixAndOffset({
     coordinateSystem,
     coordinateOrigin,
     coordinateZoom,
@@ -177,6 +185,7 @@ function calculateViewportUniforms({
     project_uScale: viewport.scale, // This is the mercator scale (2 ** zoom)
 
     project_uViewProjectionMatrix: viewProjectionMatrix,
+    project_uPixelProjectionMatrix: pixelProjectionMatrix,
 
     // This is for lighting calculations
     project_uCameraPosition: cameraPos

--- a/test/bench/screen-grid-aggregator.bench.js
+++ b/test/bench/screen-grid-aggregator.bench.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 - 2017 Uber Technologies, Inc.
+// Copyright (c) 2015 - 2018 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -19,28 +19,20 @@
 // THE SOFTWARE.
 
 /* eslint-disable no-console, no-invalid-this */
-import {Bench} from 'probe.gl/bench';
+import ScreenGridAggregator from 'deck.gl/core/experimental/utils/screen-grid-aggregator';
+import {gl} from '@deck.gl/test-utils';
+import {ScreenGridAggregatorData} from 'deck.gl/test/data';
 
-import layerBench from './layer.bench';
-import coreLayersBench from './core-layers.bench';
-import viewportBench from './viewport.bench';
-import colorBench from './color.bench';
-import pickLayersBench from './pick-layers.bench';
-import utilsBench from './utils.bench';
-import tesselationBench from './tesselation.bench';
-import screenGridAggregatorBench from './screen-grid-aggregator.bench';
+const {fixture2} = ScreenGridAggregatorData;
+const sa = new ScreenGridAggregator(gl);
 
-const suite = new Bench();
-
-// add tests
-layerBench(suite);
-coreLayersBench(suite);
-viewportBench(suite);
-colorBench(suite);
-utilsBench(suite);
-pickLayersBench(suite);
-tesselationBench(suite);
-screenGridAggregatorBench(suite);
-
-// Run the suite
-suite.run();
+export default function screenGridAggregatorBench(suite) {
+  return suite
+    .group('AGGREGATION')
+    .add('AGGREGATION#CPU', () => {
+      return sa.run(Object.assign({}, fixture2, {useGPU: false}));
+    })
+    .add('AGGREGATION#GPU', () => {
+      return sa.run(Object.assign({}, fixture2, {useGPU: true, readData: true}));
+    });
+}

--- a/test/data/index.js
+++ b/test/data/index.js
@@ -20,6 +20,7 @@
 
 export * from '../../examples/layer-browser/src/data-samples';
 export * from './viewport';
+export * from './screen-grid-aggregator-data.js';
 
 import * as data from '../../examples/layer-browser/src/data-samples';
 export const lines = data.choropleths.features.map(f => ({path: f.geometry.coordinates[0]}));

--- a/test/data/screen-grid-aggregator-data.js
+++ b/test/data/screen-grid-aggregator-data.js
@@ -1,0 +1,68 @@
+import {WebMercatorViewport} from 'deck.gl';
+const POINT_COUNT = 500000;
+const viewport = new WebMercatorViewport({
+  longitude: -119.3,
+  latitude: 35.6,
+  zoom: 4,
+  maxZoom: 20,
+  pitch: 0,
+  bearing: 0,
+  width: 500,
+  height: 500
+});
+
+const fixture = {
+  positions: [
+    // Inside the current viewport bounds
+    -120.4193,
+    34.7751,
+
+    // Merged to same grid
+    -118.67079,
+    34.03948,
+
+    -118.67079,
+    34.03948,
+
+    // Outside the current viewport bounds
+    -122.4193,
+    10
+  ],
+  windowSize: [500, 500],
+  cellSize: [25, 25],
+  gridSize: [20, 20],
+  viewport
+};
+const positions = generateRandomPoints(POINT_COUNT);
+const fixture2 = Object.assign({}, fixture, {positions});
+function generateRandomPoints(pointCount) {
+  const topLeft = {
+    lng: -128.0, // -124.506026,
+    lat: 40.0 // 38.203636
+  };
+  const bottomRight = {
+    lng: -110.0, // -116.068526,
+    lat: 30.0 // 32.842653
+  };
+
+  const opts = {
+    x: topLeft.lng,
+    y: topLeft.lat,
+    width: bottomRight.lng - topLeft.lng,
+    height: bottomRight.lat - topLeft.lat,
+    count: pointCount
+  };
+  const points = new Array(opts.count * 2);
+  for (let i = 0; i < opts.count; i++) {
+    points[i * 2] = Math.floor(Math.random() * opts.width) + opts.x;
+    points[i * 2 + 1] = Math.floor(Math.random() * opts.height) + opts.y;
+  }
+  return points;
+}
+
+export const ScreenGridAggregatorData = {
+  viewport,
+  fixture,
+  fixture2,
+  generateRandomPoints
+};

--- a/test/src/core/experimental/index.js
+++ b/test/src/core/experimental/index.js
@@ -20,3 +20,4 @@
 
 import './lib';
 import './container.spec';
+import './utils/screen-grid-aggregator.spec';

--- a/test/src/core/experimental/utils/screen-grid-aggregator.spec.js
+++ b/test/src/core/experimental/utils/screen-grid-aggregator.spec.js
@@ -1,0 +1,36 @@
+import test from 'tape-catch';
+import ScreenGridAggregator from 'deck.gl/core/experimental/utils/screen-grid-aggregator';
+import {isWebGL2} from 'luma.gl';
+import {gl} from 'deck.gl-test-utils';
+import {ScreenGridAggregatorData} from 'deck.gl/test/data';
+
+const {fixture, fixture2} = ScreenGridAggregatorData;
+
+test('ScreenGridAggregator#GPU', t => {
+  const sa = new ScreenGridAggregator(gl);
+
+  const result = sa.run(Object.assign({}, fixture, {useGPU: true, readData: true}));
+
+  t.equal(result.maxCount, 2, 'maxCount should match');
+  t.equal(result.totalCount, 3, 'totalCount should match');
+  t.end();
+});
+
+test('ScreenGridAggregator#CPU', t => {
+  const sa = new ScreenGridAggregator(gl);
+
+  const result = sa.run(Object.assign({}, fixture, {useGPU: false}));
+
+  t.equal(result.maxCount, 2, 'maxCount should match');
+  t.equal(result.totalCount, 3, 'totalCount should match');
+  t.end();
+});
+
+test('ScreenGridAggregator#CompareCPUandGPU', t => {
+  const sa = new ScreenGridAggregator(gl);
+  const cpuResults = sa.run(Object.assign({}, fixture2, {useGPU: false}));
+  const gpuResults = sa.run(Object.assign({}, fixture2, {useGPU: true, readData: true}));
+
+  t.deepEqual(cpuResults, gpuResults, 'cpu and gpu results should match');
+  t.end();
+});

--- a/website/package.json
+++ b/website/package.json
@@ -25,7 +25,7 @@
     "expr-eval": "^1.0.0",
     "highlight.js": "^9.7.0",
     "immutable": "^3.7.5",
-    "luma.gl": "^5.1.0-beta.1",
+    "luma.gl": ">=5.2.0-alpha.3",
     "marked": "^0.3.6",
     "prop-types": "^15.5.8",
     "rbush": "^2.0.1",

--- a/website/src/components/demos/screen-grid-demo.js
+++ b/website/src/components/demos/screen-grid-demo.js
@@ -2,13 +2,16 @@ import React, {Component} from 'react';
 import {readableInteger} from '../../utils/format-utils';
 import {MAPBOX_STYLES, DATA_URI} from '../../constants/defaults';
 import ScreenGridOverlay from '../../../../examples/screen-grid/deckgl-overlay';
+import ScatterplotOverlay from '../../../../examples/scatterplot/deckgl-overlay';
 
 export default class ScreenGridDemo extends Component {
 
   static get data() {
     return {
-      url: `${DATA_URI}/screen-grid-data.txt`,
-      worker: 'workers/screen-grid-data-decoder.js'
+//      url: `${DATA_URI}/screen-grid-data.txt`,
+      url: `${DATA_URI}/scatterplot-data.txt`,
+//      worker: 'workers/screen-grid-data-decoder.js'
+      worker: 'workers/scatterplot-data-decoder.js'
     };
   }
 
@@ -20,7 +23,8 @@ export default class ScreenGridDemo extends Component {
 
   static get viewport() {
     return {
-      ...ScreenGridOverlay.defaultViewport,
+//      ...ScreenGridOverlay.defaultViewport,
+      ...ScatterplotOverlay.defaultViewport,
       dragToRotate: false,
       mapStyle: MAPBOX_STYLES.DARK
     };

--- a/website/src/components/demos/screen-grid-demo.js
+++ b/website/src/components/demos/screen-grid-demo.js
@@ -38,7 +38,7 @@ export default class ScreenGridDemo extends Component {
         <p>The layer aggregates data within the boundary of screen grid cells
            and maps the aggregated values to a dynamic color scale</p>
         <p>Data source: <a href="http://openstreetmap.org">OpenStreetMaps</a></p>
-        <div className="stat">No. of Samples<b>{ readableInteger(meta.count || 0) }</b></div>
+        <div className="stat">No. of Samples<b>{ readableInteger(meta.points || 0) }</b></div>
       </div>
     );
   }


### PR DESCRIPTION
NOTE: Not ready to land yet.
- Add a new class `ScreenGridAggregator`, does aggregation either or CPU or GPU based on options.
- Added a new prop `gpuAggregation` to ScreenGridLayer, will allow to switch between CPU and GPU aggregation.
- Aggregation data is returned in form for Float textures, which requires following changes to ScreenGridLayer
    - AttributeSetup: During CPU aggregation, aggregated data is sent in the form of Array Buffers, during GPU aggregation, data is sent as form of uniforms (Texture2D objects). 
   - Shaders : GPU and CPU aggregations require different set of Vertex shaders.

- Added new performance tests for ScreenGridLayer with 500K, 1M, 2M and 10M points, in layer-browser example.

- Observations: FPS observed in above added performance tests while changing cell size

| Number of points | FPS with CPU Aggregation | FPS with GPU Aggregation |
|---------|---------|--------------------------------------------------------|
| 500 Thousand | 5 - 8 | 54 - 57 |
| 1 Million | 3 - 4 | 40 - 43 |
| 2 Million | 2 - 3 | 25 - 30 |

    - When using 10 Million points, CPU aggregation takes 4-5 seconds to respond for cell size, GPU aggregation is almost instantaneous. 
- **Next steps**: Layer consuming aggregated data in form of Textures requires several changes in original layer code as mentioned above. Next I am going to try PBO (pixel buffer objects) instead of textures, so both CPU and GPU version of layer code will have minimal impact.

