### PR TITLE
Integrate the existing JS controllers into Deck component

### DIFF
--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -1,9 +1,9 @@
 /* global window */
 
 // deck.gl ES6 components
-import {COORDINATE_SYSTEM, experimental} from 'deck.gl';
+import {COORDINATE_SYSTEM, MapView, FirstPersonView, OrbitView, experimental} from 'deck.gl';
 
-const {MapState, OrbitState, MapView, FirstPersonView, OrbitView, ReflectionEffect} = experimental;
+const {MapState, OrbitState, ReflectionEffect} = experimental;
 
 // deck.gl react components
 import DeckGL from 'deck.gl';

--- a/src/core/controllers/map-controller.js
+++ b/src/core/controllers/map-controller.js
@@ -1,5 +1,6 @@
 import MapControls from '../controllers/map-controls';
 import {MAPBOX_LIMITS} from '../controllers/map-state';
+import assert from '../utils/assert';
 import {EventManager} from 'mjolnir.js';
 
 const PREFIX = '-webkit-';
@@ -69,6 +70,8 @@ const defaultProps = Object.assign({}, MAPBOX_LIMITS, {
 
 export default class MapController {
   constructor(props) {
+    assert(!props.children, 'MapController is no longer a React component');
+
     props = Object.assign({}, defaultProps, props);
 
     this.props = props;

--- a/src/core/controllers/orbit-controller.js
+++ b/src/core/controllers/orbit-controller.js
@@ -1,6 +1,7 @@
 import OrbitViewport from '../viewports/orbit-viewport';
 import OrbitState from '../controllers/orbit-state';
 import ViewportControls from '../controllers/viewport-controls';
+import assert from '../utils/assert';
 import {EventManager} from 'mjolnir.js';
 
 const PREFIX = '-webkit-';
@@ -71,6 +72,8 @@ export default class OrbitController {
   }
 
   constructor(props) {
+    assert(!props.children, 'OrbitController is no longer a React component');
+
     props = Object.assign({}, defaultProps, props);
 
     this.props = props;
@@ -98,7 +101,6 @@ export default class OrbitController {
   setProps(props) {
     props = Object.assign({}, this.props, props);
     this.props = props;
-
     this._controls.setOptions(props);
   }
 

--- a/src/core/views/orthographic-view.js
+++ b/src/core/views/orthographic-view.js
@@ -4,40 +4,39 @@ import Viewport from '../viewports/viewport';
 import mat4_lookAt from 'gl-mat4/lookAt';
 import mat4_ortho from 'gl-mat4/ortho';
 
-function ORTHO_PROJECTION({left, right, bottom, top, near, far, width, height}) {
-  right = Number.isFinite(right) ? right : left + width;
-  bottom = Number.isFinite(bottom) ? bottom : top + height;
-
-  return mat4_ortho([], left, right, bottom, top, near, far);
-}
-
 export default class OrthographicView extends View {
-  constructor(props = {}) {
-    super(
-      Object.assign(
-        {
-          projection: props.projection || ORTHO_PROJECTION
-        },
-        props
-      )
-    );
-  }
-
   _getViewport({x, y, width, height, viewState}) {
     const {
       // view matrix arguments
       eye = [0, 0, 1], // Defines eye position
       lookAt = [0, 0, 0], // Which point is camera looking at, default origin
-      up = [0, 1, 0] // Defines up direction, default positive y axis
+      up = [0, 1, 0], // Defines up direction, default positive y axis
+
+      // projection matrix arguments
+      left, // Left bound of the frustum
+      top // Top bound of the frustum
     } = viewState;
 
+    let {
+      // automatically calculated
+      right = null, // Right bound of the frustum
+      bottom = null // Bottom bound of the frustum
+    } = viewState;
+
+    const {
+      near = 1, // Distance of near clipping plane
+      far = 100 // Distance of far clipping plane
+    } = this.props;
+
+    right = Number.isFinite(right) ? right : left + width;
+    bottom = Number.isFinite(bottom) ? bottom : top + height;
     return new Viewport({
       x,
       y,
       width,
       height,
       viewMatrix: mat4_lookAt([], eye, lookAt, up),
-      projectionMatrix: this._getProjectionMatrix({width, height})
+      projectionMatrix: mat4_ortho([], left, right, bottom, top, near, far)
     });
   }
 }

--- a/src/core/views/view.js
+++ b/src/core/views/view.js
@@ -1,51 +1,52 @@
 import Viewport from '../viewports/viewport';
 import {parsePosition, getPosition} from '../utils/positions';
-import {Matrix4} from 'math.gl';
 import {deepEqual} from '../utils/deep-equal';
 import assert from '../utils/assert';
-
-const PERSPECTIVE_PROJECTION = props => new Matrix4().perspective(props);
 
 export default class View {
   constructor(props = {}) {
     const {
       id = null,
-      type = Viewport, // Viewport Type
 
-      // View extents (relative or absolute)
+      // Window width/height in pixels (for pixel projection)
       x = 0,
       y = 0,
       width = '100%',
       height = '100%',
 
-      // Projection parameters,
-      projection = PERSPECTIVE_PROJECTION, // Projection matrix generator
-      fovy = 75,
+      // Viewport Type
+      type = Viewport, // TODO - default to WebMercator?
+
+      // Viewport Options
+      projectionMatrix = null, // Projection matrix
+      fovy = 75, // Perspective projection parameters, used if projectionMatrix not supplied
       near = 0.1, // Distance of near clipping plane
       far = 1000, // Distance of far clipping plane
+      modelMatrix = null, // A model matrix to be applied to position, to match the layer props API
 
-      // DEPRECATED: A View can be a wrapper for a viewport instance
+      // A View can be a wrapper for a viewport instance
       viewportInstance = null
     } = props;
 
     assert(!viewportInstance || viewportInstance instanceof Viewport);
+    this.viewportInstance = viewportInstance;
 
     // Id
     this.id = id || this.constructor.displayName || 'view';
-    this.viewportInstance = viewportInstance;
     this.type = type;
-    this.projection = projection;
 
     this.props = Object.assign({}, props, {
+      projectionMatrix,
       fovy,
       near,
-      far
+      far,
+      modelMatrix
     });
 
-    // Parse extent strings
+    // Extents
     this._parseDimensions({x, y, width, height});
 
-    // Bind methods
+    // Bind methods for easy access
     this.equals = this.equals.bind(this);
 
     Object.seal(this);
@@ -91,18 +92,11 @@ export default class View {
     };
   }
 
-  // INTERNAL METHODS
-
   // Overridable method
   _getViewport(props) {
     // Get the type of the viewport
     const {type: ViewportType} = this;
     return new ViewportType(props);
-  }
-
-  _getProjectionMatrix({width, height, distance}) {
-    const props = Object.assign({}, this.props, {width, height, aspect: width / height, distance});
-    return this.projection(props);
   }
 
   // Parse relative viewport dimension descriptors (e.g {y: '50%', height: '50%'})


### PR DESCRIPTION
For #1429
#### Background
- Similar logic to the scripting PR, but now shared inside `Deck` component
#### Change List
- Add handling of existing controllers to `Deck` component

Depends on one or two of the PRs opened today, but isolated to simplify review.
