### PR TITLE
Support 3d rotation in MeshLayer

### DIFF
--- a/examples/layer-browser/src/examples/experimental-layers.js
+++ b/examples/layer-browser/src/examples/experimental-layers.js
@@ -40,7 +40,7 @@ const MeshLayerExample = {
     }),
     sizeScale: 10,
     getPosition: d => d.COORDINATES,
-    getAngleDegreesCW: d => Math.random() * 360,
+    getYaw: d => Math.random() * 360,
     getColor: d => [0, d.RACKS * 50, d.SPACES * 20]
   }
 };

--- a/src/experimental-layers/src/mesh-layer/mesh-layer-vertex.glsl.js
+++ b/src/experimental-layers/src/mesh-layer/mesh-layer-vertex.glsl.js
@@ -12,7 +12,7 @@ attribute vec2 texCoords;
 // Instance attributes
 attribute vec3 instancePositions;
 attribute vec2 instancePositions64xy;
-attribute float instanceAngles;
+attribute vec3 instanceRotations;
 attribute vec4 instanceColors;
 attribute vec3 instancePickingColors;
 
@@ -21,15 +21,37 @@ varying vec2 vTexCoord;
 varying vec4 vColor;
 varying float vLightWeight;
 
+// yaw(z) pitch(y) roll(x)
+mat3 getRotationMatrix(vec3 rotation) {
+  float sr = sin(rotation.x);
+  float sp = sin(rotation.y);
+  float sw = sin(rotation.z);
+
+  float cr = cos(rotation.x);
+  float cp = cos(rotation.y);
+  float cw = cos(rotation.z);
+
+  return mat3(
+    cw * cp,                  // 0,0
+    sw * cp,                  // 1,0
+    -sp,                      // 2,0
+    -sw * cr + cw * sp * sr,  // 0,1
+    cw * cr + sw * sp * sr,   // 1,1
+    cp * sr,                  // 2,1
+    sw * sr + cw * sp * cr,   // 0,2
+    -cw * sr + sw * sp * cr,  // 1,2
+    cp * cr                   // 2,2
+  );
+}
+
 void main(void) {
   vec3 instancePos = project_position(instancePositions);
 
-  float angle = instanceAngles;
-  mat2 rotationMatrix = mat2(cos(angle), -sin(angle), sin(angle), cos(angle));
+  mat3 rotationMatrix = getRotationMatrix(instanceRotations);
 
   vec3 pos = positions;
   pos = project_scale(pos * sizeScale);
-  pos = vec3(rotationMatrix * pos.xy, pos.z);
+  pos = rotationMatrix * pos;
   vec4 worldPosition;
   gl_Position = project_position_to_clipspace(instancePositions, instancePositions64xy, pos, worldPosition);
 

--- a/src/experimental-layers/src/mesh-layer/mesh-layer.md
+++ b/src/experimental-layers/src/mesh-layer/mesh-layer.md
@@ -74,11 +74,27 @@ Multiplier to scale each geometry by.
 This accessor returns the center position corresponding to an object in the `data` stream.
 
 
-##### `getAngleDegreesCW` (Function, optional)
+##### `getYaw` (Function, optional)
 
-- Default: `object => object.angle || 0`
+- Default: `object => object.yaw || object.angle || 0`
 
-The orientation (heading) in degrees of each object.
+The yaw (heading) in degrees of each object.
+
+
+##### `getPitch` (Function, optional)
+
+- Default: `object => object.pitch || 0`
+
+The pitch (elevation) in degrees of each object.
+
+
+##### `getRoll` (Function, optional)
+
+- Default: `object => object.roll || 0`
+
+The roll (bank) in degrees of each object.
+
+See [Euler angles](https://en.wikipedia.org/wiki/Euler_angles).
 
 
 ##### `getColor` (Function, optional)


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/1564

#### Change List
- Remove prop `getAngleDegreesCW`
- Add props `getYaw` `getPitch` `getRoll`

`PathMarkerLayer` uses `MeshLayer` but does not specify an accessor. Looks like it relies on `object.angle`. Checks in layer-browser and the render test passes.