### PR TITLE
Update layer browser

### DIFF
--- a/examples/layer-browser/app.css
+++ b/examples/layer-browser/app.css
@@ -42,8 +42,8 @@ h4 {
   overflow-x: hidden;
   overflow-y: auto;
   height: 100%;
-  width: 280px;
-  background: rgba(255, 255, 255, 0.5);
+  width: 400px;
+  background: rgba(255, 255, 255, 0.8);
 }
 
 #control-panel > div{
@@ -61,15 +61,31 @@ h4 {
 .input-group {
   color: #333;
   line-height: 28px;
-  display: table;
+  display: flex;
   width: 100%;
+  align-items: center;
 }
 .input-group > * {
-  display: table-cell;
-  width: 50%;
-  vertical-align: middle;
+  min-width: 24px;
 }
-.input-group input[type=range] {
+.input-group > label {
+  width: 140px;
+}
+.input-group .addon {
+  cursor: pointer;
+  color: #ccc;
+  text-align: right;
+}
+.input-group .addon:hover {
+  color: #000;
+}
+.input-group .addon.on {
+  color: #048 !important;
+}
+.input-group .input {
+  flex-grow: 1;
+}
+.input-group .input input {
   width: 100%;
   vertical-align: middle;
 }

--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -294,6 +294,7 @@ export default class App extends PureComponent {
         >
           <StaticMap
             viewId="basemap"
+            mapStyle="mapbox://styles/uberdata/cive48w2e001a2imn5mcu2vrs"
             {...mapViewState}
             mapboxApiAccessToken={MapboxAccessToken || 'no_token'}
           />


### PR DESCRIPTION
#### Background
Add ability to test transition and constant accessors with layer-browser 
![image](https://user-images.githubusercontent.com/2059298/40271123-9ed7e3ae-5b4d-11e8-86d6-2ca03ca67c1d.png)

#### Change List
- Display controls for accessor props
- Add `T` (transition) and `C` (constant) toggles to accessor controls
- Fix network errors in the console due to trying to execute `props.fetch`
- Clean up LayerControls component
- Minor styling tweaks
