### PR TITLE
Fix assert import from missing dependency

### DIFF
--- a/modules/core/src/lib/attribute.js
+++ b/modules/core/src/lib/attribute.js
@@ -1,5 +1,5 @@
 /* eslint-disable complexity */
-import assert from 'assert';
+import assert from '../utils/assert';
 import {GL, Buffer} from 'luma.gl';
 
 export default class Attribute {


### PR DESCRIPTION
#### Background
Importing from missing dependency

#### Change List
- import `assert` from utils
