### PR TITLE
Attribute: Add custom Buffer support.

### DIFF
--- a/modules/experimental-layers/src/gpu-screen-grid-layer/gpu-screen-grid-layer.js
+++ b/modules/experimental-layers/src/gpu-screen-grid-layer/gpu-screen-grid-layer.js
@@ -59,12 +59,12 @@ export default class GPUScreenGridLayer extends Layer {
     /* eslint-disable max-len */
     attributeManager.addInstanced({
       instancePositions: {size: 3, update: this.calculateInstancePositions},
-      // TODO: Needed, since attributeManger.update() only updates existing attributes.
       instanceCounts: {
         size: 4,
         transition: true,
         accessor: ['getPosition', 'getWeight'],
-        update: this.calculateInstanceCounts
+        update: this.calculateInstanceCounts,
+        noAlloc: true
       }
     });
     /* eslint-disable max-len */
@@ -136,8 +136,10 @@ export default class GPUScreenGridLayer extends Layer {
   }
 
   calculateInstanceCounts(attribute, {numInstances}) {
-    // Empty method: Attribute manager requires an update method for each added attribute
-    // TODO: remove this when proper external buffer support is added to Attribute Manager.
+    const {countsBuffer} = this.state;
+    attribute.update({
+      buffer: countsBuffer
+    });
   }
 
   // HELPER Methods
@@ -222,15 +224,16 @@ export default class GPUScreenGridLayer extends Layer {
   }
 
   _updateAggregation(changeFlags) {
+    const attributeManager = this.getAttributeManager();
     if (changeFlags.cellSizeChanged || changeFlags.viewportChanged) {
       this._updateGridParams();
+      attributeManager.invalidateAll();
     }
+    const {cellSizePixels, gpuAggregation} = this.props;
 
-    const {data, cellSizePixels, gpuAggregation} = this.props;
+    const {positions, weights, maxCountBuffer, countsBuffer} = this.state;
 
-    const {positions, weights, maxCountBuffer, countsBuffer, numInstances} = this.state;
-
-    const aggregatedData = this.state.gpuGridAggregator.run({
+    this.state.gpuGridAggregator.run({
       positions,
       weights,
       cellSize: [cellSizePixels, cellSizePixels],
@@ -241,20 +244,7 @@ export default class GPUScreenGridLayer extends Layer {
       useGPU: gpuAggregation
     });
 
-    const attributeManager = this.getAttributeManager();
-
-    // TODO: AttributeManager should be able to just take new buffer for one or more attributes.
-    // data and numInstances shouldn't be needed.
-    attributeManager.update({
-      data,
-      numInstances,
-      buffers: {
-        instanceCounts: aggregatedData.countsBuffer
-      },
-      context: this,
-      ignoreUnknownAttributes: true
-    });
-    attributeManager.invalidateAll();
+    attributeManager.invalidate('instanceCounts');
   }
 
   _updateGridParams() {

--- a/test/render/test-cases.js
+++ b/test/render/test-cases.js
@@ -1,7 +1,7 @@
 import * as dataSamples from '../../examples/layer-browser/src/data-samples';
 import {parseColor, setOpacity} from '../../examples/layer-browser/src/utils/color';
 // TODO: remove hard path once @deck.gl/experimental-layers published with GPUScreenGridLayer
-// import {GPUScreenGridLayer} from '@deck.gl/experimental-layers';
+import {GPUScreenGridLayer} from '@deck.gl/experimental-layers';
 import {GL} from 'luma.gl';
 import {OrbitView, OrthographicView} from 'deck.gl';
 
@@ -959,7 +959,6 @@ export const TEST_CASES = [
     ],
     referenceImageUrl: './test/render/golden-images/text-layer.png'
   },
-  /*
   {
     name: 'gpu-screengrid-lnglat',
     viewState: {
@@ -982,7 +981,6 @@ export const TEST_CASES = [
     ],
     referenceImageUrl: './test/render/golden-images/screengrid-lnglat.png'
   },
-  */
   {
     name: 'text-layer-64',
     viewState: {


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #1828 
<!-- For other PRs without open issue -->
#### Background
Existing `External Buffer` support for Attributes is only through `Layer` props. This state is non persistent, and when buffer is not supported for an attribute through props, it will switch back to normal attribute where `AttributeManger` creates the Buffer object.
For GPGPU layers, we need to support another way of providing `Buffer` object, which will persist until the layer resets it. Added a new flag `isCustomBuffer` to `Attribute` class.
<!-- For all the PRs -->
#### Change List
- Attribute: Add custom buffer support.
- Enable GPUScreenGridLayer rendering tests.