### PR TITLE
Fix standalone bundle inline version

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,11 +3,17 @@
     "es5": {
       "presets": [
         ["@babel/es2015", {modules: 'commonjs'}]
+      ],
+      "plugins": [
+        "version-inline"
       ]
     },
     "esm": {
       "presets": [
         ["@babel/es2015", {modules: false}]
+      ],
+      "plugins": [
+        "version-inline"
       ]
     },
     "es6": {
@@ -23,6 +29,9 @@
           },
           "modules": false
         }]
+      ],
+      "plugins": [
+        "version-inline"
       ]
     },
     "test": {

--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,4 @@
 {
-  "plugins": [
-    "version-inline"
-  ],
   "env": {
     "es5": {
       "presets": [

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -25,9 +25,9 @@
   ],
   "scripts": {
     "clean": "rm -fr dist dist-es6 && mkdir -p dist/es5 dist/esm dist/es6",
-    "build-es6": "BABEL_ENV=es6 babel src --plugins version-inline --out-dir dist/es6 --source-maps --ignore 'node_modules/'",
-    "build-esm": "BABEL_ENV=esm babel src --plugins version-inline --out-dir dist/esm --source-maps --ignore 'node_modules/'",
-    "build-es5": "BABEL_ENV=es5 babel src --plugins version-inline --out-dir dist/es5 --source-maps --ignore 'node_modules/'",
+    "build-es6": "BABEL_ENV=es6 babel src --out-dir dist/es6 --source-maps --ignore 'node_modules/'",
+    "build-esm": "BABEL_ENV=esm babel src --out-dir dist/esm --source-maps --ignore 'node_modules/'",
+    "build-es5": "BABEL_ENV=es5 babel src --out-dir dist/es5 --source-maps --ignore 'node_modules/'",
     "build": "npm run clean && npm run build-es6 && npm run build-esm && npm run build-es5",
     "prepublishOnly": "npm run build"
   },

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -25,9 +25,9 @@
   ],
   "scripts": {
     "clean": "rm -fr dist dist-es6 && mkdir -p dist/es5 dist/esm dist/es6",
-    "build-es6": "BABEL_ENV=es6 babel src --out-dir dist/es6 --source-maps --ignore 'node_modules/'",
-    "build-esm": "BABEL_ENV=esm babel src --out-dir dist/esm --source-maps --ignore 'node_modules/'",
-    "build-es5": "BABEL_ENV=es5 babel src --out-dir dist/es5 --source-maps --ignore 'node_modules/'",
+    "build-es6": "BABEL_ENV=es6 babel src --plugins version-inline --out-dir dist/es6 --source-maps --ignore 'node_modules/'",
+    "build-esm": "BABEL_ENV=esm babel src --plugins version-inline --out-dir dist/esm --source-maps --ignore 'node_modules/'",
+    "build-es5": "BABEL_ENV=es5 babel src --plugins version-inline --out-dir dist/es5 --source-maps --ignore 'node_modules/'",
     "build": "npm run clean && npm run build-es6 && npm run build-esm && npm run build-es5",
     "prepublishOnly": "npm run build"
   },

--- a/modules/lite/package.json
+++ b/modules/lite/package.json
@@ -2,7 +2,7 @@
   "name": "@deck.gl/lite",
   "description": "Scripting with deck.gl",
   "license": "MIT",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "private": "true",
   "publishConfig": {
     "access": "public"

--- a/modules/lite/package.json
+++ b/modules/lite/package.json
@@ -2,6 +2,7 @@
   "name": "@deck.gl/lite",
   "description": "Scripting with deck.gl",
   "license": "MIT",
+  "version": "0.0.1",
   "private": "true",
   "publishConfig": {
     "access": "public"

--- a/modules/lite/package.json
+++ b/modules/lite/package.json
@@ -2,7 +2,6 @@
   "name": "@deck.gl/lite",
   "description": "Scripting with deck.gl",
   "license": "MIT",
-  "version": "5.2.0-alpha.1",
   "private": "true",
   "publishConfig": {
     "access": "public"

--- a/modules/lite/webpack.config.js
+++ b/modules/lite/webpack.config.js
@@ -4,6 +4,7 @@ const webpack = require('webpack');
 
 const PACKAGE_ROOT = resolve(__dirname, '.');
 const ROOT = resolve(PACKAGE_ROOT, '../..');
+const CORE_VERSION = require(resolve(ROOT, 'node_modules/@deck.gl/core/package.json')).version;
 
 const config = {
   resolve: {
@@ -50,6 +51,12 @@ const prodConfig = Object.assign({}, config, {
     path: resolve(PACKAGE_ROOT, 'dist'),
     filename: 'deckgl.min.js'
   },
+
+  plugins: [
+    new webpack.DefinePlugin({
+      __VERSION__: JSON.stringify(CORE_VERSION) // eslint-disable-line
+    })
+  ],
 
   devtool: ''
 });

--- a/modules/lite/webpack.config.js
+++ b/modules/lite/webpack.config.js
@@ -4,6 +4,10 @@ const webpack = require('webpack');
 
 const PACKAGE_ROOT = resolve(__dirname, '.');
 const ROOT = resolve(PACKAGE_ROOT, '../..');
+// This is used to define the __VERSION__ constant in core/lib/init.js
+// babel-plugin-version-inline uses the package version from the working directory
+// Therefore we need to manually import the correct version from the core
+// This is called in prepublishOnly, after lerna bumps the package versions
 const CORE_VERSION = require(resolve(ROOT, 'node_modules/@deck.gl/core/package.json')).version;
 
 const config = {

--- a/modules/lite/webpack.config.js
+++ b/modules/lite/webpack.config.js
@@ -54,7 +54,7 @@ const prodConfig = Object.assign({}, config, {
 
   plugins: [
     new webpack.DefinePlugin({
-      __VERSION__: JSON.stringify(CORE_VERSION) // eslint-disable-line
+      __VERSION__: JSON.stringify(CORE_VERSION)
     })
   ],
 


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/1742

`babel-plugin-version-inline` uses the package version from the working directory.

#### Change List
- Apply appropriate version string at build time
