### PR TITLE
Focal distance

### DIFF
--- a/docs/api-reference/viewport.md
+++ b/docs/api-reference/viewport.md
@@ -38,7 +38,7 @@ Geospatial Anchor Options (Optional)
   * `latitude` (Number, optional) - Center of viewport on map (alternative to center). Default to `37`.
   * `longitude` (Number, optional) - Center of viewport on map (alternative to center). Default to `-122`.
   * `zoom` (Number, optional) - [zoom level](https://wiki.openstreetmap.org/wiki/Zoom_levels) of the viewport. Default to `11`.
-  * `focalDistance` (Number, optional) - modifier of viewport scale if `zoom` is not supplied. Default to `1`.
+  * `focalDistance` (Number, optional) - modifier of viewport scale if `zoom` is not supplied. Corresponds to the number of pixels per meter. Default to `1`.
 
 ## Methods
 

--- a/docs/api-reference/viewport.md
+++ b/docs/api-reference/viewport.md
@@ -37,7 +37,8 @@ Projection Matrix Options
 Geospatial Anchor Options (Optional)
   * `latitude` (Number, optional) - Center of viewport on map (alternative to center). Default to `37`.
   * `longitude` (Number, optional) - Center of viewport on map (alternative to center). Default to `-122`.
-  * `zoom` (Number, optional) - `center`. Default to `11`.
+  * `zoom` (Number, optional) - [zoom level](https://wiki.openstreetmap.org/wiki/Zoom_levels) of the viewport. Default to `11`.
+  * `focalDistance` (Number, optional) - modifier of viewport scale if `zoom` is not supplied. Default to `1`.
 
 ## Methods
 

--- a/src/core/viewports/viewport.js
+++ b/src/core/viewports/viewport.js
@@ -88,6 +88,8 @@ export default class Viewport {
       latitude = null,
       zoom = null,
 
+      focalDistance = 1,
+
       // Anchor position offset (in meters for geospatial viewports)
       position = null,
       // A model matrix to be applied to position, to match the layer props API
@@ -109,7 +111,9 @@ export default class Viewport {
 
     this.zoom = zoom;
     if (!Number.isFinite(this.zoom)) {
-      this.zoom = this.isGeospatial ? getMeterZoom({latitude}) : DEFAULT_ZOOM;
+      this.zoom = this.isGeospatial
+        ? getMeterZoom({latitude}) + Math.log2(focalDistance)
+        : DEFAULT_ZOOM;
     }
     this.scale = Math.pow(2, this.zoom);
 
@@ -118,7 +122,7 @@ export default class Viewport {
       ? getDistanceScales({latitude, longitude, scale: this.scale})
       : distanceScales || DEFAULT_DISTANCE_SCALES;
 
-    this.focalDistance = opts.focalDistance || 1;
+    this.focalDistance = focalDistance;
 
     this.distanceScales.metersPerPixel = new Vector3(this.distanceScales.metersPerPixel);
     this.distanceScales.pixelsPerMeter = new Vector3(this.distanceScales.pixelsPerMeter);


### PR DESCRIPTION
#### Background
The `Viewport` constructor accepts an `focalDistance` option but does not handle it properly.

#### Impact
This PR only affects viewports without `zoom`, i.e. `FirstPersonViewport` and `ThirdPersonViewport`. Both are experimental exports.

#### Change List
- Adjust default geospatial zoom with `focalDistance`
- Add documentation
