### PR TITLE
Fix constant attribute transition

### DIFF
--- a/modules/core/src/lib/attribute-manager.js
+++ b/modules/core/src/lib/attribute-manager.js
@@ -243,7 +243,11 @@ export default class AttributeManager {
       logFunctions.onUpdateEnd({level: LOG_START_END_PRIORITY, id: this.id, numInstances});
     }
 
-    this.attributeTransitionManager.update(this.attributes, transitions);
+    this.attributeTransitionManager.update({
+      attributes: this.attributes,
+      numInstances,
+      transitions
+    });
   }
 
   // Update attribute transition to the current timestamp

--- a/modules/core/src/lib/attribute-transition-manager.js
+++ b/modules/core/src/lib/attribute-transition-manager.js
@@ -69,7 +69,7 @@ export default class AttributeTransitionManager {
     if (!this.transform) {
       this._createModel();
     } else if (this.transform) {
-      const {sourceBuffers, destinationBuffers, elementCount} = getBuffers(changedTransitions);
+      const {sourceBuffers, destinationBuffers} = getBuffers(changedTransitions);
       this.transform.elementCount = this.numInstances;
       this.transform.update({
         sourceBuffers,
@@ -218,7 +218,7 @@ export default class AttributeTransitionManager {
     }
     const fromState = transition.buffer || toState;
     const toLength = this.numInstances * size;
-    const fromLength = fromState.data && fromState.data.length || toLength;
+    const fromLength = (fromState.data && fromState.data.length) || toLength;
 
     // Alternate between two buffers when new transitions start.
     // Last destination buffer is used as an attribute (from state),

--- a/modules/core/src/lib/attribute-transition-manager.js
+++ b/modules/core/src/lib/attribute-transition-manager.js
@@ -16,6 +16,7 @@ export default class AttributeTransitionManager {
     this.attributeTransitions = {};
     this.needsRedraw = false;
     this.transform = null;
+    this.numInstances = 0;
 
     if (Transform.isSupported(gl)) {
       this.isSupported = true;
@@ -37,8 +38,9 @@ export default class AttributeTransitionManager {
 
   // Called when attribute manager updates
   // Check the latest attributes for updates.
-  update(attributes, opts = {}) {
-    this.opts = opts;
+  update({attributes, transitions = {}, numInstances}) {
+    this.opts = transitions;
+    this.numInstances = numInstances;
 
     if (!this.isSupported) {
       return;
@@ -206,10 +208,15 @@ export default class AttributeTransitionManager {
     const {attribute} = transition;
     const {value, size} = attribute;
 
-    // TODO - support attribute in Transform class
-    const toState = attribute.getBuffer();
-    toState.setDataLayout({size});
+    let toState;
+    if (attribute.isGeneric) {
+      toState = {isGeneric: true, value: attribute.value, size};
+    } else {
+      toState = {isGeneric: false, buffer: attribute.getBuffer(), size};
+    }
     const fromState = transition.buffer || toState;
+    const toLength = this.numInstances * size;
+    const fromLength = fromState.data && fromState.data.length || toLength;
 
     // Alternate between two buffers when new transitions start.
     // Last destination buffer is used as an attribute (from state),
@@ -220,21 +227,21 @@ export default class AttributeTransitionManager {
     if (!buffer) {
       buffer = new Buffer(this.gl, {
         size,
-        data: new Float32Array(value.length),
+        data: new Float32Array(toLength),
         usage: GL.DYNAMIC_COPY
       });
     }
 
     // Pad buffers to be the same length
-    if (buffer.data.length < value.length) {
+    if (buffer.data.length < toLength) {
       buffer.setData({
-        data: new Float32Array(value.length)
+        data: new Float32Array(toLength)
       });
     }
-    if (fromState.data.length < value.length) {
-      const data = new Float32Array(value.length);
+    if (fromLength < toLength) {
+      const data = new Float32Array(toLength);
       data.set(fromState.getData({}));
-      data.set(value.subarray(fromState.data.length), fromState.data.length);
+      data.set(value.subarray(fromLength), fromLength);
 
       fromState.setData({data});
     }

--- a/modules/core/src/lib/attribute-transition-utils.js
+++ b/modules/core/src/lib/attribute-transition-utils.js
@@ -1,3 +1,6 @@
+import {Buffer} from 'luma.gl';
+import {fillArray} from '../utils/flatten';
+
 const ATTRIBUTE_MAPPING = {
   1: 'float',
   2: 'vec2',
@@ -61,14 +64,35 @@ void main(void) {
 export function getBuffers(transitions) {
   const sourceBuffers = {};
   const destinationBuffers = {};
-  let elementCount = null;
   for (const attributeName in transitions) {
     const {fromState, toState, buffer, attribute} = transitions[attributeName];
-    const count = attribute.value.length / attribute.size;
     sourceBuffers[`${attributeName}From`] = fromState;
     sourceBuffers[`${attributeName}To`] = toState;
     destinationBuffers[`${attributeName}`] = buffer;
-    elementCount = elementCount === null ? count : Math.min(elementCount, count);
   }
-  return {sourceBuffers, destinationBuffers, elementCount};
+  return {sourceBuffers, destinationBuffers};
+}
+
+export function padBuffer({fromState, toState, fromLength, toLength}) {
+  // check if buffer needs to be padded
+  if (fromLength >= toLength || !(fromState instanceof Buffer)) {
+    return;
+  }
+
+  const data = new Float32Array(toLength);
+  // copy the currect values
+  data.set(fromState.getData({}));
+  
+  if (toState.isGeneric) {
+    fillArray({
+      target: data,
+      source: data.value,
+      start: fromLength,
+      count: (toLength - startLength) / data.value.length
+    });
+  } else {
+    data.set(toState.data.subarray(fromLength), fromLength);
+  }
+
+  fromState.setData({data});
 }

--- a/modules/core/src/lib/attribute-transition-utils.js
+++ b/modules/core/src/lib/attribute-transition-utils.js
@@ -65,7 +65,7 @@ export function getBuffers(transitions) {
   const sourceBuffers = {};
   const destinationBuffers = {};
   for (const attributeName in transitions) {
-    const {fromState, toState, buffer, attribute} = transitions[attributeName];
+    const {fromState, toState, buffer} = transitions[attributeName];
     sourceBuffers[`${attributeName}From`] = fromState;
     sourceBuffers[`${attributeName}To`] = toState;
     destinationBuffers[`${attributeName}`] = buffer;
@@ -82,13 +82,13 @@ export function padBuffer({fromState, toState, fromLength, toLength}) {
   const data = new Float32Array(toLength);
   // copy the currect values
   data.set(fromState.getData({}));
-  
+
   if (toState.isGeneric) {
     fillArray({
       target: data,
       source: data.value,
       start: fromLength,
-      count: (toLength - startLength) / data.value.length
+      count: (toLength - fromLength) / data.value.length
     });
   } else {
     data.set(toState.data.subarray(fromLength), fromLength);

--- a/modules/core/src/lib/attribute.js
+++ b/modules/core/src/lib/attribute.js
@@ -175,7 +175,7 @@ export default class LayerAttribute extends Attribute {
 
       if (buffer instanceof Buffer) {
         if (this.externalBuffer !== buffer) {
-          this.update({externalBuffer: buffer});
+          this.update({isGeneric: false, buffer});
           state.needsRedraw = true;
         }
       } else {


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/1797

#### Change List
- `AttributeTransitionManager` can no longer infer instance count from attribute value length. `attributeManager` must pass `numInstances` during update.
- Check if target buffer is a generic attribute when padding the source buffer
