### PR TITLE
Bump examples to 5.2 alpha versions

### DIFF
--- a/examples/3d-heatmap/package.json
+++ b/examples/3d-heatmap/package.json
@@ -5,8 +5,8 @@
   },
   "dependencies": {
     "d3-request": "^1.0.5",
-    "deck.gl": "^5.2.0",
-    "luma.gl": "^5.2.0",
+    "deck.gl": ">=5.2.0-alpha.7",
+    "luma.gl": ">=5.2.0-alpha.11",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-map-gl": "^3.2.0"

--- a/examples/arc/package.json
+++ b/examples/arc/package.json
@@ -6,8 +6,8 @@
   "dependencies": {
     "d3-request": "^1.0.5",
     "d3-scale": "^1.0.5",
-    "deck.gl": "^5.2.0",
-    "luma.gl": "^5.2.0",
+    "deck.gl": ">=5.2.0-alpha.7",
+    "luma.gl": ">=5.2.0-alpha.11",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-map-gl": "^3.2.0"

--- a/examples/bezier/package.json
+++ b/examples/bezier/package.json
@@ -6,9 +6,9 @@
   "dependencies": {
     "d3-request": "^1.0.5",
     "d3-scale": "^1.0.5",
-    "deck.gl": "^5.2.0",
+    "deck.gl": ">=5.2.0-alpha.7",
     "deck.gl-layers": "0.1.0-beta.2",
-    "luma.gl": "^5.2.0",
+    "luma.gl": ">=5.2.0-alpha.11",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-map-gl": "^3.2.0"

--- a/examples/brushing/package.json
+++ b/examples/brushing/package.json
@@ -6,8 +6,8 @@
   "dependencies": {
     "d3-request": "^1.0.5",
     "d3-scale": "^1.0.5",
-    "deck.gl": "^5.2.0",
-    "luma.gl": "^5.2.0",
+    "deck.gl": ">=5.2.0-alpha.7",
+    "luma.gl": ">=5.2.0-alpha.11",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-map-gl": "^3.2.0"

--- a/examples/experimental/js/with-mapbox-map/package.json
+++ b/examples/experimental/js/with-mapbox-map/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "d3-request": "^1.0.5",
-    "deck.gl": "^5.2.0",
+    "deck.gl": ">=5.2.0-alpha.7",
     "mapbox-gl": "0.38.0",
     "stats.js": "^0.17.0"
   },

--- a/examples/experimental/multi-viewport/package.json
+++ b/examples/experimental/multi-viewport/package.json
@@ -5,8 +5,8 @@
     "start-es6": "webpack-dev-server --env.es6 --progress --hot --open"
   },
   "dependencies": {
-    "deck.gl": "^5.2.0",
-    "luma.gl": "^5.2.0",
+    "deck.gl": ">=5.2.0-alpha.7",
+    "luma.gl": ">=5.2.0-alpha.11",
     "math.gl": "^1.0.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",

--- a/examples/experimental/orthographic-zooming/package.json
+++ b/examples/experimental/orthographic-zooming/package.json
@@ -4,8 +4,8 @@
     "start-local": "webpack-dev-server --env.local --progress --hot --open"
   },
   "dependencies": {
-    "deck.gl": "^5.2.0",
-    "luma.gl": "^5.2.0",
+    "deck.gl": ">=5.2.0-alpha.7",
+    "luma.gl": ">=5.2.0-alpha.11",
     "react": "^16.2.0",
     "react-dom": "^16.2.0"
   },

--- a/examples/experimental/viewport-transitions-flyTo/package.json
+++ b/examples/experimental/viewport-transitions-flyTo/package.json
@@ -4,7 +4,7 @@
     "start-local": "webpack-dev-server --env.local --progress --hot --open"
   },
   "dependencies": {
-    "deck.gl": "^5.2.0",
+    "deck.gl": ">=5.2.0-alpha.7",
     "immutable": "^3.8.1",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",

--- a/examples/experimental/viewport-transitions/package.json
+++ b/examples/experimental/viewport-transitions/package.json
@@ -5,8 +5,8 @@
   },
   "dependencies": {
     "d3-request": "^1.0.5",
-    "deck.gl": "^5.2.0",
-    "luma.gl": "^5.2.0",
+    "deck.gl": ">=5.2.0-alpha.7",
+    "luma.gl": ">=5.2.0-alpha.11",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-map-gl": "^3.2.0"

--- a/examples/geojson/package.json
+++ b/examples/geojson/package.json
@@ -5,8 +5,8 @@
   },
   "dependencies": {
     "d3-request": "^1.0.5",
-    "deck.gl": "^5.2.0",
-    "luma.gl": "^5.2.0",
+    "deck.gl": ">=5.2.0-alpha.7",
+    "luma.gl": ">=5.2.0-alpha.11",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-map-gl": "^3.2.0"

--- a/examples/graph/package.json
+++ b/examples/graph/package.json
@@ -12,8 +12,8 @@
     "d3-force": "^1.0.6",
     "d3-request": "^1.0.5",
     "d3-scale": "^1.0.5",
-    "deck.gl": "^5.2.0",
-    "luma.gl": "^5.2.0",
+    "deck.gl": ">=5.2.0-alpha.7",
+    "luma.gl": ">=5.2.0-alpha.11",
     "react": "^16.2.0",
     "react-dom": "^16.2.0"
   },

--- a/examples/icon/package.json
+++ b/examples/icon/package.json
@@ -5,8 +5,8 @@
   },
   "dependencies": {
     "d3-request": "^1.0.5",
-    "deck.gl": "^5.2.0",
-    "luma.gl": "^5.2.0",
+    "deck.gl": ">=5.2.0-alpha.7",
+    "luma.gl": ">=5.2.0-alpha.11",
     "rbush": "^2.0.1",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",

--- a/examples/line/package.json
+++ b/examples/line/package.json
@@ -5,8 +5,8 @@
   },
   "dependencies": {
     "d3-request": "^1.0.5",
-    "deck.gl": "^5.2.0",
-    "luma.gl": "^5.2.0",
+    "deck.gl": ">=5.2.0-alpha.7",
+    "luma.gl": ">=5.2.0-alpha.11",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-map-gl": "^3.2.0"

--- a/examples/plot/package.json
+++ b/examples/plot/package.json
@@ -6,8 +6,8 @@
   },
   "dependencies": {
     "d3-scale": "^1.0.6",
-    "deck.gl": "^5.2.0",
-    "luma.gl": "^5.2.0",
+    "deck.gl": ">=5.2.0-alpha.7",
+    "luma.gl": ">=5.2.0-alpha.11",
     "react": "^16.2.0",
     "react-dom": "^16.2.0"
   },

--- a/examples/point-cloud-laz/package.json
+++ b/examples/point-cloud-laz/package.json
@@ -11,7 +11,7 @@
     "build": "npm run build-clean && npm run build-script && npm run build-copy"
   },
   "dependencies": {
-    "deck.gl": "^5.2.0",
+    "deck.gl": ">=5.2.0-alpha.7",
     "gl-matrix": "^2.3.2",
     "is-little-endian": "0.0.0",
     "react": "^16.2.0",

--- a/examples/point-cloud-ply/package.json
+++ b/examples/point-cloud-ply/package.json
@@ -11,7 +11,7 @@
     "build": "npm run build-clean && npm run build-script && npm run build-copy"
   },
   "dependencies": {
-    "deck.gl": "^5.2.0",
+    "deck.gl": ">=5.2.0-alpha.7",
     "gl-matrix": "^2.3.2",
     "is-little-endian": "0.0.0",
     "react": "^16.2.0",

--- a/examples/scatterplot/package.json
+++ b/examples/scatterplot/package.json
@@ -5,8 +5,8 @@
   },
   "dependencies": {
     "d3-request": "^1.0.5",
-    "deck.gl": "^5.2.0",
-    "luma.gl": "^5.2.0",
+    "deck.gl": ">=5.2.0-alpha.7",
+    "luma.gl": ">=5.2.0-alpha.11",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-map-gl": "^3.2.0"

--- a/examples/screen-grid/package.json
+++ b/examples/screen-grid/package.json
@@ -5,8 +5,8 @@
   },
   "dependencies": {
     "d3-request": "^1.0.5",
-    "deck.gl": "^5.2.0",
-    "luma.gl": "^5.2.0",
+    "deck.gl": ">=5.2.0-alpha.7",
+    "luma.gl": ">=5.2.0-alpha.11",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-map-gl": "^3.2.0"

--- a/examples/svg-interoperability/package.json
+++ b/examples/svg-interoperability/package.json
@@ -11,8 +11,8 @@
     "build": "npm run build-clean && npm run build-script && npm run build-copy"
   },
   "dependencies": {
-    "deck.gl": "^5.2.0",
-    "luma.gl": "^5.2.0",
+    "deck.gl": ">=5.2.0-alpha.7",
+    "luma.gl": ">=5.2.0-alpha.11",
     "react": "^16.2.0",
     "react-dom": "^16.2.0"
   },

--- a/examples/test-utils/package.json
+++ b/examples/test-utils/package.json
@@ -5,8 +5,8 @@
   },
   "dependencies": {
     "d3-request": "^1.0.5",
-    "deck.gl": "^5.2.0",
-    "luma.gl": "^5.2.0",
+    "deck.gl": ">=5.2.0-alpha.7",
+    "luma.gl": ">=5.2.0-alpha.11",
     "react": "^16.2.0",
     "react-dom": "^16.2.0"
   },

--- a/examples/test/tree-shaking/package.json
+++ b/examples/test/tree-shaking/package.json
@@ -6,8 +6,8 @@
   },
   "dependencies": {
     "babel-polyfill": "^6.16.0",
-    "deck.gl": "^5.2.0",
-    "luma.gl": "^5.2.0",
+    "deck.gl": ">=5.2.0-alpha.7",
+    "luma.gl": ">=5.2.0-alpha.11",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-map-gl": "^3.2.0"

--- a/examples/text-layer/package.json
+++ b/examples/text-layer/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "d3-request": "^1.0.5",
-    "deck.gl": "^5.2.0",
+    "deck.gl": ">=5.2.0-alpha.7",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-map-gl": "^3.2.0"

--- a/examples/trips/package.json
+++ b/examples/trips/package.json
@@ -5,8 +5,8 @@
   },
   "dependencies": {
     "d3-request": "^1.0.5",
-    "deck.gl": "^5.2.0",
-    "luma.gl": "^5.2.0",
+    "deck.gl": ">=5.2.0-alpha.7",
+    "luma.gl": ">=5.2.0-alpha.11",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-map-gl": "^3.2.0"

--- a/examples/wip/attribute-transition/package.json
+++ b/examples/wip/attribute-transition/package.json
@@ -5,8 +5,8 @@
   },
   "dependencies": {
     "d3-ease": "^1.0.3",
-    "deck.gl": "^5.2.0",
-    "luma.gl": "^5.2.0",
+    "deck.gl": ">=5.2.0-alpha.7",
+    "luma.gl": ">=5.2.0-alpha.11",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-map-gl": "^3.2.0"

--- a/examples/without-map/package.json
+++ b/examples/without-map/package.json
@@ -4,8 +4,8 @@
     "start-local": "webpack-dev-server --env.local --progress --hot --open"
   },
   "dependencies": {
-    "deck.gl": "^5.2.0",
-    "luma.gl": "^5.2.0",
+    "deck.gl": ">=5.2.0-alpha.7",
+    "luma.gl": ">=5.2.0-alpha.11",
     "react": "^16.2.0",
     "react-dom": "^16.2.0"
   },


### PR DESCRIPTION
#### Background
- Previous commit went a little bit too far, breaking ability to install in examples, which breaks `test-examples` script, and interferes which example cleanup work.
#### Change List
- example package.json updates to 5.2 alpha versions
