### PR TITLE
Fix transpile failure in examples

### DIFF
--- a/examples/website/brushing/webpack.config.js
+++ b/examples/website/brushing/webpack.config.js
@@ -15,9 +15,13 @@ const CONFIG = {
         test: /\.js$/,
         loader: 'buble-loader',
         include: [resolve('.')],
-        exclude: [/node_modules/],
+        exclude: [/node_modules\/(?!@deck.gl)/],
         options: {
-          objectAssign: 'Object.assign'
+          objectAssign: 'Object.assign',
+          transforms: {
+            dangerousForOf: true,
+            modules: false
+          }
         }
       }
     ]

--- a/examples/website/plot/webpack.config.js
+++ b/examples/website/plot/webpack.config.js
@@ -21,9 +21,13 @@ const CONFIG = {
         test: /\.js$/,
         loader: 'buble-loader',
         include: [resolve('.')],
-        exclude: [/node_modules/],
+        exclude: [/node_modules\/(?!@deck.gl)/],
         options: {
-          objectAssign: 'Object.assign'
+          objectAssign: 'Object.assign',
+          transforms: {
+            dangerousForOf: true,
+            modules: false
+          }
         }
       }
     ]

--- a/examples/website/trips/webpack.config.js
+++ b/examples/website/trips/webpack.config.js
@@ -19,9 +19,13 @@ const CONFIG = {
         test: /\.js$/,
         loader: 'buble-loader',
         include: [resolve('.')],
-        exclude: [/node_modules/],
+        exclude: [/node_modules\/(?!@deck.gl)/],
         options: {
-          objectAssign: 'Object.assign'
+          objectAssign: 'Object.assign',
+          transforms: {
+            dangerousForOf: true,
+            modules: false
+          }
         }
       }
     ]


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/1801

#### Background
Webpack by default resolves to the `esm` folder. Inheriting ES5 class from ES6 causes runtime error.

#### Change List
- Transpile deck.gl packages in all custom layer examples

Looking to @ibgreen for a long-term solution - do we need to switch to Babel to avoid this issue?