### PR TITLE
fix(docs): wdith to width typo

### DIFF
--- a/docs/layers/arc-layer.md
+++ b/docs/layers/arc-layer.md
@@ -24,7 +24,7 @@ const App = ({data, viewport}) => {
   const layer = new ArcLayer({
     id: 'arc-layer',
     data,
-    strokeWdith: 2
+    strokeWidth: 2
   });
 
   return (<DeckGL {...viewport} layers={[layer]} />);

--- a/docs/layers/line-layer.md
+++ b/docs/layers/line-layer.md
@@ -24,7 +24,7 @@ const App = ({data, viewport}) => {
   const layer = new LineLayer({
     id: 'line-layer',
     data,
-    strokeWdith: 2
+    strokeWidth: 2
   });
 
   return (<DeckGL {...viewport} layers={[layer]} />);


### PR DESCRIPTION
#### For `docs/layers<arc/line>-layer`
<!-- For other PRs without open issue -->

#### Background
- Typo on strokeWidth
