### PR TITLE
 ScreenGrid GPU Aggregation (Part-3, Add GPU Aggregation)

### DIFF
--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -69,7 +69,7 @@ export default class App extends PureComponent {
         maxDistance: 20
       },
       activeExamples: {
-        GPUScreenGridLayer: true
+        ScatterplotLayer: true
       },
       settings: {
         infovis: false,

--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -69,7 +69,7 @@ export default class App extends PureComponent {
         maxDistance: 20
       },
       activeExamples: {
-        ScatterplotLayer: true
+        GPUScreenGridLayer: true
       },
       settings: {
         infovis: false,

--- a/examples/layer-browser/src/data-samples.js
+++ b/examples/layer-browser/src/data-samples.js
@@ -142,6 +142,12 @@ export function getPoints1M() {
   return _points1M;
 }
 
+let _points5M = null;
+export function getPoints5M() {
+  _points5M = _points5M || pointGrid(5 * 1e6, [-122.6, 37.6, -122.2, 37.9]);
+  return _points5M;
+}
+
 let _points10M = null;
 export function getPoints10M() {
   _points10M = _points10M || pointGrid(1e7, [-122.6, 37.6, -122.2, 37.9]);

--- a/examples/layer-browser/src/examples/experimental-layers.js
+++ b/examples/layer-browser/src/examples/experimental-layers.js
@@ -195,6 +195,6 @@ export default {
     GPUScreenGridLayer: GPUScreenGridLayerExample,
     'GPUScreenGridLayer (1M)': GPUScreenGridLayerPerfExample('1M', dataSamples.getPoints1M),
     'GPUScreenGridLayer (5M)': GPUScreenGridLayerPerfExample('5M', dataSamples.getPoints5M),
-    'ScreenGridLayer (10M)': GPUScreenGridLayerPerfExample('10M', dataSamples.getPoints10M)
+    'GPUScreenGridLayer (10M)': GPUScreenGridLayerPerfExample('10M', dataSamples.getPoints10M)
   }
 };

--- a/examples/layer-browser/src/examples/experimental-layers.js
+++ b/examples/layer-browser/src/examples/experimental-layers.js
@@ -191,7 +191,6 @@ export default {
     'PathMarkerLayer (LngLat Offset)': PathMarkerExampleLngLatOffset,
     'PathMarkerLayer (Meter)': PathMarkerExampleMeter,
     AdvancedTextLayer: AdvancedTextLayerExample,
-    'TextLayer (100K)': TextLayer100KExample,
     GPUScreenGridLayer: GPUScreenGridLayerExample,
     'GPUScreenGridLayer (1M)': GPUScreenGridLayerPerfExample('1M', dataSamples.getPoints1M),
     'GPUScreenGridLayer (5M)': GPUScreenGridLayerPerfExample('5M', dataSamples.getPoints5M),

--- a/examples/layer-browser/src/examples/experimental-layers.js
+++ b/examples/layer-browser/src/examples/experimental-layers.js
@@ -160,7 +160,7 @@ const GPUScreenGridLayerExample = {
   layer: GPUScreenGridLayer,
   getData: () => dataSamples.points,
   props: {
-    id: 'screenGridLayer',
+    id: 'gpuScreenGridLayer',
     getPosition: d => d.COORDINATES,
     cellSizePixels: 40,
     minColor: [0, 0, 80, 0],
@@ -168,6 +168,19 @@ const GPUScreenGridLayerExample = {
     pickable: false
   }
 };
+
+const GPUScreenGridLayerPerfExample = (id, getData) => ({
+  layer: GPUScreenGridLayer,
+  getData,
+  props: {
+    id: `gpuScreenGridLayerPerf-${id}`,
+    getPosition: d => d,
+    cellSizePixels: 40,
+    minColor: [0, 0, 80, 0],
+    maxColor: [100, 255, 0, 128],
+    pickable: false
+  }
+});
 
 /* eslint-disable quote-props */
 export default {
@@ -178,6 +191,10 @@ export default {
     'PathMarkerLayer (LngLat Offset)': PathMarkerExampleLngLatOffset,
     'PathMarkerLayer (Meter)': PathMarkerExampleMeter,
     AdvancedTextLayer: AdvancedTextLayerExample,
-    GPUScreenGridLayer: GPUScreenGridLayerExample
+    'TextLayer (100K)': TextLayer100KExample,
+    GPUScreenGridLayer: GPUScreenGridLayerExample,
+    'GPUScreenGridLayer (1M)': GPUScreenGridLayerPerfExample('1M', dataSamples.getPoints1M),
+    'GPUScreenGridLayer (5M)': GPUScreenGridLayerPerfExample('5M', dataSamples.getPoints5M),
+    'ScreenGridLayer (10M)': GPUScreenGridLayerPerfExample('10M', dataSamples.getPoints10M)
   }
 };

--- a/src/experimental-layers/src/gpu-screen-grid-layer/gpu-screen-grid-layer-fragment.glsl.js
+++ b/src/experimental-layers/src/gpu-screen-grid-layer/gpu-screen-grid-layer-fragment.glsl.js
@@ -33,10 +33,8 @@ out vec4 fragColor;
 void main(void) {
   fragColor = vColor;
 
-  // use highlight color if this fragment belongs to the selected object.
+  // TODO: Enable picking (https://github.com/uber/deck.gl/issues/1592)
   // fragColor = picking_filterHighlightColor(fragColor);
-
-  // use picking color if rendering to picking FBO.
   // fragColor = picking_filterPickingColor(fragColor);
 }
 `;

--- a/src/experimental-layers/src/gpu-screen-grid-layer/gpu-screen-grid-layer-vertex.glsl.js
+++ b/src/experimental-layers/src/gpu-screen-grid-layer/gpu-screen-grid-layer-vertex.glsl.js
@@ -44,6 +44,7 @@ void main(void) {
   vec4 color = mix(minColor, maxColor, step) / 255.;
   vColor = vec4(color.rgb, color.a * opacity);
 
+  // TODO: Enable picking (https://github.com/uber/deck.gl/issues/1592)
   // // Set color to be rendered to picking fbo (also used to check for selection highlight).
   // picking_setPickingColor(instancePickingColors);
 

--- a/src/experimental-layers/src/utils/gpu-grid-aggregator.js
+++ b/src/experimental-layers/src/utils/gpu-grid-aggregator.js
@@ -105,10 +105,19 @@ export default class GPUGridAggregator {
 
   // PRIVATE
 
-  _runAggregationOnGPU(opts) {
-    this._updateModels(opts);
-    this._runGridAggregation(opts);
-    return this._getAggregateData(opts);
+  _getAggregateData(opts) {
+    let {countsBuffer, maxCountBuffer} = opts;
+    countsBuffer = this.gridAggregationFramebuffer.readPixelsToBuffer({
+      buffer: countsBuffer,
+      type: GL.FLOAT
+    });
+    maxCountBuffer = this.allAggregrationFramebuffer.readPixelsToBuffer({
+      width: 1,
+      height: 1,
+      type: GL.FLOAT,
+      buffer: maxCountBuffer
+    });
+    return {countsBuffer, maxCountBuffer};
   }
 
   _projectPositions(opts) {
@@ -121,15 +130,6 @@ export default class GPUGridAggregator {
       }
       this._setState({projectedPositions});
     }
-  }
-
-  _updateGridSize(opts) {
-    const {viewport, cellSize} = opts;
-    const width = opts.width || viewport.width;
-    const height = opts.height || viewport.height;
-    const numCol = Math.ceil(width / cellSize[0]);
-    const numRow = Math.ceil(height / cellSize[1]);
-    this._setState({numCol, numRow, windowSize: [width, height]});
   }
 
   /* eslint-disable max-statements */
@@ -181,6 +181,12 @@ export default class GPUGridAggregator {
       maxCountBuffer = new Buffer(this.gl, {data: maxCountBufferData});
     }
     return {countsBuffer, maxCountBuffer};
+  }
+
+  _runAggregationOnGPU(opts) {
+    this._updateModels(opts);
+    this._runGridAggregation(opts);
+    return this._getAggregateData(opts);
   }
 
   // Update priveate state
@@ -324,19 +330,13 @@ export default class GPUGridAggregator {
     allAggregrationFramebuffer.unbind();
   }
 
-  _getAggregateData(opts) {
-    let {countsBuffer, maxCountBuffer} = opts;
-    countsBuffer = this.gridAggregationFramebuffer.readPixelsToBuffer({
-      buffer: countsBuffer,
-      type: GL.FLOAT
-    });
-    maxCountBuffer = this.allAggregrationFramebuffer.readPixelsToBuffer({
-      width: 1,
-      height: 1,
-      type: GL.FLOAT,
-      buffer: maxCountBuffer
-    });
-    return {countsBuffer, maxCountBuffer};
+  _updateGridSize(opts) {
+    const {viewport, cellSize} = opts;
+    const width = opts.width || viewport.width;
+    const height = opts.height || viewport.height;
+    const numCol = Math.ceil(width / cellSize[0]);
+    const numRow = Math.ceil(height / cellSize[1]);
+    this._setState({numCol, numRow, windowSize: [width, height]});
   }
 }
 

--- a/src/experimental-layers/src/utils/gpu-grid-aggregator.js
+++ b/src/experimental-layers/src/utils/gpu-grid-aggregator.js
@@ -1,35 +1,154 @@
-// import {Buffer, Model, GL, Framebuffer, Texture2D, FEATURES, hasFeatures} from 'luma.gl';
+import {Buffer, Model, GL, Framebuffer, Texture2D, FEATURES, hasFeatures, isWebGL2} from 'luma.gl';
+import log from 'deck.gl';
 // import log from '../../utils/log';
 import assert from 'assert';
+const AGGREGATE_TO_GRID_VS = `\
+attribute vec2 positions;
+uniform vec2 windowSize;
+uniform vec2 cellSize;
+uniform vec2 gridSize;
+uniform mat4 uProjectionMatrix;
+
+vec2 project_to_pixel(vec2 pixels) {
+  vec4 pixPosition = vec4(pixels, 0., 1.);
+  vec4 result =  uProjectionMatrix * pixPosition;
+  return result.xy/result.w;
+}
+
+void main(void) {
+
+  vec2 windowPos = project_position(positions);
+  windowPos = project_to_pixel(windowPos);
+
+  // Transform (0,0):windowSize -> (0, 0): gridSize
+  vec2 pos = floor(windowPos / cellSize);
+
+  // Transform (0,0):gridSize -> (-1, -1):(1,1)
+  pos = (pos * (2., 2.) / (gridSize)) - (1., 1.);
+
+  // Move to pixel center, pixel-size in screen sapce (2/gridSize) * 0.5 => 1/gridSize
+  vec2 offset = 1.0 / gridSize;
+  pos = pos + offset;
+
+  gl_Position = vec4(pos, 0.0, 1.0);
+}
+`;
+
+const AGGREGATE_TO_GRID_FS = `\
+#ifdef GL_ES
+precision highp float;
+#endif
+
+void main(void) {
+  // TODO: green channel should be weight
+  gl_FragColor = vec4(1., 1., 0, 0.0);
+}
+`;
+
+const AGGREGATE_ALL_VS = `\
+attribute vec2 positions;
+attribute vec2 texCoords;
+varying vec2 vTextureCoord;
+void main(void) {
+  // Map each position to single pixel
+   gl_Position = vec4(-1.0, -1.0, 0.0, 1.0);
+
+  vTextureCoord = texCoords;
+}
+`;
+
+const AGGREGATE_ALL_FS = `\
+#ifdef GL_ES
+precision highp float;
+#endif
+
+varying vec2 vTextureCoord;
+uniform sampler2D uSampler;
+
+void main(void) {
+  vec4 textureColor = texture2D(uSampler, vec2(vTextureCoord.s, vTextureCoord.t));
+  // Aggregate total count Red channel, max count in alpha channel.
+  gl_FragColor = vec4(textureColor.r, 0., 0., textureColor.r);
+}
+`;
 
 export default class GPUGridAggregator {
   constructor(gl, opts = {}) {
     this.id = opts.id || 'gpu-grid-aggregator';
     this.shaderCache = opts.shaderCache || null;
     this.gl = gl;
+    this.state = {};
+    this._hasGPUSupport =
+      isWebGL2(gl) &&
+      hasFeatures(
+        this.gl,
+        FEATURES.BLEND_EQUATION_MINMAX,
+        FEATURES.COLOR_ATTACHMENT_RGBA32F,
+        FEATURES.TEXTURE_FILTER_LINEAR_FLOAT
+      );
+    if (this._hasGPUSupport) {
+      this._setupModels();
+    }
   }
 
   // Perform aggregation and retun the results
   run(opts) {
+    this._updateGridSize(opts);
+    if (this._hasGPUSupport && opts.useGPU) {
+      return this._runAggregationOnGPU(opts);
+    }
+    if (opts.useGPU) {
+      log.warn('ScreenGridAggregator: WebGL2 not supported, falling back to CPU');
+    }
     return this._runAggregationOnCPU(opts);
   }
 
   // PRIVATE
-  /* eslint-disable max-statements */
-  _runAggregationOnCPU(opts) {
-    const ELEMENTCOUNT = 4;
-    const {positions, weights, viewport, cellSize, countsBuffer, maxCountBuffer} = opts;
+
+  _runAggregationOnGPU(opts) {
+    this._updateModels(opts);
+    this._runGridAggregation(opts);
+    return this._getAggregateData(opts);
+  }
+
+  _projectPositions(opts) {
+    if (opts.changeFlags.dataChanged || opts.changeFlags.viewportChanged) {
+      const {positions, viewport} = opts;
+      const projectedPositions = [];
+      for (let index = 0; index < positions.length; index += 2) {
+        const [x, y] = viewport.project([positions[index], positions[index + 1]]);
+        projectedPositions.push({x, y});
+      }
+      this._setState({projectedPositions});
+    }
+  }
+
+  _updateGridSize(opts) {
+    const {viewport, cellSize} = opts;
     const width = opts.width || viewport.width;
     const height = opts.height || viewport.height;
     const numCol = Math.ceil(width / cellSize[0]);
     const numRow = Math.ceil(height / cellSize[1]);
+    this._setState({numCol, numRow, windowSize: [width, height]});
+  }
+
+  /* eslint-disable max-statements */
+  _runAggregationOnCPU(opts) {
+    const ELEMENTCOUNT = 4;
+    const {weights, cellSize} = opts;
+    let {countsBuffer, maxCountBuffer} = opts;
+    const {numCol, numRow} = this.state;
     // Each element contains 4 floats to match with GPU ouput
     const counts = new Float32Array(numCol * numRow * ELEMENTCOUNT);
+
+    this._projectPositions(opts);
+
     counts.fill(0);
     let maxCount = 0;
     let totalCount = 0;
-    for (let index = 0; index < weights.length; index++) {
-      const [x, y] = viewport.project([positions[index * 2], positions[index * 2 + 1]]);
+    const {projectedPositions} = this.state;
+    for (let index = 0; index < projectedPositions.length; index++) {
+      const {x, y} = projectedPositions[index];
       const weight = weights ? weights[index] : 1;
       assert(Number.isFinite(weight));
       const colId = Math.floor(x / cellSize[0]);
@@ -51,9 +170,215 @@ export default class GPUGridAggregator {
     maxCountBufferData[3] = maxCount;
 
     // Load data to WebGL buffer.
-    countsBuffer.subData({data: counts});
-    maxCountBuffer.subData({data: maxCountBufferData});
+    if (countsBuffer) {
+      countsBuffer.subData({data: counts});
+    } else {
+      countsBuffer = new Buffer(this.gl, {data: counts});
+    }
+    if (maxCountBuffer) {
+      maxCountBuffer.subData({data: maxCountBufferData});
+    } else {
+      maxCountBuffer = new Buffer(this.gl, {data: maxCountBufferData});
+    }
     return {countsBuffer, maxCountBuffer};
   }
+
+  // Update priveate state
+  _setState(updateObject) {
+    Object.assign(this.state, updateObject);
+  }
+
   /* eslint-enable max-statements */
+  _setupModels() {
+    const {gl, shaderCache} = this;
+
+    this.gridAggregationModel = new Model(gl, {
+      id: 'Gird-Aggregation-Model',
+      vs: AGGREGATE_TO_GRID_VS,
+      fs: AGGREGATE_TO_GRID_FS,
+      shaderCache,
+      vertexCount: 0,
+      drawMode: GL.POINTS
+    });
+    this.allAggregationModel = new Model(gl, {
+      id: 'All-Aggregation-Model',
+      vs: AGGREGATE_ALL_VS,
+      fs: AGGREGATE_ALL_FS,
+      shaderCache,
+      vertexCount: 0,
+      drawMode: GL.POINTS
+    });
+
+    this.gridAggregationFramebuffer = setupFramebuffer(gl, {id: 'GridAggregation'});
+    this.allAggregrationFramebuffer = setupFramebuffer(gl, {id: 'AllAggregation'});
+  }
+
+  /* eslint-disable max-statements */
+  _updateModels(opts) {
+    const {gl} = this;
+    const {positions} = opts;
+    const {numCol, numRow} = this.state;
+
+    let {positionsBuffer, gridPixelBuffer, gridTexCoordsBuffer} = this.state;
+
+    if (opts.changeFlags.dataChanged || !positionsBuffer) {
+      // TODO: add support for weights
+      if (positionsBuffer) {
+        positionsBuffer.delete();
+      }
+      positionsBuffer = new Buffer(gl, {size: 2, data: new Float32Array(positions)});
+      this.gridAggregationModel.setAttributes({
+        positions: positionsBuffer
+      });
+      this.gridAggregationModel.setVertexCount(positions.length / 2);
+      this._setState({positionsBuffer});
+    }
+
+    if (opts.changeFlags.cellSizeChanged || !gridPixelBuffer) {
+      if (gridPixelBuffer) {
+        gridPixelBuffer.delete();
+      }
+      if (gridTexCoordsBuffer) {
+        gridTexCoordsBuffer.delete();
+      }
+      const gridPixels = new Float32Array(numCol * numRow * 2);
+      const gridTexCoords = new Float32Array(getTexCoordPerPixel([numCol, numRow]));
+      gridPixelBuffer = new Buffer(gl, {
+        size: 2,
+        data: gridPixels
+      });
+      gridTexCoordsBuffer = new Buffer(gl, {
+        size: 2,
+        data: gridTexCoords
+      });
+
+      this.allAggregationModel.setAttributes({
+        positions: gridPixelBuffer,
+        texCoords: gridTexCoordsBuffer
+      });
+      this.allAggregationModel.setVertexCount(gridPixels.length / 2);
+
+      const framebufferSize = {width: numCol, height: numRow};
+      this.gridAggregationFramebuffer.resize(framebufferSize);
+      this.allAggregrationFramebuffer.resize(framebufferSize);
+      this._setState({gridPixelBuffer, gridTexCoordsBuffer});
+    }
+  }
+  /* eslint-enable max-statements */
+
+  _runGridAggregation(opts) {
+    const {cellSize, viewport} = opts;
+    const {numCol, numRow, windowSize} = this.state;
+    const {
+      gl,
+      gridAggregationFramebuffer,
+      gridAggregationModel,
+      allAggregrationFramebuffer,
+      allAggregationModel
+    } = this;
+
+    const {pixelProjectionMatrix} = opts.viewport;
+    const gridSize = [numCol, numRow];
+
+    gridAggregationFramebuffer.bind();
+    gl.viewport(0, 0, gridSize[0], gridSize[1]);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    gridAggregationModel.draw({
+      parameters: {
+        clearColor: [0, 0, 0, 0],
+        clearDepth: 0,
+        blend: true,
+        depthTest: false,
+        blendEquation: GL.FUNC_ADD,
+        blendFunc: [GL.ONE, GL.ONE]
+      },
+      moduleSettings: {
+        viewport
+      },
+      uniforms: {
+        windowSize,
+        cellSize,
+        gridSize,
+        uProjectionMatrix: pixelProjectionMatrix
+      }
+    });
+    gridAggregationFramebuffer.unbind();
+
+    allAggregrationFramebuffer.bind();
+    gl.viewport(0, 0, gridSize[0], gridSize[1]);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    allAggregationModel.draw({
+      parameters: {
+        clearColor: [0, 0, 0, 0],
+        clearDepth: 0,
+        blend: true,
+        depthTest: false,
+        blendEquation: [GL.FUNC_ADD, GL.MAX],
+        blendFunc: [GL.ONE, GL.ONE]
+        // viewport: [0, 0, 1, 1] : TODO: do we need this?
+      },
+      uniforms: {
+        uSampler: gridAggregationFramebuffer.texture
+      }
+    });
+    allAggregrationFramebuffer.unbind();
+  }
+
+  _getAggregateData(opts) {
+    let {countsBuffer, maxCountBuffer} = opts;
+    countsBuffer = this.gridAggregationFramebuffer.readPixelsToBuffer({
+      buffer: countsBuffer,
+      type: GL.FLOAT
+    });
+    maxCountBuffer = this.allAggregrationFramebuffer.readPixelsToBuffer({
+      width: 1,
+      height: 1,
+      type: GL.FLOAT,
+      buffer: maxCountBuffer
+    });
+    return {countsBuffer, maxCountBuffer};
+  }
+}
+
+// Helper methods.
+
+// Generates (s, t) tex coordinates for each point in the rect
+// s, t are in [0, 1] range
+function getTexCoordPerPixel(rectSize) {
+  assert(Number.isFinite(rectSize[0]) && Number.isFinite(rectSize[1]));
+  const points = [];
+  for (let i = 0; i < rectSize[0]; i++) {
+    for (let j = 0; j < rectSize[1]; j++) {
+      const s = i / rectSize[0];
+      const t = j / rectSize[1];
+      points.push(s);
+      points.push(t);
+    }
+  }
+  return points;
+}
+
+function setupFramebuffer(gl, opts) {
+  const {id} = opts;
+  const texture = new Texture2D(gl, {
+    data: null,
+    format: GL.RGBA32F,
+    type: GL.FLOAT,
+    border: 0,
+    mipmaps: false,
+    parameters: {
+      [GL.TEXTURE_MAG_FILTER]: GL.NEAREST,
+      [GL.TEXTURE_MIN_FILTER]: GL.NEAREST
+    },
+    dataFormat: GL.RGBA
+  });
+
+  const fb = new Framebuffer(gl, {
+    id,
+    attachments: {
+      [GL.COLOR_ATTACHMENT0]: texture
+    }
+  });
+
+  return fb;
 }

--- a/test/bench/gpu-grid-aggregator.bench.js
+++ b/test/bench/gpu-grid-aggregator.bench.js
@@ -1,0 +1,64 @@
+// Copyright (c) 2015 - 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+/* eslint-disable no-console, no-invalid-this */
+// TODO: remove hard path once deck.gl-layers published with GPUScreenGridLayer
+import GPUGridAggregator from '../../src/experimental-layers/src/utils/gpu-grid-aggregator';
+import {gl} from 'deck.gl-test-utils';
+import {GridAggregationData} from 'deck.gl/test/data';
+
+const {fixture, generateRandomGridPoints} = GridAggregationData;
+const aggregator = new GPUGridAggregator(gl);
+const changeFlags = {dataChanged: true};
+const positions1K = generateRandomGridPoints(1000);
+const positions100K = generateRandomGridPoints(100000);
+const positions1M = generateRandomGridPoints(1000000);
+
+export default function gridAggregatorBench(suite) {
+  return suite
+    .group('GRID AGGREGATION')
+    .add('CPU 1K', () => {
+      runAggregation({useGPU: false, positions: positions1K});
+    })
+    .add('GPU 1K', () => {
+      runAggregation({useGPU: true, positions: positions1K});
+    })
+    .add('CPU 100K', () => {
+      runAggregation({useGPU: false, positions: positions100K});
+    })
+    .add('GPU 100K', () => {
+      runAggregation({useGPU: true, positions: positions100K});
+    })
+    .add('CPU 1M', () => {
+      runAggregation({useGPU: false, positions: positions1M});
+    })
+    .add('GPU 1M', () => {
+      runAggregation({useGPU: true, positions: positions1M});
+    });
+}
+
+function runAggregation(opts) {
+  const results = aggregator.run(Object.assign({}, fixture, {changeFlags}, opts));
+  if (opts.useGPU) {
+    // Call getData to sync GPU and CPU.
+    results.countsBuffer.getData();
+    results.maxCountBuffer.getData();
+  }
+}

--- a/test/bench/index.js
+++ b/test/bench/index.js
@@ -28,6 +28,7 @@ import colorBench from './color.bench';
 import pickLayersBench from './pick-layers.bench';
 import utilsBench from './utils.bench';
 import tesselationBench from './tesselation.bench';
+import gridAggregatorBench from './gpu-grid-aggregator.bench';
 
 const suite = new Bench();
 
@@ -40,5 +41,6 @@ utilsBench(suite);
 pickLayersBench(suite);
 tesselationBench(suite);
 
+gridAggregatorBench(suite);
 // Run the suite
 suite.run();

--- a/test/data/grid-aggregation-data.js
+++ b/test/data/grid-aggregation-data.js
@@ -1,0 +1,67 @@
+import {WebMercatorViewport} from 'deck.gl';
+const viewport = new WebMercatorViewport({
+  longitude: -119.3,
+  latitude: 35.6,
+  zoom: 4,
+  maxZoom: 20,
+  pitch: 0,
+  bearing: 0,
+  width: 500,
+  height: 500
+});
+
+const fixture = {
+  positions: [
+    // Inside the current viewport bounds
+    -120.4193,
+    34.7751,
+
+    // Merged to same grid
+    -118.67079,
+    34.03948,
+
+    -118.67079,
+    34.03948,
+
+    // Outside the current viewport bounds
+    -122.4193,
+    10
+  ],
+  windowSize: [500, 500],
+  cellSize: [25, 25],
+  gridSize: [20, 20],
+  changeFlags: {
+    dataChanged: true
+  },
+  viewport
+};
+function generateRandomGridPoints(pointCount) {
+  const topLeft = {
+    lng: -128.0, // -124.506026,
+    lat: 40.0 // 38.203636
+  };
+  const bottomRight = {
+    lng: -110.0, // -116.068526,
+    lat: 30.0 // 32.842653
+  };
+
+  const opts = {
+    x: topLeft.lng,
+    y: topLeft.lat,
+    width: bottomRight.lng - topLeft.lng,
+    height: bottomRight.lat - topLeft.lat,
+    count: pointCount
+  };
+  const points = new Array(opts.count * 2);
+  for (let i = 0; i < opts.count; i++) {
+    points[i * 2] = Math.floor(Math.random() * opts.width) + opts.x;
+    points[i * 2 + 1] = Math.floor(Math.random() * opts.height) + opts.y;
+  }
+  return points;
+}
+
+export const GridAggregationData = {
+  viewport,
+  fixture,
+  generateRandomGridPoints
+};

--- a/test/data/grid-aggregation-data.js
+++ b/test/data/grid-aggregation-data.js
@@ -27,6 +27,17 @@ const fixture = {
     -122.4193,
     10
   ],
+  weights: [
+    // Inside the current viewport bounds
+    1,
+
+    // Merged to same grid
+    1,
+    3,
+
+    // Outside the current viewport bounds
+    10
+  ],
   windowSize: [500, 500],
   cellSize: [25, 25],
   gridSize: [20, 20],
@@ -52,12 +63,13 @@ function generateRandomGridPoints(pointCount) {
     height: bottomRight.lat - topLeft.lat,
     count: pointCount
   };
-  const points = new Array(opts.count * 2);
+  const positions = new Array(opts.count * 2);
+  const weights = new Array(opts.count).fill(2);
   for (let i = 0; i < opts.count; i++) {
-    points[i * 2] = Math.floor(Math.random() * opts.width) + opts.x;
-    points[i * 2 + 1] = Math.floor(Math.random() * opts.height) + opts.y;
+    positions[i * 2] = Math.floor(Math.random() * opts.width) + opts.x;
+    positions[i * 2 + 1] = Math.floor(Math.random() * opts.height) + opts.y;
   }
-  return points;
+  return {positions, weights};
 }
 
 export const GridAggregationData = {

--- a/test/data/index.js
+++ b/test/data/index.js
@@ -20,6 +20,7 @@
 
 export * from '../../examples/layer-browser/src/data-samples';
 export * from './viewport';
+export * from './grid-aggregation-data.js';
 
 import * as data from '../../examples/layer-browser/src/data-samples';
 export const lines = data.choropleths.features.map(f => ({path: f.geometry.coordinates[0]}));

--- a/test/src/experimental-layers/gpu-grid-aggregator.spec.js
+++ b/test/src/experimental-layers/gpu-grid-aggregator.spec.js
@@ -1,0 +1,48 @@
+import test from 'tape-catch';
+import GPUGridAggregator from '../../../src/experimental-layers/src/utils/gpu-grid-aggregator';
+import {gl} from 'deck.gl-test-utils';
+import {GridAggregationData} from 'deck.gl/test/data';
+
+const {fixture, generateRandomGridPoints} = GridAggregationData;
+
+test('GPUGridAggregator#GPU', t => {
+  const sa = new GPUGridAggregator(gl);
+
+  const result = sa.run(Object.assign({}, fixture, {useGPU: true}));
+  const maxCountBufferData = result.maxCountBuffer.getData();
+  t.equal(maxCountBufferData[3], 2, 'maxCount should match');
+  t.equal(maxCountBufferData[0], 3, 'totalCount should match');
+  t.end();
+});
+
+test('GPUGridAggregator#CPU', t => {
+  const sa = new GPUGridAggregator(gl);
+
+  const result = sa.run(Object.assign({}, fixture, {useGPU: false}));
+
+  const maxCountBufferData = result.maxCountBuffer.getData();
+  t.equal(maxCountBufferData[3], 2, 'maxCount should match');
+  t.equal(maxCountBufferData[0], 3, 'totalCount should match');
+  // t.equal(result.maxCount, 2, 'maxCount should match');
+  // t.equal(result.totalCount, 3, 'totalCount should match');
+  t.end();
+});
+
+test('GPUGridAggregator#CompareCPUandGPU', t => {
+  const sa = new GPUGridAggregator(gl);
+  const positions = generateRandomGridPoints(5000);
+  let result = sa.run(Object.assign({}, fixture, {useGPU: false, positions}));
+  const cpuResults = {
+    counts: result.countsBuffer.getData(),
+    maxCount: result.maxCountBuffer.getData()
+  };
+  result = sa.run(Object.assign({}, fixture, {useGPU: true, positions}));
+  const gpuResults = {
+    counts: result.countsBuffer.getData(),
+    maxCount: result.maxCountBuffer.getData()
+  };
+
+  // Compare aggregation details for each grid-cell, total count and max count.
+  t.deepEqual(cpuResults, gpuResults, 'cpu and gpu results should match');
+  t.end();
+});

--- a/test/src/experimental-layers/gpu-grid-aggregator.spec.js
+++ b/test/src/experimental-layers/gpu-grid-aggregator.spec.js
@@ -10,8 +10,9 @@ test('GPUGridAggregator#GPU', t => {
 
   const result = sa.run(Object.assign({}, fixture, {useGPU: true}));
   const maxCountBufferData = result.maxCountBuffer.getData();
-  t.equal(maxCountBufferData[3], 2, 'maxCount should match');
-  t.equal(maxCountBufferData[0], 3, 'totalCount should match');
+  t.equal(maxCountBufferData[0], 3, 'total count should match');
+  t.equal(maxCountBufferData[1], 5, 'total weight should match');
+  t.equal(maxCountBufferData[3], 4, 'max weight should match');
   t.end();
 });
 
@@ -21,22 +22,21 @@ test('GPUGridAggregator#CPU', t => {
   const result = sa.run(Object.assign({}, fixture, {useGPU: false}));
 
   const maxCountBufferData = result.maxCountBuffer.getData();
-  t.equal(maxCountBufferData[3], 2, 'maxCount should match');
-  t.equal(maxCountBufferData[0], 3, 'totalCount should match');
-  // t.equal(result.maxCount, 2, 'maxCount should match');
-  // t.equal(result.totalCount, 3, 'totalCount should match');
+  t.equal(maxCountBufferData[0], 3, 'total count should match');
+  t.equal(maxCountBufferData[1], 5, 'total weight should match');
+  t.equal(maxCountBufferData[3], 4, 'max weight should match');
   t.end();
 });
 
 test('GPUGridAggregator#CompareCPUandGPU', t => {
   const sa = new GPUGridAggregator(gl);
-  const positions = generateRandomGridPoints(5000);
-  let result = sa.run(Object.assign({}, fixture, {useGPU: false, positions}));
+  const pointsData = generateRandomGridPoints(5000);
+  let result = sa.run(Object.assign({}, fixture, {useGPU: false}, pointsData));
   const cpuResults = {
     counts: result.countsBuffer.getData(),
     maxCount: result.maxCountBuffer.getData()
   };
-  result = sa.run(Object.assign({}, fixture, {useGPU: true, positions}));
+  result = sa.run(Object.assign({}, fixture, {useGPU: true}, pointsData));
   const gpuResults = {
     counts: result.countsBuffer.getData(),
     maxCount: result.maxCountBuffer.getData()

--- a/test/src/experimental-layers/index.js
+++ b/test/src/experimental-layers/index.js
@@ -38,3 +38,5 @@ test('Top-level imports', t => {
   t.ok(BezierCurveLayer, 'BezierCurveLayer symbol imported');
   t.end();
 });
+
+import './gpu-grid-aggregator.spec';


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #1414
<!-- For other PRs without open issue -->
#### Background

- Add support for GPU Aggregation
- Add Bench tests.
- Add Unit tests.
- Add GPUScreenGrid Perf layers in layer-browser

Bench Results: (GPU path performs CPU and GPU sync after every iteration)

GRID AGGREGATION
├─ CPU 1K: 991 iterations/s
├─ GPU 1K: 389 iterations/s
├─ CPU 100K: 8.26 iterations/s
├─ GPU 100K: 32.3 iterations/s
├─ CPU 1M: 1.03 iterations/s
├─ GPU 1M: 4.76 iterations/s

GPUScreenGridLayer with 1M points, zoom in/out performance on CPU vs GPU

CPU:
![screengridcpuaggregationzoomchange1m](https://user-images.githubusercontent.com/9502731/38117508-3ffda31a-336a-11e8-8246-89ba2dd543d7.gif)

GPU:
![screengridgpuaggregationzoomchange1m](https://user-images.githubusercontent.com/9502731/38117510-44c07fe4-336a-11e8-80c6-54a61a61e444.gif)


<!-- For all the PRs -->
#### Change List
- ScreenGrid GPU Aggregation (Part-3, Add GPU Aggregation)
- Add Unit and Bench tests