### PR TITLE
Auto Controls: Automatic Event Handling if no callback is specified

### DIFF
--- a/docs/api-reference/deck.md
+++ b/docs/api-reference/deck.md
@@ -71,6 +71,17 @@ A geospatial `viewState` would typically contain the following fields:
 * `pitch` (Number, optional) - Current pitch - used to define a mercator projection if `viewport` is not supplied.
 
 
+#### `initialViewState` (Object)
+
+If `initialViewState` is provided, the `Deck` component will track view state changes from any attached `controller` using internal state, with `initialViewState` as its initial view state.
+
+Notes:
+* The `props.onViewStateChange` callback will still be called, if provided.
+* If `props.viewState` is supplied by the application, the supplied `viewState` will always be used, "shadowing" the `Deck` component's internal `viewState`.
+* In simple applications, use of the `initialViewState` prop can avoid the need track the view state in the application .
+* One drawback of using `initialViewState` for reactive/functional applications is that the `Deck` component becomes more stateful.
+
+
 ### Configuration Properties
 
 ##### `id` (String, optional)

--- a/docs/api-reference/deck.md
+++ b/docs/api-reference/deck.md
@@ -135,6 +135,18 @@ Callback arguments:
 
 * `gl` - the WebGL context.
 
+##### `onViewStateChange` (Function)
+
+The `onViewStateChange` callback is fired when the user has interacted with the deck.gl canvas, e.g. using mouse, touch or keyboard.
+
+`onViewStateChanged({viewState})`
+
+* `viewState` - An updated [view state](/docs/advanced/view-state.md) object containing parameters such as `longitude`, `latitude`, `zoom` etc.
+
+Returns:
+
+* The application can return an updated view state. If a view state is returned, it will be used instead of the passed in `viewState` to update the application's internal view state (see `initialViewState`).
+
 ##### `onLayerHover` (Function, optional)
 
 Callback - called when the object under the pointer changes.

--- a/examples/get-started/react-without-map/app.js
+++ b/examples/get-started/react-without-map/app.js
@@ -8,19 +8,18 @@ import DeckGL, {GeoJsonLayer, MapController} from 'deck.gl';
 const GEOJSON =
   'https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_110m_admin_1_states_provinces_shp.geojson'; //eslint-disable-line
 
+const INITIAL_VIEW_STATE = {
+  latitude: 40,
+  longitude: -100,
+  zoom: 3,
+  bearing: 0,
+  pitch: 60
+};
+
 class Root extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      viewport: {
-        latitude: 40,
-        longitude: -100,
-        zoom: 3,
-        bearing: 0,
-        pitch: 60,
-        width: 0,
-        height: 0
-      },
       data: null
     };
 
@@ -30,15 +29,14 @@ class Root extends Component {
   }
 
   render() {
-    const {viewport, data} = this.state;
+    const {data} = this.state;
 
     return (
       <DeckGL
         width="100%"
         height="100%"
         controller={MapController}
-        viewState={viewport}
-        onViewportChange={v => this.setState({viewport: v})}
+        initialViewState={INITIAL_VIEW_STATE}
         layers={[
           new GeoJsonLayer({
             data,

--- a/modules/core/src/core/lib/deck.js
+++ b/modules/core/src/core/lib/deck.js
@@ -161,7 +161,11 @@ export default class Deck {
 
     // Update controller props
     if (this.controller) {
-      this.controller.setProps(newProps);
+      this.controller.setProps(
+        Object.assign(newProps, {
+          onViewStateChange: this._onViewStateChange
+        })
+      );
     }
     this.stats.timeEnd('deck.setProps');
   }
@@ -324,19 +328,16 @@ export default class Deck {
   // Callbacks
 
   _onViewStateChange({viewState}, ...args) {
+    // Let app know that view state is changing, and give it a chance to change it
+    if (this.props.onViewStateChange) {
+      viewState = this.props.onViewStateChange({viewState}, ...args) || viewState;
+    }
+
     // If initialViewState was set on creation, auto track position
     if (this.viewState) {
       this.viewState = viewState;
       this.layerManager.setParameters({viewState});
       this.controller.setProps({viewState});
-    }
-    // Let app know that view state has changed
-    if (this.props.onViewStateChange) {
-      this.props.onViewStateChange({viewState}, ...args);
-    }
-    // "HACK": Calling onResize to inform React component that it needs to update
-    if (this.props.onResize) {
-      this.props.onResize({width: this.width, height: this.height});
     }
   }
 

--- a/modules/core/src/core/lib/deck.js
+++ b/modules/core/src/core/lib/deck.js
@@ -45,6 +45,7 @@ function getPropTypes(PropTypes) {
     views: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
     viewState: PropTypes.object,
     controller: PropTypes.func,
+    onViewStateChange: PropTypes.func,
     effects: PropTypes.arrayOf(PropTypes.instanceOf(Effect)),
 
     // GL settings
@@ -103,10 +104,14 @@ export default class Deck {
     this.controller = null;
     this.stats = new Stats({id: 'deck.gl'});
 
+    this.viewState = props.initialViewState || null; // Internal view state if no callback is supplied
+
     // Bind methods
     this._onRendererInitialized = this._onRendererInitialized.bind(this);
     this._onRenderFrame = this._onRenderFrame.bind(this);
+    this._onViewStateChange = this._onViewStateChange.bind(this);
 
+    // Note: LayerManager creation deferred until gl context available
     this.canvas = this._createCanvas(props);
     this.controller = this._createController(props);
     this.animationLoop = this._createAnimationLoop(props);
@@ -139,7 +144,7 @@ export default class Deck {
     // Update CSS size of canvas
     this._setCanvasSize(props);
 
-    // We need to overwrite width and height with actual, numeric values
+    // We need to overwrite CSS style width and height with actual, numeric values
     const newProps = Object.assign({}, props, {
       viewState: this._getViewState(props),
       width: this.width,
@@ -239,6 +244,8 @@ export default class Deck {
     }
     if (height || height === 0) {
       height = Number.isFinite(height) ? `${height}px` : height;
+      // Note: position==='absolute' required for height 100% to work
+      canvas.style.position = 'absolute';
       canvas.style.height = height;
     }
   }
@@ -277,8 +284,11 @@ export default class Deck {
     const Controller = props.controller;
     if (Controller) {
       return new Controller(
-        Object.assign({}, this._getViewState(props), props, {
-          canvas: this.canvas
+        Object.assign({}, props, {
+          canvas: this.canvas,
+          viewState: this._getViewState(props),
+          // Set an internal callback that calls the prop callback if provided
+          onViewStateChange: this._onViewStateChange
         })
       );
     }
@@ -302,14 +312,33 @@ export default class Deck {
     });
   }
 
+  // Get the most relevant view state: props.viewState, if supplied, shadows internal viewState
+  // TODO: For backwards compatibility ensure numeric width and height is added to the viewState
   _getViewState(props) {
-    return Object.assign({}, props.viewState || {}, {
+    return Object.assign({}, props.viewState || this.viewState || {}, {
       width: this.width,
       height: this.height
     });
   }
 
   // Callbacks
+
+  _onViewStateChange({viewState}, ...args) {
+    // If initialViewState was set on creation, auto track position
+    if (this.viewState) {
+      this.viewState = viewState;
+      this.layerManager.setParameters({viewState});
+      this.controller.setProps({viewState});
+    }
+    // Let app know that view state has changed
+    if (this.props.onViewStateChange) {
+      this.props.onViewStateChange({viewState}, ...args);
+    }
+    // "HACK": Calling onResize to inform React component that it needs to update
+    if (this.props.onResize) {
+      this.props.onResize({width: this.width, height: this.height});
+    }
+  }
 
   _onRendererInitialized({gl, canvas}) {
     setParameters(gl, {

--- a/modules/react/src/deckgl.js
+++ b/modules/react/src/deckgl.js
@@ -46,7 +46,8 @@ export default class DeckGL extends React.Component {
         canvas: this.deckCanvas,
         viewState: this._getViewState(this.props),
         // Note: If Deck event handling change size or view state, it calls onResize to update
-        onResize: size => this.forceUpdate()
+        onViewStateChange: this._onViewStateChange,
+        onResize: this._onResize
       })
     );
     this._updateFromProps(this.props);
@@ -82,6 +83,24 @@ export default class DeckGL extends React.Component {
   queryVisibleObjects(opts) {
     log.deprecated('queryVisibleObjects', 'pickObjects')();
     return this.pickObjects(opts);
+  }
+
+  // Callbacks
+
+  // Forward callback and then call forceUpdate to guarantee that sub components update
+  _onResize(...args) {
+    if (this.props.onResize) {
+      this.props.onResize(...args);
+    }
+    this.forceUpdate();
+  }
+
+  // Forward callback and then call forceUpdate to guarantee that sub components update
+  _onViewStateChange(...args) {
+    if (this.props.onViewStateChange) {
+      this.props.onViewStateChange(...args);
+    }
+    this.forceUpdate();
   }
 
   // Private Helpers

--- a/modules/react/src/deckgl.js
+++ b/modules/react/src/deckgl.js
@@ -45,7 +45,7 @@ export default class DeckGL extends React.Component {
       Object.assign({}, this.props, {
         canvas: this.deckCanvas,
         viewState: this._getViewState(this.props),
-        // Note: If Deck event handling changes size, it calls onResize to update
+        // Note: If Deck event handling change size or view state, it calls onResize to update
         onResize: size => this.forceUpdate()
       })
     );


### PR DESCRIPTION
My last feature PR for 5.2

For #1661
#### Background
- Most small examples don't need event handling, we can get rid of a callback that clutters the code.
#### Change List
- Fixes to controller classes
- Support for default viewState and initialViewState.
