### PR TITLE
Add Deck.parameters prop to enable declarative setting of initial GL params

### DIFF
--- a/docs/api-reference/deck.md
+++ b/docs/api-reference/deck.md
@@ -111,6 +111,13 @@ Note:
 
 gl context, will be autocreated if not supplied.
 
+##### `parameters` (Object, optional)
+
+This prop will only be consulted once after deck.gl's WebGL context is initialized. If set, the value will be passed to luma.gl's `setParameters` function to do an initial configuration of the context, e.g. to disable depth testing, changing blending modes etc.
+
+Please refer to the luma.gl [setParameters](http://uber.github.io/luma.gl/#/documentation/api-reference/get-parameter) API for documentation on supported parameters and values.
+
+
 ##### `debug` (Boolean, optional)
 
 Flag to enable debug mode.

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -66,6 +66,11 @@ Many layer accessor props now accept constant values. For example, when construc
 Core layers are broken out from ` @deck.gl/core` to a new submodule ` @deck.gl/layers`. Users of `deck.gl` are not affected by this change.
 
 
+#### Set initial WebGL parameters using a prop
+
+It is now possible to set the initial WebGL parameters on the `Deck` WebGL context by supplying a `parameters` prop object, avoiding the need to define an `onWebGLInitialized` callback: `new Deck({..., parameters: {depthTest: false}});`
+
+
 ## deck.gl v5.2
 
 Release date: April 24, 2018

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -13,6 +13,10 @@ deck.gl layers can now specify additional type information about properties. Whe
 
 > For layer writers: use of prop types is optional, and deck.gl layers will automatically deduce partial prop type information for any properties that lack type information, as long as a default value is specified in the `defaultProps` object.
 
+### Set initial WebGL parameters using a prop
+
+It is now possible to set the initial WebGL parameters on the `Deck` WebGL context by supplying a `parameters` prop object, avoiding the need to define an `onWebGLInitialized` callback: `new Deck({..., parameters: {depthTest: false}});`
+
 
 #### Pixel Sizes
 
@@ -64,11 +68,6 @@ Many layer accessor props now accept constant values. For example, when construc
 #### @deck.gl/layers submodule
 
 Core layers are broken out from ` @deck.gl/core` to a new submodule ` @deck.gl/layers`. Users of `deck.gl` are not affected by this change.
-
-
-#### Set initial WebGL parameters using a prop
-
-It is now possible to set the initial WebGL parameters on the `Deck` WebGL context by supplying a `parameters` prop object, avoiding the need to define an `onWebGLInitialized` callback: `new Deck({..., parameters: {depthTest: false}});`
 
 
 ## deck.gl v5.2

--- a/examples/website/line/app.js
+++ b/examples/website/line/app.js
@@ -4,7 +4,7 @@ import {render} from 'react-dom';
 
 import {StaticMap} from 'react-map-gl';
 import DeckGL, {MapView, MapController, LineLayer, ScatterplotLayer} from 'deck.gl';
-import {setParameters} from 'luma.gl';
+import {GL} from 'luma.gl';
 
 // Set your mapbox token here
 const MAPBOX_TOKEN = process.env.MapboxAccessToken; // eslint-disable-line
@@ -24,6 +24,11 @@ const INITIAL_VIEW_STATE = {
   maxZoom: 16,
   pitch: 50,
   bearing: 0
+};
+
+const WEBGL_PARAMETERS = {
+  blendFunc: [GL.SRC_ALPHA, GL.ONE, GL.ONE_MINUS_DST_ALPHA, GL.ONE],
+  blendEquation: GL.FUNC_ADD
 };
 
 function getColor(d) {
@@ -47,13 +52,6 @@ class App extends Component {
   constructor(props) {
     super(props);
     this.state = {viewState: INITIAL_VIEW_STATE};
-  }
-
-  _initialize(gl) {
-    setParameters(gl, {
-      blendFunc: [gl.SRC_ALPHA, gl.ONE, gl.ONE_MINUS_DST_ALPHA, gl.ONE],
-      blendEquation: gl.FUNC_ADD
-    });
   }
 
   render() {
@@ -100,7 +98,7 @@ class App extends Component {
         viewState={viewState}
         onViewStateChange={onViewStateChange}
         controller={MapController}
-        onWebGLInitialized={this._initialize}
+        parameters={WEBGL_PARAMETERS}
       >
         <StaticMap
           viewId="map"

--- a/examples/website/line/deckgl-overlay.js
+++ b/examples/website/line/deckgl-overlay.js
@@ -1,0 +1,72 @@
+import React, {Component} from 'react';
+import {GL} from 'luma.gl';
+import DeckGL, {LineLayer, ScatterplotLayer} from 'deck.gl';
+
+const WEBGL_PARAMETERS = {
+  blendFunc: [GL.SRC_ALPHA, GL.ONE, GL.ONE_MINUS_DST_ALPHA, GL.ONE],
+  blendEquation: GL.FUNC_ADD
+};
+
+function getColor(d) {
+  const z = d.start[2];
+  const r = z / 10000;
+
+  return [255 * (1 - r * 2), 128 * r, 255 * r, 255 * (1 - r)];
+}
+
+function getSize(type) {
+  if (type.search('major') >= 0) {
+    return 100;
+  }
+  if (type.search('small') >= 0) {
+    return 30;
+  }
+  return 60;
+}
+
+export default class DeckGLOverlay extends Component {
+  static get defaultViewport() {
+    return {
+      latitude: 47.65,
+      longitude: 7,
+      zoom: 4.5,
+      maxZoom: 16,
+      pitch: 50,
+      bearing: 0
+    };
+  }
+
+  render() {
+    const {viewport, flightPaths, airports, strokeWidth} = this.props;
+
+    if (!flightPaths || !airports) {
+      return null;
+    }
+
+    const layers = [
+      new ScatterplotLayer({
+        id: 'airports',
+        data: airports,
+        radiusScale: 20,
+        getPosition: d => d.coordinates,
+        getColor: d => [255, 140, 0],
+        getRadius: d => getSize(d.type),
+        pickable: Boolean(this.props.onHover),
+        onHover: this.props.onHover
+      }),
+      new LineLayer({
+        id: 'flight-paths',
+        data: flightPaths,
+        strokeWidth,
+        fp64: false,
+        getSourcePosition: d => d.start,
+        getTargetPosition: d => d.end,
+        getColor,
+        pickable: Boolean(this.props.onHover),
+        onHover: this.props.onHover
+      })
+    ];
+
+    return <DeckGL {...viewport} layers={layers} parameters={WEBGL_PARAMETERS} />;
+  }
+}

--- a/examples/website/point-cloud-laz/app.js
+++ b/examples/website/point-cloud-laz/app.js
@@ -5,7 +5,7 @@ import {render} from 'react-dom';
 import DeckGL, {COORDINATE_SYSTEM, PointCloudLayer, OrbitView, experimental} from 'deck.gl';
 const {OrbitController} = experimental;
 
-import {setParameters} from 'luma.gl';
+import {GL} from 'luma.gl';
 import {loadLazFile, parseLazData} from './utils/laslaz-loader';
 
 const DATA_REPO = 'https://raw.githubusercontent.com/uber-common/deck.gl-data/master';
@@ -20,6 +20,11 @@ const INITIAL_VIEW_STATE = {
   fov: 30,
   minDistance: 0.5,
   maxDistance: 3
+};
+
+const WEBGL_PARAMETERS = {
+  clearColor: [0.07, 0.14, 0.19, 1],
+  blendFunc: [GL.SRC_ALPHA, GL.ONE_MINUS_SRC_ALPHA]
 };
 
 function normalize(points) {
@@ -64,7 +69,6 @@ class Example extends PureComponent {
       viewState: INITIAL_VIEW_STATE
     };
 
-    this._onInitialize = this._onInitialize.bind(this);
     this._onResize = this._onResize.bind(this);
     this._onViewportChange = this._onViewportChange.bind(this);
     this._onUpdate = this._onUpdate.bind(this);
@@ -97,13 +101,6 @@ class Example extends PureComponent {
 
   componentWillUnmount() {
     window.removeEventListener('resize', this._onResize);
-  }
-
-  _onInitialize(gl) {
-    setParameters(gl, {
-      clearColor: [0.07, 0.14, 0.19, 1],
-      blendFunc: [gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA]
-    });
   }
 
   _onResize() {
@@ -169,7 +166,7 @@ class Example extends PureComponent {
         viewState={viewState}
         controller={OrbitController}
         layers={[this._renderLazPointCloudLayer()]}
-        onWebGLInitialized={this._onInitialize}
+        parameters={WEBGL_PARAMETERS}
         onViewportChange={this._onViewportChange}
       />
     );

--- a/examples/website/text-layer/deckgl-overlay.js
+++ b/examples/website/text-layer/deckgl-overlay.js
@@ -1,0 +1,37 @@
+import React, {Component} from 'react';
+import {GL} from 'luma.gl';
+import DeckGL, {TextLayer} from 'deck.gl';
+
+const WEBGL_PARAMETERS = {
+  blendFunc: [GL.SRC_ALPHA, GL.ONE, GL.ONE_MINUS_DST_ALPHA, GL.ONE],
+  blendEquation: GL.FUNC_ADD
+};
+
+export default class DeckGLOverlay extends Component {
+  static get defaultViewport() {
+    return {
+      latitude: 39.1,
+      longitude: -94.57,
+      zoom: 3.8,
+      maxZoom: 16,
+      pitch: 0,
+      bearing: 0
+    };
+  }
+
+  render() {
+    const {viewport, data} = this.props;
+
+    const layers = [
+      new TextLayer({
+        id: 'hashtag-layer',
+        data,
+        sizeScale: 8,
+        getColor: d => d.color,
+        getSize: d => d.size
+      })
+    ];
+
+    return <DeckGL {...viewport} layers={layers} parameters={WEBGL_PARAMETERS} />;
+  }
+}

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -51,8 +51,9 @@ function getPropTypes(PropTypes) {
     controller: PropTypes.func,
 
     // GL settings
-    glOptions: PropTypes.object,
     gl: PropTypes.object,
+    glOptions: PropTypes.object,
+    parameters: PropTypes.object,
     pickingRadius: PropTypes.number,
     useDevicePixels: PropTypes.bool,
 
@@ -396,6 +397,9 @@ export default class Deck {
       depthFunc: GL.LEQUAL
     });
 
+    if (this.props.parameters) {
+      setParameters(gl, this.props.parameters);
+    }
     this.props.onWebGLInitialized(gl);
 
     this.eventManager = new EventManager(canvas);


### PR DESCRIPTION
#### Background
- For #1840 
#### Change List
- Add new prop.
- Update examples: replace `onWebGLInitialized` callback with new `parameters` prop
