### PR TITLE
ignore standalone module for now

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,6 +4,7 @@
   "commands": {
     "publish": {
       "ignore": [
+        "@deck.gl/lite",
         "test",
         "*.md"
       ]

--- a/modules/lite/package.json
+++ b/modules/lite/package.json
@@ -3,6 +3,7 @@
   "description": "Scripting with deck.gl",
   "license": "MIT",
   "version": "5.2.0-alpha.1",
+  "private": "true",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/1625

#### Background
Disable publishing of the standalone submodule

#### Change List
- Add to lerna's `publish.ignore`
- Add `private` field to submodule package.json
