### PR TITLE
More website link fixes

### DIFF
--- a/docs/advanced/controllers.md
+++ b/docs/advanced/controllers.md
@@ -8,7 +8,7 @@ deck.gl supports several models of event handling and viewport controls
 
 ## React Integration
 
-Use the [`ViewportController`](docs/api-reference/react/viewport-controller.md) component.
+Use the [`ViewportController`](/docs/api-reference/react/viewport-controller.md) component.
 
 
 ## States

--- a/docs/api-reference/deck.md
+++ b/docs/api-reference/deck.md
@@ -2,7 +2,7 @@
 
 `Deck` is a class that takes deck.gl layer instances and viewport parameters, renders those layers as a transparent overlay, and handles events.
 
-If you are using React, you should not use this component directly. Instead you should be rendering the [`DeckGL` React Component](docs/api-reference/react/deckgl.md).
+If you are using React, you should not use this component directly. Instead you should be rendering the [`DeckGL` React Component](/docs/api-reference/react/deckgl.md).
 
 
 ## Usage

--- a/docs/api-reference/map-controller.md
+++ b/docs/api-reference/map-controller.md
@@ -5,7 +5,7 @@ The `MapController` class can be passed to the `Deck.controller` or `DeckGL.cont
 
 ## Usage
 
-```js
+```jsx
 import DeckGL, {MapController} from 'deck.gl';
 
 <DeckGL

--- a/docs/get-started/interactivity.md
+++ b/docs/get-started/interactivity.md
@@ -1,6 +1,6 @@
 # Adding Interactivity
 
-> This article discusses interacting with data (i.e. selecting, or picking objects). Viewport controls (panning, zooming etc) are discussed in [Controllers](docs/advanced/controllers.md).
+> This article discusses interacting with data (i.e. selecting, or picking objects). Viewport controls (panning, zooming etc) are discussed in [Controllers](/docs/api-reference/map-controller.md).
 
 ## Overview
 

--- a/docs/get-started/using-standalone.md
+++ b/docs/get-started/using-standalone.md
@@ -58,7 +58,7 @@ To use deck.gl in a scripting environment, include the standalone version in a `
 
 It exposes two global objects `deck` and `luma`. Any exports from the deck.gl core can be accessed by `deck.<Class>`.
 
-The scripting API's [DeckGL](docs/api-reference/standalone/deckgl.md) class extends the core `Deck` class with some additional features such as Mapbox integration.
+The scripting API's [DeckGL](/docs/api-reference/standalone/deckgl.md) class extends the core `Deck` class with some additional features such as Mapbox integration.
 
 ```js
 new deck.DeckGL({

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -73,7 +73,7 @@ Following WebGL parameters are set during DeckGL component initialization.
 
 All our layers enable depth test so we are going set this state during initialization. We are also changing blend function for more appropriate rendering when multiple elements are blended.
 
-For any custom needs, these parameters can be overwritten by updating them in [`onWebGLInitialized`](docs/api-reference/react/deckgl.md#onWebGLInitialized) callback or by passing them in `parameters` object to `drawLayer` method of `Layer` class.
+For any custom needs, these parameters can be overwritten by updating them in [`onWebGLInitialized`](/docs/api-reference/react/deckgl.md#onWebGLInitialized) callback or by passing them in `parameters` object to `drawLayer` method of `Layer` class.
 
 
 ### assembleShaders

--- a/website/contents/pages.js
+++ b/website/contents/pages.js
@@ -389,6 +389,15 @@ export const docPages = generatePath([
         ]
       },
       {
+        name: 'Standalone',
+        children: [
+          {
+            name: 'DeckGL',
+            content: getDocUrl('api-reference/standalone/deckgl.md')
+          }
+        ]
+      },
+      {
         name: 'Shader Modules',
         children: [
           {


### PR DESCRIPTION
#### Change List
- Internal links require `/` at the beginning
- Add standalone DeckGL class doc