### PR TITLE
Clean up LayerManager context handling

### DIFF
--- a/src/core/lib/deck.js
+++ b/src/core/lib/deck.js
@@ -36,8 +36,8 @@ function getPropTypes(PropTypes) {
   // Note: Arrays (layers, views, ) can contain falsy values
   return {
     id: PropTypes.string,
-    width: PropTypes.number,
-    height: PropTypes.number,
+    width: PropTypes.number.isRequired,
+    height: PropTypes.number.isRequired,
 
     // layer/view/controller settings
     layers: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
@@ -102,7 +102,6 @@ export default class Deck {
     this._onRenderFrame = this._onRenderFrame.bind(this);
 
     this.canvas = this._createCanvas(props);
-    this._updateCanvas(props);
     this.controller = this._createController(props);
     this.animationLoop = this._createAnimationLoop(props);
 
@@ -130,8 +129,6 @@ export default class Deck {
     this.stats.timeStart('deck.setProps');
     props = Object.assign({}, this.props, props);
     this.props = props;
-
-    this._updateCanvas(props);
 
     this._setLayerManagerProps(props);
 
@@ -179,22 +176,18 @@ export default class Deck {
     }
 
     if (!canvas) {
+      const {id, width, height, style} = props;
       canvas = document.createElement('canvas');
+      canvas.id = id;
+      canvas.width = width;
+      canvas.height = height;
+      Object.assign(canvas.style, style);
+
       const parent = props.parent || document.body;
       parent.appendChild(canvas);
     }
 
     return canvas;
-  }
-
-  _updateCanvas(props) {
-    const {id, width, height, style, controlCanvas} = props;
-    // if (controlCanvas) {
-      this.canvas.id = id;
-      this.canvas.width = width;
-      this.canvas.height = height;
-      Object.assign(this.canvas.style, style);
-    // }
   }
 
   // Note: props.controller must be a class, not an already created instance
@@ -234,6 +227,8 @@ export default class Deck {
     }
 
     const {
+      width,
+      height,
       views,
       viewState,
       layers,
@@ -246,8 +241,9 @@ export default class Deck {
     } = props;
 
     // If more parameters need to be updated on layerManager add them to this method.
-    this.layerManager.setParameters(props);
     this.layerManager.setParameters({
+      width,
+      height,
       views,
       viewState,
       layers,

--- a/src/core/lib/deck.js
+++ b/src/core/lib/deck.js
@@ -36,8 +36,8 @@ function getPropTypes(PropTypes) {
   // Note: Arrays (layers, views, ) can contain falsy values
   return {
     id: PropTypes.string,
-    width: PropTypes.number.isRequired,
-    height: PropTypes.number.isRequired,
+    width: PropTypes.number,
+    height: PropTypes.number,
 
     // layer/view/controller settings
     layers: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
@@ -102,6 +102,7 @@ export default class Deck {
     this._onRenderFrame = this._onRenderFrame.bind(this);
 
     this.canvas = this._createCanvas(props);
+    this._updateCanvas(props);
     this.controller = this._createController(props);
     this.animationLoop = this._createAnimationLoop(props);
 
@@ -129,6 +130,8 @@ export default class Deck {
     this.stats.timeStart('deck.setProps');
     props = Object.assign({}, this.props, props);
     this.props = props;
+
+    this._updateCanvas(props);
 
     this._setLayerManagerProps(props);
 
@@ -176,18 +179,22 @@ export default class Deck {
     }
 
     if (!canvas) {
-      const {id, width, height, style} = props;
       canvas = document.createElement('canvas');
-      canvas.id = id;
-      canvas.width = width;
-      canvas.height = height;
-      Object.assign(canvas.style, style);
-
       const parent = props.parent || document.body;
       parent.appendChild(canvas);
     }
 
     return canvas;
+  }
+
+  _updateCanvas(props) {
+    const {id, width, height, style, controlCanvas} = props;
+    // if (controlCanvas) {
+      this.canvas.id = id;
+      this.canvas.width = width;
+      this.canvas.height = height;
+      Object.assign(this.canvas.style, style);
+    // }
   }
 
   // Note: props.controller must be a class, not an already created instance
@@ -227,8 +234,6 @@ export default class Deck {
     }
 
     const {
-      width,
-      height,
       views,
       viewState,
       layers,
@@ -241,9 +246,8 @@ export default class Deck {
     } = props;
 
     // If more parameters need to be updated on layerManager add them to this method.
+    this.layerManager.setParameters(props);
     this.layerManager.setParameters({
-      width,
-      height,
       views,
       viewState,
       layers,

--- a/src/core/lib/layer-manager.js
+++ b/src/core/lib/layer-manager.js
@@ -49,21 +49,26 @@ const INITIAL_VIEW_STATE = {latitude: 0, longitude: 0, zoom: 1};
 // CONTEXT IS EXPOSED TO LAYERS
 const INITIAL_CONTEXT = Object.seal({
   layerManager: null,
-
   gl: null,
+
+  // Settings
+  useDevicePixels: true, // Exposed in case custom layers need to adjust sizes
+
+  // General resources
+  stats: null, // for tracking lifecycle performance
+  viewport: null, // Current viewport, exposed to layers for project* function
+
+  // GL Resources
   shaderCache: null,
-  stats: null,
+  pickingFBO: null, // Screen-size framebuffer that layers can reuse
 
-  viewport: null, // Exposed to layers for project* function
-  pickingFBO: null, // Big buffer that layers can reuse
-  useDevicePixels: true,
+  // State
+  lastPickedInfo: { // For callback tracking and autohighlight
+    index: -1,
+    layerId: null
+  },
 
-  // lastPickedInfo: {
-  //   index: -1,
-  //   layerId: null
-  // },
-
-  userData: {}
+  userData: {} // Place for any custom app `context`
 });
 
 const layerName = layer => (layer instanceof Layer ? `${layer}` : !layer ? 'null' : 'invalid');

--- a/src/core/lib/layer-manager.js
+++ b/src/core/lib/layer-manager.js
@@ -63,7 +63,8 @@ const INITIAL_CONTEXT = Object.seal({
   pickingFBO: null, // Screen-size framebuffer that layers can reuse
 
   // State
-  lastPickedInfo: { // For callback tracking and autohighlight
+  lastPickedInfo: {
+    // For callback tracking and autohighlight
     index: -1,
     layerId: null
   },
@@ -104,11 +105,12 @@ export default class LayerManager {
     this.viewState = INITIAL_VIEW_STATE;
     this.viewsChanged = true;
     this.viewports = []; // Generated viewports
-    this._needsRedraw = 'Initial render';
-    this._needsUpdate = false;
-
 
     this.layerFilter = null;
+    this.drawPickingColors = false;
+
+    this._needsRedraw = 'Initial render';
+    this._needsUpdate = false;
 
     // Event handling
     this._pickingRadius = 0;
@@ -338,7 +340,7 @@ export default class LayerManager {
 
   // Draw all layers in all views
   drawLayers({pass = 'render to screen', redrawReason = 'unknown reason'} = {}) {
-    const {drawPickingColors} = this.context;
+    const {drawPickingColors} = this;
     const {gl, useDevicePixels} = this.context;
 
     // render this viewport

--- a/src/core/lib/layer-manager.js
+++ b/src/core/lib/layer-manager.js
@@ -243,9 +243,9 @@ export default class LayerManager {
       }
     }
 
-    // A way for apps to add data to context to access in layers
-    if ('context' in parameters) {
-      Object.assign(this.context.userData, parameters.context);
+    // A way for apps to add data to context that can be accessed in layers
+    if ('userData' in parameters) {
+      this.context.userData = parameters.userData;
     }
   }
   /* eslint-enable complexity */
@@ -515,17 +515,12 @@ export default class LayerManager {
       log.log(4, 'Viewport', viewport)();
 
       this.context.viewport = viewport;
-      this.context.viewportChanged = true;
 
       // Update layers states
       // Let screen space layers update their state based on viewport
-      // TODO - reimplement viewport change detection (single viewport optimization)
-      // TODO - don't set viewportChanged during setViews?
-      if (viewportChanged) {
-        for (const layer of this.layers) {
-          layer.setChangeFlags({viewportChanged: 'Viewport changed'});
-          this._updateLayer(layer);
-        }
+      for (const layer of this.layers) {
+        layer.setChangeFlags({viewportChanged: 'Viewport changed'});
+        this._updateLayer(layer);
       }
     }
 

--- a/src/core/lib/layer-manager.js
+++ b/src/core/lib/layer-manager.js
@@ -228,15 +228,15 @@ export default class LayerManager {
     }
 
     if ('layerFilter' in parameters) {
-      if (this.context.layerFilter !== parameters.layerFilter) {
-        this.context.layerFilter = parameters.layerFilter;
+      if (this.layerFilter !== parameters.layerFilter) {
+        this.layerFilter = parameters.layerFilter;
         this.setNeedsRedraw('layerFilter changed');
       }
     }
 
     if ('drawPickingColors' in parameters) {
-      if (parameters.drawPickingColors !== this.context.drawPickingColors) {
-        this.context.drawPickingColors = parameters.drawPickingColors;
+      if (parameters.drawPickingColors !== this.drawPickingColors) {
+        this.drawPickingColors = parameters.drawPickingColors;
         this.setNeedsRedraw('drawPickingColors changed');
       }
     }
@@ -338,7 +338,8 @@ export default class LayerManager {
 
   // Draw all layers in all views
   drawLayers({pass = 'render to screen', redrawReason = 'unknown reason'} = {}) {
-    const {gl, useDevicePixels, drawPickingColors} = this.context;
+    const {drawPickingColors} = this.context;
+    const {gl, useDevicePixels} = this.context;
 
     // render this viewport
     drawLayers(gl, {

--- a/src/core/lib/layer.js
+++ b/src/core/lib/layer.js
@@ -245,13 +245,13 @@ export default class Layer {
   }
 
   // Let's layer control if updateState should be called
-  shouldUpdateState({oldProps, props, oldContext, context, changeFlags}) {
+  shouldUpdateState({oldProps, props, context, changeFlags}) {
     return changeFlags.propsOrDataChanged;
   }
 
   // Default implementation, all attributes will be invalidated and updated
   // when data changes
-  updateState({oldProps, props, oldContext, context, changeFlags}) {
+  updateState({oldProps, props, context, changeFlags}) {
     const attributeManager = this.getAttributeManager();
     if (changeFlags.dataChanged && attributeManager) {
       attributeManager.invalidateAll();
@@ -605,7 +605,6 @@ ${flags.viewportChanged ? 'viewport' : ''}\
       props: this.props,
       oldProps: this.internalState.oldProps || this.props,
       context: this.context,
-      oldContext: this.oldContext || {},
       changeFlags: this.internalState.changeFlags
     };
   }


### PR DESCRIPTION
For #1421 
#### Background
- Our messy internal context handling interfered with the auto size feature.
#### Change List
- Copy only props that are actually wanted to the context object.
- Remove `oldContext`
- Remove unused props from
