### PR TITLE
Upgrade point cloud LAZ to webpack 4

### DIFF
--- a/examples/website/point-cloud-laz/package.json
+++ b/examples/website/point-cloud-laz/package.json
@@ -12,8 +12,6 @@
   },
   "dependencies": {
     "deck.gl": ">=5.2.0-alpha.7",
-    "gl-matrix": "^2.3.2",
-    "is-little-endian": "0.0.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0"
   },

--- a/examples/website/point-cloud-laz/package.json
+++ b/examples/website/point-cloud-laz/package.json
@@ -18,8 +18,10 @@
     "react-dom": "^16.2.0"
   },
   "devDependencies": {
-    "buble-loader": "^0.4.1",
-    "webpack": "^2.6.1",
-    "webpack-dev-server": "^2.4.5"
+    "buble": "^0.19.3",
+    "buble-loader": "^0.5.0",
+    "webpack": "^4.3.0",
+    "webpack-cli": "^2.0.13",
+    "webpack-dev-server": "^3.1.1"
   }
 }

--- a/examples/website/point-cloud-laz/webpack.config.js
+++ b/examples/website/point-cloud-laz/webpack.config.js
@@ -1,7 +1,7 @@
 const {resolve} = require('path');
-const webpack = require('webpack');
 
 const CONFIG = {
+  mode: 'production',
   entry: {
     app: resolve('./app.js')
   },
@@ -22,8 +22,7 @@ const CONFIG = {
         }
       }
     ]
-  },
-  plugins: [new webpack.HotModuleReplacementPlugin()]
+  }
 };
 
 // This line enables bundling against src in this repo rather than installed deck.gl module


### PR DESCRIPTION
#### Background
Webpack 4's UglifyJS can handle ES6, plus better tree-shaking / minification.
#### Change List
- webpack config/package.json
