### PR TITLE
Remove React checks in controller classes

### DIFF
--- a/modules/core/src/core/controllers/map-controller.js
+++ b/modules/core/src/core/controllers/map-controller.js
@@ -1,6 +1,5 @@
 import MapControls from '../controllers/map-controls';
 import {MAPBOX_LIMITS} from '../controllers/map-state';
-import assert from '../utils/assert';
 import {EventManager} from 'mjolnir.js';
 
 const PREFIX = '-webkit-';
@@ -70,8 +69,6 @@ const defaultProps = Object.assign({}, MAPBOX_LIMITS, {
 
 export default class MapController {
   constructor(props) {
-    assert(!props.children, 'MapController is no longer a React component');
-
     props = Object.assign({}, defaultProps, props);
 
     this.props = props;

--- a/modules/core/src/core/controllers/orbit-controller.js
+++ b/modules/core/src/core/controllers/orbit-controller.js
@@ -1,7 +1,6 @@
 import OrbitViewport from '../viewports/orbit-viewport';
 import OrbitState from '../controllers/orbit-state';
 import ViewportControls from '../controllers/viewport-controls';
-import assert from '../utils/assert';
 import {EventManager} from 'mjolnir.js';
 
 const PREFIX = '-webkit-';
@@ -72,8 +71,6 @@ export default class OrbitController {
   }
 
   constructor(props) {
-    assert(!props.children, 'OrbitController is no longer a React component');
-
     props = Object.assign({}, defaultProps, props);
 
     this.props = props;


### PR DESCRIPTION
#### Background
- The check to make sure that OrbitControllers are not React components can fail.
#### Change List
- Remove the check, it was only intended to be temporary while we fixed examples.
