### PR TITLE
Improve text layer perf

### DIFF
--- a/src/experimental-layers/src/text-layer/text-layer.js
+++ b/src/experimental-layers/src/text-layer/text-layer.js
@@ -62,33 +62,28 @@ export default class TextLayer extends CompositeLayer {
     if (
       changeFlags.dataChanged ||
       (changeFlags.updateTriggersChanged &&
-        (changeFlags.updateTriggersChanged.all ||
-          changeFlags.updateTriggersChanged.getText ||
-          changeFlags.updateTriggersChanged.getPosition))
+        (changeFlags.updateTriggersChanged.all || changeFlags.updateTriggersChanged.getText))
     ) {
       this.transformStringToLetters();
     }
   }
 
   transformStringToLetters() {
-    const {data, getText, getPosition} = this.props;
+    const {data, getText} = this.props;
     if (!data || data.length === 0) {
       return;
     }
-
-    const transformedData = data
-      .map(val => {
-        const text = getText(val);
+    const transformedData = [];
+    data.forEach(val => {
+      const text = getText(val);
+      if (text) {
         const letters = Array.from(text);
-        const position = getPosition(val);
-        if (!text) {
-          return [];
-        }
-        return letters.map((letter, i) =>
-          Object.assign({}, val, {text: letter, position, index: i, len: text.length})
-        );
-      })
-      .reduce((prev, curr) => [...prev, ...curr]);
+        letters.forEach((letter, i) => {
+          const datum = {text: letter, index: i, len: text.length, object: val};
+          transformedData.push(datum);
+        });
+      }
+    });
 
     this.setState({data: transformedData});
   }
@@ -115,6 +110,7 @@ export default class TextLayer extends CompositeLayer {
     }
 
     const {
+      getPosition,
       getColor,
       getSize,
       getAngle,
@@ -133,15 +129,15 @@ export default class TextLayer extends CompositeLayer {
           iconAtlas,
           iconMapping,
           getIcon: d => d.text,
-          getPosition: d => d.position,
           getIndexOfIcon: d => d.index,
           getNumOfIcon: d => d.len,
-          getColor,
-          getSize,
-          getAngle,
-          getAnchorX: d => this.getAnchorXFromTextAnchor(getTextAnchor(d)),
-          getAnchorY: d => this.getAnchorYFromAlignmentBaseline(getAlignmentBaseline(d)),
-          getPixelOffset,
+          getPosition: d => getPosition(d.object),
+          getColor: d => getColor(d.object),
+          getSize: d => getSize(d.object),
+          getAngle: d => getAngle(d.object),
+          getAnchorX: d => this.getAnchorXFromTextAnchor(getTextAnchor(d.object)),
+          getAnchorY: d => this.getAnchorYFromAlignmentBaseline(getAlignmentBaseline(d.object)),
+          getPixelOffset: d => getPixelOffset(d.object),
           fp64,
           sizeScale,
           updateTriggers: {

--- a/src/experimental-layers/src/text-layer/text-layer.js
+++ b/src/experimental-layers/src/text-layer/text-layer.js
@@ -68,6 +68,13 @@ export default class TextLayer extends CompositeLayer {
     }
   }
 
+  getPickingInfo({info}) {
+    return Object.assign(info, {
+      // override object with original data
+      object: info.object && info.object.object
+    });
+  }
+
   transformStringToLetters() {
     const {data, getText} = this.props;
     if (!data || data.length === 0) {

--- a/test/bench/core-layers.bench.js
+++ b/test/bench/core-layers.bench.js
@@ -27,6 +27,7 @@ import {testInitializeLayer} from 'deck.gl-test-utils';
 
 import SolidPolygonLayer from 'deck.gl/core-layers/solid-polygon-layer/solid-polygon-layer';
 import {SolidPolygonLayer as SolidPolygonLayer2} from 'deck.gl/experimental-layers/src';
+import {TextLayer} from 'deck.gl/experimental-layers/src';
 
 // add tests
 export default function coreLayersBench(suite) {
@@ -148,6 +149,14 @@ export default function coreLayersBench(suite) {
         extruded: true,
         wireframe: true,
         fp64: true
+      });
+      testInitializeLayer({layer});
+    })
+    .add('TextLayer#initialize', () => {
+      const layer = new TextLayer({
+        data: data.points,
+        getPosition: d => d.COORDINATES,
+        getText: d => d.LOCATION_NAME
       });
       testInitializeLayer({layer});
     });


### PR DESCRIPTION
#### Background

TextLayer (100k) example in layer-browser:

| method | time (old) | time (new) |
| -- | -- | -- |
| `transformStringToLetters` | 32585ms | 78ms |

#### Change List
- Remove spread operator construction of arrays
- Avoid merging objects