### PR TITLE
Fix viewport transition and auto controls

### DIFF
--- a/modules/core/src/controllers/controller.js
+++ b/modules/core/src/controllers/controller.js
@@ -151,7 +151,7 @@ export default class Controller {
       this.toggleEvents(this.events, true);
     }
 
-    this.transitionManager.processViewStateChange(props);
+    this.transitionManager.processViewStateChange(this.controllerStateProps);
 
     // TODO - make sure these are not reset on every setProps
     const {
@@ -217,14 +217,12 @@ export default class Controller {
     // const changed = Object.keys(viewState).some(key => oldViewState[key] !== viewState[key]);
 
     if (changed) {
+      const oldViewState = this.controllerState ? this.controllerState.getViewportProps() : null;
       if (this.onViewportChange) {
-        const viewport = this.controllerState.getViewport
-          ? this.controllerState.getViewport()
-          : null;
-        this.onViewportChange(viewState, interactionState, viewport);
+        this.onViewportChange(viewState, interactionState, oldViewState);
       }
       if (this.onViewStateChange) {
-        this.onViewStateChange({viewState, interactionState});
+        this.onViewStateChange({viewState, interactionState, oldViewState});
       }
     }
 

--- a/modules/core/src/controllers/transition-manager.js
+++ b/modules/core/src/controllers/transition-manager.js
@@ -161,6 +161,9 @@ export default class TransitionManager {
     if (this.props.onViewportChange) {
       this.props.onViewportChange(this.propsInTransition, {inTransition: true});
     }
+    if (this.props.onViewStateChange) {
+      this.props.onViewStateChange({viewState: this.propsInTransition}, {inTransition: true});
+    }
   }
 }
 

--- a/test/apps/viewport-transitions-flyTo/index.html
+++ b/test/apps/viewport-transitions-flyTo/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset='UTF-8' />
     <title>react-map-gl Interaction Example</title>
+    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.44.1/mapbox-gl.css' rel='stylesheet' />
     <link rel="stylesheet" type="text/css" href="app.css" />
   </head>
   <body>

--- a/test/apps/viewport-transitions/index.html
+++ b/test/apps/viewport-transitions/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset='UTF-8' />
     <title>deck.gl example</title>
+    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.44.1/mapbox-gl.css' rel='stylesheet' />
     <style>
       body {margin: 0; padding: 0; overflow: hidden;}
     </style>


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/1874

#### Change List
- Update viewport-transition-flyto test app to use the latest API
- Support `onViewStateChange` prop in TransitionManager
- Support `viewState` prop in TransitionManager
- Fix `onViewportChange` callback arguments in Controller (`this.controllerState.getViewport` no longer exists)