### PR TITLE
Add transition prop forwarding for composite layers; docs

### DIFF
--- a/docs/layers/arc-layer.md
+++ b/docs/layers/arc-layer.md
@@ -61,19 +61,19 @@ Whether the layer should be rendered in high-precision 64-bit mode
 
 ### Data Accessors
 
-##### `getSourcePosition` (Function, optional)
+##### `getSourcePosition` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `object => object.sourcePosition`
 
 Method called to retrieve the source position of each object.
 
-##### `getTargetPosition` (Function, optional)
+##### `getTargetPosition` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `object => object.targetPosition`
 
 Method called to retrieve the target position of each object.
 
-##### `getSourceColor` (Function|Array, optional)
+##### `getSourceColor` (Function|Array, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `object => object.color || [0, 0, 0, 255]`
 
@@ -82,7 +82,7 @@ The rgba color at the source, in `r, g, b, [a]`. Each component is in the 0-255 
 * If an array is provided, it is used as the source color for all objects.
 * If a function is provided, it is called on each object to retrieve its source color.
 
-##### `getTargetColor` (Function|Array, optional)
+##### `getTargetColor` (Function|Array, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default `object => object.color || [0, 0, 0, 255]`
 
@@ -91,7 +91,7 @@ The rgba color at the target, in `r, g, b, [a]`. Each component is in the 0-255 
 * If an array is provided, it is used as the target color for all objects.
 * If a function is provided, it is called on each object to retrieve its target color.
 
-##### `getStrokeWidth` (Function|Number, optional)
+##### `getStrokeWidth` (Function|Number, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `1`
 

--- a/docs/layers/grid-cell-layer.md
+++ b/docs/layers/grid-cell-layer.md
@@ -81,21 +81,21 @@ Be aware that this prop will likely be changed in a future version of deck.gl.
 
 ### Data Accessors
 
-##### `getPosition` (Function, optional)
+##### `getPosition` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `cell => cell.position`
 
 Method called to retrieve the top left corner of each cell.
 Expecting [lon, lat].
 
-##### `getElevation` (Function, optional)
+##### `getElevation` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `cell => cell.elevation`
 
 Method called to retrieve the elevation of each cell.
 Expecting a number, 1 unit approximate to 100 meter
 
-##### `getColor` (Function|Array, optional)
+##### `getColor` (Function|Array, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `cell => cell.color`
 

--- a/docs/layers/grid-layer.md
+++ b/docs/layers/grid-layer.md
@@ -149,7 +149,7 @@ Be aware that this prop will likely be changed in a future version of deck.gl.
 
 Method called to retrieve the position of each point.
 
-##### `getColorValue` (Function, optional)
+##### `getColorValue` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `points => points.length`
 
@@ -178,7 +178,7 @@ You should pass in the function defined outside the render function so it doesn'
  }
 ```
 
-##### `getElevationValue` (Function, optional)
+##### `getElevationValue` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `points => points.length`
 

--- a/docs/layers/hexagon-cell-layer.md
+++ b/docs/layers/hexagon-cell-layer.md
@@ -96,14 +96,14 @@ Be aware that this prop will likely be changed in a future version of deck.gl.
 
 ### Data Accessors
 
-##### `getCentroid` (Function, optional)
+##### `getCentroid` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `object => object.centroid`
 
 Method called to retrieve the centroid of each hexagon. Centorid should be
 set to [lon, lat]
 
-##### `getColor` (Function|Array, optional)
+##### `getColor` (Function|Array, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `object => object.color`
 
@@ -112,7 +112,7 @@ The rgba color of each object, in `r, g, b, [a]`. Each component is in the 0-255
 * If an array is provided, it is used as the color for all objects.
 * If a function is provided, it is called on each object to retrieve its color.
 
-##### `getElevation` (Function, optional)
+##### `getElevation` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `object => object.elevation`
 

--- a/docs/layers/hexagon-layer.md
+++ b/docs/layers/hexagon-layer.md
@@ -83,37 +83,6 @@ to number of counts by passing in an arbitrary color domain. This property is ex
 Hexagon color ranges as an array of colors formatted as `[[255, 255, 255, 255]]`. Default is
 [colorbrewer](http://colorbrewer2.org/#type=sequential&scheme=YlOrRd&n=6) `6-class YlOrRd`.
 
-##### `getColorValue` (Function, optional)
-
-* Default: `points => points.length`
-
-`getColorValue` is the accessor function to get the value that bin color is based on.
-It takes an array of points inside each bin as arguments, returns a number. For example,
-You can pass in `getColorValue` to color the bins by avg/mean/max of a specific attributes of each point.
-By default `getColorValue` returns the length of the points array.
-
-Note: hexagon layer compares whether `getColorValue` has changed to
-recalculate the value for each bin that its color based on. You should
-pass in the function defined outside the render function so it doesn't create a
-new function on every rendering pass.
-
-```js
- class MyHexagonLayer {
-    getColorValue (points) {
-        return points.length;
-    }
-
-    renderLayers() {
-      return new HexagonLayer({
-        id: 'hexagon-layer',
-        getColorValue: this.getColorValue // instead of getColorValue: (points) => { return points.length; }
-        data,
-        radius: 500
-      });
-    }
- }
-```
-
 ##### `coverage` (Number, optional)
 
 * Default: `1`
@@ -137,19 +106,6 @@ with the same elevation scale for comparison.
 * Default: `[0, 1000]`
 
 Elevation scale output range
-
-##### `getElevationValue` (Function, optional)
-
-* Default: `points => points.length`
-
-Similar to `getColorValue`, `getElevationValue` is the accessor function to get the value that bin elevation is based on.
-It takes an array of points inside each bin as arguments, returns a number.
-By default `getElevationValue` returns the length of the points array.
-
-Note: hexagon layer compares whether `getElevationValue` has changed to
-recalculate the value for each bin for elevation. You should
-pass in the function defined outside the render function so it doesn't create a
-new function on every rendering pass.
 
 ##### `elevationScale` (Number, optional)
 
@@ -211,6 +167,52 @@ This is an object that contains light settings for extruded polygons.
 * Default: `object => object.position`
 
 Method called to retrieve the position of each point.
+
+
+##### `getColorValue` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
+
+* Default: `points => points.length`
+
+`getColorValue` is the accessor function to get the value that bin color is based on.
+It takes an array of points inside each bin as arguments, returns a number. For example,
+You can pass in `getColorValue` to color the bins by avg/mean/max of a specific attributes of each point.
+By default `getColorValue` returns the length of the points array.
+
+Note: hexagon layer compares whether `getColorValue` has changed to
+recalculate the value for each bin that its color based on. You should
+pass in the function defined outside the render function so it doesn't create a
+new function on every rendering pass.
+
+```js
+ class MyHexagonLayer {
+    getColorValue (points) {
+        return points.length;
+    }
+
+    renderLayers() {
+      return new HexagonLayer({
+        id: 'hexagon-layer',
+        getColorValue: this.getColorValue // instead of getColorValue: (points) => { return points.length; }
+        data,
+        radius: 500
+      });
+    }
+ }
+```
+
+##### `getElevationValue` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
+
+* Default: `points => points.length`
+
+Similar to `getColorValue`, `getElevationValue` is the accessor function to get the value that bin elevation is based on.
+It takes an array of points inside each bin as arguments, returns a number.
+By default `getElevationValue` returns the length of the points array.
+
+Note: hexagon layer compares whether `getElevationValue` has changed to
+recalculate the value for each bin for elevation. You should
+pass in the function defined outside the render function so it doesn't create a
+new function on every rendering pass.
+
 
 ##### `onSetColorDomain` (Function, optional)
 

--- a/docs/layers/icon-layer.md
+++ b/docs/layers/icon-layer.md
@@ -90,7 +90,7 @@ Whether the layer should be rendered in high-precision 64-bit mode
 
 ### Data Accessors
 
-##### `getPosition` (Function, optional)
+##### `getPosition` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `d => d.position`
 
@@ -102,7 +102,7 @@ Method called to retrieve the position of each object, returns `[lng, lat, z]`.
 
 Method called to retrieve the icon name of each object, returns string.
 
-##### `getSize` (Function|Number, optional)
+##### `getSize` (Function|Number, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `d => d.size || 1`
 
@@ -112,7 +112,7 @@ The height of each object, in pixels.
 * If a function is provided, it is called on each object to retrieve its size.
 
 
-##### `getColor` (Function|Array, optional)
+##### `getColor` (Function|Array, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `d => d.color || [0, 0, 0, 255]`
 
@@ -122,7 +122,7 @@ The rgba color of each object, in `r, g, b, [a]`. Each component is in the 0-255
 * If a function is provided, it is called on each object to retrieve its color.
 
 
-##### `getAngle` (Function|Number, optional)
+##### `getAngle` (Function|Number, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `d => d.angle || 0`
 

--- a/docs/layers/line-layer.md
+++ b/docs/layers/line-layer.md
@@ -62,19 +62,19 @@ Whether the layer should be rendered in high-precision 64-bit mode
 
 ### Data Accessors
 
-##### `getSourcePosition` (Function, optional)
+##### `getSourcePosition` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `object => object.sourcePosition`
 
 Method called to retrieve the source position of each object.
 
-##### `getTargetPosition` (Function, optional)
+##### `getTargetPosition` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `object => object.targetPosition`
 
 Method called to retrieve the target position of each object.
 
-##### `getColor` (Function|Array, optional)
+##### `getColor` (Function|Array, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `object => object.color || [0, 0, 0, 255]`
 
@@ -83,7 +83,7 @@ The rgba color of each object, in `r, g, b, [a]`. Each component is in the 0-255
 * If an array is provided, it is used as the color for all objects.
 * If a function is provided, it is called on each object to retrieve its color.
 
-##### `getStrokeWidth` (Function|Number, optional)
+##### `getStrokeWidth` (Function|Number, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `1`
 

--- a/docs/layers/point-cloud-layer.md
+++ b/docs/layers/point-cloud-layer.md
@@ -64,13 +64,13 @@ Be aware that this prop will likely be changed in a future version of deck.gl.
 
 ### Data Accessors
 
-##### `getPosition` (Function, optional)
+##### `getPosition` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `object => object.position`
 
 Method called to retrieve the position of each object.
 
-##### `getNormal` (Function|Array, optional)
+##### `getNormal` (Function|Array, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `object => object.normal`
 
@@ -80,7 +80,7 @@ The normal of each object, in `[nx, ny, nz]`.
 * If a function is provided, it is called on each object to retrieve its normal.
 
 
-##### `getColor` (Function|Array, optional)
+##### `getColor` (Function|Array, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `object => object.color || [0, 0, 0, 255]`
 

--- a/docs/layers/scatterplot-layer.md
+++ b/docs/layers/scatterplot-layer.md
@@ -83,13 +83,13 @@ Whether the layer should be rendered in high-precision 64-bit mode.
 
 ### Data Accessors
 
-##### `getPosition` (Function, optional)
+##### `getPosition` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `object => object.position`
 
 Method called to retrieve the position of each object.
 
-##### `getRadius` (Function|Number, optional)
+##### `getRadius` (Function|Number, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `object => object.radius || 1`
 
@@ -98,7 +98,7 @@ The radius of each object, in meters.
 * If a number is provided, it is used as the radius for all objects.
 * If a function is provided, it is called on each object to retrieve its radius.
 
-##### `getColor` (Function|Array, optional)
+##### `getColor` (Function|Array, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `object => object.color || [0, 0, 0, 255]`
 

--- a/docs/layers/text-layer.md
+++ b/docs/layers/text-layer.md
@@ -50,15 +50,14 @@ const App = ({data, viewport}) => {
 
 Method called to retrieve the content of each text label.
 
-##### `getPosition` (Function, optional)
+##### `getPosition` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `x => x.position || x.coordinates`
 
 Method called to retrieve the location of each text label.
 
-### Rendering Options
 
-##### `getSize` (Function|Number, optional)
+##### `getSize` (Function|Number, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `d => d.size || 32`
 
@@ -68,7 +67,7 @@ The font size of each text label, in pixels.
 * If a function is provided, it is called on each object to retrieve its size.
 
 
-##### `getColor` (Function|Array, optional)
+##### `getColor` (Function|Array, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `d => d.color || [0, 0, 0, 255]`
 
@@ -78,7 +77,7 @@ The rgba color of each text label, in `r, g, b, [a]`. Each component is in the 0
 * If a function is provided, it is called on each object to retrieve its color.
 
 
-##### `getAngle` (Function|Number, optional)
+##### `getAngle` (Function|Number, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `d => d.angle || 0`
 
@@ -87,6 +86,8 @@ The rotating angle of each text label, in degrees.
 * If a number is provided, it is used as the angle for all objects.
 * If a function is provided, it is called on each object to retrieve its angle.
 
+
+### Rendering Options
 
 ##### `sizeScale` (Number, optional)
 
@@ -132,7 +133,7 @@ The alignment baseline. Available options include `'top'`, `'center'` and `'bott
 * If a function is provided, it is called on each object to retrieve its alignment baseline.
 
 
-##### `getPixelOffset` (Function|Array, optional)
+##### `getPixelOffset` (Function|Array, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `x.pixelOffset || [0, 0]`
 

--- a/modules/layers/src/grid-cell-layer/grid-cell-layer-vertex.glsl.js
+++ b/modules/layers/src/grid-cell-layer/grid-cell-layer-vertex.glsl.js
@@ -26,8 +26,9 @@ export default `\
 attribute vec3 positions;
 attribute vec3 normals;
 
-attribute vec4 instancePositions;
+attribute vec3 instancePositions;
 attribute vec2 instancePositions64xyLow;
+attribute float instanceElevations;
 attribute vec4 instanceColors;
 attribute vec3 instancePickingColors;
 
@@ -47,13 +48,13 @@ varying vec4 vColor;
 void main(void) {
 
   // if ahpha == 0.0 or z < 0.0, do not render element
-  float noRender = float(instanceColors.a == 0.0 || instancePositions.w < 0.0);
+  float noRender = float(instanceColors.a == 0.0 || instanceElevations < 0.0);
   float finalCellSize = project_scale(cellSize) * mix(1.0, 0.0, noRender);
 
   float elevation = 0.0;
 
   if (extruded > 0.5) {
-    elevation = instancePositions.w  * (positions.z + 1.0) *
+    elevation = instanceElevations  * (positions.z + 1.0) *
       ELEVATION_SCALE * elevationScale;
   }
 

--- a/modules/layers/src/grid-cell-layer/grid-cell-layer.js
+++ b/modules/layers/src/grid-cell-layer/grid-cell-layer.js
@@ -126,27 +126,6 @@ export default class GridCellLayer extends Layer {
     );
   }
 
-  // calculateInstancePositions(attribute) {
-  //   const {data, getPosition} = this.props;
-  //   const {value} = attribute;
-  //   let i = 0;
-  //   for (const object of data) {
-  //     const position = getPosition(object);
-  //     value[i++] = position[0];
-  //     value[i++] = position[1];
-  //     value[i++] = 0;
-  //   }
-  // }
-
-  // calculateInstanceElevations(attribute) {
-  //   const {data, getElevation} = this.props;
-  //   const {value} = attribute;
-  //   let i = 0;
-  //   for (const object of data) {
-  //     value[i++] = getElevation(object) || 0;
-  //   }
-  // }
-
   calculateInstancePositions64xyLow(attribute) {
     const isFP64 = this.is64bitEnabled();
     attribute.isGeneric = !isFP64;

--- a/modules/layers/src/grid-cell-layer/grid-cell-layer.js
+++ b/modules/layers/src/grid-cell-layer/grid-cell-layer.js
@@ -64,10 +64,14 @@ export default class GridCellLayer extends Layer {
     const attributeManager = this.getAttributeManager();
     attributeManager.addInstanced({
       instancePositions: {
-        size: 4,
+        size: 3,
         transition: true,
-        accessor: ['getPosition', 'getElevation'],
-        update: this.calculateInstancePositions
+        accessor: 'getPosition'
+      },
+      instanceElevations: {
+        size: 1,
+        transition: true,
+        accessor: 'getElevation'
       },
       instancePositions64xyLow: {
         size: 2,
@@ -122,20 +126,26 @@ export default class GridCellLayer extends Layer {
     );
   }
 
-  calculateInstancePositions(attribute) {
-    const {data, getPosition, getElevation} = this.props;
-    const {value, size} = attribute;
-    let i = 0;
-    for (const object of data) {
-      const position = getPosition(object);
-      const elevation = getElevation(object) || 0;
-      value[i + 0] = position[0];
-      value[i + 1] = position[1];
-      value[i + 2] = 0;
-      value[i + 3] = elevation;
-      i += size;
-    }
-  }
+  // calculateInstancePositions(attribute) {
+  //   const {data, getPosition} = this.props;
+  //   const {value} = attribute;
+  //   let i = 0;
+  //   for (const object of data) {
+  //     const position = getPosition(object);
+  //     value[i++] = position[0];
+  //     value[i++] = position[1];
+  //     value[i++] = 0;
+  //   }
+  // }
+
+  // calculateInstanceElevations(attribute) {
+  //   const {data, getElevation} = this.props;
+  //   const {value} = attribute;
+  //   let i = 0;
+  //   for (const object of data) {
+  //     value[i++] = getElevation(object) || 0;
+  //   }
+  // }
 
   calculateInstancePositions64xyLow(attribute) {
     const isFP64 = this.is64bitEnabled();

--- a/modules/layers/src/grid-layer/grid-layer.js
+++ b/modules/layers/src/grid-layer/grid-layer.js
@@ -309,7 +309,15 @@ export default class GridLayer extends CompositeLayer {
   // for subclassing, override this method to return
   // customized sub layer props
   getSubLayerProps() {
-    const {elevationScale, fp64, extruded, cellSize, coverage, lightSettings} = this.props;
+    const {
+      elevationScale,
+      fp64,
+      extruded,
+      cellSize,
+      coverage,
+      lightSettings,
+      transitions
+    } = this.props;
 
     // return props to the sublayer constructor
     return super.getSubLayerProps({
@@ -325,6 +333,10 @@ export default class GridLayer extends CompositeLayer {
 
       getColor: this._onGetSublayerColor.bind(this),
       getElevation: this._onGetSublayerElevation.bind(this),
+      transitions: transitions && {
+        getColor: transitions.getColorValue,
+        getElevation: transitions.getElevationValue
+      },
       updateTriggers: this.getUpdateTriggers()
     });
   }

--- a/modules/layers/src/hexagon-cell-layer/hexagon-cell-layer-vertex.glsl.js
+++ b/modules/layers/src/hexagon-cell-layer/hexagon-cell-layer-vertex.glsl.js
@@ -25,7 +25,8 @@ export default `\
 attribute vec3 positions;
 attribute vec3 normals;
 
-attribute vec3 instancePositions;
+attribute vec2 instancePositions;
+attribute float instanceElevations;
 attribute vec2 instancePositions64xyLow;
 attribute vec4 instanceColors;
 attribute vec3 instancePickingColors;
@@ -54,16 +55,16 @@ void main(void) {
   float elevation = 0.0;
 
   if (extruded > 0.5) {
-    elevation = instancePositions.z * (positions.z + 0.5) *
+    elevation = instanceElevations * (positions.z + 0.5) *
       ELEVATION_SCALE * elevationScale;
   }
 
   // if ahpha == 0.0 or z < 0.0, do not render element
-  float noRender = float(instanceColors.a == 0.0 || instancePositions.z < 0.0);
+  float noRender = float(instanceColors.a == 0.0 || instanceElevations < 0.0);
   float dotRadius = project_scale(radius) * mix(coverage, 0.0, noRender);
 
   // project center of hexagon
-  vec3 centroidPosition = vec3(instancePositions.xy, elevation);
+  vec3 centroidPosition = vec3(instancePositions, elevation);
   vec2 centroidPosition64xyLow = instancePositions64xyLow;
   vec3 offset = vec3(rotationMatrix * positions.xy * dotRadius, 0.);
 

--- a/modules/layers/src/hexagon-cell-layer/hexagon-cell-layer.js
+++ b/modules/layers/src/hexagon-cell-layer/hexagon-cell-layer.js
@@ -85,10 +85,14 @@ export default class HexagonCellLayer extends Layer {
     /* eslint-disable max-len */
     attributeManager.addInstanced({
       instancePositions: {
-        size: 3,
+        size: 2,
         transition: true,
-        accessor: ['getCentroid', 'getElevation'],
-        update: this.calculateInstancePositions
+        accessor: 'getCentroid'
+      },
+      instanceElevations: {
+        size: 1,
+        transition: true,
+        accessor: 'getElevation'
       },
       instancePositions64xyLow: {
         size: 2,
@@ -197,19 +201,25 @@ export default class HexagonCellLayer extends Layer {
     );
   }
 
-  calculateInstancePositions(attribute) {
-    const {data, getCentroid, getElevation} = this.props;
-    const {value, size} = attribute;
-    let i = 0;
-    for (const object of data) {
-      const [lon, lat] = getCentroid(object);
-      const elevation = getElevation(object);
-      value[i + 0] = lon;
-      value[i + 1] = lat;
-      value[i + 2] = elevation || 0;
-      i += size;
-    }
-  }
+  // calculateInstancePositions(attribute) {
+  //   const {data, getCentroid} = this.props;
+  //   const {value} = attribute;
+  //   let i = 0;
+  //   for (const object of data) {
+  //     const position = getCentroid(object);
+  //     value[i++] = position[0];
+  //     value[i++] = position[1];
+  //   }
+  // }
+
+  // calculateInstanceElevations(attribute) {
+  //   const {data, getElevation} = this.props;
+  //   const {value} = attribute;
+  //   let i = 0;
+  //   for (const object of data) {
+  //     value[i++] = getElevation(object) || 0;
+  //   }
+  // }
 
   calculateInstancePositions64xyLow(attribute) {
     const isFP64 = this.is64bitEnabled();

--- a/modules/layers/src/hexagon-cell-layer/hexagon-cell-layer.js
+++ b/modules/layers/src/hexagon-cell-layer/hexagon-cell-layer.js
@@ -201,26 +201,6 @@ export default class HexagonCellLayer extends Layer {
     );
   }
 
-  // calculateInstancePositions(attribute) {
-  //   const {data, getCentroid} = this.props;
-  //   const {value} = attribute;
-  //   let i = 0;
-  //   for (const object of data) {
-  //     const position = getCentroid(object);
-  //     value[i++] = position[0];
-  //     value[i++] = position[1];
-  //   }
-  // }
-
-  // calculateInstanceElevations(attribute) {
-  //   const {data, getElevation} = this.props;
-  //   const {value} = attribute;
-  //   let i = 0;
-  //   for (const object of data) {
-  //     value[i++] = getElevation(object) || 0;
-  //   }
-  // }
-
   calculateInstancePositions64xyLow(attribute) {
     const isFP64 = this.is64bitEnabled();
     attribute.isGeneric = !isFP64;

--- a/modules/layers/src/hexagon-layer/hexagon-layer.js
+++ b/modules/layers/src/hexagon-layer/hexagon-layer.js
@@ -357,7 +357,15 @@ export default class HexagonLayer extends CompositeLayer {
   // for subclassing, override this method to return
   // customized sub layer props
   getSubLayerProps() {
-    const {radius, elevationScale, extruded, coverage, lightSettings, fp64} = this.props;
+    const {
+      radius,
+      elevationScale,
+      extruded,
+      coverage,
+      lightSettings,
+      fp64,
+      transitions
+    } = this.props;
 
     // return props to the sublayer constructor
     return super.getSubLayerProps({
@@ -375,6 +383,10 @@ export default class HexagonLayer extends CompositeLayer {
 
       getColor: this._onGetSublayerColor.bind(this),
       getElevation: this._onGetSublayerElevation.bind(this),
+      transitions: transitions && {
+        getColor: transitions.getColorValue,
+        getElevation: transitions.getElevationValue
+      },
       updateTriggers: this.getUpdateTriggers()
     });
   }

--- a/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer.js
+++ b/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer.js
@@ -87,16 +87,6 @@ export default class MultiIconLayer extends IconLayer {
     }
   }
 
-  // calculatePixelOffset(attribute) {
-  //   const {data, getPixelOffset} = this.props;
-  //   const {value} = attribute;
-  //   let i = 0;
-  //   for (const object of data) {
-  //     const pixelOffset = getPixelOffset(object);
-  //     value[i++] = pixelOffset[0] || 0;
-  //     value[i++] = pixelOffset[1] || 0;
-  //   }
-  // }
 }
 
 MultiIconLayer.layerName = 'MultiIconLayer';

--- a/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer.js
+++ b/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer.js
@@ -46,8 +46,8 @@ export default class MultiIconLayer extends IconLayer {
     attributeManager.addInstanced({
       instancePixelOffset: {
         size: 2,
-        accessor: 'getPixelOffset',
-        update: this.calculatePixelOffset
+        transition: true,
+        accessor: 'getPixelOffset'
       }
     });
   }

--- a/modules/layers/src/text-layer/text-layer.js
+++ b/modules/layers/src/text-layer/text-layer.js
@@ -179,6 +179,7 @@ export default class TextLayer extends CompositeLayer {
       getPixelOffset,
       fp64,
       sizeScale,
+      transitions,
       updateTriggers
     } = this.props;
 
@@ -201,6 +202,13 @@ export default class TextLayer extends CompositeLayer {
           getPixelOffset: this._getAccessor(getPixelOffset),
           fp64,
           sizeScale: sizeScale * scale,
+          transitions: transitions && {
+            getPosition: transitions.getPosition,
+            getAngle: transitions.getAngle,
+            getColor: transitions.getColor,
+            getSize: transitions.getSize,
+            getPixelOffset: updateTriggers.getPixelOffset
+          },
           updateTriggers: {
             getPosition: updateTriggers.getPosition,
             getAngle: updateTriggers.getAngle,


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/1889
For #1810

#### Change List
- Update layer docs: mark all transition enabled data accessors
- Enable transitions in TextLayer: getPosition, getColor, getSize, getAngle, getPixelOffset
- Enable transitions in GridLayer: getElevationValue, getColorValue
- Enable transitions in HexagonLayer: getElevationValue, getColorValue
