### PR TITLE
Support non-monospace fonts in TextLayer

### DIFF
--- a/examples/layer-browser/src/examples/core-layers.js
+++ b/examples/layer-browser/src/examples/core-layers.js
@@ -291,7 +291,7 @@ const TextLayerExample = {
     fontFamily: {
       name: 'fontFamily',
       type: 'category',
-      value: ['Monaco', 'Helvetica', 'monospace', 'Courier', 'Courier New']
+      value: ['Monaco', 'Helvetica', 'Garamond', 'Palatino', 'Courier', 'Courier New']
     }
   },
   props: {

--- a/modules/core/src/core-layers/text-layer/multi-icon-layer/multi-icon-layer-vertex.glsl.js
+++ b/modules/core/src/core-layers/text-layer/multi-icon-layer/multi-icon-layer-vertex.glsl.js
@@ -34,8 +34,6 @@ attribute float instanceColorModes;
 attribute vec2 instanceOffsets;
 
 // the following three attributes are for the multi-icon layer
-attribute float instanceIndexOfIcon;
-attribute float instanceNumOfIcon;
 attribute vec2 instancePixelOffset;
 
 uniform float sizeScale;
@@ -53,21 +51,13 @@ vec2 rotate_by_angle(vec2 vertex, float angle) {
   return rotationMatrix * vertex;
 }
 
-vec2 getShift(float instanceIndexOfIcon, float instanceNumOfIcon) {
-  // calculate the middle index of the string
-  float midIndex = (instanceNumOfIcon - 1.0) / 2.0;
-  // calculate horizontal shift of each letter
-  return vec2(instanceIndexOfIcon - midIndex, 0.0);
-}
-
 void main(void) {
   vec2 iconSize = instanceIconFrames.zw;
   // scale icon height to match instanceSize
   float instanceScale = iconSize.y == 0.0 ? 0.0 : instanceSizes / iconSize.y;
 
   // scale and rotate vertex in "pixel" value and convert back to fraction in clipspace
-  vec2 shift = getShift(instanceIndexOfIcon, instanceNumOfIcon);
-  vec2 pixelOffset = (positions / 2.0 + shift) * iconSize + instanceOffsets;
+  vec2 pixelOffset = positions / 2.0 * iconSize + instanceOffsets;
 
   pixelOffset = rotate_by_angle(pixelOffset, instanceAngles) * sizeScale * instanceScale;
   pixelOffset += instancePixelOffset;


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/1679

Before & After:
![text-layer-font](https://user-images.githubusercontent.com/2059298/38526858-cab0852c-3c0c-11e8-85e4-edb5c512c82f.jpg)

#### Change List
- Support non-monospace fonts in TextLayer
- Fix minor updateTrigger issues
