### PR TITLE
Update params per frame

### DIFF
--- a/docs/api-reference/deck.md
+++ b/docs/api-reference/deck.md
@@ -113,21 +113,22 @@ gl context, will be autocreated if not supplied.
 
 ##### `parameters` (Object, optional)
 
-This prop will only be consulted once after deck.gl's WebGL context is initialized. If set, the value will be passed to luma.gl's `setParameters` function to do an initial configuration of the context, e.g. to disable depth testing, changing blending modes etc.
+Expects an object with WebGL settings. This object will be passed to luma.gl's `setParameters` function to configure the WebGL context, e.g. to disable depth testing, change blending modes etc.
+
+The `parameters` will be set before each frame is rendered. Naturally, any WebGL `parameters` prop supplied to individual layers will still override global parameters for that layer.
 
 Please refer to the luma.gl [setParameters](http://uber.github.io/luma.gl/#/documentation/api-reference/get-parameter) API for documentation on supported parameters and values.
 
-
 ##### `debug` (Boolean, optional)
 
-Flag to enable debug mode.
+Flag to enable WebGL debug mode.
 
 Default value is `false`.
 
 Notes:
 
 * debug mode is slower as it will use synchronous operations to keep track of GPU state.
-* Enabling debug mode requires an extra luma.gl import:
+* Enabling debug mode also requires an extra luma.gl import:
 
 ```js
 import 'luma.gl/debug'
@@ -147,7 +148,7 @@ Callback arguments:
 
 The `onViewStateChange` callback is fired when the user has interacted with the deck.gl canvas, e.g. using mouse, touch or keyboard.
 
-`onViewStateChanged({viewState})`
+`onViewStateChange({viewState})`
 
 * `viewState` - An updated [view state](/docs/developer-guide/view-state.md) object containing parameters such as `longitude`, `latitude`, `zoom` etc.
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -13,14 +13,14 @@ deck.gl layers can now specify additional type information about properties. Whe
 
 > For layer writers: use of prop types is optional, and deck.gl layers will automatically deduce partial prop type information for any properties that lack type information, as long as a default value is specified in the `defaultProps` object.
 
-### Set initial WebGL parameters using a prop
+### Declaratively set WebGL parameters
 
-It is now possible to set the initial WebGL parameters on the `Deck` WebGL context by supplying a `parameters` prop object, avoiding the need to define an `onWebGLInitialized` callback: `new Deck({..., parameters: {depthTest: false}});`
-
+It is now possible to globally set WebGL parameters (controlling how the GPU renders) by supplying a `Deck.parameters` prop object. This gives applications a simple declarative way to control things like blend modes and depth testing (`new Deck({..., parameters: {depthTest: false}});`), without having to define an `onWebGLInitialized()` callback. Note that `parameters` supplied to individual layers will of course override any global parameters.
 
 #### Pixel Sizes
 
-Pixel sizes in line, icon and text layers now match their HTML/SVG counterparts.
+Pixel sizes in `LineLayer`, `IconLayer` and `TextLayer` now match their HTML/SVG counterparts.
+
 
 ## deck.gl v5.3
 


### PR DESCRIPTION
For #1840 
#### Background
- This closes the open question in #1840 whether to apply params each frame or only on initialization.
#### Change List
- Apply params each frame. It makes the prop more useful and matches better with how other props work
- luma already caches params so perf impact should be smalle.
