### PR TITLE
Unbold console output after test

### DIFF
--- a/test/scripts/collect-metrics.sh
+++ b/test/scripts/collect-metrics.sh
@@ -52,3 +52,4 @@ print_size ESM
 build_bundle es5
 print_size ES5
 
+echo "\033[0m"


### PR DESCRIPTION
#### Background
- `npm run test` does not clean up formatting after itself

#### Change List
- Unbold console output
