### PR TITLE
Disable failing rendertests for Intel GPU

### DIFF
--- a/modules/test-utils/src/scene-renderer.js
+++ b/modules/test-utils/src/scene-renderer.js
@@ -23,7 +23,7 @@ import {Deck, MapView} from 'deck.gl';
 
 import {getImageFromContext} from './luma.gl/io-basic/browser-image-utils';
 
-const GL_VENDOR = 0x1f00;
+const GL_VENDOR = 0x1F00;
 
 function noop() {}
 
@@ -126,18 +126,15 @@ export default class SceneRenderer {
     let nextSceneIndex = sceneIndex;
     while (nextSceneIndex < this.scenes.length) {
       const scene = this.scenes[nextSceneIndex];
-      let skipScene = false;
-      if (scene.gpuVendorSkipList) {
-        skipScene = scene.gpuVendorSkipList.reduce((skip, vendor) => {
-          skip = skip || vendor.startsWith(this.gpuVendor);
-          return skip;
-        });
+      let skip = false;
+      if (scene.ignoreGPUs) {
+        skip = scene.ignoreGPUs.some(gpu => this.gpuVendor.indexOf(gpu) >= 0);
       }
-      if (!skipScene) {
+      if (!skip) {
         break;
       }
       console.log(`Skipping render test ${scene.name} for ${this.gpuVendor} GPU`); // eslint-disable-line
-      nextSceneIndex++;
+      nextSceneIndex++
     }
     return nextSceneIndex;
   }

--- a/test/render/test-cases.js
+++ b/test/render/test-cases.js
@@ -228,7 +228,7 @@ export const TEST_CASES = [
       })
     ],
     referenceImageUrl: './test/render/golden-images/path-lnglat.png',
-    gpuVendorSkipList: [`Intel`]
+    ignoreGPUs: [`Intel`]
   },
   {
     name: 'path-lnglat-64',
@@ -253,7 +253,7 @@ export const TEST_CASES = [
       })
     ],
     referenceImageUrl: './test/render/golden-images/path-lnglat.png',
-    gpuVendorSkipList: [`Intel`]
+    ignoreGPUs: [`Intel`]
   },
   {
     name: 'scatterplot-lnglat',
@@ -328,7 +328,7 @@ export const TEST_CASES = [
       })
     ],
     referenceImageUrl: './test/render/golden-images/arc-lnglat.png',
-    gpuVendorSkipList: [`Intel`]
+    ignoreGPUs: [`Intel`]
   },
   {
     name: 'arc-lnglat-64',
@@ -353,7 +353,7 @@ export const TEST_CASES = [
       })
     ],
     referenceImageUrl: './test/render/golden-images/arc-lnglat-64.png',
-    gpuVendorSkipList: [`Intel`]
+    ignoreGPUs: [`Intel`]
   },
   {
     name: 'line-lnglat',
@@ -376,7 +376,7 @@ export const TEST_CASES = [
       })
     ],
     referenceImageUrl: './test/render/golden-images/line-lnglat.png',
-    gpuVendorSkipList: [`Intel`]
+    ignoreGPUs: [`Intel`]
   },
   {
     name: 'line-lnglat-64',
@@ -492,7 +492,7 @@ export const TEST_CASES = [
       })
     ],
     referenceImageUrl: './test/render/golden-images/geojson-lnglat.png',
-    gpuVendorSkipList: [`Intel`]
+    ignoreGPUs: [`Intel`]
   },
   {
     name: 'geojson-extruded-lnglat',
@@ -517,7 +517,7 @@ export const TEST_CASES = [
       })
     ],
     referenceImageUrl: './test/render/golden-images/geojson-extruded-lnglat.png',
-    gpuVendorSkipList: [`Intel`]
+    ignoreGPUs: [`Intel`]
   },
   {
     name: 'gridcell-lnglat',
@@ -542,7 +542,7 @@ export const TEST_CASES = [
       })
     ],
     referenceImageUrl: './test/render/golden-images/gridcell-lnglat.png',
-    gpuVendorSkipList: [`Intel`]
+    ignoreGPUs: [`Intel`]
   },
   {
     name: 'gridcell-lnglat-64',
@@ -593,7 +593,7 @@ export const TEST_CASES = [
       })
     ],
     referenceImageUrl: './test/render/golden-images/grid-lnglat.png',
-    gpuVendorSkipList: [`Intel`]
+    ignoreGPUs: [`Intel`]
   },
   {
     name: 'screengrid-lnglat',
@@ -642,7 +642,7 @@ export const TEST_CASES = [
       })
     ],
     referenceImageUrl: './test/render/golden-images/hexagoncell-lnglat.png',
-    gpuVendorSkipList: [`Intel`]
+    ignoreGPUs: [`Intel`]
   },
   {
     name: 'hexagoncell-lnglat-64',
@@ -723,7 +723,7 @@ export const TEST_CASES = [
       })
     ],
     referenceImageUrl: './test/render/golden-images/pointcloud-lnglat.png',
-    gpuVendorSkipList: [`Intel`]
+    ignoreGPUs: [`Intel`]
   },
   {
     name: 'pointcloud-lnglat-64',
@@ -755,7 +755,7 @@ export const TEST_CASES = [
       })
     ],
     referenceImageUrl: './test/render/golden-images/pointcloud-lnglat-64.png',
-    gpuVendorSkipList: [`Intel`]
+    ignoreGPUs: [`Intel`]
   },
   {
     name: 'pointcloud-meter',

--- a/test/render/test-cases.js
+++ b/test/render/test-cases.js
@@ -227,7 +227,8 @@ export const TEST_CASES = [
         pickable: true
       })
     ],
-    referenceImageUrl: './test/render/golden-images/path-lnglat.png'
+    referenceImageUrl: './test/render/golden-images/path-lnglat.png',
+    gpuVendorSkipList: [`Intel`]
   },
   {
     name: 'path-lnglat-64',
@@ -251,7 +252,8 @@ export const TEST_CASES = [
         pickable: true
       })
     ],
-    referenceImageUrl: './test/render/golden-images/path-lnglat.png'
+    referenceImageUrl: './test/render/golden-images/path-lnglat.png',
+    gpuVendorSkipList: [`Intel`]
   },
   {
     name: 'scatterplot-lnglat',
@@ -325,7 +327,8 @@ export const TEST_CASES = [
         pickable: true
       })
     ],
-    referenceImageUrl: './test/render/golden-images/arc-lnglat.png'
+    referenceImageUrl: './test/render/golden-images/arc-lnglat.png',
+    gpuVendorSkipList: [`Intel`]
   },
   {
     name: 'arc-lnglat-64',
@@ -349,7 +352,8 @@ export const TEST_CASES = [
         pickable: true
       })
     ],
-    referenceImageUrl: './test/render/golden-images/arc-lnglat-64.png'
+    referenceImageUrl: './test/render/golden-images/arc-lnglat-64.png',
+    gpuVendorSkipList: [`Intel`]
   },
   {
     name: 'line-lnglat',
@@ -371,7 +375,8 @@ export const TEST_CASES = [
         pickable: true
       })
     ],
-    referenceImageUrl: './test/render/golden-images/line-lnglat.png'
+    referenceImageUrl: './test/render/golden-images/line-lnglat.png',
+    gpuVendorSkipList: [`Intel`]
   },
   {
     name: 'line-lnglat-64',
@@ -486,7 +491,8 @@ export const TEST_CASES = [
         lightSettings: LIGHT_SETTINGS
       })
     ],
-    referenceImageUrl: './test/render/golden-images/geojson-lnglat.png'
+    referenceImageUrl: './test/render/golden-images/geojson-lnglat.png',
+    gpuVendorSkipList: [`Intel`]
   },
   {
     name: 'geojson-extruded-lnglat',
@@ -510,7 +516,8 @@ export const TEST_CASES = [
         lightSettings: LIGHT_SETTINGS
       })
     ],
-    referenceImageUrl: './test/render/golden-images/geojson-extruded-lnglat.png'
+    referenceImageUrl: './test/render/golden-images/geojson-extruded-lnglat.png',
+    gpuVendorSkipList: [`Intel`]
   },
   {
     name: 'gridcell-lnglat',
@@ -534,7 +541,8 @@ export const TEST_CASES = [
         lightSettings: LIGHT_SETTINGS
       })
     ],
-    referenceImageUrl: './test/render/golden-images/gridcell-lnglat.png'
+    referenceImageUrl: './test/render/golden-images/gridcell-lnglat.png',
+    gpuVendorSkipList: [`Intel`]
   },
   {
     name: 'gridcell-lnglat-64',
@@ -584,7 +592,8 @@ export const TEST_CASES = [
         lightSettings: LIGHT_SETTINGS
       })
     ],
-    referenceImageUrl: './test/render/golden-images/grid-lnglat.png'
+    referenceImageUrl: './test/render/golden-images/grid-lnglat.png',
+    gpuVendorSkipList: [`Intel`]
   },
   {
     name: 'screengrid-lnglat',
@@ -632,7 +641,8 @@ export const TEST_CASES = [
         lightSettings: LIGHT_SETTINGS
       })
     ],
-    referenceImageUrl: './test/render/golden-images/hexagoncell-lnglat.png'
+    referenceImageUrl: './test/render/golden-images/hexagoncell-lnglat.png',
+    gpuVendorSkipList: [`Intel`]
   },
   {
     name: 'hexagoncell-lnglat-64',
@@ -712,7 +722,8 @@ export const TEST_CASES = [
         lightSettings: LIGHT_SETTINGS
       })
     ],
-    referenceImageUrl: './test/render/golden-images/pointcloud-lnglat.png'
+    referenceImageUrl: './test/render/golden-images/pointcloud-lnglat.png',
+    gpuVendorSkipList: [`Intel`]
   },
   {
     name: 'pointcloud-lnglat-64',
@@ -743,7 +754,8 @@ export const TEST_CASES = [
         lightSettings: LIGHT_SETTINGS
       })
     ],
-    referenceImageUrl: './test/render/golden-images/pointcloud-lnglat-64.png'
+    referenceImageUrl: './test/render/golden-images/pointcloud-lnglat-64.png',
+    gpuVendorSkipList: [`Intel`]
   },
   {
     name: 'pointcloud-meter',


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #1896
<!-- For other PRs without open issue -->
#### Background
Following render tests are failing when run on Intel GPU, blocking engineers in opening PRs.
Add a mechanism so render test can specify GPU name , on which it should be skipped
Disable following render tests on Intel GPU (some of these are failing randomly)

- path-lnglat
- path-lnglat-64
- arc-lnglat
- arc-lnglat-64
- line-lnglat
- geojson-lnglat
- geojson-extruded-lnglat
- gridcell-lnglat
- grid-lnglat
- hexagoncell-lnglat
- pointcloud-lnglat
- pointcloud-lnglat-64

<!-- For all the PRs -->
#### Change List
-  Disable failing render tests for Intel GPU
