### PR TITLE
Use auto control in standalone version

### DIFF
--- a/modules/lite/test/index.js
+++ b/modules/lite/test/index.js
@@ -41,7 +41,7 @@ const nonGeoExample = new deck.DeckGL({
   container: document.getElementById('non-geo'),
   mapbox: false /* disable map */,
   views: [new deck.OrbitView()],
-  viewState: {distance: 1, rotationX: 45, rotationOrbit: 30, zoom: 0.05},
+  viewState: {distance: 1, fov: 50, rotationX: 45, rotationOrbit: 30, zoom: 0.05},
   layers: [
     new deck.PointCloudLayer({
       id: 'pointCloud',


### PR DESCRIPTION
#### Change List
- remove `onViewportChange` hack, use the new automatic control API instead
- minor fix to test app
