### PR TITLE
Fix TextLayer props handling

### DIFF
--- a/src/experimental-layers/src/text-layer/text-layer.js
+++ b/src/experimental-layers/src/text-layer/text-layer.js
@@ -45,7 +45,8 @@ const defaultProps = {
   getTextAnchor: x => x.textAnchor || 'middle',
   getAlignmentBaseline: x => x.alignmentBaseline || 'center',
   getPixelOffset: x => x.pixelOffset || [0, 0],
-  fp64: false
+  fp64: false,
+  sizeScale: 1
 };
 
 export default class TextLayer extends CompositeLayer {
@@ -122,7 +123,8 @@ export default class TextLayer extends CompositeLayer {
       getAlignmentBaseline,
       getPixelOffset,
       fp64,
-      sizeScale
+      sizeScale,
+      updateTriggers
     } = this.props;
 
     return [
@@ -145,9 +147,13 @@ export default class TextLayer extends CompositeLayer {
           fp64,
           sizeScale,
           updateTriggers: {
-            getAngle,
-            getColor,
-            getSize
+            getPosition: updateTriggers.getPosition,
+            getAngle: updateTriggers.getAngle,
+            getColor: updateTriggers.getColor,
+            getSize: updateTriggers.getSize,
+            getPixelOffset: updateTriggers.getPixelOffset,
+            getAnchorX: updateTriggers.getTextAnchor,
+            getAnchorY: updateTriggers.getAlignmentBaseline
           }
         })
       )


### PR DESCRIPTION
#### Background
Current issues with TextLayer:
- TextLayer is not passing update triggers to MultiIconLayer
- If `sizeScale` is not specified, luma.gl throws warning of missing uniform

#### Change List
- Add default value for `sizeScale`
- Correct updateTriggers
