### PR TITLE
Fix memory leak by deleting unused models

### DIFF
--- a/src/core-layers/arc-layer/arc-layer.js
+++ b/src/core-layers/arc-layer/arc-layer.js
@@ -99,6 +99,9 @@ export default class ArcLayer extends Layer {
     // Re-generate model if geometry changed
     if (props.fp64 !== oldProps.fp64) {
       const {gl} = this.context;
+      if (this.state.model) {
+        this.state.model.delete();
+      }
       this.setState({model: this._getModel(gl)});
     }
     this.updateAttribute({props, oldProps, changeFlags});

--- a/src/core-layers/grid-cell-layer/grid-cell-layer.js
+++ b/src/core-layers/grid-cell-layer/grid-cell-layer.js
@@ -91,6 +91,9 @@ export default class GridCellLayer extends Layer {
     // Re-generate model if geometry changed
     if (props.fp64 !== oldProps.fp64) {
       const {gl} = this.context;
+      if (this.state.model) {
+        this.state.model.delete();
+      }
       this.setState({model: this._getModel(gl)});
       this.state.attributeManager.invalidateAll();
     }

--- a/src/core-layers/hexagon-cell-layer/hexagon-cell-layer.js
+++ b/src/core-layers/hexagon-cell-layer/hexagon-cell-layer.js
@@ -110,6 +110,9 @@ export default class HexagonCellLayer extends Layer {
     super.updateState({props, oldProps, changeFlags});
     if (props.fp64 !== oldProps.fp64) {
       const {gl} = this.context;
+      if (this.state.model) {
+        this.state.model.delete();
+      }
       this.setState({model: this._getModel(gl)});
       this.state.attributeManager.invalidateAll();
     }

--- a/src/core-layers/icon-layer/icon-layer.js
+++ b/src/core-layers/icon-layer/icon-layer.js
@@ -152,6 +152,9 @@ export default class IconLayer extends Layer {
 
     if (props.fp64 !== oldProps.fp64) {
       const {gl} = this.context;
+      if (this.state.model) {
+        this.state.model.delete();
+      }
       this.setState({model: this._getModel(gl)});
       this.state.attributeManager.invalidateAll();
     }

--- a/src/core-layers/line-layer/line-layer.js
+++ b/src/core-layers/line-layer/line-layer.js
@@ -80,6 +80,9 @@ export default class LineLayer extends Layer {
 
     if (props.fp64 !== oldProps.fp64) {
       const {gl} = this.context;
+      if (this.state.model) {
+        this.state.model.delete();
+      }
       this.setState({model: this._getModel(gl)});
       this.state.attributeManager.invalidateAll();
     }

--- a/src/core-layers/path-layer/path-layer.js
+++ b/src/core-layers/path-layer/path-layer.js
@@ -106,6 +106,9 @@ export default class PathLayer extends Layer {
     const attributeManager = this.getAttributeManager();
     if (props.fp64 !== oldProps.fp64) {
       const {gl} = this.context;
+      if (this.state.model) {
+        this.state.model.delete();
+      }
       this.setState({model: this._getModel(gl)});
     }
     this.updateAttribute({props, oldProps, changeFlags});

--- a/src/core-layers/point-cloud-layer/point-cloud-layer.js
+++ b/src/core-layers/point-cloud-layer/point-cloud-layer.js
@@ -80,6 +80,9 @@ export default class PointCloudLayer extends Layer {
     super.updateState({props, oldProps, changeFlags});
     if (props.fp64 !== oldProps.fp64) {
       const {gl} = this.context;
+      if (this.state.model) {
+        this.state.model.delete();
+      }
       this.setState({model: this._getModel(gl)});
       this.state.attributeManager.invalidateAll();
     }

--- a/src/core-layers/scatterplot-layer/scatterplot-layer.js
+++ b/src/core-layers/scatterplot-layer/scatterplot-layer.js
@@ -82,6 +82,9 @@ export default class ScatterplotLayer extends Layer {
     super.updateState({props, oldProps, changeFlags});
     if (props.fp64 !== oldProps.fp64) {
       const {gl} = this.context;
+      if (this.state.model) {
+        this.state.model.delete();
+      }
       this.setState({model: this._getModel(gl)});
       this.state.attributeManager.invalidateAll();
     }

--- a/src/core-layers/solid-polygon-layer/solid-polygon-layer.js
+++ b/src/core-layers/solid-polygon-layer/solid-polygon-layer.js
@@ -103,6 +103,9 @@ export default class SolidPolygonLayer extends Layer {
 
     if (regenerateModel) {
       const {gl} = this.context;
+      if (this.state.model) {
+        this.state.model.delete();
+      }
       this.setState({model: this._getModel(gl)});
       this.state.attributeManager.invalidateAll();
     }

--- a/src/core/lib/layer.js
+++ b/src/core/lib/layer.js
@@ -261,7 +261,11 @@ export default class Layer {
 
   // Called once when layer is no longer matched and state will be discarded
   // App can destroy WebGL resources here
-  finalizeState() {}
+  finalizeState() {
+    for (const model of this.getModels()) {
+      model.delete();
+    }
+  }
 
   // If state has a model, draw it with supplied uniforms
   draw(opts) {


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/1560

#### Change List
- Layer class: delete all models in the default implementation of `layer.finalizeState`
- Core layers: delete existing model before creating a new one