### PR TITLE
Make DeckGL doc refer to Deck docs

### DIFF
--- a/docs/api-reference/deck.md
+++ b/docs/api-reference/deck.md
@@ -105,9 +105,14 @@ Flag to enable debug mode.
 
 Default value is `false`.
 
-Note:
+Notes:
 
-* debug mode is somewhat slower as it will use synchronous operations to keep track of GPU state.
+* debug mode is slower as it will use synchronous operations to keep track of GPU state.
+* Enabling debug mode requires an extra luma.gl import:
+
+```js
+import 'luma.gl/debug'
+````
 
 ### Event Callbacks
 
@@ -161,7 +166,7 @@ deck.setProps({...});
 
 ##### `pickObject`
 
-Get the closest pickable and visible object at screen coordinate.
+Get the closest pickable and visible object at the given screen coordinate.
 
 ```js
 deck.pickObject({x, y, radius, layerIds})
@@ -175,6 +180,29 @@ deck.pickObject({x, y, radius, layerIds})
 Returns:
 
 * a single [`info`](/docs/get-started/interactivity.md#the-picking-info-object) object, or `null` if nothing is found.
+
+
+##### `pickMultipleObjects`
+
+Performs deep picking. Finds all close pickable and visible object at the given screen coordinate, even if those objects are occluded by other objects.
+
+```js
+deck.pickObject({x, y, radius, layerIds, depth})
+```
+
+* `x` (Number) - x position in pixels
+* `y` (Number) - y position in pixels
+* `radius`=`0` (Number, optional) - radius of tolerance in pixels.
+* `layerIds`=`null` (Array, optional) - a list of layer ids to query from. If not specified, then all pickable and visible layers are queried.
+* `depth`=`10` - Specifies the max
+
+Returns:
+
+* An array of [`info`](/docs/get-started/interactivity.md#the-picking-info-object) objects. The array will be empty if no object was picked.
+
+Notes:
+
+* Deep picking is implemented as a sequence of simpler picking operations and can have a performance impact. Should this become a concern, you can use the `depth` parameter to limit the number of matches that can be returned, and thus the maximum number of picking operations.
 
 
 ##### `pickObjects`
@@ -197,12 +225,11 @@ Returns:
 
 * an array of unique [`info`](/docs/get-started/interactivity.md#the-picking-info-object) objects
 
-Remarks:
+Notes:
 
-* This query methods are designed to quickly find objects by utilizing the picking buffer. They offer more flexibility for developers to handle events in addition to the built-in hover and click callbacks.
-* Note there is a limitation in the query methods:
-
-* occluded objects are not returned. To improve the results, you may try setting the `layerIds` parameter to limit the query to fewer layers.
+* The query methods are designed to quickly find objects by utilizing the picking buffer.
+* The query methods offer more flexibility for developers to handle events compared to the built-in hover and click callbacks.
+* Note there is a limitation in the query methods: occluded objects are not returned. To improve the results, you may try setting the `layerIds` parameter to limit the query to fewer layers.
 
 
 ## Remarks

--- a/docs/api-reference/deck.md
+++ b/docs/api-reference/deck.md
@@ -130,10 +130,8 @@ Callback - called when the object under the pointer changes.
 
 Callback Arguments:
 
-* `info` - the [`info`](/docs/get-started/interactivity.md#the-picking-info-object)
-object for the topmost picked layer at the coordinate, null when no object is picked.
-* `pickedInfos` - an array of info objects for all pickable layers that
-are affected.
+* `info` - the [`info`](/docs/get-started/interactivity.md#the-picking-info-object) object for the topmost picked layer at the coordinate, null when no object is picked.
+* `pickedInfos` - an array of info objects for all pickable layers that are affected.
 * `event` - the original [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) object
 
 ##### `onLayerClick` (Function, optional)
@@ -142,8 +140,7 @@ Callback - called when clicking on the layer.
 
 Callback Arguments:
 
-* `info` - the [`info`](/docs/get-started/interactivity.md#the-picking-info-object)
-object for the topmost picked layer at the coordinate, null when no object is picked.
+* `info` - the [`info`](/docs/get-started/interactivity.md#the-picking-info-object) object for the topmost picked layer at the coordinate, null when no object is picked.
 * `pickedInfos` - an array of info objects for all pickable layers that are affected.
 * `event` - the original [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) object
 
@@ -238,4 +235,5 @@ Notes:
 
 
 ## Source
+
 [modules/core/src/core/lib/deck.js](https://github.com/uber/deck.gl/blob/5.2-release/modules/core/src/core/lib/deck.js)

--- a/docs/api-reference/react/deckgl.md
+++ b/docs/api-reference/react/deckgl.md
@@ -49,7 +49,7 @@ render() {
 
 ## Properties
 
-All [Deck](/docs/api-reference/deck.md) class properties, with these additional semantics:
+`DeckGL` accepts all [Deck](/docs/api-reference/deck.md#properties) properties, with these additional semantics:
 
 
 ##### `views` (`View[]`, optional)
@@ -123,6 +123,11 @@ Additional Notes:
 * Child repositioning is done with CSS styling on a wrapper div, resizing is done through width and height properties.
 * Hiding of children is performed by removing the elements from the child list
 * Children without the `viewId` property are rendered as is.
+
+
+## Methods
+
+All [Deck](/docs/api-reference/deck.md#methods) methods are available on the `DeckGL` component.
 
 
 ## Source

--- a/docs/api-reference/react/deckgl.md
+++ b/docs/api-reference/react/deckgl.md
@@ -4,6 +4,8 @@
 
 Make sure to read the [Using deck.gl with React](/docs/get-started/using-with-react.md) article.
 
+The `DeckGL` class is a React wrapper of the `Deck` JavaScript class which exposes essentially the same props. The `Deck` class should not be used directly in React applications.
+
 
 ## Usage
 
@@ -47,21 +49,8 @@ render() {
 
 ## Properties
 
-##### `width` (Number, required)
+All [Deck](/docs/api-reference/deck.md) class properties, with these additional semantics:
 
-Width of the canvas.
-
-##### `height` (Number, required)
-
-Height of the canvas.
-
-##### `layers` (Array, required)
-
-The array of deck.gl layers to be rendered. This array is expected to be an array of newly allocated instances of your deck.gl layers, created with updated properties derived from the current application state.
-
-##### `layerFilter`
-
-Optionally takes a function `({layer, viewport, isPicking}) => Boolean` that is called before a layer is rendered. Gives the application an opportunity to filter out layers from the layer list during either rendering or picking. Filtering can be done per viewport or per layer or both. This enables techniques like adding helper layers that work as masks during picking but do not show up during rendering. All the lifecycle methods are still triggered even a if a layer is filtered out using this prop.
 
 ##### `views` (`View[]`, optional)
 
@@ -76,11 +65,7 @@ Default: If the `views` property is not supplied, deck.gl will create a full scr
 
 ### View State Properties
 
-##### `viewState` (Object, optional)
-
-A set of parameters that specify a view point. The exact parameters depend on the choice of `View` and `Controller` classes in use. For geospatial views, the view state should contain fields like `longitude`, `latitude`, `zoom` etc..
-
-If a `viewState` prop is not supplied, `DeckGL` will attempt to autocreate a geospatial view state from the following props.
+For backwards compatibility, the `DeckGL` component can be used without the `viewState` prop. If a `viewState` prop is not supplied, `DeckGL` will attempt to autocreate a geospatial view state from the following props.
 
 ##### `latitude` (Number, optional)
 
@@ -103,74 +88,10 @@ Current bearing - used to define a mercator projection if `viewState` is not sup
 Current pitch - used to define a mercator projection if `viewState` is not supplied.
 
 
-### Configuration Properties
-
-##### `id` (String, optional)
-
-Canvas ID to allow style customization in CSS.
-
-##### `style` (Object, optional)
-
-Css styles for the deckgl-canvas.
-
-##### `pickingRadius` (Number, optional)
-
-Extra pixels around the pointer to include while picking. This is helpful when rendered objects are difficult to target, for example irregularly shaped icons, small moving circles or interaction by touch. Default `0`.
-
-##### `useDevicePixels` (Boolean, optional)
-
-When true, device's full resolution will be used for rendering, this value can change per frame, like when moving windows between screens or when changing zoom level of the browser.
-
-Default value is `true`.
-
-Note: Consider setting to `false` unless you require high resolution, as it affects rendering performance.
-
-##### `gl` (Object, optional)
-
-gl context, will be autocreated if not supplied.
-
-##### `debug` (Boolean, optional)
-
-Flag to enable debug mode.
-
-Default value is `false`.
-
-Note: debug mode is somewhat slower as it will use synchronous operations to keep track of GPU state.
-
-### Event Callbacks
-
-##### `onWebGLInitialized` (Function, optional)
-
-Callback, called once the WebGL context has been initiated
-
-Callback arguments:
-
-* `gl` - the WebGL context.
-
-##### `onLayerHover` (Function, optional)
-
-Callback - called when the object under the pointer changes.
-
-Callback Arguments:
-
-* `info` - the [`info`](/docs/get-started/interactivity.md#the-picking-info-object) object for the topmost picked layer at the coordinate, null when no object is picked.
-* `pickedInfos` - an array of info objects for all pickable layers that are affected.
-* `event` - the original [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) object
-
-##### `onLayerClick` (Function, optional)
-
-Callback - called when clicking on the layer.
-
-Callback Arguments:
-
-* `info` - the [`info`](/docs/get-started/interactivity.md#the-picking-info-object) object for the topmost picked layer at the coordinate, null when no object is picked.
-* `pickedInfos` - an array of info objects for all pickable layers that are affected.
-* `event` - the original [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) object
-
-
 ### Children
 
 The following semantics of the standard React `children` property are considered experimental.
+
 
 #### JSX layers
 
@@ -185,7 +106,7 @@ It is possible to use JSX syntax to create deck.gl layers as React children of t
 For more information on this syntax and its limitations, see [Using deck.gl with React](/docs/get-started/using-with-react.md) article.
 
 
-#### Autopositioned Children
+#### Auto-Positioned Children
 
 To make it easy to use React components in combination with deck.gl views (e.g. to place a base map under a view, or add a label on top of a view), deck.gl can make such components automatically adjust as that view is added, removed or resized.
 
@@ -202,66 +123,6 @@ Additional Notes:
 * Child repositioning is done with CSS styling on a wrapper div, resizing is done through width and height properties.
 * Hiding of children is performed by removing the elements from the child list
 * Children without the `viewId` property are rendered as is.
-
-
-## Methods
-
-### Picking Methods
-
-The picking methods are supplied to enable applications to use their own event handling.
-
-##### `pickObject`
-
-Get the closest pickable and visible object at screen coordinate.
-
-```js
-deck.pickObject({x, y, radius, layerIds});
-```
-
-Parameters:
-
-* `options` (Object)
-  + `x` (Number) - x position in pixels
-  + `y` (Number) - y position in pixels
-  + `radius` (Number, optional) - radius of tolerance in pixels. Default `0`.
-  + `layerIds` (Array, optional) - a list of layer ids to query from.
-    If not specified, then all pickable and visible layers are queried.
-
-Returns:
-
-* A single [`info`](/docs/get-started/interactivity.md#the-picking-info-object) object, or `null` if nothing is found.
-
-NOTE: replaces deprecated method `queryObject`.
-
-##### `pickObjects`
-
-> replaces deprecated method `queryVisibleObjects`.
-
-Get all pickable and visible objects within a bounding box.
-
-```js
-deck.pickObjects({x, y, width, height, layerIds});
-```
-
-Parameters:
-
-* `options` (Object)
-  + `x` (Number) - left of the bounding box in pixels
-  + `y` (Number) - top of the bouding box in pixels
-  + `width` (Number, optional) - width of the bouding box in pixels. Default `1`.
-  + `height` (Number, optional) - height of the bouding box in pixels. Default `1`.
-  + `layerIds` (Array, optional) - a list of layer ids to query from.
-    If not specified, then all pickable and visible layers are queried.
-
-Returns:
-
-* An array of unique [`info`](/docs/get-started/interactivity.md#the-picking-info-object) objects
-
-Remarks:
-
-* This query methods are designed to quickly find objects by utilizing the picking buffer. They offer more flexibility for developers to handle events in addition to the built-in hover and click callbacks.
-* Note there is a limitation in the query methods: occluded objects are not returned. To improve the results, you may try setting the `layerIds` parameter to limit the query to fewer layers.
-* Since deck.gl is WebGL based (and WebGL contexts are limited to a single canvas), deck.gl can only render into a single canvas. Thus all views need to render into in the same canvas. (You could of course use multiple DeckGL instances, but that can have significant resource and performance impact).
 
 
 ## Source


### PR DESCRIPTION
#### Background
- Remove duplicated documentation of `Deck` properties
#### Change List
- docs
