### PR TITLE
Handle right button pan in MapControls

### DIFF
--- a/modules/core/src/core/controllers/map-controls.js
+++ b/modules/core/src/core/controllers/map-controls.js
@@ -32,6 +32,8 @@ export default class MapControls extends ViewportControls {
 
   // Default handler for the `panmove` event.
   _onPan(event) {
-    return this.isFunctionKeyPressed(event) ? this._onPanRotate(event) : this._onPanMove(event);
+    return this.isFunctionKeyPressed(event) || event.rightButton
+      ? this._onPanRotate(event)
+      : this._onPanMove(event);
   }
 }

--- a/modules/core/src/core/controllers/viewport-controls.js
+++ b/modules/core/src/core/controllers/viewport-controls.js
@@ -234,8 +234,8 @@ export default class ViewportControls {
   // Default handler for the `panmove` event.
   _onPan(event) {
     return this.isFunctionKeyPressed(event) || event.rightButton
-      ? this._onPanRotate(event)
-      : this._onPanMove(event);
+      ? this._onPanMove(event)
+      : this._onPanRotate(event);
   }
 
   // Default handler for the `panend` event.


### PR DESCRIPTION
For related bug found in https://github.com/uber/deck.gl/issues/1743

#### Background
- `MapControls` does not handle right button pan
- `ViewportControls` pan/rotate accidentally got reversed in https://github.com/uber/deck.gl/pull/1330

#### Change List
- Add right button handling to MapControls
- Reverse pan/rotate in ViewportControls. This affects the behavior of OrbitController.
