### PR TITLE
View Manager cleanup

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,7 +12,8 @@
     "guard-for-in": 0,
     "no-inline-comments": 0,
     "camelcase": 0,
-    "react/forbid-prop-types": 0
+    "react/forbid-prop-types": 0,
+    "react/no-deprecated": 0
   },
   "parserOptions": {
     "ecmaVersion": 2017

--- a/examples/experimental/bezier/app.js
+++ b/examples/experimental/bezier/app.js
@@ -124,9 +124,7 @@ class App extends Component {
     const {viewport} = this.state;
     const {width, height} = viewport;
 
-    const {
-      data = layoutGraph(SAMPLE_GRAPH)
-    } = this.props;
+    const {data = layoutGraph(SAMPLE_GRAPH)} = this.props;
 
     const view = new OrthographicView({
       left: -width / 2,

--- a/examples/website/3d-heatmap/app.js
+++ b/examples/website/3d-heatmap/app.js
@@ -80,7 +80,7 @@ class App extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.data && this.props.data && (nextProps.data.length !== this.props.data.length)) {
+    if (nextProps.data && this.props.data && nextProps.data.length !== this.props.data.length) {
       this._animate();
     }
   }
@@ -139,7 +139,7 @@ class App extends Component {
       viewState = this.state.viewState,
 
       mapboxApiAccessToken = MAPBOX_TOKEN,
-      mapStyle = "mapbox://styles/mapbox/dark-v9"
+      mapStyle = 'mapbox://styles/mapbox/dark-v9'
     } = this.props;
 
     const layers = [
@@ -169,17 +169,14 @@ class App extends Component {
         onViewStateChange={onViewStateChange}
         controller={MapController}
       >
-
         <StaticMap
           viewId="map"
           {...viewState}
           reuseMaps
-
           mapStyle={mapStyle}
           preventStyleDiffing={true}
           mapboxApiAccessToken={mapboxApiAccessToken}
         />
-
       </DeckGL>
     );
   }

--- a/examples/website/arc/app.js
+++ b/examples/website/arc/app.js
@@ -61,7 +61,6 @@ class App extends Component {
             selectedCounty: features.find(f => f.properties.name === 'Los Angeles, CA')
           });
           this._recalculateArcs(this.state.counties, this.state.selectedCounty);
-
         });
     } else {
       this._recalculateArcs(this.props.data, this.props.selectedFeature);
@@ -145,7 +144,7 @@ class App extends Component {
       viewState = this.state.viewState,
 
       mapboxApiAccessToken = MAPBOX_TOKEN,
-      mapStyle = "mapbox://styles/mapbox/light-v9"
+      mapStyle = 'mapbox://styles/mapbox/light-v9'
     } = this.props;
 
     const layers = [
@@ -178,17 +177,14 @@ class App extends Component {
         onViewStateChange={onViewStateChange}
         controller={MapController}
       >
-
         <StaticMap
           viewId="map"
           {...viewState}
           reuseMaps
-
           mapStyle={mapStyle}
           preventStyleDiffing={true}
           mapboxApiAccessToken={mapboxApiAccessToken}
         />
-
       </DeckGL>
     );
   }

--- a/examples/website/brushing/app.js
+++ b/examples/website/brushing/app.js
@@ -7,7 +7,6 @@ import ArcBrushingLayer from './arc-brushing-layer';
 import ScatterplotBrushingLayer from './scatterplot-brushing-layer';
 import {scaleLinear} from 'd3-scale';
 
-
 // Set your mapbox token here
 const MAPBOX_TOKEN = process.env.MapboxAccessToken; // eslint-disable-line
 
@@ -214,7 +213,7 @@ class App extends Component {
       viewState = this.state.viewState,
 
       mapboxApiAccessToken = MAPBOX_TOKEN,
-      mapStyle = "mapbox://styles/mapbox/dark-v9"
+      mapStyle = 'mapbox://styles/mapbox/dark-v9'
     } = this.props;
     const {arcs, targets, sources} = this.state;
 
@@ -297,19 +296,15 @@ class App extends Component {
           onViewStateChange={onViewStateChange}
           controller={MapController}
         >
-
           <StaticMap
             viewId="map"
             {...viewState}
             reuseMaps
-
             mapStyle={mapStyle}
             preventStyleDiffing={true}
             mapboxApiAccessToken={mapboxApiAccessToken}
           />
-
         </DeckGL>
-
       </div>
     );
   }

--- a/examples/website/geojson/app.js
+++ b/examples/website/geojson/app.js
@@ -32,7 +32,6 @@ const INITIAL_VIEW_STATE = {
 const DEFAULT_COLOR_SCALE = r => [r * 255, 140, 200 * (1 - r)];
 
 class App extends Component {
-
   constructor(props) {
     super(props);
     this.state = {viewState: INITIAL_VIEW_STATE};
@@ -42,7 +41,7 @@ class App extends Component {
     const {
       data = DATA_URL,
       colorScale = DEFAULT_COLOR_SCALE,
-      onViewStateChange = (({viewState}) => this.setState({viewState})),
+      onViewStateChange = ({viewState}) => this.setState({viewState}),
       viewState = this.state.viewState,
       mapboxApiAccessToken = MAPBOX_TOKEN,
       mapStyle = null
@@ -75,17 +74,14 @@ class App extends Component {
         onViewStateChange={onViewStateChange}
         controller={MapController}
       >
-
         <StaticMap
           viewId="map"
           {...viewState}
           reuseMaps
-
           mapStyle={mapStyle}
           preventStyleDiffing={true}
           mapboxApiAccessToken={mapboxApiAccessToken}
         />
-
       </DeckGL>
     );
   }

--- a/examples/website/icon/app.js
+++ b/examples/website/icon/app.js
@@ -42,7 +42,6 @@ function getIconSize(size) {
 
 /* eslint-disable react/no-deprecated */
 class App extends Component {
-
   constructor(props) {
     super(props);
 
@@ -155,14 +154,14 @@ class App extends Component {
     const {
       data = this.state.data,
       iconMapping = this.state.iconMapping,
-      iconAtlas = "data/location-icon-atlas.png",
+      iconAtlas = 'data/location-icon-atlas.png',
       showCluster = true,
 
       onViewStateChange = this._onViewStateChange.bind(this),
       viewState = this.state.viewState,
 
       mapboxApiAccessToken = MAPBOX_TOKEN,
-      mapStyle = "mapbox://styles/mapbox/dark-v9"
+      mapStyle = 'mapbox://styles/mapbox/dark-v9'
     } = this.props;
 
     this._updateCluster({data, viewState});
@@ -172,23 +171,24 @@ class App extends Component {
     const updateTrigger = z * showCluster;
 
     const layers = [
-      iconMapping && new IconLayer({
-        id: 'icon',
-        data,
-        pickable: this.props.onHover || this.props.onClick,
-        iconAtlas,
-        iconMapping,
-        sizeScale: ICON_SIZE * size * window.devicePixelRatio,
-        getPosition: d => d.coordinates,
-        getIcon: d => (showCluster ? d.zoomLevels[z] && d.zoomLevels[z].icon : 'marker'),
-        getSize: d => (showCluster ? d.zoomLevels[z] && d.zoomLevels[z].size : 1),
-        onHover: this.props.onHover,
-        onClick: this.props.onClick,
-        updateTriggers: {
-          getIcon: updateTrigger,
-          getSize: updateTrigger
-        }
-      })
+      iconMapping &&
+        new IconLayer({
+          id: 'icon',
+          data,
+          pickable: this.props.onHover || this.props.onClick,
+          iconAtlas,
+          iconMapping,
+          sizeScale: ICON_SIZE * size * window.devicePixelRatio,
+          getPosition: d => d.coordinates,
+          getIcon: d => (showCluster ? d.zoomLevels[z] && d.zoomLevels[z].icon : 'marker'),
+          getSize: d => (showCluster ? d.zoomLevels[z] && d.zoomLevels[z].size : 1),
+          onHover: this.props.onHover,
+          onClick: this.props.onClick,
+          updateTriggers: {
+            getIcon: updateTrigger,
+            getSize: updateTrigger
+          }
+        })
     ];
 
     return (
@@ -199,17 +199,14 @@ class App extends Component {
         onViewStateChange={onViewStateChange}
         controller={MapController}
       >
-
         <StaticMap
           viewId="map"
           {...viewState}
           reuseMaps
-
           mapStyle={mapStyle}
           mapboxApiAccessToken={mapboxApiAccessToken}
           preventStyleDiffing={true}
         />
-
       </DeckGL>
     );
   }

--- a/examples/website/line/app.js
+++ b/examples/website/line/app.js
@@ -62,11 +62,11 @@ class App extends Component {
       flightPaths = DATA_URL.FLIGHT_PATHS,
       strokeWidth = 3,
 
-      onViewStateChange = (({viewState}) => this.setState({viewState})),
+      onViewStateChange = ({viewState}) => this.setState({viewState}),
       viewState = this.state.viewState,
 
       mapboxApiAccessToken = MAPBOX_TOKEN,
-      mapStyle = "mapbox://styles/mapbox/dark-v9"
+      mapStyle = 'mapbox://styles/mapbox/dark-v9'
     } = this.props;
 
     const layers = [
@@ -102,17 +102,14 @@ class App extends Component {
         controller={MapController}
         onWebGLInitialized={this._initialize}
       >
-
         <StaticMap
           viewId="map"
           {...viewState}
           reuseMaps
-
           mapStyle={mapStyle}
           preventStyleDiffing={true}
           mapboxApiAccessToken={mapboxApiAccessToken}
         />
-
       </DeckGL>
     );
   }

--- a/examples/website/plot/app.js
+++ b/examples/website/plot/app.js
@@ -125,12 +125,7 @@ class Root extends Component {
 
     return (
       <div>
-        <App
-          equation={EQUATION}
-          resolution={200}
-          showAxis={true}
-          onHover={this.props.onHover}
-        />
+        <App equation={EQUATION} resolution={200} showAxis={true} onHover={this.props.onHover} />
 
         {hoverInfo && (
           <div className="tooltip" style={{left: hoverInfo.x, top: hoverInfo.y}}>

--- a/examples/website/scatterplot/app.js
+++ b/examples/website/scatterplot/app.js
@@ -22,7 +22,6 @@ const INITIAL_VIEW_STATE = {
   bearing: 0
 };
 
-
 class App extends Component {
   constructor(props) {
     super(props);
@@ -62,7 +61,7 @@ class App extends Component {
       viewState = this.state.viewState,
 
       mapboxApiAccessToken = MAPBOX_TOKEN,
-      mapStyle = "mapbox://styles/mapbox/dark-v9"
+      mapStyle = 'mapbox://styles/mapbox/dark-v9'
     } = this.props;
 
     const layers = [
@@ -88,17 +87,14 @@ class App extends Component {
         onViewStateChange={onViewStateChange}
         controller={MapController}
       >
-
         <StaticMap
           viewId="map"
           {...viewState}
           reuseMaps
-
           mapStyle={mapStyle}
           preventStyleDiffing={true}
           mapboxApiAccessToken={mapboxApiAccessToken}
         />
-
       </DeckGL>
     );
   }

--- a/examples/website/screen-grid/app.js
+++ b/examples/website/screen-grid/app.js
@@ -56,7 +56,7 @@ class App extends Component {
       viewState = this.state.viewState,
 
       mapboxApiAccessToken = MAPBOX_TOKEN,
-      mapStyle = "mapbox://styles/mapbox/dark-v9"
+      mapStyle = 'mapbox://styles/mapbox/dark-v9'
     } = this.props;
 
     const layer = new ScreenGridLayer({
@@ -71,19 +71,12 @@ class App extends Component {
       <MapGL
         {...viewState}
         reuseMaps
-
         onViewportChange={viewport => onViewStateChange({viewState: viewport})}
         mapStyle={mapStyle}
         preventStyleDiffing={true}
         mapboxApiAccessToken={mapboxApiAccessToken}
       >
-
-        <DeckGL
-          layers={[layer]}
-          views={new MapView({id: 'map'})}
-          viewState={viewState}
-          />;
-
+        <DeckGL layers={[layer]} views={new MapView({id: 'map'})} viewState={viewState} />;
       </MapGL>
     );
   }

--- a/examples/website/tagmap/app.js
+++ b/examples/website/tagmap/app.js
@@ -105,17 +105,14 @@ class App extends Component {
         onViewStateChange={onViewStateChange}
         controller={MapController}
       >
-
         <StaticMap
           viewId="map"
           {...viewState}
           reuseMaps
-
           mapStyle={mapStyle}
           preventStyleDiffing={true}
           mapboxApiAccessToken={mapboxApiAccessToken}
         />
-
       </DeckGL>
     );
   }

--- a/examples/website/text-layer/app.js
+++ b/examples/website/text-layer/app.js
@@ -127,7 +127,6 @@ class App extends Component {
       mapStyle = MAPBOX_STYLE
     } = this.props;
 
-
     const layers = [
       new TextLayer({
         id: 'hashtag-layer',
@@ -146,17 +145,14 @@ class App extends Component {
         onViewStateChange={onViewStateChange}
         controller={MapController}
       >
-
         <StaticMap
           viewId="map"
           {...viewState}
           reuseMaps
-
           mapStyle={mapStyle}
           preventStyleDiffing={true}
           mapboxApiAccessToken={mapboxApiAccessToken}
         />
-
       </DeckGL>
     );
   }

--- a/examples/website/trips/app.js
+++ b/examples/website/trips/app.js
@@ -91,7 +91,7 @@ export default class App extends Component {
       viewState = this.state.viewState,
 
       mapboxApiAccessToken = MAPBOX_TOKEN,
-      mapStyle = "mapbox://styles/mapbox/dark-v9"
+      mapStyle = 'mapbox://styles/mapbox/dark-v9'
     } = this.props;
 
     const layers = [
@@ -127,17 +127,14 @@ export default class App extends Component {
         onViewStateChange={onViewStateChange}
         controller={MapController}
       >
-
         <StaticMap
           viewId="map"
           {...viewState}
           reuseMaps
-
           mapStyle={mapStyle}
           preventStyleDiffing={true}
           mapboxApiAccessToken={mapboxApiAccessToken}
         />
-
       </DeckGL>
     );
   }

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -47,22 +47,23 @@ function getPropTypes(PropTypes) {
     layerFilter: PropTypes.func,
     views: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
     viewState: PropTypes.object,
-    controller: PropTypes.func,
-    onViewStateChange: PropTypes.func,
     effects: PropTypes.arrayOf(PropTypes.instanceOf(Effect)),
+    controller: PropTypes.func,
 
     // GL settings
     glOptions: PropTypes.object,
     gl: PropTypes.object,
     pickingRadius: PropTypes.number,
+    useDevicePixels: PropTypes.bool,
 
+    // Callbacks
     onWebGLInitialized: PropTypes.func,
     onResize: PropTypes.func,
+    onViewStateChange: PropTypes.func,
     onBeforeRender: PropTypes.func,
     onAfterRender: PropTypes.func,
     onLayerClick: PropTypes.func,
     onLayerHover: PropTypes.func,
-    useDevicePixels: PropTypes.bool,
 
     // Debug settings
     debug: PropTypes.bool,
@@ -83,13 +84,15 @@ const defaultProps = {
   effects: [],
   views: null,
   controller: null, // Rely on external controller, e.g. react-map-gl
+  useDevicePixels: true,
 
   onWebGLInitialized: noop,
+  onResize: noop,
+  onViewStateChange: noop,
   onBeforeRender: noop,
   onAfterRender: noop,
   onLayerClick: null,
   onLayerHover: null,
-  useDevicePixels: true,
 
   debug: false,
   drawPickingColors: false
@@ -299,9 +302,7 @@ export default class Deck {
           height: this.height
         });
       }
-      if (this.props.onResize) {
-        this.props.onResize({width: this.width, height: this.height});
-      }
+      this.props.onResize({width: this.width, height: this.height});
     }
   }
 
@@ -367,9 +368,7 @@ export default class Deck {
 
   _onViewStateChange({viewState}, ...args) {
     // Let app know that view state is changing, and give it a chance to change it
-    if (this.props.onViewStateChange) {
-      viewState = this.props.onViewStateChange({viewState}, ...args) || viewState;
-    }
+    viewState = this.props.onViewStateChange({viewState}, ...args) || viewState;
 
     // If initialViewState was set on creation, auto track position
     if (this.viewState) {

--- a/modules/core/src/views/view-manager.js
+++ b/modules/core/src/views/view-manager.js
@@ -36,7 +36,7 @@ export default class ViewManager {
     this.viewState = INITIAL_VIEW_STATE;
 
     this._viewports = []; // Generated viewports
-    this._viewportMap = [];
+    this._viewportMap = {};
     this._needsRedraw = 'Initial render';
     this._needsUpdate = true;
 

--- a/modules/core/src/views/view-manager.js
+++ b/modules/core/src/views/view-manager.js
@@ -36,6 +36,7 @@ export default class ViewManager {
     this.viewState = INITIAL_VIEW_STATE;
 
     this._viewports = []; // Generated viewports
+    this._viewportMap = [];
     this._needsRedraw = 'Initial render';
     this._needsUpdate = true;
 
@@ -73,6 +74,11 @@ export default class ViewManager {
   getViewports() {
     this._rebuildViewportsFromViews();
     return this._viewports;
+  }
+
+  getViewport(viewId) {
+    this._rebuildViewportsFromViews();
+    return this._viewportMap[viewId];
   }
 
   /**
@@ -196,10 +202,23 @@ export default class ViewManager {
 
       this._viewports = views.map(view => view.makeViewport({width, height, viewState}));
 
+      this._buildViewportMap();
+
       // We've just rebuilt the Viewports to match the View descriptors,
       // so clear the update flag and set the render flag
       this._needsUpdate = false;
     }
+  }
+
+  _buildViewportMap() {
+    // Build a view id to view index
+    this._viewportMap = {};
+    this._viewports.forEach(viewport => {
+      if (viewport.id) {
+        // TODO - issue warning if multiple viewports use same id
+        this._viewportMap[viewport.id] = this._viewportMap[viewport.id] || viewport;
+      }
+    });
   }
 
   // Check if viewport array has changed, returns true if any change

--- a/modules/react/src/utils/extract-jsx-layers.js
+++ b/modules/react/src/utils/extract-jsx-layers.js
@@ -21,7 +21,7 @@ export default function extractJSXLayers(children, layers) {
   });
 
   // Avoid modifying layers array if no JSX layers were found
-  layers = jsxLayers.length > 0 ? [...jsxLayers, ...layers] : layers
+  layers = jsxLayers.length > 0 ? [...jsxLayers, ...layers] : layers;
 
   return {layers, children: reactChildren};
 }

--- a/modules/react/src/utils/extract-jsx-layers.js
+++ b/modules/react/src/utils/extract-jsx-layers.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import {inheritsFrom} from './inherits-from';
+import {Layer} from '@deck.gl/core';
+
+// extracts any deck.gl layers masquerading as react elements from props.children
+export default function extractJSXLayers(children, layers) {
+  const reactChildren = []; // extract real react elements (i.e. not deck.gl layers)
+  const jsxLayers = []; // extracted layer from react children, will add to deck.gl layer array
+
+  React.Children.forEach(children, reactElement => {
+    if (reactElement) {
+      // For some reason Children.forEach doesn't filter out `null`s
+      const LayerType = reactElement.type;
+      if (inheritsFrom(LayerType, Layer)) {
+        const layer = new LayerType(reactElement.props);
+        jsxLayers.push(layer);
+      } else {
+        reactChildren.push(reactElement);
+      }
+    }
+  });
+
+  // Avoid modifying layers array if no JSX layers were found
+  layers = jsxLayers.length > 0 ? [...jsxLayers, ...layers] : layers
+
+  return {layers, children: reactChildren};
+}


### PR DESCRIPTION
#### Background
- Light `ViewManager`, `Deck`, `DeckGL` cleanup
#### Change List
- Move some child position related calculation from `DeckGL` to `ViewManager`
- Clean up some props handling in `Deck`
- Make `DeckGL` class smaller/simpler by reducing child positioning logic and moving JSX layers to util. 
