### PR TITLE
[EXPERIMENT]: Use data urls in website examples.

### DIFF
--- a/examples/website/brushing/app.js
+++ b/examples/website/brushing/app.js
@@ -90,6 +90,7 @@ class Root extends Component {
       </div>
     );
   }
+
   render() {
     const {viewport, data, mousePosition, mouseEntered} = this.state;
 

--- a/examples/website/geojson/app.js
+++ b/examples/website/geojson/app.js
@@ -1,4 +1,4 @@
-/* global document, fetch, window */
+/* global document, window */
 import React, {Component} from 'react';
 import {render} from 'react-dom';
 import MapGL from 'react-map-gl';

--- a/examples/website/geojson/app.js
+++ b/examples/website/geojson/app.js
@@ -7,10 +7,6 @@ import DeckGLOverlay from './deckgl-overlay.js';
 // Set your mapbox token here
 const MAPBOX_TOKEN = process.env.MapboxAccessToken; // eslint-disable-line
 
-// Source data GeoJSON
-const DATA_URL =
-  'https://raw.githubusercontent.com/uber-common/deck.gl-data/master/examples/geojson/vancouver-blocks.json'; // eslint-disable-line
-
 const colorScale = r => [r * 255, 140, 200 * (1 - r)];
 
 class Root extends Component {
@@ -21,13 +17,8 @@ class Root extends Component {
         ...DeckGLOverlay.defaultViewport,
         width: 500,
         height: 500
-      },
-      data: null
+      }
     };
-
-    fetch(DATA_URL)
-      .then(resp => resp.json())
-      .then(data => this.setState({data}));
   }
 
   componentDidMount() {

--- a/examples/website/geojson/deckgl-overlay.js
+++ b/examples/website/geojson/deckgl-overlay.js
@@ -1,6 +1,10 @@
 import React, {Component} from 'react';
 import DeckGL, {GeoJsonLayer} from 'deck.gl';
 
+// Source data GeoJSON
+const DATA_URL =
+  'https://raw.githubusercontent.com/uber-common/deck.gl-data/master/examples/geojson/vancouver-blocks.json'; // eslint-disable-line
+
 const LIGHT_SETTINGS = {
   lightsPosition: [-125, 50.5, 5000, -122.8, 48.5, 8000],
   ambientRatio: 0.2,
@@ -23,15 +27,11 @@ export default class DeckGLOverlay extends Component {
   }
 
   render() {
-    const {viewport, data, colorScale} = this.props;
-
-    if (!data) {
-      return null;
-    }
+    const {viewport, colorScale} = this.props;
 
     const layer = new GeoJsonLayer({
       id: 'geojson',
-      data,
+      data: DATA_URL,
       opacity: 0.8,
       stroked: false,
       filled: true,

--- a/examples/website/line/app.js
+++ b/examples/website/line/app.js
@@ -1,4 +1,4 @@
-/* global document, fetch, window */
+/* global document, window */
 import React, {Component} from 'react';
 import {render} from 'react-dom';
 import MapGL from 'react-map-gl';
@@ -48,10 +48,7 @@ class Root extends Component {
         onViewportChange={this._onViewportChange.bind(this)}
         mapboxApiAccessToken={MAPBOX_TOKEN}
       >
-        <DeckGLOverlay
-          viewport={viewport}
-          strokeWidth={3}
-        />
+        <DeckGLOverlay viewport={viewport} strokeWidth={3} />
       </MapGL>
     );
   }

--- a/examples/website/line/app.js
+++ b/examples/website/line/app.js
@@ -8,13 +8,6 @@ import DeckGLOverlay from './deckgl-overlay.js';
 const MAPBOX_TOKEN = process.env.MapboxAccessToken; // eslint-disable-line
 
 // Source data CSV
-const DATA_URL = {
-  AIRPORTS:
-    'https://raw.githubusercontent.com/uber-common/deck.gl-data/master/examples/line/airports.json', // eslint-disable-line
-  FLIGHT_PATHS:
-    'https://raw.githubusercontent.com/uber-common/deck.gl-data/master/examples/line/heathrow-flights.json' // eslint-disable-line
-};
-
 class Root extends Component {
   constructor(props) {
     super(props);
@@ -23,18 +16,8 @@ class Root extends Component {
         ...DeckGLOverlay.defaultViewport,
         width: 500,
         height: 500
-      },
-      flightPaths: null,
-      airports: null
+      }
     };
-
-    fetch(DATA_URL)
-      .then(resp => resp.json())
-      .then(data => this.setState({flightPaths: data}));
-
-    fetch(DATA_URL)
-      .then(resp => resp.json())
-      .then(data => this.setState({airports: data}));
   }
 
   componentDidMount() {
@@ -56,7 +39,7 @@ class Root extends Component {
   }
 
   render() {
-    const {viewport, flightPaths, airports} = this.state;
+    const {viewport} = this.state;
 
     return (
       <MapGL
@@ -68,8 +51,6 @@ class Root extends Component {
         <DeckGLOverlay
           viewport={viewport}
           strokeWidth={3}
-          flightPaths={flightPaths}
-          airports={airports}
         />
       </MapGL>
     );

--- a/examples/website/line/deckgl-overlay.js
+++ b/examples/website/line/deckgl-overlay.js
@@ -2,6 +2,14 @@ import React, {Component} from 'react';
 import {setParameters} from 'luma.gl';
 import DeckGL, {LineLayer, ScatterplotLayer} from 'deck.gl';
 
+// Source data CSV
+const DATA_URL = {
+  AIRPORTS:
+    'https://raw.githubusercontent.com/uber-common/deck.gl-data/master/examples/line/airports.json', // eslint-disable-line
+  FLIGHT_PATHS:
+    'https://raw.githubusercontent.com/uber-common/deck.gl-data/master/examples/line/heathrow-flights.json' // eslint-disable-line
+};
+
 function getColor(d) {
   const z = d.start[2];
   const r = z / 10000;
@@ -39,16 +47,12 @@ export default class DeckGLOverlay extends Component {
   }
 
   render() {
-    const {viewport, flightPaths, airports, strokeWidth} = this.props;
-
-    if (!flightPaths || !airports) {
-      return null;
-    }
+    const {viewport, strokeWidth} = this.props;
 
     const layers = [
       new ScatterplotLayer({
         id: 'airports',
-        data: airports,
+        data: DATA_URL.AIRPORTS,
         radiusScale: 20,
         getPosition: d => d.coordinates,
         getColor: d => [255, 140, 0],
@@ -58,7 +62,7 @@ export default class DeckGLOverlay extends Component {
       }),
       new LineLayer({
         id: 'flight-paths',
-        data: flightPaths,
+        data: DATA_URL.FLIGHT_PATHS,
         strokeWidth,
         fp64: false,
         getSourcePosition: d => d.start,

--- a/examples/website/scatterplot/app.js
+++ b/examples/website/scatterplot/app.js
@@ -1,4 +1,4 @@
-/* global document, fetch, window */
+/* global document, window */
 import React, {Component} from 'react';
 import {render} from 'react-dom';
 import MapGL from 'react-map-gl';

--- a/examples/website/scatterplot/app.js
+++ b/examples/website/scatterplot/app.js
@@ -9,10 +9,6 @@ const MAPBOX_TOKEN = process.env.MapboxAccessToken; // eslint-disable-line
 const MALE_COLOR = [0, 128, 255];
 const FEMALE_COLOR = [255, 0, 128];
 
-// Source data CSV
-const DATA_URL =
-  'https://raw.githubusercontent.com/uber-common/deck.gl-data/master/examples/scatterplot/manhattan.json'; // eslint-disable-line
-
 class Root extends Component {
   constructor(props) {
     super(props);
@@ -21,13 +17,8 @@ class Root extends Component {
         ...DeckGLOverlay.defaultViewport,
         width: 0,
         height: 0
-      },
-      data: null
+      }
     };
-
-    fetch(DATA_URL)
-      .then(resp => resp.json())
-      .then(data => this.setState({data}));
   }
 
   componentDidMount() {
@@ -49,7 +40,7 @@ class Root extends Component {
   }
 
   render() {
-    const {viewport, data} = this.state;
+    const {viewport} = this.state;
 
     return (
       <MapGL
@@ -59,7 +50,6 @@ class Root extends Component {
       >
         <DeckGLOverlay
           viewport={viewport}
-          data={data}
           maleColor={MALE_COLOR}
           femaleColor={FEMALE_COLOR}
           radius={30}

--- a/examples/website/scatterplot/deckgl-overlay.js
+++ b/examples/website/scatterplot/deckgl-overlay.js
@@ -1,6 +1,10 @@
 import React, {Component} from 'react';
 import DeckGL, {ScatterplotLayer} from 'deck.gl';
 
+// Source data
+const DATA_URL =
+  'https://raw.githubusercontent.com/uber-common/deck.gl-data/master/examples/scatterplot/manhattan.json'; // eslint-disable-line
+
 export default class DeckGLOverlay extends Component {
   static get defaultViewport() {
     return {
@@ -14,11 +18,11 @@ export default class DeckGLOverlay extends Component {
   }
 
   render() {
-    const {viewport, maleColor, femaleColor, data, radius} = this.props;
+    const {viewport, maleColor, femaleColor, radius} = this.props;
 
     const layer = new ScatterplotLayer({
       id: 'scatter-plot',
-      data,
+      data: DATA_URL,
       radiusScale: radius,
       radiusMinPixels: 0.25,
       getPosition: d => [d[0], d[1], 0],

--- a/examples/website/trips/app.js
+++ b/examples/website/trips/app.js
@@ -66,11 +66,7 @@ class Root extends Component {
         onViewportChange={this._onViewportChange.bind(this)}
         mapboxApiAccessToken={MAPBOX_TOKEN}
       >
-        <DeckGLOverlay
-          viewport={viewport}
-          trailLength={180}
-          time={time}
-        />
+        <DeckGLOverlay viewport={viewport} trailLength={180} time={time} />
       </MapGL>
     );
   }

--- a/examples/website/trips/app.js
+++ b/examples/website/trips/app.js
@@ -1,4 +1,4 @@
-/* global document, fetch, window */
+/* global document, window */
 import React, {Component} from 'react';
 import {render} from 'react-dom';
 import MapGL from 'react-map-gl';
@@ -6,14 +6,6 @@ import DeckGLOverlay from './deckgl-overlay.js';
 
 // Set your mapbox token here
 const MAPBOX_TOKEN = process.env.MapboxAccessToken; // eslint-disable-line
-
-// Source data CSV
-const DATA_URL = {
-  BUILDINGS:
-    'https://raw.githubusercontent.com/uber-common/deck.gl-data/master/examples/trips/buildings.json', // eslint-disable-line
-  TRIPS:
-    'https://raw.githubusercontent.com/uber-common/deck.gl-data/master/examples/trips/trips.json' // eslint-disable-line
-};
 
 class Root extends Component {
   constructor(props) {
@@ -24,18 +16,8 @@ class Root extends Component {
         width: 500,
         height: 500
       },
-      buildings: null,
-      trips: null,
       time: 0
     };
-
-    fetch(DATA_URL.BUILDINGS)
-      .then(resp => resp.json())
-      .then(data => this.setState({buildings: data}));
-
-    fetch(DATA_URL.TRIPS)
-      .then(resp => resp.json())
-      .then(data => this.setState({trips: data}));
   }
 
   componentDidMount() {
@@ -75,7 +57,7 @@ class Root extends Component {
   }
 
   render() {
-    const {viewport, buildings, trips, time} = this.state;
+    const {viewport, time} = this.state;
 
     return (
       <MapGL
@@ -86,8 +68,6 @@ class Root extends Component {
       >
         <DeckGLOverlay
           viewport={viewport}
-          buildings={buildings}
-          trips={trips}
           trailLength={180}
           time={time}
         />

--- a/examples/website/trips/deckgl-overlay.js
+++ b/examples/website/trips/deckgl-overlay.js
@@ -2,6 +2,14 @@ import React, {Component} from 'react';
 import DeckGL, {PolygonLayer} from 'deck.gl';
 import TripsLayer from './trips-layer';
 
+// Source data
+const DATA_URL = {
+  BUILDINGS:
+    'https://raw.githubusercontent.com/uber-common/deck.gl-data/master/examples/trips/buildings.json', // eslint-disable-line
+  TRIPS:
+    'https://raw.githubusercontent.com/uber-common/deck.gl-data/master/examples/trips/trips.json' // eslint-disable-line
+};
+
 const LIGHT_SETTINGS = {
   lightsPosition: [-74.05, 40.7, 8000, -73.5, 41, 5000],
   ambientRatio: 0.05,
@@ -24,16 +32,12 @@ export default class DeckGLOverlay extends Component {
   }
 
   render() {
-    const {viewport, buildings, trips, trailLength, time} = this.props;
-
-    if (!buildings || !trips) {
-      return null;
-    }
+    const {viewport, trailLength, time} = this.props;
 
     const layers = [
       new TripsLayer({
         id: 'trips',
-        data: trips,
+        data: DATA_URL.TRIPS,
         getPath: d => d.segments,
         getColor: d => (d.vendor === 0 ? [253, 128, 93] : [23, 184, 190]),
         opacity: 0.3,
@@ -43,7 +47,7 @@ export default class DeckGLOverlay extends Component {
       }),
       new PolygonLayer({
         id: 'buildings',
-        data: buildings,
+        data: DATA_URL.BUILDINGS,
         extruded: true,
         wireframe: false,
         fp64: true,

--- a/modules/core/src/lifecycle/component-state.js
+++ b/modules/core/src/lifecycle/component-state.js
@@ -189,7 +189,7 @@ export default class ComponentState {
   _createAsyncPropData(propName, value, defaultValue) {
     const asyncProp = this.asyncProps[propName];
     if (!asyncProp) {
-      // assert(defaultValue !== undefined);
+      assert(defaultValue !== undefined);
       this.asyncProps[propName] = {
         lastValue: null, // Supplied prop value (can be url/promise, not visible to layer)
         resolvedValue: defaultValue, // Resolved prop value (valid data, can be "shown" to layer)

--- a/modules/core/src/lifecycle/component-state.js
+++ b/modules/core/src/lifecycle/component-state.js
@@ -189,7 +189,7 @@ export default class ComponentState {
   _createAsyncPropData(propName, value, defaultValue) {
     const asyncProp = this.asyncProps[propName];
     if (!asyncProp) {
-      assert(defaultValue !== undefined);
+      // assert(defaultValue !== undefined);
       this.asyncProps[propName] = {
         lastValue: null, // Supplied prop value (can be url/promise, not visible to layer)
         resolvedValue: defaultValue, // Resolved prop value (valid data, can be "shown" to layer)


### PR DESCRIPTION
#### Background
- Would like our examples to leverage the simplifications of the deck.gl v5 API

#### Change List
- Update examples: geojson, line, scatterplot, trips etc to use data URLs, removing existing fetch logic.
- Remaining examples have complications (CSV instead of JSON, additional post processing, workers etc) requiring more work.

#### Remains
- Make sure this change integrates with website