### PR TITLE
Reduce projection-specific code

### DIFF
--- a/modules/core/src/shaderlib/project/viewport-uniforms.js
+++ b/modules/core/src/shaderlib/project/viewport-uniforms.js
@@ -27,8 +27,6 @@ import memoize from '../../utils/memoize';
 import log from '../../utils/log';
 import assert from '../../utils/assert';
 
-import {lngLatToWorld} from 'viewport-mercator-project';
-
 // To quickly set a vector to zero
 const ZERO_VECTOR = [0, 0, 0, 0];
 // 4x4 matrix that drops 4th component of vector
@@ -69,7 +67,7 @@ function calculateMatrixAndOffset({
       // Calculate transformed projectionCenter (using 64 bit precision JS)
       // This is the key to offset mode precision
       // (avoids doing this addition in 32 bit precision in GLSL)
-      const positionPixels = lngLatToWorld(coordinateOrigin, Math.pow(2, coordinateZoom));
+      const positionPixels = viewport.projectFlat(coordinateOrigin, Math.pow(2, coordinateZoom));
       // projectionCenter = new Matrix4(viewProjectionMatrix)
       //   .transformVector([positionPixels[0], positionPixels[1], 0.0, 1.0]);
       projectionCenter = vec4_transformMat4(

--- a/modules/core/src/viewports/web-mercator-viewport.js
+++ b/modules/core/src/viewports/web-mercator-viewport.js
@@ -203,12 +203,12 @@ export default class WebMercatorViewport extends Viewport {
    */
   getMapCenterByLngLatPosition({lngLat, pos}) {
     const fromLocation = pixelsToWorld(pos, this.pixelUnprojectionMatrix);
-    const toLocation = lngLatToWorld(lngLat, this.scale);
+    const toLocation = this.projectFlat(lngLat);
 
     const translate = vec2_add([], toLocation, vec2_negate([], fromLocation));
     const newCenter = vec2_add([], this.center, translate);
 
-    return worldToLngLat(newCenter, this.scale);
+    return this.unprojectFlat(newCenter);
   }
 
   // Legacy method name


### PR DESCRIPTION
#### Background
Make it easier to create viewport of a different projection.

#### Change List
- Reduce hard-coded `lngLatToWorld` and `worldToLngLat` usage
