### PR TITLE
Fix website dependencies

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "start": "webpack-dev-server --env.local --progress --content-base ./src/static --open",
     "build-clean": "rm -rf ./dist && mkdir dist",
-    "build-static": "cp -r ./src/static/* dist && babel ./src/static/workers --out-dir dist/workers && cd `git rev-parse --show-toplevel` && git checkout origin/blog -- blog && mv blog website/dist/ && cd -",
+    "build-static": "cp -r ./src/static/* dist && babel ./src/static/workers --out-dir dist/workers",
     "build-script": "webpack -p --env.prod",
     "build": "node scripts/validate-token.js && npm run build-clean && npm run build-static && npm run build-script",
     "lint": "eslint src --ignore-pattern workers"
@@ -36,7 +36,8 @@
     "redux": "^3.6.0",
     "redux-actions": "^1.2.0",
     "redux-thunk": "^2.1.0",
-    "stats.js": "^0.17.0"
+    "stats.js": "^0.17.0",
+    "tagmap.js": "^1.1.1"
   },
   "devDependencies": {
     "autoprefixer-loader": "^3.2.0",

--- a/website/webpack.config.js
+++ b/website/webpack.config.js
@@ -46,17 +46,14 @@ const COMMON_CONFIG = {
   },
 
   resolve: {
+    // Prefer root dependencies (dev) over local (prod)
+    modules: [resolve('../node_modules'), resolve('./node_modules')],
     alias: {
-      // For importing modules that are not exported at root
-      'deck.gl': resolve('.', '../node_modules/deck.gl'),
-      'luma.gl': resolve('.', '../node_modules/luma.gl'),
+      // Website is using React 15
       react: resolve('.', './node_modules/react'),
-      // // used by Mapbox
-      // webworkify: 'webworkify-webpack-dropin',
+      'react-dom': resolve('.', './node_modules/react-dom'),
       // From mapbox-gl-js README. Required for non-browserify bundlers (e.g. webpack):
-      'mapbox-gl$': resolve('./node_modules/mapbox-gl/dist/mapbox-gl.js'),
-      'd3-scale': resolve('.', './node_modules/d3-scale'),
-      rbush: resolve('.', './node_modules/rbush')
+      'mapbox-gl$': resolve('./node_modules/mapbox-gl/dist/mapbox-gl.js')
     }
   },
 


### PR DESCRIPTION
#### Background
Fix website build broken by the text layer example

#### Change List
- Add tagmap.js as dependency
- Remove unused build script that copies blog post from branch
- Clean up webpack aliases
