### PR TITLE
Fix memory leak via oldProps

### DIFF
--- a/src/core/lib/layer.js
+++ b/src/core/lib/layer.js
@@ -431,13 +431,7 @@ export default class Layer {
     const stateNeedsUpdate = this.needsUpdate();
     // End lifecycle method
 
-    const updateParams = {
-      props: this.props,
-      oldProps: this.oldProps,
-      context: this.context,
-      oldContext: this.oldContext,
-      changeFlags: this.internalState.changeFlags
-    };
+    const updateParams = this._getUpdateParams();
 
     if (stateNeedsUpdate) {
       this._updateState(updateParams);
@@ -449,6 +443,8 @@ export default class Layer {
     }
 
     this.clearChangeFlags();
+    // Release old props for GC once update is complete
+    this.oldProps = EMPTY_PROPS;
   }
   /* eslint-enable max-statements */
 


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/1548

#### Change List
- reset `layer.oldProps` once update is complete

Tests: node, browser, layer-browser