### PR TITLE
fix index type in webgl 2 context

### DIFF
--- a/modules/core/src/core-layers/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/core/src/core-layers/solid-polygon-layer/solid-polygon-layer.js
@@ -20,7 +20,7 @@
 
 import {Layer, experimental} from '../../core';
 const {enable64bitSupport, get} = experimental;
-import {GL, Model, Geometry} from 'luma.gl';
+import {GL, Model, Geometry, isWebGL2} from 'luma.gl';
 
 // Polygon geometry generation is managed by the polygon tesselator
 import {PolygonTesselator} from './polygon-tesselator';
@@ -124,7 +124,8 @@ export default class SolidPolygonLayer extends Layer {
     const {gl} = this.context;
     this.setState({
       numInstances: 0,
-      IndexType: gl.getExtension('OES_element_index_uint') ? Uint32Array : Uint16Array
+      IndexType:
+        isWebGL2(gl) || gl.getExtension('OES_element_index_uint') ? Uint32Array : Uint16Array
     });
 
     const attributeManager = this.getAttributeManager();

--- a/modules/core/src/core-layers/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/core/src/core-layers/solid-polygon-layer/solid-polygon-layer.js
@@ -20,7 +20,7 @@
 
 import {Layer, experimental} from '../../core';
 const {enable64bitSupport, get} = experimental;
-import {GL, Model, Geometry, isWebGL2} from 'luma.gl';
+import {GL, Model, Geometry, hasFeature, FEATURES} from 'luma.gl';
 
 // Polygon geometry generation is managed by the polygon tesselator
 import {PolygonTesselator} from './polygon-tesselator';
@@ -124,8 +124,7 @@ export default class SolidPolygonLayer extends Layer {
     const {gl} = this.context;
     this.setState({
       numInstances: 0,
-      IndexType:
-        isWebGL2(gl) || gl.getExtension('OES_element_index_uint') ? Uint32Array : Uint16Array
+      IndexType: hasFeature(gl, FEATURES.ELEMENT_INDEX_UINT32) ? Uint32Array : Uint16Array
     });
 
     const attributeManager = this.getAttributeManager();


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/1784

#### Change List
- SolidPolygonLayer checks if context is WebGL2 when choosing index type
