### PR TITLE
Remove GL_ES from fragment shaders

### DIFF
--- a/docs/developer-guide/subclassed-layers.md
+++ b/docs/developer-guide/subclassed-layers.md
@@ -120,9 +120,7 @@ RoundedRectangleLayer.defaultProps = {
 export default `\
 #define SHADER_NAME my-scatterplot-layer-fragment-shader
 
-#ifdef GL_ES
 precision highp float;
-#endif
 
 uniform float cornerRadius;
 

--- a/examples/website/brushing/arc-brushing-layer/arc-brushing-layer-fragment.glsl.js
+++ b/examples/website/brushing/arc-brushing-layer/arc-brushing-layer-fragment.glsl.js
@@ -21,9 +21,7 @@
 export default `\
 #define SHADER_NAME arc-layer-fragment-shader
 
-#ifdef GL_ES
 precision highp float;
-#endif
 
 varying vec4 vColor;
 

--- a/examples/website/brushing/scatterplot-brushing-layer/scatterplot-brushing-layer-fragment.glsl.js
+++ b/examples/website/brushing/scatterplot-brushing-layer/scatterplot-brushing-layer-fragment.glsl.js
@@ -21,9 +21,7 @@
 export default `\
 #define SHADER_NAME scatterplot-layer-fragment-shader
 
-#ifdef GL_ES
 precision highp float;
-#endif
 
 varying vec4 vColor;
 varying vec2 unitPosition;

--- a/examples/website/plot/plot-layer/axes-fragment.glsl.js
+++ b/examples/website/plot/plot-layer/axes-fragment.glsl.js
@@ -21,9 +21,7 @@
 export default `\
 #define SHADER_NAME graph-layer-fragment-shader
 
-#ifdef GL_ES
 precision highp float;
-#endif
 
 varying vec4 vColor;
 varying float shouldDiscard;

--- a/examples/website/plot/plot-layer/fragment.glsl.js
+++ b/examples/website/plot/plot-layer/fragment.glsl.js
@@ -21,9 +21,7 @@
 export default `\
 #define SHADER_NAME graph-layer-fragment-shader
 
-#ifdef GL_ES
 precision highp float;
-#endif
 
 varying vec4 vColor;
 varying float shouldDiscard;

--- a/examples/website/plot/plot-layer/label-fragment.glsl.js
+++ b/examples/website/plot/plot-layer/label-fragment.glsl.js
@@ -21,9 +21,7 @@
 export default `\
 #define SHADER_NAME graph-layer-fragment-shader
 
-#ifdef GL_ES
 precision highp float;
-#endif
 
 uniform sampler2D labelTexture;
 

--- a/examples/website/trips/trips-layer/trips-layer-fragment.glsl.js
+++ b/examples/website/trips/trips-layer/trips-layer-fragment.glsl.js
@@ -21,9 +21,7 @@
 export default `\
 #define SHADER_NAME trips-layer-fragment-shader
 
-#ifdef GL_ES
 precision highp float;
-#endif
 
 varying float vTime;
 varying vec4 vColor;

--- a/modules/core/src/experimental/reflection-effect/reflection-effect-fragment.glsl.js
+++ b/modules/core/src/experimental/reflection-effect/reflection-effect-fragment.glsl.js
@@ -21,9 +21,7 @@
 export default `\
 #define SHADER_NAME reflection-effect-fs
 
-#ifdef GL_ES
 precision highp float;
-#endif
 
 uniform sampler2D reflectionTexture;
 uniform int reflectionTextureWidth;

--- a/modules/core/src/lib/attribute-transition-utils.js
+++ b/modules/core/src/lib/attribute-transition-utils.js
@@ -48,9 +48,7 @@ void main(void) {
   const fs = `\
 #define SHADER_NAME feedback-fragment-shader
 
-#ifdef GL_ES
 precision highp float;
-#endif
 
 ${varyingDeclarations.join('\n')}
 

--- a/modules/experimental-layers/src/advanced-text-layer/advanced-text-layer-fragment.glsl.js
+++ b/modules/experimental-layers/src/advanced-text-layer/advanced-text-layer-fragment.glsl.js
@@ -21,9 +21,7 @@
 export default `\
 #define SHADER_NAME advanced-text-layer-fragment-shader
 
-#ifdef GL_ES
 precision highp float;
-#endif
 
 uniform float opacity;
 uniform float smoothing;

--- a/modules/experimental-layers/src/bezier-curve-layer/bezier-curve-layer-fragment.glsl.js
+++ b/modules/experimental-layers/src/bezier-curve-layer/bezier-curve-layer-fragment.glsl.js
@@ -21,9 +21,7 @@
 export default `\
 #define SHADER_NAME bezier-curve-layer-fragment-shader
 
-#ifdef GL_ES
 precision highp float;
-#endif
 
 varying vec4 vColor;
 

--- a/modules/experimental-layers/src/gpu-screen-grid-layer/gpu-screen-grid-layer-fragment.glsl.js
+++ b/modules/experimental-layers/src/gpu-screen-grid-layer/gpu-screen-grid-layer-fragment.glsl.js
@@ -23,9 +23,7 @@ export default `\
 #version 300 es
 #define SHADER_NAME screen-grid-layer-fragment-shader
 
-#ifdef GL_ES
 precision highp float;
-#endif
 
 in vec4 vColor;
 out vec4 fragColor;

--- a/modules/experimental-layers/src/mesh-layer/mesh-layer-fragment.glsl.js
+++ b/modules/experimental-layers/src/mesh-layer/mesh-layer-fragment.glsl.js
@@ -1,9 +1,7 @@
 export default `
 #define SHADER_NAME mesh-layer-fs
 
-#ifdef GL_ES
 precision highp float;
-#endif
 
 uniform bool hasTexture;
 uniform sampler2D sampler;

--- a/modules/experimental-layers/src/utils/gpu-grid-aggregator.js
+++ b/modules/experimental-layers/src/utils/gpu-grid-aggregator.js
@@ -38,9 +38,7 @@ void main(void) {
 `;
 
 const AGGREGATE_TO_GRID_FS = `\
-#ifdef GL_ES
 precision highp float;
-#endif
 
 varying float vWeights;
 
@@ -71,9 +69,7 @@ void main(void) {
 `;
 
 const AGGREGATE_ALL_FS = `\
-#ifdef GL_ES
 precision highp float;
-#endif
 
 varying vec2 vTextureCoord;
 uniform sampler2D uSampler;

--- a/modules/layers/src/arc-layer/arc-layer-fragment.glsl.js
+++ b/modules/layers/src/arc-layer/arc-layer-fragment.glsl.js
@@ -21,9 +21,7 @@
 export default `\
 #define SHADER_NAME arc-layer-fragment-shader
 
-#ifdef GL_ES
 precision highp float;
-#endif
 
 varying vec4 vColor;
 

--- a/modules/layers/src/grid-cell-layer/grid-cell-layer-fragment.glsl.js
+++ b/modules/layers/src/grid-cell-layer/grid-cell-layer-fragment.glsl.js
@@ -21,9 +21,7 @@
 export default `\
 #define SHADER_NAME grid-cell-layer-fragment-shader
 
-#ifdef GL_ES
 precision highp float;
-#endif
 
 varying vec4 vColor;
 

--- a/modules/layers/src/hexagon-cell-layer/hexagon-cell-layer-fragment.glsl.js
+++ b/modules/layers/src/hexagon-cell-layer/hexagon-cell-layer-fragment.glsl.js
@@ -21,9 +21,7 @@
 export default `\
 #define SHADER_NAME hexagon-cell-layer-fragment-shader
 
-#ifdef GL_ES
 precision highp float;
-#endif
 
 varying vec4 vColor;
 

--- a/modules/layers/src/icon-layer/icon-layer-fragment.glsl.js
+++ b/modules/layers/src/icon-layer/icon-layer-fragment.glsl.js
@@ -21,9 +21,7 @@
 export default `\
 #define SHADER_NAME icon-layer-fragment-shader
 
-#ifdef GL_ES
 precision highp float;
-#endif
 
 uniform float opacity;
 uniform sampler2D iconsTexture;

--- a/modules/layers/src/line-layer/line-layer-fragment.glsl.js
+++ b/modules/layers/src/line-layer/line-layer-fragment.glsl.js
@@ -21,9 +21,7 @@
 export default `\
 #define SHADER_NAME line-layer-fragment-shader
 
-#ifdef GL_ES
 precision highp float;
-#endif
 
 varying vec4 vColor;
 

--- a/modules/layers/src/path-layer/path-layer-fragment.glsl.js
+++ b/modules/layers/src/path-layer/path-layer-fragment.glsl.js
@@ -21,9 +21,7 @@
 export default `\
 #define SHADER_NAME path-layer-fragment-shader
 
-#ifdef GL_ES
 precision highp float;
-#endif
 
 uniform float jointType;
 uniform float miterLimit;

--- a/modules/layers/src/point-cloud-layer/point-cloud-layer-fragment.glsl.js
+++ b/modules/layers/src/point-cloud-layer/point-cloud-layer-fragment.glsl.js
@@ -21,9 +21,7 @@
 export default `\
 #define SHADER_NAME point-cloud-layer-fragment-shader
 
-#ifdef GL_ES
 precision highp float;
-#endif
 
 varying vec4 vColor;
 varying vec2 unitPosition;

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer-fragment.glsl.js
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer-fragment.glsl.js
@@ -21,9 +21,7 @@
 export default `\
 #define SHADER_NAME scatterplot-layer-fragment-shader
 
-#ifdef GL_ES
 precision highp float;
-#endif
 
 varying vec4 vColor;
 varying vec2 unitPosition;

--- a/modules/layers/src/screen-grid-layer/screen-grid-layer-fragment.glsl.js
+++ b/modules/layers/src/screen-grid-layer/screen-grid-layer-fragment.glsl.js
@@ -22,9 +22,7 @@
 export default `\
 #define SHADER_NAME screen-grid-layer-fragment-shader
 
-#ifdef GL_ES
 precision highp float;
-#endif
 
 varying vec4 vColor;
 

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer-fragment.glsl.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer-fragment.glsl.js
@@ -21,9 +21,7 @@
 export default `\
 #define SHADER_NAME solid-polygon-layer-fragment-shader
 
-#ifdef GL_ES
 precision highp float;
-#endif
 
 varying vec4 vColor;
 

--- a/showcases/ascii/ascii-layer/ascii-filter.js
+++ b/showcases/ascii/ascii-layer/ascii-filter.js
@@ -35,9 +35,7 @@ void main(void) {
 const fs = `
 #define SHADER_NAME feedback-fragment-shader
 
-#ifdef GL_ES
 precision highp float;
-#endif
 
 varying vec4 instanceIconFrames;
 varying vec4 instanceColors;

--- a/showcases/wind/src/layers/delaunay-interpolation/delaunay-interpolation-fragment.glsl.js
+++ b/showcases/wind/src/layers/delaunay-interpolation/delaunay-interpolation-fragment.glsl.js
@@ -21,9 +21,7 @@
 export default `\
 #define SHADER_NAME delaunay-fragment-shader
 
-#ifdef GL_ES
 precision highp float;
-#endif
 
 varying vec4 vColor;
 

--- a/showcases/wind/src/layers/elevation-layer/elevation-layer.js
+++ b/showcases/wind/src/layers/elevation-layer/elevation-layer.js
@@ -101,9 +101,7 @@ export default class ElevationLayer extends Layer {
     const fsSource = shaders.fs;
 
     const fsShader = `\
-#ifdef GL_ES
 precision highp float;
-#endif
 ${fsSource}`;
 
     const {lngResolution, latResolution, boundingBox} = this.props;

--- a/showcases/wind/src/layers/particle-layer/particle-layer-fragment.glsl.js
+++ b/showcases/wind/src/layers/particle-layer/particle-layer-fragment.glsl.js
@@ -21,9 +21,7 @@
 export default `\
 #define SHADER_NAME particle-layer-fragment-shader
 
-#ifdef GL_ES
 precision highp float;
-#endif
 
 varying vec4 vColor;
 varying float vAltitude;

--- a/test/apps/carto-wip/time-sliced-scatterplot-layer/time-sliced-scatterplot-layer-fragment.glsl.js
+++ b/test/apps/carto-wip/time-sliced-scatterplot-layer/time-sliced-scatterplot-layer-fragment.glsl.js
@@ -21,9 +21,7 @@
 export default `\
 #define SHADER_NAME time-sliced-scatterplot-layer-fragment-shader
 
-#ifdef GL_ES
 precision highp float;
-#endif
 
 varying vec4 vColor;
 varying vec2 unitPosition;

--- a/test/apps/sample-layers/bitmap-layer/bitmap-layer-fragment.glsl.js
+++ b/test/apps/sample-layers/bitmap-layer/bitmap-layer-fragment.glsl.js
@@ -1,9 +1,7 @@
 export default `
 #define SHADER_NAME bitmap-layer-fragment-shader
 
-#ifdef GL_ES
 precision highp float;
-#endif
 
 uniform sampler2D uBitmap0;
 uniform sampler2D uBitmap1;

--- a/test/apps/sample-layers/enhanced-choropleth-layer/enhanced-choropleth-layer-fragment.glsl.js
+++ b/test/apps/sample-layers/enhanced-choropleth-layer/enhanced-choropleth-layer-fragment.glsl.js
@@ -21,9 +21,7 @@
 module.exports = `\
 #define SHADER_NAME enhanced-choropleth-layer-fragment-shader
 
-#ifdef GL_ES
 precision highp float;
-#endif
 
 varying vec4 vColor;
 


### PR DESCRIPTION
#### Background
- [Best practices](https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_best_practices)
#### Change List
- Remove GL_ES references
