### PR TITLE
Remove break in pick layers to clear onHover events (#1882)

### DIFF
--- a/modules/core/src/lib/pick-layers.js
+++ b/modules/core/src/lib/pick-layers.js
@@ -91,10 +91,6 @@ export function pickObject(
         })) ||
       NO_PICKED_OBJECT;
 
-    if (!pickInfo.pickedColor) {
-      break;
-    }
-
     // only exclude if we need to run picking again
     if (i + 1 < depth) {
       const layerId = pickInfo.pickedColor[3] - 1;


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #1882 
<!-- For all the PRs -->
#### Change List
- Removed break statement in pick-layers to clear onHover events
