### PR TITLE
Remove `oldProps` and `prevLayers` references

### DIFF
--- a/src/core/lib/composite-layer.js
+++ b/src/core/lib/composite-layer.js
@@ -96,9 +96,9 @@ export default class CompositeLayer extends Layer {
   }
 
   // Called by layer manager to render subLayers
-  _renderLayers() {
+  _renderLayers(needsUpdate) {
     let {subLayers} = this.internalState;
-    if (subLayers && !this.needsUpdate()) {
+    if (subLayers && !needsUpdate) {
       log.log(3, `Composite layer reused subLayers ${this}`, this.internalState.subLayers)();
     } else {
       subLayers = this.renderLayers();

--- a/src/core/lib/composite-layer.js
+++ b/src/core/lib/composite-layer.js
@@ -96,9 +96,9 @@ export default class CompositeLayer extends Layer {
   }
 
   // Called by layer manager to render subLayers
-  _renderLayers(needsUpdate) {
+  _renderLayers() {
     let {subLayers} = this.internalState;
-    if (subLayers && !needsUpdate) {
+    if (subLayers && !this.needsUpdate()) {
       log.log(3, `Composite layer reused subLayers ${this}`, this.internalState.subLayers)();
     } else {
       subLayers = this.renderLayers();

--- a/src/core/lib/layer-manager.js
+++ b/src/core/lib/layer-manager.js
@@ -580,6 +580,7 @@ export default class LayerManager {
           this._initializeLayer(newLayer);
           initLayerInSeer(newLayer); // Initializes layer in seer chrome extension (if connected)
         } else {
+          this._markLayerMatched(oldLayer, newLayer);
           this._updateLayer(newLayer, {transferStateFromLayer: oldLayer});
           updateLayerInSeer(newLayer); // Updates layer in seer chrome extension (if connected)
         }
@@ -645,7 +646,8 @@ export default class LayerManager {
     return error;
   }
 
-  _transferLayerState(oldLayer, newLayer) {
+  _markLayerMatched(oldLayer, newLayer) {
+    newLayer.lifecycle = LIFECYCLE.MATCHED;
     if (newLayer !== oldLayer) {
       log.log(
         LOG_PRIORITY_LIFECYCLE_MINOR,
@@ -654,19 +656,16 @@ export default class LayerManager {
         '->',
         newLayer
       )();
-      newLayer.lifecycle = LIFECYCLE.MATCHED;
       oldLayer.lifecycle = LIFECYCLE.AWAITING_GC;
-      newLayer._transferState(oldLayer);
     } else {
       log.log(LOG_PRIORITY_LIFECYCLE_MINOR, `Matching layer is unchanged ${newLayer.id}`)();
-      newLayer.lifecycle = LIFECYCLE.MATCHED;
     }
   }
 
   // Updates a single layer, cleaning all flags
   _updateLayer(layer, {transferStateFromLayer} = {}) {
     if (transferStateFromLayer) {
-      this._transferLayerState(transferStateFromLayer, layer);
+      layer._transferState(transferStateFromLayer);
     }
 
     log.log(

--- a/src/core/lib/layer.js
+++ b/src/core/lib/layer.js
@@ -409,11 +409,6 @@ export default class Layer {
       model.setAttributes(this.getAttributeManager().getAttributes());
     }
 
-    // Last but not least, update any sublayers
-    if (this.isComposite) {
-      this._renderLayers();
-    }
-
     this.clearChangeFlags();
   }
 
@@ -429,11 +424,6 @@ export default class Layer {
       this._updateState(updateParams);
     }
 
-    // Render or update previously rendered sublayers
-    if (this.isComposite) {
-      this._renderLayers(stateNeedsUpdate);
-    }
-
     this.clearChangeFlags();
   }
   /* eslint-enable max-statements */
@@ -442,6 +432,11 @@ export default class Layer {
     // Call subclass lifecycle methods
     this.updateState(updateParams);
     // End subclass lifecycle methods
+
+    // Render or update previously rendered sublayers
+    if (this.isComposite) {
+      this._renderLayers(true);
+    }
 
     // Add any subclass attributes
     this.updateAttributes(this.props);
@@ -661,6 +656,10 @@ ${flags.viewportChanged ? 'viewport' : ''}\
 
   // Called by layer manager to transfer state from an old layer
   _transferState(oldLayer) {
+    if (this === oldLayer) {
+      return;
+    }
+
     const {state, internalState, props} = oldLayer;
     assert(state && internalState);
 

--- a/src/core/lib/layer.js
+++ b/src/core/lib/layer.js
@@ -416,6 +416,10 @@ export default class Layer {
       model.geometry.id = `${this.props.id}-geometry`;
       model.setAttributes(this.getAttributeManager().getAttributes());
     }
+
+    // Clear temporary states
+    this.clearChangeFlags();
+    this.internalState.oldProps = null;
   }
 
   // Called by layer manager
@@ -428,6 +432,10 @@ export default class Layer {
     if (stateNeedsUpdate) {
       this._updateState();
     }
+
+    // Clear temporary states
+    this.clearChangeFlags();
+    this.internalState.oldProps = null;
   }
   /* eslint-enable max-statements */
 
@@ -451,10 +459,6 @@ export default class Layer {
     if (this.state.model) {
       this.state.model.setInstanceCount(this.getNumInstances());
     }
-
-    // Clear temporary states after update
-    this.internalState.oldProps = null;
-    this.clearChangeFlags();
   }
 
   // Called by manager when layer is about to be disposed


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/1548
Addressing additional comments in https://github.com/uber/deck.gl/pull/1549

#### Change List
- Remove `layer.oldProps`
- Remove `layerManager.prevLayers`

Tests: node, browser, layer-browser