### PR TITLE
Orthographic support in WebMercatorViewport

### DIFF
--- a/docs/advanced/views.md
+++ b/docs/advanced/views.md
@@ -63,7 +63,12 @@ deck.gl offers a set of `View` classes that lets you specify how deck.gl should 
 
 ## Choosing a Projection Mode
 
-The `View` class allows the application full control of what projection to use through the `projection` prop. It is designed to accept a function that can directly call matrix creation methods from math libraries like math.gl or gl-matrix. Examples of functions that can be used are:
+The `View` class allows the application full control of what projection to use through the `projection` prop, which expects a function that can transform view properties into a projection matrix:
+
+* The `projection` function will be called with the `View`s props, merged with `width`, `height`, `aspect` and `distance`.
+* The `projection` function must return a 4x4 matrix (a 16 element array in column-major order).
+
+Applications would typically use matrix creation methods from math libraries like [math.gl](https://uber-web.github.io/math.gl/#/documentation/overview) or [gl-matrix](http://glmatrix.net/). Examples of math.gl functions that can be used are:
 
 | Projection                      | Needs View Parameters | Description    |
 | ---                             | ---                   | ---            |
@@ -71,9 +76,9 @@ The `View` class allows the application full control of what projection to use t
 | `Matrix4.orthographic`          | `fovy`, `near`, `far` | An orthographic projection based on same parameters as `perspective`. Uses `distance` in the view state. |
 | `Matrix4.ortho`                 | `top`, `bottom`, `left`, `rignt`, `near`, `far` | Traditional, explicit ortographic projection parameters. Needs the additional parameters to be specified on the `View`. |
 
-While the projections suggested in the table leverage stock methods in the math.gl library, custom projection functions can be provided. The `View.projection` prop accepts any function that returns a 4x4 projection matrix. The function will be called with the `View`s props, merged with `width`, `height`, `aspect` and `distance`.
+While the projections suggested in the table leverage stock methods in the math.gl library, custom projection matrices can be returned.
 
-A perspective / orthographic mode switch could be implemented as follows:
+As an example, a perspective / orthographic mode switch could be implemented as follows:
 
 ```js
 import {View} from 'deck.gl';

--- a/modules/core/src/core/viewports/viewport.js
+++ b/modules/core/src/core/viewports/viewport.js
@@ -379,10 +379,10 @@ export default class Viewport {
       near = 0.1, // Distance of near clipping plane
       far = 1000, // Distance of far clipping plane
       focalDistance = 1, // Only needed for orthographic views
-      orthographicFocalDistance,
+      orthographicFocalDistance
     } = opts;
 
-    const radians = fovyRadians || ((fovyDegrees || fovy) * DEGREES_TO_RADIANS);
+    const radians = fovyRadians || (fovyDegrees || fovy) * DEGREES_TO_RADIANS;
 
     this.projectionMatrix =
       projectionMatrix ||
@@ -443,7 +443,6 @@ export default class Viewport {
       // throw new Error('Pixel project matrix not invertible');
     }
   }
-
 }
 
 Viewport.displayName = 'Viewport';

--- a/modules/core/src/core/viewports/viewport.js
+++ b/modules/core/src/core/viewports/viewport.js
@@ -374,19 +374,23 @@ export default class Viewport {
       // Projection matrix parameters, used if projectionMatrix not supplied
       orthographic = false,
       fovyRadians = 75 * DEGREES_TO_RADIANS,
+      fovyDegrees,
       fovy,
       near = 0.1, // Distance of near clipping plane
       far = 1000, // Distance of far clipping plane
-      focalDistance = 1 // Only needed for orthographic views
+      focalDistance = 1, // Only needed for orthographic views
+      orthographicFocalDistance,
     } = opts;
+
+    const radians = fovyRadians || ((fovyDegrees || fovy) * DEGREES_TO_RADIANS);
 
     this.projectionMatrix =
       projectionMatrix ||
       this._createProjectionMatrix({
         orthographic,
-        fovyRadians: fovyRadians || fovy * DEGREES_TO_RADIANS,
+        fovyRadians: radians,
         aspect: this.width / this.height,
-        focalDistance,
+        focalDistance: orthographicFocalDistance || focalDistance,
         near,
         far
       });
@@ -439,6 +443,7 @@ export default class Viewport {
       // throw new Error('Pixel project matrix not invertible');
     }
   }
+
 }
 
 Viewport.displayName = 'Viewport';

--- a/modules/core/src/core/viewports/viewport.js
+++ b/modules/core/src/core/viewports/viewport.js
@@ -373,7 +373,7 @@ export default class Viewport {
 
       // Projection matrix parameters, used if projectionMatrix not supplied
       orthographic = false,
-      fovyRadians = 75 * DEGREES_TO_RADIANS,
+      fovyRadians,
       fovyDegrees,
       fovy,
       near = 0.1, // Distance of near clipping plane
@@ -382,7 +382,7 @@ export default class Viewport {
       orthographicFocalDistance
     } = opts;
 
-    const radians = fovyRadians || (fovyDegrees || fovy) * DEGREES_TO_RADIANS;
+    const radians = fovyRadians || (fovyDegrees || fovy || 75) * DEGREES_TO_RADIANS;
 
     this.projectionMatrix =
       projectionMatrix ||

--- a/modules/core/src/core/viewports/web-mercator-viewport.js
+++ b/modules/core/src/core/viewports/web-mercator-viewport.js
@@ -107,7 +107,8 @@ export default class WebMercatorViewport extends Viewport {
       orthographic,
       fovyRadians: fov,
       aspect,
-      focalDistance, // TODO Viewport is already carefully set up to "focus" on ground
+      // TODO Viewport is already carefully set up to "focus" on ground, so can't use focal distance
+      orthographicFocalDistance: focalDistance,
       near,
       far
     });


### PR DESCRIPTION
Not yet passing render tests

#### Background
For #1507 

#### Change List
- Add `orthographic` projection flag and `orthographicFocalDistance` option to `Viewport`
- Add `orthographic` projection flag and `orthographicFocalDistance` option to `WebMercatorViewport`
- Update docs

### History
- Landed in 5.2 but reverted due to render test issue.

