### PR TITLE
Fixes: disable babel-minify, check if stats object is provided

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,10 +10,7 @@
     },
     "esm": {
       "presets": [
-        ["@babel/es2015", {modules: false}],
-        [ "minify", {
-          "mangle": false
-        }]
+        ["@babel/es2015", {modules: false}]
       ]
     },
     "es6": {
@@ -28,9 +25,6 @@
             "node": "8"
           },
           "modules": false
-        }],
-        [ "minify", {
-          "mangle": false
         }]
       ]
     },

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -40,6 +40,6 @@
     "mjolnir.js": "^1.0.0",
     "probe.gl": "^1.0.0",
     "seer": "^0.2.4",
-    "viewport-mercator-project": "^5.2.0"
+    "viewport-mercator-project": "^5.1.0"
   }
 }

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -35,11 +35,11 @@
     "d3-hexbin": "^0.2.1",
     "earcut": "^2.0.6",
     "lodash.flattendeep": "^4.4.0",
-    "luma.gl": ">=5.2.0-beta.1",
+    "luma.gl": ">=5.2.0-beta.2",
     "math.gl": "^1.1.0",
     "mjolnir.js": "^1.0.0",
     "probe.gl": "^1.0.0",
     "seer": "^0.2.4",
-    "viewport-mercator-project": "^5.1.0"
+    "viewport-mercator-project": "^5.2.0"
   }
 }

--- a/modules/core/src/core/lib/draw-layers.js
+++ b/modules/core/src/core/lib/draw-layers.js
@@ -284,7 +284,9 @@ ${visibleCount} (of ${totalCount} layers) to ${pass} because ${redrawReason} `;
 
     log.log(LOG_PRIORITY_DRAW, message)();
 
-    stats.increment('redraw layers', visibleCount);
+    if (stats) {
+      stats.increment('redraw layers', visibleCount);
+    }
   }
 }
 


### PR DESCRIPTION
#### Background
- Fix two issues found during app integration
#### Change List
- disable `babel-minify`, since it disrupts source-maps
- check if `stats` object is provided before calling it
