### PR TITLE
Dist Size Reduction: Remove default attribute updaters

### DIFF
--- a/modules/core-layers/src/arc-layer/arc-layer.js
+++ b/modules/core-layers/src/arc-layer/arc-layer.js
@@ -62,14 +62,14 @@ export default class ArcLayer extends Layer {
         type: GL.UNSIGNED_BYTE,
         transition: true,
         accessor: 'getSourceColor',
-        update: this.calculateInstanceSourceColors
+        defaultValue: DEFAULT_COLOR
       },
       instanceTargetColors: {
         size: 4,
         type: GL.UNSIGNED_BYTE,
         transition: true,
         accessor: 'getTargetColor',
-        update: this.calculateInstanceTargetColors
+        defaultValue: DEFAULT_COLOR
       }
     });
     /* eslint-enable max-len */
@@ -181,6 +181,7 @@ export default class ArcLayer extends Layer {
     }
   }
 
+  /*
   calculateInstanceSourceColors(attribute) {
     const {data, getSourceColor} = this.props;
     const {value, size} = attribute;
@@ -208,6 +209,7 @@ export default class ArcLayer extends Layer {
       i += size;
     }
   }
+  */
 }
 
 ArcLayer.layerName = 'ArcLayer';

--- a/modules/core-layers/src/grid-cell-layer/grid-cell-layer.js
+++ b/modules/core-layers/src/grid-cell-layer/grid-cell-layer.js
@@ -62,7 +62,6 @@ export default class GridCellLayer extends Layer {
 
   initializeState() {
     const attributeManager = this.getAttributeManager();
-    /* eslint-disable max-len */
     attributeManager.addInstanced({
       instancePositions: {
         size: 4,
@@ -80,10 +79,9 @@ export default class GridCellLayer extends Layer {
         type: GL.UNSIGNED_BYTE,
         transition: true,
         accessor: 'getColor',
-        update: this.calculateInstanceColors
+        defaultValue: DEFAULT_COLOR
       }
     });
-    /* eslint-enable max-len */
   }
 
   updateState({props, oldProps, changeFlags}) {
@@ -158,6 +156,7 @@ export default class GridCellLayer extends Layer {
     }
   }
 
+  /*
   calculateInstanceColors(attribute) {
     const {data, getColor} = this.props;
     const {value, size} = attribute;
@@ -171,6 +170,7 @@ export default class GridCellLayer extends Layer {
       i += size;
     }
   }
+  */
 }
 
 GridCellLayer.layerName = 'GridCellLayer';

--- a/modules/core-layers/src/hexagon-cell-layer/hexagon-cell-layer.js
+++ b/modules/core-layers/src/hexagon-cell-layer/hexagon-cell-layer.js
@@ -100,7 +100,7 @@ export default class HexagonCellLayer extends Layer {
         type: GL.UNSIGNED_BYTE,
         transition: true,
         accessor: 'getColor',
-        update: this.calculateInstanceColors
+        defaultValue: DEFAULT_COLOR
       }
     });
     /* eslint-enable max-len */
@@ -229,6 +229,7 @@ export default class HexagonCellLayer extends Layer {
     }
   }
 
+  /*
   calculateInstanceColors(attribute) {
     const {data, getColor} = this.props;
     const {value, size} = attribute;
@@ -243,6 +244,7 @@ export default class HexagonCellLayer extends Layer {
       i += size;
     }
   }
+  */
 }
 
 HexagonCellLayer.layerName = 'HexagonCellLayer';

--- a/modules/core-layers/src/icon-layer/icon-layer.js
+++ b/modules/core-layers/src/icon-layer/icon-layer.js
@@ -79,8 +79,7 @@ export default class IconLayer extends Layer {
       instancePositions: {
         size: 3,
         transition: true,
-        accessor: 'getPosition',
-        update: this.calculateInstancePositions
+        accessor: 'getPosition'
       },
       instancePositions64xyLow: {
         size: 2,
@@ -91,7 +90,7 @@ export default class IconLayer extends Layer {
         size: 1,
         transition: true,
         accessor: 'getSize',
-        update: this.calculateInstanceSizes
+        defaultValue: 1
       },
       instanceOffsets: {size: 2, accessor: 'getIcon', update: this.calculateInstanceOffsets},
       instanceIconFrames: {size: 4, accessor: 'getIcon', update: this.calculateInstanceIconFrames},
@@ -106,13 +105,13 @@ export default class IconLayer extends Layer {
         type: GL.UNSIGNED_BYTE,
         transition: true,
         accessor: 'getColor',
-        update: this.calculateInstanceColors
+        defaultValue: DEFAULT_COLOR
       },
       instanceAngles: {
         size: 1,
         transition: true,
         accessor: 'getAngle',
-        update: this.calculateInstanceAngles
+        defaultValue: 0
       }
     });
     /* eslint-enable max-len */
@@ -194,6 +193,7 @@ export default class IconLayer extends Layer {
     );
   }
 
+  /*
   calculateInstancePositions(attribute) {
     const {data, getPosition} = this.props;
     const {value} = attribute;
@@ -203,25 +203,6 @@ export default class IconLayer extends Layer {
       value[i++] = position[0];
       value[i++] = position[1];
       value[i++] = position[2] || 0;
-    }
-  }
-
-  calculateInstancePositions64xyLow(attribute) {
-    const isFP64 = enable64bitSupport(this.props);
-    attribute.isGeneric = !isFP64;
-
-    if (!isFP64) {
-      attribute.value = new Float32Array(2);
-      return;
-    }
-
-    const {data, getPosition} = this.props;
-    const {value} = attribute;
-    let i = 0;
-    for (const point of data) {
-      const position = getPosition(point);
-      value[i++] = fp64LowPart(position[0]);
-      value[i++] = fp64LowPart(position[1]);
     }
   }
 
@@ -254,6 +235,26 @@ export default class IconLayer extends Layer {
       value[i++] = color[1];
       value[i++] = color[2];
       value[i++] = isNaN(color[3]) ? 255 : color[3];
+    }
+  }
+  */
+
+  calculateInstancePositions64xyLow(attribute) {
+    const isFP64 = enable64bitSupport(this.props);
+    attribute.isGeneric = !isFP64;
+
+    if (!isFP64) {
+      attribute.value = new Float32Array(2);
+      return;
+    }
+
+    const {data, getPosition} = this.props;
+    const {value} = attribute;
+    let i = 0;
+    for (const point of data) {
+      const position = getPosition(point);
+      value[i++] = fp64LowPart(position[0]);
+      value[i++] = fp64LowPart(position[1]);
     }
   }
 

--- a/modules/core-layers/src/line-layer/line-layer.js
+++ b/modules/core-layers/src/line-layer/line-layer.js
@@ -50,14 +50,12 @@ export default class LineLayer extends Layer {
       instanceSourcePositions: {
         size: 3,
         transition: true,
-        accessor: 'getSourcePosition',
-        update: this.calculateInstanceSourcePositions
+        accessor: 'getSourcePosition'
       },
       instanceTargetPositions: {
         size: 3,
         transition: true,
-        accessor: 'getTargetPosition',
-        update: this.calculateInstanceTargetPositions
+        accessor: 'getTargetPosition'
       },
       instanceSourceTargetPositions64xyLow: {
         size: 4,
@@ -69,7 +67,7 @@ export default class LineLayer extends Layer {
         type: GL.UNSIGNED_BYTE,
         transition: true,
         accessor: 'getColor',
-        update: this.calculateInstanceColors
+        defaultValue: [0, 0, 0, 255]
       }
     });
     /* eslint-enable max-len */
@@ -124,6 +122,30 @@ export default class LineLayer extends Layer {
     );
   }
 
+  calculateInstanceSourceTargetPositions64xyLow(attribute) {
+    const isFP64 = enable64bitSupport(this.props);
+    attribute.isGeneric = !isFP64;
+
+    if (!isFP64) {
+      attribute.value = new Float32Array(4);
+      return;
+    }
+
+    const {data, getSourcePosition, getTargetPosition} = this.props;
+    const {value, size} = attribute;
+    let i = 0;
+    for (const object of data) {
+      const sourcePosition = getSourcePosition(object);
+      const targetPosition = getTargetPosition(object);
+      value[i + 0] = fp64LowPart(sourcePosition[0]);
+      value[i + 1] = fp64LowPart(sourcePosition[1]);
+      value[i + 2] = fp64LowPart(targetPosition[0]);
+      value[i + 3] = fp64LowPart(targetPosition[1]);
+      i += size;
+    }
+  }
+
+  /*
   calculateInstanceSourcePositions(attribute) {
     const {data, getSourcePosition} = this.props;
     const {value, size} = attribute;
@@ -150,29 +172,6 @@ export default class LineLayer extends Layer {
     }
   }
 
-  calculateInstanceSourceTargetPositions64xyLow(attribute) {
-    const isFP64 = enable64bitSupport(this.props);
-    attribute.isGeneric = !isFP64;
-
-    if (!isFP64) {
-      attribute.value = new Float32Array(4);
-      return;
-    }
-
-    const {data, getSourcePosition, getTargetPosition} = this.props;
-    const {value, size} = attribute;
-    let i = 0;
-    for (const object of data) {
-      const sourcePosition = getSourcePosition(object);
-      const targetPosition = getTargetPosition(object);
-      value[i + 0] = fp64LowPart(sourcePosition[0]);
-      value[i + 1] = fp64LowPart(sourcePosition[1]);
-      value[i + 2] = fp64LowPart(targetPosition[0]);
-      value[i + 3] = fp64LowPart(targetPosition[1]);
-      i += size;
-    }
-  }
-
   calculateInstanceColors(attribute) {
     const {data, getColor} = this.props;
     const {value, size} = attribute;
@@ -186,6 +185,7 @@ export default class LineLayer extends Layer {
       i += size;
     }
   }
+  */
 }
 
 LineLayer.layerName = 'LineLayer';

--- a/modules/core-layers/src/point-cloud-layer/point-cloud-layer.js
+++ b/modules/core-layers/src/point-cloud-layer/point-cloud-layer.js
@@ -50,8 +50,7 @@ export default class PointCloudLayer extends Layer {
       instancePositions: {
         size: 3,
         transition: true,
-        accessor: 'getPosition',
-        update: this.calculateInstancePositions
+        accessor: 'getPosition'
       },
       instancePositions64xyLow: {
         size: 2,
@@ -62,15 +61,14 @@ export default class PointCloudLayer extends Layer {
         size: 3,
         transition: true,
         accessor: 'getNormal',
-        defaultValue: 1,
-        update: this.calculateInstanceNormals
+        defaultValue: 1
       },
       instanceColors: {
         size: 4,
         type: GL.UNSIGNED_BYTE,
         transition: true,
         accessor: 'getColor',
-        update: this.calculateInstanceColors
+        defaultValue: [0, 0, 0, 255]
       }
     });
     /* eslint-enable max-len */
@@ -121,18 +119,6 @@ export default class PointCloudLayer extends Layer {
     );
   }
 
-  calculateInstancePositions(attribute) {
-    const {data, getPosition} = this.props;
-    const {value} = attribute;
-    let i = 0;
-    for (const point of data) {
-      const position = getPosition(point);
-      value[i++] = position[0];
-      value[i++] = position[1];
-      value[i++] = position[2] || 0;
-    }
-  }
-
   calculateInstancePositions64xyLow(attribute) {
     const isFP64 = enable64bitSupport(this.props);
     attribute.isGeneric = !isFP64;
@@ -149,6 +135,19 @@ export default class PointCloudLayer extends Layer {
       const position = getPosition(point);
       value[i++] = fp64LowPart(position[0]);
       value[i++] = fp64LowPart(position[1]);
+    }
+  }
+
+  /*
+  calculateInstancePositions(attribute) {
+    const {data, getPosition} = this.props;
+    const {value} = attribute;
+    let i = 0;
+    for (const point of data) {
+      const position = getPosition(point);
+      value[i++] = position[0];
+      value[i++] = position[1];
+      value[i++] = position[2] || 0;
     }
   }
 
@@ -176,6 +175,7 @@ export default class PointCloudLayer extends Layer {
       value[i++] = isNaN(color[3]) ? 255 : color[3];
     }
   }
+  */
 }
 
 PointCloudLayer.layerName = 'PointCloudLayer';

--- a/modules/core-layers/src/scatterplot-layer/scatterplot-layer.js
+++ b/modules/core-layers/src/scatterplot-layer/scatterplot-layer.js
@@ -47,13 +47,11 @@ export default class ScatterplotLayer extends Layer {
   }
 
   initializeState() {
-    /* eslint-disable max-len */
     this.state.attributeManager.addInstanced({
       instancePositions: {
         size: 3,
         transition: true,
-        accessor: 'getPosition',
-        update: this.calculateInstancePositions
+        accessor: 'getPosition'
       },
       instancePositions64xyLow: {
         size: 2,
@@ -64,18 +62,16 @@ export default class ScatterplotLayer extends Layer {
         size: 1,
         transition: true,
         accessor: 'getRadius',
-        defaultValue: 1,
-        update: this.calculateInstanceRadius
+        defaultValue: 1
       },
       instanceColors: {
         size: 4,
         transition: true,
         type: GL.UNSIGNED_BYTE,
         accessor: 'getColor',
-        update: this.calculateInstanceColors
+        defaultValue: [0, 0, 0, 255]
       }
     });
-    /* eslint-enable max-len */
   }
 
   updateState({props, oldProps, changeFlags}) {
@@ -123,18 +119,6 @@ export default class ScatterplotLayer extends Layer {
     );
   }
 
-  calculateInstancePositions(attribute) {
-    const {data, getPosition} = this.props;
-    const {value} = attribute;
-    let i = 0;
-    for (const point of data) {
-      const position = getPosition(point);
-      value[i++] = position[0];
-      value[i++] = position[1];
-      value[i++] = position[2] || 0;
-    }
-  }
-
   calculateInstancePositions64xyLow(attribute) {
     const isFP64 = enable64bitSupport(this.props);
     attribute.isGeneric = !isFP64;
@@ -151,6 +135,19 @@ export default class ScatterplotLayer extends Layer {
       const position = getPosition(point);
       value[i++] = fp64LowPart(position[0]);
       value[i++] = fp64LowPart(position[1]);
+    }
+  }
+
+  /*
+  calculateInstancePositions(attribute) {
+    const {data, getPosition} = this.props;
+    const {value} = attribute;
+    let i = 0;
+    for (const point of data) {
+      const position = getPosition(point);
+      value[i++] = position[0];
+      value[i++] = position[1];
+      value[i++] = position[2] || 0;
     }
   }
 
@@ -176,6 +173,7 @@ export default class ScatterplotLayer extends Layer {
       value[i++] = isNaN(color[3]) ? 255 : color[3];
     }
   }
+  */
 }
 
 ScatterplotLayer.layerName = 'ScatterplotLayer';


### PR DESCRIPTION
For #1676 

#### Background
- Many attribute update function do the same simple copying of accessor values into arrays.
- The AttributeManager already has a default implementation that covers these cases.
- By using the default updaters we can make layer code smaller and reduce overall dist size. 
- This PR removes the simple updaters to measure the bundle size
#### Change List
- Drop the unnecessary updater functions
#### Remaining
- [ ] Measure perf difference to ensure default updater matches perf of individual updaters

#### Results
* A 3.5KB saving on minified bundle.
* However, duplicated code compresses well, so the compressed bundle size savings are only 0.5KB

Before

<img width="449" alt="screen shot 2018-03-26 at 6 41 07 am" src="https://user-images.githubusercontent.com/7025232/37910221-d6b263d2-30c1-11e8-8aa7-3dd11d2cadc1.png">

After

<img width="442" alt="screen shot 2018-03-26 at 6 48 11 am" src="https://user-images.githubusercontent.com/7025232/37910151-b1cc3ae8-30c1-11e8-9dfa-523f6d17b50b.png">
