### PR TITLE
Buffer reuse in SolidPolygonLayer

### DIFF
--- a/modules/layers/src/solid-polygon-layer/polygon-tesselator.js
+++ b/modules/layers/src/solid-polygon-layer/polygon-tesselator.js
@@ -67,8 +67,7 @@ export class PolygonTesselator {
     const {attributes, polygons, pointCount} = this;
 
     attributes.positions = attributes.positions || new Float32Array(pointCount * 3);
-    attributes.vertexEnabled =
-      attributes.vertexEnabled || new Uint8ClampedArray(pointCount).fill(1);
+    attributes.vertexValid = attributes.vertexValid || new Uint8ClampedArray(pointCount).fill(1);
 
     if (fp64) {
       // We only need x, y component
@@ -90,8 +89,8 @@ export class PolygonTesselator {
     return this.attributes.positions64xyLow;
   }
 
-  vertexEnabled() {
-    return this.attributes.vertexEnabled;
+  vertexValid() {
+    return this.attributes.vertexValid;
   }
 
   elevations({key = 'elevations', getElevation = x => 100} = {}) {
@@ -156,7 +155,7 @@ function calculateIndices({polygons, IndexType = Uint32Array}) {
 }
 
 function updatePositions({
-  cache: {positions, positions64xyLow, vertexEnabled},
+  cache: {positions, positions64xyLow, vertexValid},
   polygons,
   extruded,
   fp64
@@ -183,13 +182,13 @@ function updatePositions({
       /* We are reusing the some buffer for `nextPositions` by offsetting one vertex
        * to the left. As a result,
        * the last vertex of each loop overlaps with the first vertex of the next loop.
-       * `vertexEnabled` is used to mark the end of each loop so we don't draw these
+       * `vertexValid` is used to mark the end of each loop so we don't draw these
        * segments:
         positions      A0 A1 A2 A3 A4 B0 B1 B2 C0 ...
         nextPositions  A1 A2 A3 A4 B0 B1 B2 C0 C1 ...
-        vertexEnabled   1  1  1  1  0  1  1  0  1 ...
+        vertexValid    1  1  1  1  0  1  1  0  1 ...
        */
-      vertexEnabled[i - 1] = 0;
+      vertexValid[i - 1] = 0;
     });
   });
 }

--- a/modules/layers/src/solid-polygon-layer/polygon.js
+++ b/modules/layers/src/solid-polygon-layer/polygon.js
@@ -39,6 +39,21 @@ export function isSimple(polygon) {
 }
 
 /**
+ * Ensure that all simple polygons have the same start and end vertex
+ */
+function closeLoop(simplePolygon) {
+  // check if first and last vertex are the same
+  const p0 = simplePolygon[0];
+  const p1 = simplePolygon[simplePolygon.length - 1];
+
+  if (p0[0] === p1[0] && p0[1] === p1[1] && p0[2] === p1[2]) {
+    return simplePolygon;
+  }
+  // duplicate the starting vertex at end
+  return simplePolygon.concat([p0]);
+}
+
+/**
  * Normalize to ensure that all polygons in a list are complex - simplifies processing
  * @param {Array} polygon - either a complex or a simple polygon
  * @param {Object} opts
@@ -46,7 +61,7 @@ export function isSimple(polygon) {
  * @return {Array} - returns a complex polygons
  */
 export function normalize(polygon, {dimensions = 3} = {}) {
-  return isSimple(polygon) ? [polygon] : polygon;
+  return isSimple(polygon) ? [closeLoop(polygon)] : polygon.map(closeLoop);
 }
 
 /**
@@ -74,17 +89,6 @@ export function getTriangleCount(polygon) {
     first = false;
   }
   return triangleCount;
-}
-
-export function forEachVertex(polygon, visitor) {
-  if (isSimple(polygon)) {
-    polygon.forEach(visitor);
-    return;
-  }
-
-  polygon.forEach(simplePolygon => {
-    simplePolygon.forEach(visitor);
-  });
 }
 
 // Returns the offset of each hole polygon in the flattened array for that polygon

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer-fragment.glsl.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer-fragment.glsl.js
@@ -24,8 +24,13 @@ export default `\
 precision highp float;
 
 varying vec4 vColor;
+varying float vEnabled;
 
 void main(void) {
+  if (vEnabled < 0.5) {
+    discard;
+  }
+
   gl_FragColor = vColor;
 
   // use highlight color if this fragment belongs to the selected object.

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer-fragment.glsl.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer-fragment.glsl.js
@@ -24,10 +24,10 @@ export default `\
 precision highp float;
 
 varying vec4 vColor;
-varying float vEnabled;
+varying float isValid;
 
 void main(void) {
-  if (vEnabled < 0.5) {
+  if (isValid < 0.5) {
     discard;
   }
 

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex.glsl.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex.glsl.js
@@ -22,7 +22,7 @@ export default `\
 #define SHADER_NAME solid-polygon-layer-vertex-shader
 
 attribute vec2 vertexPositions;
-attribute float vertexEnabled;
+attribute float vertexValid;
 attribute vec3 positions;
 attribute vec2 positions64xyLow;
 attribute vec3 nextPositions;
@@ -39,7 +39,7 @@ uniform float elevationScale;
 uniform float opacity;
 
 varying vec4 vColor;
-varying float vEnabled;
+varying float isValid;
 
 void main(void) {
   vec3 pos;
@@ -50,11 +50,11 @@ void main(void) {
   if (isSideVertex) {
     pos = mix(positions, nextPositions, vertexPositions.x);
     pos64xyLow = mix(positions64xyLow, nextPositions64xyLow, vertexPositions.x);
-    vEnabled = vertexEnabled;
+    isValid = vertexValid;
   } else {
     pos = positions;
     pos64xyLow = positions64xyLow;
-    vEnabled = 1.0;
+    isValid = 1.0;
   }
   if (extruded) {
     pos.z += elevations * vertexPositions.y;

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex.glsl.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex.glsl.js
@@ -22,6 +22,7 @@ export default `\
 #define SHADER_NAME solid-polygon-layer-vertex-shader
 
 attribute vec2 vertexPositions;
+attribute float vertexEnabled;
 attribute vec3 positions;
 attribute vec2 positions64xyLow;
 attribute vec3 nextPositions;
@@ -38,6 +39,7 @@ uniform float elevationScale;
 uniform float opacity;
 
 varying vec4 vColor;
+varying float vEnabled;
 
 void main(void) {
   vec3 pos;
@@ -48,9 +50,11 @@ void main(void) {
   if (isSideVertex) {
     pos = mix(positions, nextPositions, vertexPositions.x);
     pos64xyLow = mix(positions64xyLow, nextPositions64xyLow, vertexPositions.x);
+    vEnabled = vertexEnabled;
   } else {
     pos = positions;
     pos64xyLow = positions64xyLow;
+    vEnabled = 1.0;
   }
   if (extruded) {
     pos.z += elevations * vertexPositions.y;

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -88,10 +88,10 @@ export default class SolidPolygonLayer extends Layer {
         noAlloc
       },
       positions64xyLow: {size: 2, update: this.calculatePositionsLow, noAlloc},
-      vertexEnabled: {
+      vertexValid: {
         size: 1,
         type: GL.UNSIGNED_BYTE,
-        update: this.calculateVertexEnabled,
+        update: this.calculateVertexValid,
         noAlloc
       },
       elevations: {
@@ -336,8 +336,8 @@ export default class SolidPolygonLayer extends Layer {
     attribute.value = this.state.polygonTesselator.positions64xyLow();
   }
 
-  calculateVertexEnabled(attribute) {
-    attribute.value = this.state.polygonTesselator.vertexEnabled();
+  calculateVertexValid(attribute) {
+    attribute.value = this.state.polygonTesselator.vertexValid();
   }
 
   calculateElevations(attribute) {

--- a/test/modules/layers/polygon-tesselation.spec.js
+++ b/test/modules/layers/polygon-tesselation.spec.js
@@ -55,7 +55,6 @@ test('polygon#imports', t => {
   t.ok(typeof Polygon.normalize === 'function', 'Polygon.normalize imported');
   t.ok(typeof Polygon.getVertexCount === 'function', 'Polygon.getVertexCount imported');
   t.ok(typeof Polygon.getTriangleCount === 'function', 'Polygon.getTriangleCount imported');
-  t.ok(typeof Polygon.forEachVertex === 'function', 'Polygon.forEachVertex imported');
   t.end();
 });
 
@@ -85,16 +84,12 @@ test('PolygonTesselator#constructor', t => {
       tesselator.updatePositions(testCase.params);
 
       t.ok(ArrayBuffer.isView(tesselator.positions()), 'PolygonTesselator.positions');
-      t.ok(ArrayBuffer.isView(tesselator.nextPositions()), 'PolygonTesselator.nextPositions');
+      t.ok(ArrayBuffer.isView(tesselator.vertexEnabled()), 'PolygonTesselator.vertexEnabled');
 
       if (testCase.params.fp64) {
         t.ok(
           ArrayBuffer.isView(tesselator.positions64xyLow()),
           'PolygonTesselator.positions64xyLow'
-        );
-        t.ok(
-          ArrayBuffer.isView(tesselator.nextPositions64xyLow()),
-          'PolygonTesselator.nextPositions64xyLow'
         );
       }
     });

--- a/test/modules/layers/polygon-tesselation.spec.js
+++ b/test/modules/layers/polygon-tesselation.spec.js
@@ -84,7 +84,7 @@ test('PolygonTesselator#constructor', t => {
       tesselator.updatePositions(testCase.params);
 
       t.ok(ArrayBuffer.isView(tesselator.positions()), 'PolygonTesselator.positions');
-      t.ok(ArrayBuffer.isView(tesselator.vertexEnabled()), 'PolygonTesselator.vertexEnabled');
+      t.ok(ArrayBuffer.isView(tesselator.vertexValid()), 'PolygonTesselator.vertexValid');
 
       if (testCase.params.fp64) {
         t.ok(


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/1775

#### Background
This is made possible by the new Attribute buffer feature.

SolidPolygonLayer used to generate two buffers for `positions` and `nextPositions` to draw the side quad instances. This PR offsets the `positions` buffer by 1 vertex for `nextPositions`:

        positions      A0 A1 A2 A3 A4 B0 B1 B2 C0 ...
        nextPositions  A1 A2 A3 A4 B0 B1 B2 C0 C1 ...
        vertexEnabled   1  1  1  1  0  1  1  0  1  ...

Old fp64 mode: `positions` and `nextPositions` use `2 * vertexCount * 3 * 4` bytes. `positions64xyLow` and `nextPositions64xyLow` use `2 * vertexCount * 2 * 4` bytes. Total `40 * vertexCount` bytes.

New fp64 mode: `positions` uses `vertexCount * 3 * 4` bytes. `positions64xyLow` uses `vertexCount * 2 * 4` bytes. The new `discardFlags` buffer uses `vertexCount * 1 * 1` bytes. Total `21 * vertexCount` bytes, with additional benefit of halving attribute generation/uploading time.

#### Change List
- Reuse PolygonLayer's positions buffer for 2 attributes
