### PR TITLE
[PART-1] GPUGridAggregation : Add world-space aggregation support to GPUAggregator

### DIFF
--- a/dev-docs/RFCs/v6.0/gpu-screengrid-aggregation-rfc.md
+++ b/dev-docs/RFCs/v6.0/gpu-screengrid-aggregation-rfc.md
@@ -32,6 +32,7 @@ Performs aggregation either on CPU or GPU based on the provided options and brow
 
 Input:
 * positions (Array) : Array of points in world space (lng, lat).
+* positions64xyLow (Array) : Array of low precision values of points in world space (lng, lat).
 * weights  (Array, optional, default: null) : Array of weights, if null, a default weight of 1 is used for all points.
 * cellSize: (Array) : Size of the cell, cellSize[0] is width and cellSize[1] is height.
 * width: (Number, Optional) : Grid width in pixels, deduced from ‘viewport’ when not provided.
@@ -44,6 +45,8 @@ Input:
 	* cellSizeChagned (Bool) : should be set to true when cellSize is changed.
 * countsBuffer: (Buffer, optional) : used to update aggregation data per grid, details in Output section.
 * maxCountBuffer: (Buffer, optional) : used to update total aggregation data, details in Output section.
+* projectPoints (Bool) : when true performs aggregation in screen space.
+* gridTransformMatrix (Mat4) : used to transform input positions before aggregating them (for example, lng/lat can be moved to +ve range, when doing world space aggregation, projectPoints=false).
 
 ### Output
 * results(Object): Contains following Buffer objects. If these buffers are not provided to the method, new Buffers with enough size are created and returned.

--- a/modules/experimental-layers/src/gpu-screen-grid-layer/gpu-screen-grid-layer-vertex.glsl.js
+++ b/modules/experimental-layers/src/gpu-screen-grid-layer/gpu-screen-grid-layer-vertex.glsl.js
@@ -22,10 +22,10 @@ export default `\
 #version 300 es
 #define SHADER_NAME screen-grid-layer-vertex-shader
 
-attribute vec3 vertices;
-attribute vec3 instancePositions;
-attribute vec4 instanceCounts;
-attribute vec3 instancePickingColors;
+in vec3 vertices;
+in vec3 instancePositions;
+in vec4 instanceCounts;
+in vec3 instancePickingColors;
 
 layout(std140) uniform;
 uniform float opacity;
@@ -37,7 +37,7 @@ uniform AggregationData
   vec4 maxCount;
 } aggregationData;
 
-varying vec4 vColor;
+out vec4 vColor;
 
 void main(void) {
   float step = instanceCounts.g / aggregationData.maxCount.w;

--- a/modules/experimental-layers/src/gpu-screen-grid-layer/gpu-screen-grid-layer.js
+++ b/modules/experimental-layers/src/gpu-screen-grid-layer/gpu-screen-grid-layer.js
@@ -241,7 +241,8 @@ export default class GPUScreenGridLayer extends Layer {
       countsBuffer,
       maxCountBuffer,
       changeFlags,
-      useGPU: gpuAggregation
+      useGPU: gpuAggregation,
+      projectPoints: true
     });
 
     attributeManager.invalidate('instanceCounts');

--- a/modules/experimental-layers/src/utils/gpu-grid-aggregator.js
+++ b/modules/experimental-layers/src/utils/gpu-grid-aggregator.js
@@ -1,30 +1,106 @@
 import {Buffer, Model, GL, Framebuffer, Texture2D, FEATURES, hasFeatures, isWebGL2} from 'luma.gl';
 import {log} from '@deck.gl/core';
 import assert from 'assert';
+import {fp64 as fp64Utils} from 'luma.gl';
+import {worldToPixels} from 'viewport-mercator-project';
+const {fp64ifyMatrix4} = fp64Utils;
+const IDENTITY_MATRIX = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
 const AGGREGATE_TO_GRID_VS = `\
 attribute vec2 positions;
+attribute vec2 positions64xyLow;
 attribute float weights;
 uniform vec2 windowSize;
 uniform vec2 cellSize;
 uniform vec2 gridSize;
 uniform mat4 uProjectionMatrix;
+uniform bool projectPoints;
 
 varying float vWeights;
 
-vec2 project_to_pixel(vec2 pixels) {
-  vec4 pixPosition = vec4(pixels, 0., 1.);
-  vec4 result =  uProjectionMatrix * pixPosition;
+vec2 project_to_pixel(vec2 pos) {
+  vec4 position = vec4(pos, 0., 1.);
+  vec4 result =  uProjectionMatrix * position;
   return result.xy/result.w;
 }
 
 void main(void) {
 
   vWeights = weights;
-  vec2 windowPos = project_position(positions);
+
+  vec2 windowPos = positions;
+  vec2 windowPos64xyLow = positions64xyLow;
+  if (projectPoints) {
+    windowPos = project_position(windowPos);
+  }
+
   windowPos = project_to_pixel(windowPos);
 
   // Transform (0,0):windowSize -> (0, 0): gridSize
   vec2 pos = floor(windowPos / cellSize);
+
+  // Transform (0,0):gridSize -> (-1, -1):(1,1)
+  pos = (pos * (2., 2.) / (gridSize)) - (1., 1.);
+
+  // Move to pixel center, pixel-size in screen sapce (2/gridSize) * 0.5 => 1/gridSize
+  vec2 offset = 1.0 / gridSize;
+  pos = pos + offset;
+
+  gl_Position = vec4(pos, 0.0, 1.0);
+}
+`;
+
+const AGGREGATE_TO_GRID_VS_FP64 = `\
+attribute vec2 positions;
+attribute vec2 positions64xyLow;
+attribute float weights;
+uniform vec2 windowSize;
+uniform vec2 cellSize;
+uniform vec2 gridSize;
+uniform vec2 uProjectionMatrixFP64[16];
+uniform bool projectPoints;
+
+varying float vWeights;
+
+void project_to_pixel(vec2 pos, vec2 pos64xyLow, out vec2 pixelXY64[2]) {
+
+  vec2 result64[4];
+  vec2 position64[4];
+  position64[0] = vec2(pos.x, pos64xyLow.x);
+  position64[1] = vec2(pos.y, pos64xyLow.y);
+  position64[2] = vec2(0., 0.);
+  position64[3] = vec2(1., 0.);
+  mat4_vec4_mul_fp64(uProjectionMatrixFP64, position64,
+  result64);
+
+  pixelXY64[0] = div_fp64(result64[0], result64[3]);
+  pixelXY64[1] = div_fp64(result64[1], result64[3]);
+}
+
+void main(void) {
+
+  vWeights = weights;
+
+  vec2 windowPos = positions;
+  vec2 windowPos64xyLow = positions64xyLow;
+  if (projectPoints) {
+    vec2 projectedXY[2];
+    project_position_fp64(windowPos, windowPos64xyLow, projectedXY);
+    windowPos.x = projectedXY[0].x;
+    windowPos.y = projectedXY[1].x;
+    windowPos64xyLow.x = projectedXY[0].y;
+    windowPos64xyLow.y = projectedXY[1].y;
+  }
+
+  vec2 pixelXY64[2];
+  project_to_pixel(windowPos, windowPos64xyLow, pixelXY64);
+
+  // Transform (0,0):windowSize -> (0, 0): gridSize
+  vec2 gridXY64[2];
+  gridXY64[0] = div_fp64(pixelXY64[0], vec2(cellSize.x, 0));
+  gridXY64[1] = div_fp64(pixelXY64[1], vec2(cellSize.y, 0));
+  float x = floor(gridXY64[0].x);
+  float y = floor(gridXY64[1].x);
+  vec2 pos = vec2(x, y);
 
   // Transform (0,0):gridSize -> (-1, -1):(1,1)
   pos = (pos * (2., 2.) / (gridSize)) - (1., 1.);
@@ -47,13 +123,14 @@ void main(void) {
 }
 `;
 
-const AGGREGATE_ALL_VS = `\
-attribute vec2 positions;
-attribute vec2 texCoords;
 
+const AGGREGATE_ALL_VS = `\
+#version 300 es
+
+in vec2 position;
 uniform vec2 gridSize;
 
-varying vec2 vTextureCoord;
+out vec2 vTextureCoord;
 void main(void) {
   // Map each position to single pixel
   vec2 pos = vec2(-1.0, -1.0);
@@ -64,20 +141,57 @@ void main(void) {
 
   gl_Position = vec4(pos, 0.0, 1.0);
 
-  vTextureCoord = texCoords;
+  float yIndex = floor(float(gl_InstanceID) / gridSize[0]);
+  float xIndex = float(gl_InstanceID) - (yIndex * gridSize[0]);
+
+  vTextureCoord = vec2(yIndex/gridSize[1], xIndex/gridSize[0]);
+  // vTextureCoord = vec2(0.5, 0.5);
+}
+`;
+
+const AGGREGATE_ALL_VS_FP64 = `\
+#version 300 es
+
+in vec2 position;
+uniform vec2 gridSize;
+
+out vec2 vTextureCoord;
+void main(void) {
+  // Map each position to single pixel
+  vec2 pos = vec2(-1.0, -1.0);
+
+  // Move to pixel center, pixel-size in screen sapce (2/gridSize) * 0.5 => 1/gridSize
+  vec2 offset = 1.0 / gridSize;
+  pos = pos + offset;
+
+  gl_Position = vec4(pos, 0.0, 1.0);
+
+  float yIndex = floor(float(gl_InstanceID) / gridSize[0]);
+  float xIndex = float(gl_InstanceID) - (yIndex * gridSize[0]);
+
+  vec2 yIndexFP64 = vec2(yIndex, 0.);
+  vec2 xIndexFP64 = vec2(xIndex, 0.);
+  vec2 gridSizeYFP64 = vec2(gridSize[1], 0.);
+  vec2 gridSizeXFP64 = vec2(gridSize[0], 0.);
+
+  vec2 texCoordXFP64 = div_fp64(yIndexFP64, gridSizeYFP64);
+  vec2 texCoordYFP64 = div_fp64(xIndexFP64, gridSizeXFP64);
+
+  vTextureCoord = vec2(texCoordYFP64.x, texCoordXFP64.x);
 }
 `;
 
 const AGGREGATE_ALL_FS = `\
+#version 300 es
 precision highp float;
 
-varying vec2 vTextureCoord;
+in vec2 vTextureCoord;
 uniform sampler2D uSampler;
-
+out vec4 fragColor;
 void main(void) {
-  vec4 textureColor = texture2D(uSampler, vec2(vTextureCoord.s, vTextureCoord.t));
+  vec4 textureColor = texture(uSampler, vec2(vTextureCoord.s, vTextureCoord.t));
   // Red: total count, Green: total weight, Alpha: maximum wieght
-  gl_FragColor = vec4(textureColor.r, textureColor.g, 0., textureColor.g);
+  fragColor = vec4(textureColor.r, textureColor.g, 0., textureColor.g);
 }
 `;
 
@@ -102,35 +216,46 @@ export default class GPUGridAggregator {
         FEATURES.TEXTURE_FILTER_LINEAR_FLOAT
       );
     if (this._hasGPUSupport) {
-      this._setupModels();
+      this._setupGPUResources();
     }
   }
 
   // Perform aggregation and retun the results
   run({
     positions,
+    positions64xyLow,
     weights,
     changeFlags = DEFAULT_CHANGE_FLAGS,
     cellSize,
     viewport,
-    countsBuffer = null,
-    maxCountBuffer = null,
     width,
     height,
-    useGPU = true
+    countsBuffer = null,
+    maxCountBuffer = null,
+    gridTransformMatrix = null,
+    projectPoints = false,
+    useGPU = true,
+    fp64 = false
   } = {}) {
     if (this.state.useGPU !== useGPU) {
       changeFlags = DEFAULT_CHANGE_FLAGS;
     }
     this._setState({useGPU});
+    const transformMatrix = gridTransformMatrix ||
+      (viewport && viewport.pixelProjectionMatrix) ||
+       IDENTITY_MATRIX;
     const aggregationParams = {
       positions,
+      positions64xyLow,
       weights,
       changeFlags,
       cellSize,
       viewport,
+      gridTransformMatrix: transformMatrix,
       countsBuffer,
-      maxCountBuffer
+      maxCountBuffer,
+      projectPoints,
+      fp64
     };
 
     this._updateGridSize({viewport, cellSize, width, height});
@@ -157,7 +282,41 @@ export default class GPUGridAggregator {
       type: GL.FLOAT,
       buffer: maxCountBuffer
     });
-    return {countsBuffer, maxCountBuffer};
+    return {
+      countsBuffer,
+      countsTexture: this.gridAggregationFramebuffer.texture,
+      maxCountBuffer,
+      maxCountTexture: this.allAggregrationFramebuffer.texture
+    };
+  }
+
+  _getAggregationModel(fp64 = false) {
+    const {gl, shaderCache} = this;
+    return new Model(gl, {
+      id: 'Gird-Aggregation-Model',
+      vs: fp64 ? AGGREGATE_TO_GRID_VS_FP64 : AGGREGATE_TO_GRID_VS,
+      fs: AGGREGATE_TO_GRID_FS,
+      modules: fp64 ? ['fp64', 'project64'] : [],
+      shaderCache,
+      vertexCount: 0,
+      drawMode: GL.POINTS
+    });
+  }
+
+  _getAllAggregationModel(fp64 = false) {
+    const {gl, shaderCache} = this;
+    return new Model(gl, {
+      id: 'All-Aggregation-Model',
+      vs: fp64 ? AGGREGATE_ALL_VS_FP64 : AGGREGATE_ALL_VS,
+      fs: AGGREGATE_ALL_FS,
+      modules: fp64 ? ['fp64'] : [],
+      shaderCache,
+      vertexCount: 1,
+      drawMode: GL.POINTS,
+      isInstanced: true,
+      instanceCount: 0,
+      attributes: {position: new Buffer(gl, {size: 2, data: new Float32Array([0, 0])})}
+    });
   }
 
   _projectPositions(opts) {
@@ -166,32 +325,97 @@ export default class GPUGridAggregator {
       const {positions, viewport} = opts;
       projectedPositions = [];
       for (let index = 0; index < positions.length; index += 2) {
-        const [x, y] = viewport.project([positions[index], positions[index + 1]]);
-        projectedPositions.push({x, y});
+        const [x, y] = viewport.projectFlat([positions[index], positions[index + 1]]);
+        projectedPositions.push(x, y);
       }
       this._setState({projectedPositions});
     }
   }
 
+  _renderAggregateData(opts) {
+    const {cellSize, viewport, gridTransformMatrix, projectPoints} = opts;
+    const {numCol, numRow, windowSize} = this.state;
+    const {
+      gl,
+      gridAggregationFramebuffer,
+      gridAggregationModel,
+      allAggregrationFramebuffer,
+      allAggregationModel
+    } = this;
+
+    const uProjectionMatrixFP64 = fp64ifyMatrix4(gridTransformMatrix);
+    const gridSize = [numCol, numRow];
+
+    gridAggregationFramebuffer.bind();
+    gl.viewport(0, 0, gridSize[0], gridSize[1]);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    gridAggregationModel.draw({
+      parameters: {
+        clearColor: [0, 0, 0, 0],
+        clearDepth: 0,
+        blend: true,
+        depthTest: false,
+        blendEquation: GL.FUNC_ADD,
+        blendFunc: [GL.ONE, GL.ONE]
+      },
+      moduleSettings: {
+        viewport
+      },
+      uniforms: {
+        windowSize,
+        cellSize,
+        gridSize,
+        uProjectionMatrix: gridTransformMatrix,
+        uProjectionMatrixFP64,
+        projectPoints
+      }
+    });
+    gridAggregationFramebuffer.unbind();
+
+    allAggregrationFramebuffer.bind();
+    gl.viewport(0, 0, gridSize[0], gridSize[1]);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    allAggregationModel.draw({
+      parameters: {
+        clearColor: [0, 0, 0, 0],
+        clearDepth: 0,
+        blend: true,
+        depthTest: false,
+        blendEquation: [GL.FUNC_ADD, GL.MAX],
+        blendFunc: [GL.ONE, GL.ONE]
+      },
+      uniforms: {
+        uSampler: gridAggregationFramebuffer.texture,
+        gridSize
+      }
+    });
+    allAggregrationFramebuffer.unbind();
+  }
+
   /* eslint-disable max-statements */
   _runAggregationOnCPU(opts) {
     const ELEMENTCOUNT = 4;
-    const {weights, cellSize} = opts;
+    const {positions, weights, cellSize, projectPoints, gridTransformMatrix} = opts;
     let {countsBuffer, maxCountBuffer} = opts;
     const {numCol, numRow} = this.state;
     // Each element contains 4 floats to match with GPU ouput
     const counts = new Float32Array(numCol * numRow * ELEMENTCOUNT);
 
-    this._projectPositions(opts);
+    let pos = positions;
+    if (projectPoints) {
+      this._projectPositions(opts);
+      pos = this.state.projectedPositions;
+    }
 
     counts.fill(0);
     let maxWeight = 0;
     let totalCount = 0;
     let totalWeight = 0;
-    const {projectedPositions} = this.state;
-    for (let index = 0; index < projectedPositions.length; index++) {
-      const {x, y} = projectedPositions[index];
-      const weight = weights ? weights[index] : 1;
+    for (let index = 0; index < pos.length; index+=2) {
+      const gridPos = worldToPixels([pos[index], pos[index+1], 0], gridTransformMatrix);
+      const x = gridPos[0];
+      const y = gridPos[1];
+      const weight = weights ? weights[index/2] : 1;
       assert(Number.isFinite(weight));
       const colId = Math.floor(x / cellSize[0]);
       const rowId = Math.floor(y / cellSize[1]);
@@ -227,10 +451,11 @@ export default class GPUGridAggregator {
     }
     return {countsBuffer, maxCountBuffer};
   }
+  /* eslint-enable max-statements */
 
   _runAggregationOnGPU(opts) {
     this._updateModels(opts);
-    this._runGridAggregation(opts);
+    this._renderAggregateData(opts);
     return this._getAggregateData(opts);
   }
 
@@ -239,50 +464,50 @@ export default class GPUGridAggregator {
     Object.assign(this.state, updateObject);
   }
 
-  /* eslint-enable max-statements */
-  _setupModels() {
-    const {gl, shaderCache} = this;
-
-    this.gridAggregationModel = new Model(gl, {
-      id: 'Gird-Aggregation-Model',
-      vs: AGGREGATE_TO_GRID_VS,
-      fs: AGGREGATE_TO_GRID_FS,
-      shaderCache,
-      vertexCount: 0,
-      drawMode: GL.POINTS
-    });
-    this.allAggregationModel = new Model(gl, {
-      id: 'All-Aggregation-Model',
-      vs: AGGREGATE_ALL_VS,
-      fs: AGGREGATE_ALL_FS,
-      shaderCache,
-      vertexCount: 0,
-      drawMode: GL.POINTS
-    });
+  _setupGPUResources() {
+    const {gl} = this;
 
     this.gridAggregationFramebuffer = setupFramebuffer(gl, {id: 'GridAggregation'});
     this.allAggregrationFramebuffer = setupFramebuffer(gl, {id: 'AllAggregation'});
   }
 
+  _setupModels(fp64 = false) {
+    if (this.gridAggregationModel) {
+      this.gridAggregationModel.delete();
+    }
+    this.gridAggregationModel = this._getAggregationModel(fp64);
+    if (this.allAggregationModel) {
+      this.allAggregationModel.delete();
+    }
+    this.allAggregationModel = this._getAllAggregationModel(fp64);
+  }
+
   /* eslint-disable max-statements */
   _updateModels(opts) {
     const {gl} = this;
-    const {positions, weights, changeFlags} = opts;
+    const {positions, positions64xyLow, weights, changeFlags} = opts;
     const {numCol, numRow} = this.state;
 
-    let {positionsBuffer, weightsBuffer, gridPixelBuffer, gridTexCoordsBuffer} = this.state;
+    let { positionsBuffer, positions64xyLowBuffer, weightsBuffer } = this.state;
+
+    const aggregationModelAttributes = {};
+
+    let createPos64xyLow = false;
+    if (opts.fp64 !== this.state.fp64) {
+      this._setupModels(opts.fp64);
+      this._setState({fp64: opts.fp64});
+      if (opts.fp64) {
+        createPos64xyLow = true;
+      }
+    }
 
     if (changeFlags.dataChanged || !positionsBuffer) {
-      // TODO: add support for weights
-      if (positionsBuffer) {
-        positionsBuffer.delete();
-      }
-      if (weightsBuffer) {
-        weightsBuffer.delete();
-      }
+      if (positionsBuffer) {positionsBuffer.delete();}
+      if (weightsBuffer) {weightsBuffer.delete();}
       positionsBuffer = new Buffer(gl, {size: 2, data: new Float32Array(positions)});
       weightsBuffer = new Buffer(gl, {size: 1, data: new Float32Array(weights)});
-      this.gridAggregationModel.setAttributes({
+      createPos64xyLow = opts.fp64;
+      Object.assign(aggregationModelAttributes, {
         positions: positionsBuffer,
         weights: weightsBuffer
       });
@@ -290,95 +515,30 @@ export default class GPUGridAggregator {
       this._setState({positionsBuffer, weightsBuffer});
     }
 
-    if (changeFlags.cellSizeChanged || !gridPixelBuffer) {
-      if (gridPixelBuffer) {
-        gridPixelBuffer.delete();
+    if (createPos64xyLow) {
+      assert(positions64xyLow);
+      if (positions64xyLowBuffer) {
+        positions64xyLowBuffer.delete();
       }
-      if (gridTexCoordsBuffer) {
-        gridTexCoordsBuffer.delete();
-      }
-      const gridPixels = new Float32Array(numCol * numRow * 2);
-      const gridTexCoords = new Float32Array(getTexCoordPerPixel([numCol, numRow]));
-      gridPixelBuffer = new Buffer(gl, {
-        size: 2,
-        data: gridPixels
+      positions64xyLowBuffer = new Buffer(gl, {size: 2, data: new Float32Array(positions64xyLow)});
+      Object.assign(aggregationModelAttributes, {
+        positions64xyLow: positions64xyLowBuffer,
       });
-      gridTexCoordsBuffer = new Buffer(gl, {
-        size: 2,
-        data: gridTexCoords
-      });
+      this._setState({ positions64xyLowBuffer});
+    }
 
-      this.allAggregationModel.setAttributes({
-        positions: gridPixelBuffer,
-        texCoords: gridTexCoordsBuffer
-      });
-      this.allAggregationModel.setVertexCount(gridPixels.length / 2);
+    this.gridAggregationModel.setAttributes(aggregationModelAttributes);
+
+    if (changeFlags.cellSizeChanged) {
+
+      this.allAggregationModel.setInstanceCount(numCol * numRow);
 
       const framebufferSize = {width: numCol, height: numRow};
       this.gridAggregationFramebuffer.resize(framebufferSize);
       this.allAggregrationFramebuffer.resize(framebufferSize);
-      this._setState({gridPixelBuffer, gridTexCoordsBuffer});
     }
   }
   /* eslint-enable max-statements */
-
-  _runGridAggregation(opts) {
-    const {cellSize, viewport} = opts;
-    const {numCol, numRow, windowSize} = this.state;
-    const {
-      gl,
-      gridAggregationFramebuffer,
-      gridAggregationModel,
-      allAggregrationFramebuffer,
-      allAggregationModel
-    } = this;
-
-    const {pixelProjectionMatrix} = viewport;
-    const gridSize = [numCol, numRow];
-
-    gridAggregationFramebuffer.bind();
-    gl.viewport(0, 0, gridSize[0], gridSize[1]);
-    gl.clear(gl.COLOR_BUFFER_BIT);
-    gridAggregationModel.draw({
-      parameters: {
-        clearColor: [0, 0, 0, 0],
-        clearDepth: 0,
-        blend: true,
-        depthTest: false,
-        blendEquation: GL.FUNC_ADD,
-        blendFunc: [GL.ONE, GL.ONE]
-      },
-      moduleSettings: {
-        viewport
-      },
-      uniforms: {
-        windowSize,
-        cellSize,
-        gridSize,
-        uProjectionMatrix: pixelProjectionMatrix
-      }
-    });
-    gridAggregationFramebuffer.unbind();
-
-    allAggregrationFramebuffer.bind();
-    gl.viewport(0, 0, gridSize[0], gridSize[1]);
-    gl.clear(gl.COLOR_BUFFER_BIT);
-    allAggregationModel.draw({
-      parameters: {
-        clearColor: [0, 0, 0, 0],
-        clearDepth: 0,
-        blend: true,
-        depthTest: false,
-        blendEquation: [GL.FUNC_ADD, GL.MAX],
-        blendFunc: [GL.ONE, GL.ONE]
-      },
-      uniforms: {
-        uSampler: gridAggregationFramebuffer.texture,
-        gridSize
-      }
-    });
-    allAggregrationFramebuffer.unbind();
-  }
 
   _updateGridSize(opts) {
     const {viewport, cellSize} = opts;
@@ -391,22 +551,6 @@ export default class GPUGridAggregator {
 }
 
 // Helper methods.
-
-// Generates (s, t) tex coordinates for each point in the rect
-// s, t are in [0, 1] range
-function getTexCoordPerPixel(rectSize) {
-  assert(Number.isFinite(rectSize[0]) && Number.isFinite(rectSize[1]));
-  const points = [];
-  for (let i = 0; i < rectSize[0]; i++) {
-    for (let j = 0; j < rectSize[1]; j++) {
-      const s = i / rectSize[0];
-      const t = j / rectSize[1];
-      points.push(s);
-      points.push(t);
-    }
-  }
-  return points;
-}
 
 function setupFramebuffer(gl, opts) {
   const {id} = opts;

--- a/modules/experimental-layers/src/utils/gpu-grid-aggregator.js
+++ b/modules/experimental-layers/src/utils/gpu-grid-aggregator.js
@@ -123,7 +123,6 @@ void main(void) {
 }
 `;
 
-
 const AGGREGATE_ALL_VS = `\
 #version 300 es
 
@@ -241,9 +240,8 @@ export default class GPUGridAggregator {
       changeFlags = DEFAULT_CHANGE_FLAGS;
     }
     this._setState({useGPU});
-    const transformMatrix = gridTransformMatrix ||
-      (viewport && viewport.pixelProjectionMatrix) ||
-       IDENTITY_MATRIX;
+    const transformMatrix =
+      gridTransformMatrix || (viewport && viewport.pixelProjectionMatrix) || IDENTITY_MATRIX;
     const aggregationParams = {
       positions,
       positions64xyLow,
@@ -411,11 +409,11 @@ export default class GPUGridAggregator {
     let maxWeight = 0;
     let totalCount = 0;
     let totalWeight = 0;
-    for (let index = 0; index < pos.length; index+=2) {
-      const gridPos = worldToPixels([pos[index], pos[index+1], 0], gridTransformMatrix);
+    for (let index = 0; index < pos.length; index += 2) {
+      const gridPos = worldToPixels([pos[index], pos[index + 1], 0], gridTransformMatrix);
       const x = gridPos[0];
       const y = gridPos[1];
-      const weight = weights ? weights[index/2] : 1;
+      const weight = weights ? weights[index / 2] : 1;
       assert(Number.isFinite(weight));
       const colId = Math.floor(x / cellSize[0]);
       const rowId = Math.floor(y / cellSize[1]);
@@ -488,7 +486,7 @@ export default class GPUGridAggregator {
     const {positions, positions64xyLow, weights, changeFlags} = opts;
     const {numCol, numRow} = this.state;
 
-    let { positionsBuffer, positions64xyLowBuffer, weightsBuffer } = this.state;
+    let {positionsBuffer, positions64xyLowBuffer, weightsBuffer} = this.state;
 
     const aggregationModelAttributes = {};
 
@@ -502,8 +500,12 @@ export default class GPUGridAggregator {
     }
 
     if (changeFlags.dataChanged || !positionsBuffer) {
-      if (positionsBuffer) {positionsBuffer.delete();}
-      if (weightsBuffer) {weightsBuffer.delete();}
+      if (positionsBuffer) {
+        positionsBuffer.delete();
+      }
+      if (weightsBuffer) {
+        weightsBuffer.delete();
+      }
       positionsBuffer = new Buffer(gl, {size: 2, data: new Float32Array(positions)});
       weightsBuffer = new Buffer(gl, {size: 1, data: new Float32Array(weights)});
       createPos64xyLow = opts.fp64;
@@ -522,15 +524,14 @@ export default class GPUGridAggregator {
       }
       positions64xyLowBuffer = new Buffer(gl, {size: 2, data: new Float32Array(positions64xyLow)});
       Object.assign(aggregationModelAttributes, {
-        positions64xyLow: positions64xyLowBuffer,
+        positions64xyLow: positions64xyLowBuffer
       });
-      this._setState({ positions64xyLowBuffer});
+      this._setState({positions64xyLowBuffer});
     }
 
     this.gridAggregationModel.setAttributes(aggregationModelAttributes);
 
     if (changeFlags.cellSizeChanged) {
-
       this.allAggregationModel.setInstanceCount(numCol * numRow);
 
       const framebufferSize = {width: numCol, height: numRow};

--- a/test/bench/gpu-grid-aggregator.bench.js
+++ b/test/bench/gpu-grid-aggregator.bench.js
@@ -44,17 +44,35 @@ export default function gridAggregatorBench(suite) {
     .add('GPU 1K', () => {
       runAggregation(Object.assign({}, {useGPU: true}, points1K));
     })
+    .add('CPU 1K with projection', () => {
+      runAggregation(Object.assign({}, {useGPU: false, projectPoints: true}, points1K));
+    })
+    .add('GPU 1K with projection', () => {
+      runAggregation(Object.assign({}, {useGPU: true, projectPoints: true}, points1K));
+    })
     .add('CPU 100K', () => {
       runAggregation(Object.assign({}, {useGPU: false}, points100K));
     })
     .add('GPU 100K', () => {
       runAggregation(Object.assign({}, {useGPU: true}, points100K));
     })
+    .add('CPU 100K with projection', () => {
+      runAggregation(Object.assign({}, {useGPU: false, projectPoints: true}, points100K));
+    })
+    .add('GPU 100K with projection', () => {
+      runAggregation(Object.assign({}, {useGPU: true, projectPoints: true}, points100K));
+    })
     .add('CPU 1M', () => {
       runAggregation(Object.assign({}, {useGPU: false}, points1M));
     })
     .add('GPU 1M', () => {
       runAggregation(Object.assign({}, {useGPU: true}, points1M));
+    })
+    .add('CPU 1M with projection', () => {
+      runAggregation(Object.assign({}, {useGPU: false, projectPoints: true}, points1M));
+    })
+    .add('GPU 1M with projection', () => {
+      runAggregation(Object.assign({}, {useGPU: true, projectPoints: true}, points1M));
     });
 }
 

--- a/test/data/grid-aggregation-data.js
+++ b/test/data/grid-aggregation-data.js
@@ -31,7 +31,6 @@ let positions = [
   10
 ];
 
-
 let positions64xyLow = positions.map(pos => fp64LowPart(pos));
 const fixture = {
   positions,
@@ -84,10 +83,10 @@ function generateRandomGridPoints(pointCount) {
   return {positions: pos, positions64xyLow: posLow, weights};
 }
 
-const X =  0;
+const X = 0;
 const Y = 0;
-const DX =  0.00575;
-const DY =  0.00455;
+const DX = 0.00575;
+const DY = 0.00455;
 
 positions = [
   // cell-0
@@ -98,7 +97,7 @@ positions = [
   Y + DY / 2,
 
   // cell -1
-  X + (1.1 * DX),
+  X + 1.1 * DX,
   0.8 * Y,
 
   // cell -2
@@ -127,18 +126,17 @@ positions = [
 
   X + 3.98 * DX,
   Y + 3.99 * DY
-
 ];
 positions64xyLow = positions.map(pos => fp64LowPart(pos));
 
 const fixtureWorldSpace = {
   positions,
   positions64xyLow,
-  cellSize : [DX, DY],
-  width: DX*5,
-  height: DY*5,
-  weights: [ 10, 0.1, 1, 4, 5, 6, 2, 3, 111, 44 ,123]
-}
+  cellSize: [DX, DY],
+  width: DX * 5,
+  height: DY * 5,
+  weights: [10, 0.1, 1, 4, 5, 6, 2, 3, 111, 44, 123]
+};
 export const GridAggregationData = {
   viewport,
   fixture,

--- a/test/data/grid-aggregation-data.js
+++ b/test/data/grid-aggregation-data.js
@@ -1,4 +1,8 @@
 import {WebMercatorViewport} from 'deck.gl';
+import {fp64} from 'luma.gl';
+
+const {fp64LowPart} = fp64;
+
 const viewport = new WebMercatorViewport({
   longitude: -119.3,
   latitude: 35.6,
@@ -10,23 +14,28 @@ const viewport = new WebMercatorViewport({
   height: 500
 });
 
+let positions = [
+  // Inside the current viewport bounds
+  -120.4193,
+  34.7751,
+
+  // Merged to same grid
+  -118.67079,
+  34.03948,
+
+  -118.67079,
+  34.03948,
+
+  // Outside the current viewport bounds
+  -122.4193,
+  10
+];
+
+
+let positions64xyLow = positions.map(pos => fp64LowPart(pos));
 const fixture = {
-  positions: [
-    // Inside the current viewport bounds
-    -120.4193,
-    34.7751,
-
-    // Merged to same grid
-    -118.67079,
-    34.03948,
-
-    -118.67079,
-    34.03948,
-
-    // Outside the current viewport bounds
-    -122.4193,
-    10
-  ],
+  positions,
+  positions64xyLow,
   weights: [
     // Inside the current viewport bounds
     1,
@@ -63,17 +72,76 @@ function generateRandomGridPoints(pointCount) {
     height: bottomRight.lat - topLeft.lat,
     count: pointCount
   };
-  const positions = new Array(opts.count * 2);
+  const pos = new Array(opts.count * 2);
+  const posLow = new Array(opts.count * 2);
   const weights = new Array(opts.count).fill(2);
   for (let i = 0; i < opts.count; i++) {
-    positions[i * 2] = Math.floor(Math.random() * opts.width) + opts.x;
-    positions[i * 2 + 1] = Math.floor(Math.random() * opts.height) + opts.y;
+    pos[i * 2] = Math.floor(Math.random() * opts.width) + opts.x;
+    pos[i * 2 + 1] = Math.floor(Math.random() * opts.height) + opts.y;
+    posLow[i * 2] = fp64LowPart(pos[i * 2]);
+    posLow[i * 2 + 1] = fp64LowPart(pos[i * 2 + 1]);
   }
-  return {positions, weights};
+  return {positions: pos, positions64xyLow: posLow, weights};
 }
 
+const X =  0;
+const Y = 0;
+const DX =  0.00575;
+const DY =  0.00455;
+
+positions = [
+  // cell-0
+  X,
+  Y,
+
+  X + DX / 2,
+  Y + DY / 2,
+
+  // cell -1
+  X + (1.1 * DX),
+  0.8 * Y,
+
+  // cell -2
+  X + 2.1 * DX,
+  0.9 * Y,
+
+  X + 2.5 * DX,
+  Y,
+
+  // cell -5
+  X + 2.1 * DX,
+  Y + 2.9 * DY,
+
+  X + 2.15 * DX,
+  Y + 2.05 * DY,
+
+  X + 2.4 * DX,
+  Y + 2.4 * DY,
+
+  // cell - n
+  X + 3.1 * DX,
+  Y + 3.9 * DY,
+
+  X + 3.01 * DX,
+  Y + 3.02 * DY,
+
+  X + 3.98 * DX,
+  Y + 3.99 * DY
+
+];
+positions64xyLow = positions.map(pos => fp64LowPart(pos));
+
+const fixtureWorldSpace = {
+  positions,
+  positions64xyLow,
+  cellSize : [DX, DY],
+  width: DX*5,
+  height: DY*5,
+  weights: [ 10, 0.1, 1, 4, 5, 6, 2, 3, 111, 44 ,123]
+}
 export const GridAggregationData = {
   viewport,
   fixture,
-  generateRandomGridPoints
+  generateRandomGridPoints,
+  fixtureWorldSpace
 };

--- a/test/modules/experimental-layers/gpu-grid-aggregator.spec.js
+++ b/test/modules/experimental-layers/gpu-grid-aggregator.spec.js
@@ -16,8 +16,6 @@ test('GPUGridAggregator#GPU', t => {
   t.end();
 });
 
-//*
-// NOTE:  Disabling these tests as they fail on Chromium browser, works fine on Chrome (test-browser)
 const {generateRandomGridPoints} = GridAggregationData;
 test('GPUGridAggregator#CPU', t => {
   const sa = new GPUGridAggregator(gl);
@@ -45,7 +43,6 @@ test('GPUGridAggregator#CompareCPUandGPU', t => {
     maxCount: result.maxCountBuffer.getData()
   };
 
-
   // Compare aggregation details for each grid-cell, total count and max count.
   t.deepEqual(cpuResults, gpuResults, 'cpu and gpu results should match');
   t.end();
@@ -58,7 +55,9 @@ test('GPUGridAggregator worldspace aggregation #CompareCPUandGPU', t => {
     counts: result.countsBuffer.getData(),
     maxCount: result.maxCountBuffer.getData()
   };
-  result = sa.run(Object.assign({}, fixtureWorldSpace, {useGPU: true, projectPoints: false, fp64: true}));
+  result = sa.run(
+    Object.assign({}, fixtureWorldSpace, {useGPU: true, projectPoints: false, fp64: true})
+  );
   const gpuResults = {
     counts: result.countsBuffer.getData(),
     maxCount: result.maxCountBuffer.getData()
@@ -67,5 +66,3 @@ test('GPUGridAggregator worldspace aggregation #CompareCPUandGPU', t => {
   t.deepEqual(cpuResults, gpuResults, 'cpu and gpu results should match');
   t.end();
 });
-
-//*/

--- a/test/modules/experimental-layers/gpu-grid-aggregator.spec.js
+++ b/test/modules/experimental-layers/gpu-grid-aggregator.spec.js
@@ -3,12 +3,12 @@ import GPUGridAggregator from '@deck.gl/experimental-layers/utils/gpu-grid-aggre
 import {gl} from '@deck.gl/test-utils';
 import {GridAggregationData} from 'deck.gl/test/data';
 
-const {fixture} = GridAggregationData;
+const {fixture, fixtureWorldSpace} = GridAggregationData;
 
 test('GPUGridAggregator#GPU', t => {
   const sa = new GPUGridAggregator(gl);
 
-  const result = sa.run(Object.assign({}, fixture, {useGPU: true}));
+  const result = sa.run(Object.assign({}, fixture, {useGPU: true, projectPoints: true}));
   const maxCountBufferData = result.maxCountBuffer.getData();
   t.equal(maxCountBufferData[0], 3, 'total count should match');
   t.equal(maxCountBufferData[1], 5, 'total weight should match');
@@ -16,13 +16,13 @@ test('GPUGridAggregator#GPU', t => {
   t.end();
 });
 
-/*
-NOTE:  Disabling these tests as they fail on Chromium browser, works fine on Chrome (test-browser)
+//*
+// NOTE:  Disabling these tests as they fail on Chromium browser, works fine on Chrome (test-browser)
 const {generateRandomGridPoints} = GridAggregationData;
 test('GPUGridAggregator#CPU', t => {
   const sa = new GPUGridAggregator(gl);
 
-  const result = sa.run(Object.assign({}, fixture, {useGPU: false}));
+  const result = sa.run(Object.assign({}, fixture, {useGPU: false, projectPoints: true}));
 
   const maxCountBufferData = result.maxCountBuffer.getData();
   t.equal(maxCountBufferData[0], 3, 'total count should match');
@@ -34,19 +34,38 @@ test('GPUGridAggregator#CPU', t => {
 test('GPUGridAggregator#CompareCPUandGPU', t => {
   const sa = new GPUGridAggregator(gl);
   const pointsData = generateRandomGridPoints(5000);
-  let result = sa.run(Object.assign({}, fixture, {useGPU: false}, pointsData));
+  let result = sa.run(Object.assign({}, fixture, {useGPU: false, projectPoints: true}, pointsData));
   const cpuResults = {
     counts: result.countsBuffer.getData(),
     maxCount: result.maxCountBuffer.getData()
   };
-  result = sa.run(Object.assign({}, fixture, {useGPU: true}, pointsData));
+  result = sa.run(Object.assign({}, fixture, {useGPU: true, projectPoints: true}, pointsData));
   const gpuResults = {
     counts: result.countsBuffer.getData(),
     maxCount: result.maxCountBuffer.getData()
   };
 
+
   // Compare aggregation details for each grid-cell, total count and max count.
   t.deepEqual(cpuResults, gpuResults, 'cpu and gpu results should match');
   t.end();
 });
-*/
+
+test('GPUGridAggregator worldspace aggregation #CompareCPUandGPU', t => {
+  const sa = new GPUGridAggregator(gl);
+  let result = sa.run(Object.assign({}, fixtureWorldSpace, {useGPU: false, projectPoints: false}));
+  const cpuResults = {
+    counts: result.countsBuffer.getData(),
+    maxCount: result.maxCountBuffer.getData()
+  };
+  result = sa.run(Object.assign({}, fixtureWorldSpace, {useGPU: true, projectPoints: false, fp64: true}));
+  const gpuResults = {
+    counts: result.countsBuffer.getData(),
+    maxCount: result.maxCountBuffer.getData()
+  };
+
+  t.deepEqual(cpuResults, gpuResults, 'cpu and gpu results should match');
+  t.end();
+});
+
+//*/

--- a/test/render/test-cases.js
+++ b/test/render/test-cases.js
@@ -1,7 +1,7 @@
 import * as dataSamples from '../../examples/layer-browser/src/data-samples';
 import {parseColor, setOpacity} from '../../examples/layer-browser/src/utils/color';
 // TODO: remove hard path once @deck.gl/experimental-layers published with GPUScreenGridLayer
-// import {GPUScreenGridLayer} from '@deck.gl/experimental-layers';
+import {GPUScreenGridLayer} from '@deck.gl/experimental-layers';
 import {GL} from 'luma.gl';
 import {OrbitView, OrthographicView} from 'deck.gl';
 
@@ -975,28 +975,28 @@ export const TEST_CASES = [
     ],
     referenceImageUrl: './test/render/golden-images/text-layer.png'
   },
-  // {
-  //   name: 'gpu-screengrid-lnglat',
-  //   viewState: {
-  //     latitude: 37.751537058389985,
-  //     longitude: -122.42694203247012,
-  //     zoom: 11.5,
-  //     pitch: 0,
-  //     bearing: 0
-  //   },
-  //   layers: [
-  //     new GPUScreenGridLayer({
-  //       id: 'gpu-screengrid-lnglat',
-  //       data: dataSamples.points,
-  //       getPosition: d => d.COORDINATES,
-  //       cellSizePixels: 40,
-  //       minColor: [0, 0, 80, 0],
-  //       maxColor: [100, 255, 0, 128],
-  //       pickable: false
-  //     })
-  //   ],
-  //   referenceImageUrl: './test/render/golden-images/screengrid-lnglat.png'
-  // },
+  {
+    name: 'gpu-screengrid-lnglat',
+    viewState: {
+      latitude: 37.751537058389985,
+      longitude: -122.42694203247012,
+      zoom: 11.5,
+      pitch: 0,
+      bearing: 0
+    },
+    layers: [
+      new GPUScreenGridLayer({
+        id: 'gpu-screengrid-lnglat',
+        data: dataSamples.points,
+        getPosition: d => d.COORDINATES,
+        cellSizePixels: 40,
+        minColor: [0, 0, 80, 0],
+        maxColor: [100, 255, 0, 128],
+        pickable: false
+      })
+    ],
+    referenceImageUrl: './test/render/golden-images/screengrid-lnglat.png'
+  },
   {
     name: 'text-layer-64',
     viewState: {


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #1556 

- Add support for 64 bit float operations (optional). This is needed for accuracy when doing world-space aggregation, as cellSize and positions are in lng/lat space and require high float precision.
- Add support for world-space aggregation, in addition to existing screen-space aggregation.
- Add unit tests and bench tests.
- API change: added three parameters to run() method.
1. projectPoints : Input points are projected to screen space, only when `projectPoints` is true, for world space aggregation, set this value to false.
2. gridTransformMatrix : This transformation is applied before aggregation when doing world space aggregation. (not applicable when doing screen-space aggregation, i.e. when projectPoints is true)
3. fp64, when true uses shaders with 64bit float support.

New aggregation is working but I am not 100% satisfied with `projectPoints` and  `gridTransformMatrix` API, I wanted to have some version out here for review.  Another options to this is to a have boolean to differentiate between world-space and screen-space aggregation and then an optional gridTransformMatrix that is applied in all cases, defaults to IDENTITY. 

#### Change List
-  GPUGridAggregator: Add world space and 64bit aggregation.
