### PR TITLE
Fix picking index for GeoJsonLayer

### DIFF
--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -150,6 +150,7 @@ export default class App extends PureComponent {
     if (this.state.enableDepthPickOnClick && info) {
       this._multiDepthPick(info.x, info.y);
     } else {
+      console.log('onClick', info); // eslint-disable-line
       this.setState({clickedItem: info});
     }
   }

--- a/examples/layer-browser/src/data-samples.js
+++ b/examples/layer-browser/src/data-samples.js
@@ -135,26 +135,64 @@ export function getPointCloud() {
   return _pointCloud;
 }
 
+const sfBoundingBox = [-122.6, 37.6, -122.2, 37.9];
+
+function generatePointFeatures(featureCount) {
+  const features = pointGrid(featureCount, sfBoundingBox).map(coordinate => ({
+    type: 'Feature',
+    geometry: {type: 'Point', coordinates: coordinate}
+  }));
+  return features;
+}
+
+function generateMultiPointFeatures(featureCount, pointsPerFeature) {
+  const allMultiPoints = pointGrid(featureCount * pointsPerFeature, sfBoundingBox);
+  const features = [];
+  for (let featureIndex = 0; featureIndex < featureCount; featureIndex++) {
+    const multiPoints = allMultiPoints.slice(
+      featureIndex * pointsPerFeature,
+      featureIndex * pointsPerFeature + pointsPerFeature
+    );
+    features.push({
+      type: 'Feature',
+      geometry: {type: 'MultiPoint', coordinates: multiPoints}
+    });
+  }
+  return features;
+}
+
 let _points100K = null;
 export function getPoints100K() {
-  _points100K = _points100K || pointGrid(1e5, [-122.6, 37.6, -122.2, 37.9]);
+  _points100K = _points100K || pointGrid(1e5, sfBoundingBox);
   return _points100K;
 }
 
 let _points1M = null;
 export function getPoints1M() {
-  _points1M = _points1M || pointGrid(1e6, [-122.6, 37.6, -122.2, 37.9]);
+  _points1M = _points1M || pointGrid(1e6, sfBoundingBox);
   return _points1M;
 }
 
 let _points5M = null;
 export function getPoints5M() {
-  _points5M = _points5M || pointGrid(5 * 1e6, [-122.6, 37.6, -122.2, 37.9]);
+  _points5M = _points5M || pointGrid(5 * 1e6, sfBoundingBox);
   return _points5M;
 }
 
 let _points10M = null;
 export function getPoints10M() {
-  _points10M = _points10M || pointGrid(1e7, [-122.6, 37.6, -122.2, 37.9]);
+  _points10M = _points10M || pointGrid(1e7, sfBoundingBox);
   return _points10M;
+}
+
+let _pointFeatures1M = null;
+export function getPointFeatures1M() {
+  _pointFeatures1M = _pointFeatures1M || generatePointFeatures(1e6);
+  return _pointFeatures1M;
+}
+
+let _multiPointFeatures100K = null;
+export function getMultiPointFeatures100K() {
+  _multiPointFeatures100K = _multiPointFeatures100K || generateMultiPointFeatures(1e5, 10);
+  return _multiPointFeatures100K;
 }

--- a/examples/layer-browser/src/data-samples.js
+++ b/examples/layer-browser/src/data-samples.js
@@ -135,10 +135,10 @@ export function getPointCloud() {
   return _pointCloud;
 }
 
-const sfBoundingBox = [-122.6, 37.6, -122.2, 37.9];
+const SF_BOUNDING_BOX = [-122.6, 37.6, -122.2, 37.9];
 
 function generatePointFeatures(featureCount) {
-  const features = pointGrid(featureCount, sfBoundingBox).map(coordinate => ({
+  const features = pointGrid(featureCount, SF_BOUNDING_BOX).map(coordinate => ({
     type: 'Feature',
     geometry: {type: 'Point', coordinates: coordinate}
   }));
@@ -146,7 +146,7 @@ function generatePointFeatures(featureCount) {
 }
 
 function generateMultiPointFeatures(featureCount, pointsPerFeature) {
-  const allMultiPoints = pointGrid(featureCount * pointsPerFeature, sfBoundingBox);
+  const allMultiPoints = pointGrid(featureCount * pointsPerFeature, SF_BOUNDING_BOX);
   const features = [];
   for (let featureIndex = 0; featureIndex < featureCount; featureIndex++) {
     const multiPoints = allMultiPoints.slice(
@@ -163,25 +163,25 @@ function generateMultiPointFeatures(featureCount, pointsPerFeature) {
 
 let _points100K = null;
 export function getPoints100K() {
-  _points100K = _points100K || pointGrid(1e5, sfBoundingBox);
+  _points100K = _points100K || pointGrid(1e5, SF_BOUNDING_BOX);
   return _points100K;
 }
 
 let _points1M = null;
 export function getPoints1M() {
-  _points1M = _points1M || pointGrid(1e6, sfBoundingBox);
+  _points1M = _points1M || pointGrid(1e6, SF_BOUNDING_BOX);
   return _points1M;
 }
 
 let _points5M = null;
 export function getPoints5M() {
-  _points5M = _points5M || pointGrid(5 * 1e6, sfBoundingBox);
+  _points5M = _points5M || pointGrid(5 * 1e6, SF_BOUNDING_BOX);
   return _points5M;
 }
 
 let _points10M = null;
 export function getPoints10M() {
-  _points10M = _points10M || pointGrid(1e7, sfBoundingBox);
+  _points10M = _points10M || pointGrid(1e7, SF_BOUNDING_BOX);
   return _points10M;
 }
 

--- a/examples/layer-browser/src/examples/core-layers.js
+++ b/examples/layer-browser/src/examples/core-layers.js
@@ -462,6 +462,17 @@ const ScatterplotLayer64PerfExample = (id, getData) => ({
   }
 });
 
+function GeoJsonLayerPerfExample(id, getData) {
+  return {
+    layer: GeoJsonLayer,
+    getData,
+    props: {
+      id: `geojsonlayerperf-${id}`,
+      pointRadiusMinPixels: 4
+    }
+  };
+}
+
 /* eslint-disable quote-props */
 export default {
   'Core Layers - LngLat': {
@@ -496,6 +507,14 @@ export default {
     'ScatterplotLayer 10M': ScatterplotLayerPerfExample('10M', dataSamples.getPoints10M),
     'ScatterplotLayer64 100K': ScatterplotLayer64PerfExample('100K', dataSamples.getPoints100K),
     'ScatterplotLayer64 1M': ScatterplotLayer64PerfExample('1M', dataSamples.getPoints1M),
-    'ScatterplotLayer64 10M': ScatterplotLayer64PerfExample('10M', dataSamples.getPoints10M)
+    'ScatterplotLayer64 10M': ScatterplotLayer64PerfExample('10M', dataSamples.getPoints10M),
+    'GeoJsonLayer (1M Point features)': GeoJsonLayerPerfExample(
+      '1M-point',
+      dataSamples.getPointFeatures1M
+    ),
+    'GeoJsonLayer (100K MultiPoint features, 10 points per feature)': GeoJsonLayerPerfExample(
+      '100K-multipoint',
+      dataSamples.getMultiPointFeatures100K
+    )
   }
 };

--- a/modules/layers/src/geojson-layer/geojson-layer.js
+++ b/modules/layers/src/geojson-layer/geojson-layer.js
@@ -93,11 +93,22 @@ export default class GeoJsonLayer extends CompositeLayer {
   getPickingInfo({info, sourceLayer}) {
     // `info.index` is the index within the particular sub-layer
     // We want to expose the index of the feature the user provided
+    let featureIndex = info.index;
+
+    if (sourceLayer.id === this.getSubLayerProps({id: 'points'}).id) {
+      featureIndex = this.state.features.pointFeatureIndexes[info.index];
+    } else if (sourceLayer.id === this.getSubLayerProps({id: 'line-paths'}).id) {
+      featureIndex = this.state.features.lineFeatureIndexes[info.index];
+    } else if (sourceLayer.id === this.getSubLayerProps({id: 'polygon-fill'}).id) {
+      featureIndex = this.state.features.polygonFeatureIndexes[info.index];
+    } else if (sourceLayer.id === this.getSubLayerProps({id: 'polygon-outline'}).id) {
+      featureIndex = this.state.features.polygonOutlineFeatureIndexes[info.index];
+    }
 
     return Object.assign(info, {
       // override object with picked feature
-      object: info.object ? info.object.__deckMetadata.feature : info.object,
-      index: info.object ? info.object.__deckMetadata.featureIndex : info.index
+      object: (info.object && info.object.__deckSourceFeature) || info.object,
+      index: featureIndex
     });
   }
 

--- a/modules/layers/src/geojson-layer/geojson-layer.js
+++ b/modules/layers/src/geojson-layer/geojson-layer.js
@@ -96,8 +96,8 @@ export default class GeoJsonLayer extends CompositeLayer {
 
     return Object.assign(info, {
       // override object with picked feature
-      object: info.object ? info.object.__deckMetadata.feature : info.object,
-      index: info.object ? info.object.__deckMetadata.featureIndex : info.index
+      object: info.object ? info.object.deckPickingInfo.feature : info.object,
+      index: info.object ? info.object.deckPickingInfo.featureIndex : info.index
     });
   }
 

--- a/modules/layers/src/geojson-layer/geojson-layer.js
+++ b/modules/layers/src/geojson-layer/geojson-layer.js
@@ -93,22 +93,11 @@ export default class GeoJsonLayer extends CompositeLayer {
   getPickingInfo({info, sourceLayer}) {
     // `info.index` is the index within the particular sub-layer
     // We want to expose the index of the feature the user provided
-    let featureIndex = info.index;
-
-    if (sourceLayer.id === this.getSubLayerProps({id: 'points'}).id) {
-      featureIndex = this.state.features.pointFeatureIndexes[info.index];
-    } else if (sourceLayer.id === this.getSubLayerProps({id: 'line-paths'}).id) {
-      featureIndex = this.state.features.lineFeatureIndexes[info.index];
-    } else if (sourceLayer.id === this.getSubLayerProps({id: 'polygon-fill'}).id) {
-      featureIndex = this.state.features.polygonFeatureIndexes[info.index];
-    } else if (sourceLayer.id === this.getSubLayerProps({id: 'polygon-outline'}).id) {
-      featureIndex = this.state.features.polygonOutlineFeatureIndexes[info.index];
-    }
 
     return Object.assign(info, {
       // override object with picked feature
-      object: (info.object && info.object.__deckSourceFeature) || info.object,
-      index: featureIndex
+      object: info.object ? info.object.__deckMetadata.feature : info.object,
+      index: info.object ? info.object.__deckMetadata.featureIndex : info.index
     });
   }
 

--- a/modules/layers/src/geojson-layer/geojson-layer.js
+++ b/modules/layers/src/geojson-layer/geojson-layer.js
@@ -93,23 +93,11 @@ export default class GeoJsonLayer extends CompositeLayer {
   getPickingInfo({info, sourceLayer}) {
     // `info.index` is the index within the particular sub-layer
     // We want to expose the index of the feature the user provided
-    let featureIndex = info.index;
-
-    if (sourceLayer.id === this.getSubLayerProps({id: 'points'}).id) {
-      featureIndex = this.state.features.pointFeatureIndexMap[info.index];
-    } else if (sourceLayer.id === this.getSubLayerProps({id: 'line-paths'}).id) {
-      featureIndex = this.state.features.lineFeatureIndexMap[info.index];
-    } else if (
-      sourceLayer.id === this.getSubLayerProps({id: 'polygon-fill'}).id ||
-      sourceLayer.id === this.getSubLayerProps({id: 'polygon-outline'}).id
-    ) {
-      featureIndex = this.state.features.polygonFeatureIndexMap[info.index];
-    }
 
     return Object.assign(info, {
       // override object with picked feature
-      object: (info.object && info.object.feature) || info.object,
-      index: featureIndex
+      object: info.object ? info.object.__deckMetadata.feature : info.object,
+      index: info.object ? info.object.__deckMetadata.featureIndex : info.index
     });
   }
 

--- a/modules/layers/src/geojson-layer/geojson-layer.js
+++ b/modules/layers/src/geojson-layer/geojson-layer.js
@@ -90,10 +90,26 @@ export default class GeoJsonLayer extends CompositeLayer {
     }
   }
 
-  getPickingInfo({info}) {
+  getPickingInfo({info, sourceLayer}) {
+    // `info.index` is the index within the particular sub-layer
+    // We want to expose the index of the feature the user provided
+    let featureIndex = info.index;
+
+    if (sourceLayer.id === this.getSubLayerProps({id: 'points'}).id) {
+      featureIndex = this.state.features.pointFeatureIndexMap[info.index];
+    } else if (sourceLayer.id === this.getSubLayerProps({id: 'line-paths'}).id) {
+      featureIndex = this.state.features.lineFeatureIndexMap[info.index];
+    } else if (
+      sourceLayer.id === this.getSubLayerProps({id: 'polygon-fill'}).id ||
+      sourceLayer.id === this.getSubLayerProps({id: 'polygon-outline'}).id
+    ) {
+      featureIndex = this.state.features.polygonFeatureIndexMap[info.index];
+    }
+
     return Object.assign(info, {
       // override object with picked feature
-      object: (info.object && info.object.feature) || info.object
+      object: (info.object && info.object.feature) || info.object,
+      index: featureIndex
     });
   }
 

--- a/modules/layers/src/geojson-layer/geojson.js
+++ b/modules/layers/src/geojson-layer/geojson.js
@@ -83,26 +83,26 @@ export function separateGeojsonFeatures(features) {
     } = feature;
     checkCoordinates(type, coordinates);
 
-    const __deckMetadata = {
+    const deckPickingInfo = {
       feature,
       featureIndex
     };
     // Split each feature, but keep track of the source feature and index (for Multi* geometries)
     switch (type) {
       case 'Point':
-        pointFeatures.push(Object.assign({}, feature, {__deckMetadata}));
+        pointFeatures.push(Object.assign({}, feature, {deckPickingInfo}));
         break;
       case 'MultiPoint':
         coordinates.forEach(point => {
           pointFeatures.push({
             geometry: {type: 'Point', coordinates: point},
             properties,
-            __deckMetadata
+            deckPickingInfo
           });
         });
         break;
       case 'LineString':
-        lineFeatures.push(Object.assign({}, feature, {__deckMetadata}));
+        lineFeatures.push(Object.assign({}, feature, {deckPickingInfo}));
         break;
       case 'MultiLineString':
         // Break multilinestrings into multiple lines with same properties
@@ -110,18 +110,18 @@ export function separateGeojsonFeatures(features) {
           lineFeatures.push({
             geometry: {type: 'LineString', coordinates: path},
             properties,
-            __deckMetadata
+            deckPickingInfo
           });
         });
         break;
       case 'Polygon':
-        polygonFeatures.push(Object.assign({}, feature, {__deckMetadata}));
+        polygonFeatures.push(Object.assign({}, feature, {deckPickingInfo}));
         // Break polygon into multiple lines with same properties
         coordinates.forEach(path => {
           polygonOutlineFeatures.push({
             geometry: {type: 'LineString', coordinates: path},
             properties,
-            __deckMetadata
+            deckPickingInfo
           });
         });
         break;
@@ -131,14 +131,14 @@ export function separateGeojsonFeatures(features) {
           polygonFeatures.push({
             geometry: {type: 'Polygon', coordinates: polygon},
             properties,
-            __deckMetadata
+            deckPickingInfo
           });
           // Break polygon into multiple lines with same properties
           polygon.forEach(path => {
             polygonOutlineFeatures.push({
               geometry: {type: 'LineString', coordinates: path},
               properties,
-              __deckMetadata
+              deckPickingInfo
             });
           });
         });

--- a/modules/layers/src/geojson-layer/geojson.js
+++ b/modules/layers/src/geojson-layer/geojson.js
@@ -72,12 +72,6 @@ export function separateGeojsonFeatures(features) {
   const polygonFeatures = [];
   const polygonOutlineFeatures = [];
 
-  // Store a mapping of index within each feature type to the index of the feature within `features`
-  const pointFeatureIndexes = [];
-  const lineFeatureIndexes = [];
-  const polygonFeatureIndexes = [];
-  const polygonOutlineFeatureIndexes = [];
-
   for (let featureIndex = 0; featureIndex < features.length; featureIndex++) {
     const feature = features[featureIndex];
 
@@ -89,25 +83,26 @@ export function separateGeojsonFeatures(features) {
     } = feature;
     checkCoordinates(type, coordinates);
 
+    const __deckMetadata = {
+      feature,
+      featureIndex
+    };
     // Split each feature, but keep track of the source feature and index (for Multi* geometries)
     switch (type) {
       case 'Point':
-        pointFeatures.push(feature);
-        pointFeatureIndexes.push(featureIndex);
+        pointFeatures.push(Object.assign({}, feature, {__deckMetadata}));
         break;
       case 'MultiPoint':
         coordinates.forEach(point => {
           pointFeatures.push({
             geometry: {type: 'Point', coordinates: point},
             properties,
-            __deckSourceFeature: feature
+            __deckMetadata
           });
-          pointFeatureIndexes.push(featureIndex);
         });
         break;
       case 'LineString':
-        lineFeatures.push(feature);
-        lineFeatureIndexes.push(featureIndex);
+        lineFeatures.push(Object.assign({}, feature, {__deckMetadata}));
         break;
       case 'MultiLineString':
         // Break multilinestrings into multiple lines with same properties
@@ -115,23 +110,19 @@ export function separateGeojsonFeatures(features) {
           lineFeatures.push({
             geometry: {type: 'LineString', coordinates: path},
             properties,
-            __deckSourceFeature: feature
+            __deckMetadata
           });
-          lineFeatureIndexes.push(featureIndex);
         });
         break;
       case 'Polygon':
-        polygonFeatures.push(feature);
-        polygonFeatureIndexes.push(featureIndex);
-
+        polygonFeatures.push(Object.assign({}, feature, {__deckMetadata}));
         // Break polygon into multiple lines with same properties
         coordinates.forEach(path => {
           polygonOutlineFeatures.push({
             geometry: {type: 'LineString', coordinates: path},
             properties,
-            __deckSourceFeature: feature
+            __deckMetadata
           });
-          polygonOutlineFeatureIndexes.push(featureIndex);
         });
         break;
       case 'MultiPolygon':
@@ -140,18 +131,15 @@ export function separateGeojsonFeatures(features) {
           polygonFeatures.push({
             geometry: {type: 'Polygon', coordinates: polygon},
             properties,
-            __deckSourceFeature: feature
+            __deckMetadata
           });
-          polygonFeatureIndexes.push(featureIndex);
-
           // Break polygon into multiple lines with same properties
           polygon.forEach(path => {
             polygonOutlineFeatures.push({
               geometry: {type: 'LineString', coordinates: path},
               properties,
-              __deckSourceFeature: feature
+              __deckMetadata
             });
-            polygonOutlineFeatureIndexes.push(featureIndex);
           });
         });
         break;
@@ -163,11 +151,7 @@ export function separateGeojsonFeatures(features) {
     pointFeatures,
     lineFeatures,
     polygonFeatures,
-    polygonOutlineFeatures,
-    pointFeatureIndexes,
-    lineFeatureIndexes,
-    polygonFeatureIndexes,
-    polygonOutlineFeatureIndexes
+    polygonOutlineFeatures
   };
 }
 

--- a/modules/layers/src/geojson-layer/geojson.js
+++ b/modules/layers/src/geojson-layer/geojson.js
@@ -72,7 +72,15 @@ export function separateGeojsonFeatures(features) {
   const polygonFeatures = [];
   const polygonOutlineFeatures = [];
 
-  features.forEach(feature => {
+  // Store a mapping of index within each feature type to the index of the feature within `features`
+  const pointFeatureIndexMap = [];
+  const lineFeatureIndexMap = [];
+  const polygonFeatureIndexMap = [];
+  const polygonOutlineFeatureIndexMap = [];
+
+  for (let featureIndex = 0; featureIndex < features.length; featureIndex++) {
+    const feature = features[featureIndex];
+
     assert(feature && feature.geometry, 'GeoJSON does not have geometry');
 
     const {
@@ -84,48 +92,60 @@ export function separateGeojsonFeatures(features) {
     switch (type) {
       case 'Point':
         pointFeatures.push(feature);
+        pointFeatureIndexMap.push(featureIndex);
         break;
       case 'MultiPoint':
         // TODO - split multipoints
         coordinates.forEach(point => {
           pointFeatures.push({geometry: {coordinates: point}, properties, feature});
+          pointFeatureIndexMap.push(featureIndex);
         });
         break;
       case 'LineString':
         lineFeatures.push(feature);
+        lineFeatureIndexMap.push(featureIndex);
         break;
       case 'MultiLineString':
         // Break multilinestrings into multiple lines with same properties
         coordinates.forEach(path => {
           lineFeatures.push({geometry: {coordinates: path}, properties, feature});
+          lineFeatureIndexMap.push(featureIndex);
         });
         break;
       case 'Polygon':
         polygonFeatures.push(feature);
+        polygonFeatureIndexMap.push(featureIndex);
         // Break polygon into multiple lines with same properties
         coordinates.forEach(path => {
           polygonOutlineFeatures.push({geometry: {coordinates: path}, properties, feature});
+          polygonOutlineFeatureIndexMap.push(featureIndex);
         });
         break;
       case 'MultiPolygon':
         // Break multipolygons into multiple polygons with same properties
         coordinates.forEach(polygon => {
           polygonFeatures.push({geometry: {coordinates: polygon}, properties, feature});
+          polygonFeatureIndexMap.push(featureIndex);
           // Break polygon into multiple lines with same properties
           polygon.forEach(path => {
             polygonOutlineFeatures.push({geometry: {coordinates: path}, properties, feature});
+            polygonOutlineFeatureIndexMap.push(featureIndex);
           });
         });
         break;
       default:
     }
-  });
+  }
 
   return {
     pointFeatures,
     lineFeatures,
     polygonFeatures,
-    polygonOutlineFeatures
+    polygonOutlineFeatures,
+    pointFeatureIndexMap,
+    lineFeatureIndexMap,
+    polygonFeatureIndexMap,
+    polygonOutlineFeatureIndexMap
   };
 }
 

--- a/test/modules/core-layers/geojson.spec.js
+++ b/test/modules/core-layers/geojson.spec.js
@@ -283,10 +283,12 @@ test('geojson#getGeojsonFeatures, separateGeojsonFeatures', t => {
         lineFeaturesLength: result.lineFeatures.length,
         polygonFeaturesLength: result.polygonFeatures.length,
         polygonOutlineFeaturesLength: result.polygonOutlineFeatures.length,
-        pointFeatureIndexes: result.pointFeatureIndexes,
-        lineFeatureIndexes: result.lineFeatureIndexes,
-        polygonFeatureIndexes: result.polygonFeatureIndexes,
-        polygonOutlineFeatureIndexes: result.polygonOutlineFeatureIndexes
+        pointFeatureIndexes: result.pointFeatures.map(f => f.__deckMetadata.featureIndex),
+        lineFeatureIndexes: result.lineFeatures.map(f => f.__deckMetadata.featureIndex),
+        polygonFeatureIndexes: result.polygonFeatures.map(f => f.__deckMetadata.featureIndex),
+        polygonOutlineFeatureIndexes: result.polygonOutlineFeatures.map(
+          f => f.__deckMetadata.featureIndex
+        )
       };
       t.deepEquals(
         actual,

--- a/test/modules/core-layers/geojson.spec.js
+++ b/test/modules/core-layers/geojson.spec.js
@@ -283,12 +283,10 @@ test('geojson#getGeojsonFeatures, separateGeojsonFeatures', t => {
         lineFeaturesLength: result.lineFeatures.length,
         polygonFeaturesLength: result.polygonFeatures.length,
         polygonOutlineFeaturesLength: result.polygonOutlineFeatures.length,
-        pointFeatureIndexes: result.pointFeatures.map(f => f.__deckMetadata.featureIndex),
-        lineFeatureIndexes: result.lineFeatures.map(f => f.__deckMetadata.featureIndex),
-        polygonFeatureIndexes: result.polygonFeatures.map(f => f.__deckMetadata.featureIndex),
-        polygonOutlineFeatureIndexes: result.polygonOutlineFeatures.map(
-          f => f.__deckMetadata.featureIndex
-        )
+        pointFeatureIndexes: result.pointFeatureIndexes,
+        lineFeatureIndexes: result.lineFeatureIndexes,
+        polygonFeatureIndexes: result.polygonFeatureIndexes,
+        polygonOutlineFeatureIndexes: result.polygonOutlineFeatureIndexes
       };
       t.deepEquals(
         actual,

--- a/test/modules/core-layers/geojson.spec.js
+++ b/test/modules/core-layers/geojson.spec.js
@@ -72,80 +72,112 @@ const TEST_CASES = [
     title: 'geometry: Point',
     argument: TEST_DATA.POINT,
     expected: {
-      pointFeatures: 1,
-      lineFeatures: 0,
-      polygonFeatures: 0,
-      polygonOutlineFeatures: 0
+      pointFeaturesLength: 1,
+      lineFeaturesLength: 0,
+      polygonFeaturesLength: 0,
+      polygonOutlineFeaturesLength: 0,
+      pointFeatureIndexes: [0],
+      lineFeatureIndexes: [],
+      polygonFeatureIndexes: [],
+      polygonOutlineFeatureIndexes: []
     }
   },
   {
     title: 'geometry: MultiLineString',
     argument: TEST_DATA.MULTI_LINESTRING,
     expected: {
-      pointFeatures: 0,
-      lineFeatures: 2,
-      polygonFeatures: 0,
-      polygonOutlineFeatures: 0
+      pointFeaturesLength: 0,
+      lineFeaturesLength: 2,
+      polygonFeaturesLength: 0,
+      polygonOutlineFeaturesLength: 0,
+      pointFeatureIndexes: [],
+      lineFeatureIndexes: [0, 0],
+      polygonFeatureIndexes: [],
+      polygonOutlineFeatureIndexes: []
     }
   },
   {
     title: 'geometry: Polygon',
     argument: TEST_DATA.POLYGON,
     expected: {
-      pointFeatures: 0,
-      lineFeatures: 0,
-      polygonFeatures: 1,
-      polygonOutlineFeatures: 1
+      pointFeaturesLength: 0,
+      lineFeaturesLength: 0,
+      polygonFeaturesLength: 1,
+      polygonOutlineFeaturesLength: 1,
+      pointFeatureIndexes: [],
+      lineFeatureIndexes: [],
+      polygonFeatureIndexes: [0],
+      polygonOutlineFeatureIndexes: [0]
     }
   },
   {
     title: 'GeometryCollection',
     argument: TEST_DATA.GEOMETRY_COLLECTION,
     expected: {
-      pointFeatures: 1,
-      lineFeatures: 1,
-      polygonFeatures: 0,
-      polygonOutlineFeatures: 0
+      pointFeaturesLength: 1,
+      lineFeaturesLength: 1,
+      polygonFeaturesLength: 0,
+      polygonOutlineFeaturesLength: 0,
+      pointFeatureIndexes: [0],
+      lineFeatureIndexes: [1],
+      polygonFeatureIndexes: [],
+      polygonOutlineFeatureIndexes: []
     }
   },
   {
     title: 'feature: MultiPoint',
     argument: {type: 'Feature', properties: {}, geometry: TEST_DATA.MULTI_POINT},
     expected: {
-      pointFeatures: 2,
-      lineFeatures: 0,
-      polygonFeatures: 0,
-      polygonOutlineFeatures: 0
+      pointFeaturesLength: 2,
+      lineFeaturesLength: 0,
+      polygonFeaturesLength: 0,
+      polygonOutlineFeaturesLength: 0,
+      pointFeatureIndexes: [0, 0],
+      lineFeatureIndexes: [],
+      polygonFeatureIndexes: [],
+      polygonOutlineFeatureIndexes: []
     }
   },
   {
     title: 'feature: LineString',
     argument: {type: 'Feature', properties: {}, geometry: TEST_DATA.LINESTRING},
     expected: {
-      pointFeatures: 0,
-      lineFeatures: 1,
-      polygonFeatures: 0,
-      polygonOutlineFeatures: 0
+      pointFeaturesLength: 0,
+      lineFeaturesLength: 1,
+      polygonFeaturesLength: 0,
+      polygonOutlineFeaturesLength: 0,
+      pointFeatureIndexes: [],
+      lineFeatureIndexes: [0],
+      polygonFeatureIndexes: [],
+      polygonOutlineFeatureIndexes: []
     }
   },
   {
     title: 'feature: MultiPolygon',
     argument: {type: 'Feature', properties: {}, geometry: TEST_DATA.MULTI_POLYGON},
     expected: {
-      pointFeatures: 0,
-      lineFeatures: 0,
-      polygonFeatures: 2,
-      polygonOutlineFeatures: 3
+      pointFeaturesLength: 0,
+      lineFeaturesLength: 0,
+      polygonFeaturesLength: 2,
+      polygonOutlineFeaturesLength: 3,
+      pointFeatureIndexes: [],
+      lineFeatureIndexes: [],
+      polygonFeatureIndexes: [0, 0],
+      polygonOutlineFeatureIndexes: [0, 0, 0]
     }
   },
   {
     title: 'empty data',
     argument: [],
     expected: {
-      pointFeatures: 0,
-      lineFeatures: 0,
-      polygonFeatures: 0,
-      polygonOutlineFeatures: 0
+      pointFeaturesLength: 0,
+      lineFeaturesLength: 0,
+      polygonFeaturesLength: 0,
+      polygonOutlineFeaturesLength: 0,
+      pointFeatureIndexes: [],
+      lineFeatureIndexes: [],
+      polygonFeatureIndexes: [],
+      polygonOutlineFeatureIndexes: []
     }
   },
   {
@@ -162,10 +194,14 @@ const TEST_CASES = [
       ]
     },
     expected: {
-      pointFeatures: 3,
-      lineFeatures: 3,
-      polygonFeatures: 3,
-      polygonOutlineFeatures: 4
+      pointFeaturesLength: 3,
+      lineFeaturesLength: 3,
+      polygonFeaturesLength: 3,
+      polygonOutlineFeaturesLength: 4,
+      pointFeatureIndexes: [0, 1, 1],
+      lineFeatureIndexes: [2, 3, 3],
+      polygonFeatureIndexes: [4, 5, 5],
+      polygonOutlineFeatureIndexes: [4, 5, 5, 5]
     }
   },
   {
@@ -242,12 +278,20 @@ test('geojson#getGeojsonFeatures, separateGeojsonFeatures', t => {
       t.ok(Array.isArray(featureArray), `getGeojsonFeatures ${tc.title} returned array`);
 
       const result = separateGeojsonFeatures(featureArray);
-      const stats = {};
-      for (const key in result) {
-        stats[key] = result[key].length;
-      }
+      const actual = {
+        pointFeaturesLength: result.pointFeatures.length,
+        lineFeaturesLength: result.lineFeatures.length,
+        polygonFeaturesLength: result.polygonFeatures.length,
+        polygonOutlineFeaturesLength: result.polygonOutlineFeatures.length,
+        pointFeatureIndexes: result.pointFeatures.map(f => f.__deckMetadata.featureIndex),
+        lineFeatureIndexes: result.lineFeatures.map(f => f.__deckMetadata.featureIndex),
+        polygonFeatureIndexes: result.polygonFeatures.map(f => f.__deckMetadata.featureIndex),
+        polygonOutlineFeatureIndexes: result.polygonOutlineFeatures.map(
+          f => f.__deckMetadata.featureIndex
+        )
+      };
       t.deepEquals(
-        stats,
+        actual,
         tc.expected,
         `separateGeojsonFeatures ${tc.title} returned expected result`
       );

--- a/test/modules/core-layers/geojson.spec.js
+++ b/test/modules/core-layers/geojson.spec.js
@@ -283,11 +283,11 @@ test('geojson#getGeojsonFeatures, separateGeojsonFeatures', t => {
         lineFeaturesLength: result.lineFeatures.length,
         polygonFeaturesLength: result.polygonFeatures.length,
         polygonOutlineFeaturesLength: result.polygonOutlineFeatures.length,
-        pointFeatureIndexes: result.pointFeatures.map(f => f.__deckMetadata.featureIndex),
-        lineFeatureIndexes: result.lineFeatures.map(f => f.__deckMetadata.featureIndex),
-        polygonFeatureIndexes: result.polygonFeatures.map(f => f.__deckMetadata.featureIndex),
+        pointFeatureIndexes: result.pointFeatures.map(f => f.deckPickingInfo.featureIndex),
+        lineFeatureIndexes: result.lineFeatures.map(f => f.deckPickingInfo.featureIndex),
+        polygonFeatureIndexes: result.polygonFeatures.map(f => f.deckPickingInfo.featureIndex),
         polygonOutlineFeatureIndexes: result.polygonOutlineFeatures.map(
-          f => f.__deckMetadata.featureIndex
+          f => f.deckPickingInfo.featureIndex
         )
       };
       t.deepEquals(


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
#### Background

When using Multi* geometries (e.g. `MultiPoint`, `MultiLineString`, `MultiPolygon`), the `index` of the picking info had the incorrect index (i.e. it would increment for each sub-geometry). This fixes that issue.

#### Change List
- `GeoJsonLayer`
