### PR TITLE
Real feature for accessors

### DIFF
--- a/modules/layers/src/geojson-layer/geojson-layer.js
+++ b/modules/layers/src/geojson-layer/geojson-layer.js
@@ -24,7 +24,12 @@ import PathLayer from '../path-layer/path-layer';
 // Use primitive layer to avoid "Composite Composite" layers for now
 import SolidPolygonLayer from '../solid-polygon-layer/solid-polygon-layer';
 
-import {getGeojsonFeatures, separateGeojsonFeatures} from './geojson';
+import {
+  getGeojsonFeatures,
+  separateGeojsonFeatures,
+  unwrapSourceFeature,
+  unwrapSourceFeatureIndex
+} from './geojson';
 
 const defaultLineColor = [0x0, 0x0, 0x0, 0xff];
 const defaultFillColor = [0x0, 0x0, 0x0, 0xff];
@@ -73,7 +78,18 @@ const defaultProps = {
   lightSettings: {}
 };
 
-const getCoordinates = f => f.geometry.coordinates;
+function getCoordinates(f) {
+  return f.geometry.coordinates;
+}
+
+/**
+ * Unwraps the real source feature passed into props and passes as the argument to `accessor`.
+ */
+function unwrappingAccessor(accessor) {
+  if (typeof accessor !== 'function') return accessor;
+
+  return feature => accessor(unwrapSourceFeature(feature));
+}
 
 export default class GeoJsonLayer extends CompositeLayer {
   initializeState() {
@@ -96,8 +112,8 @@ export default class GeoJsonLayer extends CompositeLayer {
 
     return Object.assign(info, {
       // override object with picked feature
-      object: info.object ? info.object.sourceFeature.feature : info.object,
-      index: info.object ? info.object.sourceFeature.index : info.index
+      object: info.object ? unwrapSourceFeature(info.object) : info.object,
+      index: info.object ? unwrapSourceFeatureIndex(info.object) : info.index
     });
   }
 
@@ -161,9 +177,9 @@ export default class GeoJsonLayer extends CompositeLayer {
           wireframe,
           lightSettings,
           getPolygon: getCoordinates,
-          getElevation,
-          getFillColor,
-          getLineColor
+          getElevation: unwrappingAccessor(getElevation),
+          getFillColor: unwrappingAccessor(getFillColor),
+          getLineColor: unwrappingAccessor(getLineColor)
         }
       );
 
@@ -192,9 +208,9 @@ export default class GeoJsonLayer extends CompositeLayer {
           dashJustified: lineDashJustified,
 
           getPath: getCoordinates,
-          getColor: getLineColor,
-          getWidth: getLineWidth,
-          getDashArray: getLineDashArray
+          getColor: unwrappingAccessor(getLineColor),
+          getWidth: unwrappingAccessor(getLineWidth),
+          getDashArray: unwrappingAccessor(getLineDashArray)
         }
       );
 
@@ -219,8 +235,8 @@ export default class GeoJsonLayer extends CompositeLayer {
           miterLimit: lineMiterLimit,
 
           getPath: getCoordinates,
-          getColor: getLineColor,
-          getWidth: getLineWidth
+          getColor: unwrappingAccessor(getLineColor),
+          getWidth: unwrappingAccessor(getLineWidth)
         }
       );
 
@@ -243,8 +259,8 @@ export default class GeoJsonLayer extends CompositeLayer {
           radiusMaxPixels: pointRadiusMaxPixels,
 
           getPosition: getCoordinates,
-          getColor: getFillColor,
-          getRadius
+          getColor: unwrappingAccessor(getFillColor),
+          getRadius: unwrappingAccessor(getRadius)
         }
       );
 

--- a/modules/layers/src/geojson-layer/geojson-layer.js
+++ b/modules/layers/src/geojson-layer/geojson-layer.js
@@ -96,8 +96,8 @@ export default class GeoJsonLayer extends CompositeLayer {
 
     return Object.assign(info, {
       // override object with picked feature
-      object: info.object ? info.object.deckPickingInfo.feature : info.object,
-      index: info.object ? info.object.deckPickingInfo.featureIndex : info.index
+      object: info.object ? info.object.sourceFeature.feature : info.object,
+      index: info.object ? info.object.sourceFeature.index : info.index
     });
   }
 

--- a/modules/layers/src/geojson-layer/geojson.js
+++ b/modules/layers/src/geojson-layer/geojson.js
@@ -78,8 +78,7 @@ export function separateGeojsonFeatures(features) {
     assert(feature && feature.geometry, 'GeoJSON does not have geometry');
 
     const {
-      geometry: {type, coordinates},
-      properties
+      geometry: {type, coordinates}
     } = feature;
     checkCoordinates(type, coordinates);
 
@@ -90,54 +89,58 @@ export function separateGeojsonFeatures(features) {
     // Split each feature, but keep track of the source feature and index (for Multi* geometries)
     switch (type) {
       case 'Point':
-        pointFeatures.push(Object.assign({}, feature, {sourceFeature}));
+        pointFeatures.push({
+          geometry: feature.geometry,
+          sourceFeature
+        });
         break;
       case 'MultiPoint':
         coordinates.forEach(point => {
           pointFeatures.push({
             geometry: {type: 'Point', coordinates: point},
-            properties,
             sourceFeature
           });
         });
         break;
       case 'LineString':
-        lineFeatures.push(Object.assign({}, feature, {sourceFeature}));
+        lineFeatures.push({
+          geometry: feature.geometry,
+          sourceFeature
+        });
         break;
       case 'MultiLineString':
-        // Break multilinestrings into multiple lines with same properties
+        // Break multilinestrings into multiple lines
         coordinates.forEach(path => {
           lineFeatures.push({
             geometry: {type: 'LineString', coordinates: path},
-            properties,
             sourceFeature
           });
         });
         break;
       case 'Polygon':
-        polygonFeatures.push(Object.assign({}, feature, {sourceFeature}));
-        // Break polygon into multiple lines with same properties
+        polygonFeatures.push({
+          geometry: feature.geometry,
+          sourceFeature
+        });
+        // Break polygon into multiple lines
         coordinates.forEach(path => {
           polygonOutlineFeatures.push({
             geometry: {type: 'LineString', coordinates: path},
-            properties,
             sourceFeature
           });
         });
         break;
       case 'MultiPolygon':
-        // Break multipolygons into multiple polygons with same properties
+        // Break multipolygons into multiple polygons
         coordinates.forEach(polygon => {
           polygonFeatures.push({
             geometry: {type: 'Polygon', coordinates: polygon},
-            properties,
             sourceFeature
           });
-          // Break polygon into multiple lines with same properties
+          // Break polygon into multiple lines
           polygon.forEach(path => {
             polygonOutlineFeatures.push({
               geometry: {type: 'LineString', coordinates: path},
-              properties,
               sourceFeature
             });
           });
@@ -153,6 +156,22 @@ export function separateGeojsonFeatures(features) {
     polygonFeatures,
     polygonOutlineFeatures
   };
+}
+
+/**
+ * Returns the source feature that was passed to `separateGeojsonFeatures`
+ */
+export function unwrapSourceFeature(wrappedFeature) {
+  // The feature provided by the user is under `sourceFeature.feature`
+  return wrappedFeature.sourceFeature.feature;
+}
+
+/**
+ * Returns the index of the source feature that was passed to `separateGeojsonFeatures`
+ */
+export function unwrapSourceFeatureIndex(wrappedFeature) {
+  // The index of the feature provided by the user is under `sourceFeature.index`
+  return wrappedFeature.sourceFeature.index;
 }
 
 /**

--- a/modules/layers/src/geojson-layer/geojson.js
+++ b/modules/layers/src/geojson-layer/geojson.js
@@ -83,26 +83,26 @@ export function separateGeojsonFeatures(features) {
     } = feature;
     checkCoordinates(type, coordinates);
 
-    const deckPickingInfo = {
+    const sourceFeature = {
       feature,
-      featureIndex
+      index: featureIndex
     };
     // Split each feature, but keep track of the source feature and index (for Multi* geometries)
     switch (type) {
       case 'Point':
-        pointFeatures.push(Object.assign({}, feature, {deckPickingInfo}));
+        pointFeatures.push(Object.assign({}, feature, {sourceFeature}));
         break;
       case 'MultiPoint':
         coordinates.forEach(point => {
           pointFeatures.push({
             geometry: {type: 'Point', coordinates: point},
             properties,
-            deckPickingInfo
+            sourceFeature
           });
         });
         break;
       case 'LineString':
-        lineFeatures.push(Object.assign({}, feature, {deckPickingInfo}));
+        lineFeatures.push(Object.assign({}, feature, {sourceFeature}));
         break;
       case 'MultiLineString':
         // Break multilinestrings into multiple lines with same properties
@@ -110,18 +110,18 @@ export function separateGeojsonFeatures(features) {
           lineFeatures.push({
             geometry: {type: 'LineString', coordinates: path},
             properties,
-            deckPickingInfo
+            sourceFeature
           });
         });
         break;
       case 'Polygon':
-        polygonFeatures.push(Object.assign({}, feature, {deckPickingInfo}));
+        polygonFeatures.push(Object.assign({}, feature, {sourceFeature}));
         // Break polygon into multiple lines with same properties
         coordinates.forEach(path => {
           polygonOutlineFeatures.push({
             geometry: {type: 'LineString', coordinates: path},
             properties,
-            deckPickingInfo
+            sourceFeature
           });
         });
         break;
@@ -131,14 +131,14 @@ export function separateGeojsonFeatures(features) {
           polygonFeatures.push({
             geometry: {type: 'Polygon', coordinates: polygon},
             properties,
-            deckPickingInfo
+            sourceFeature
           });
           // Break polygon into multiple lines with same properties
           polygon.forEach(path => {
             polygonOutlineFeatures.push({
               geometry: {type: 'LineString', coordinates: path},
               properties,
-              deckPickingInfo
+              sourceFeature
             });
           });
         });

--- a/test/modules/core-layers/geojson.spec.js
+++ b/test/modules/core-layers/geojson.spec.js
@@ -19,7 +19,12 @@
 // THE SOFTWARE.
 
 import test from 'tape-catch';
-import {getGeojsonFeatures, separateGeojsonFeatures} from '@deck.gl/layers/geojson-layer/geojson';
+import {
+  getGeojsonFeatures,
+  separateGeojsonFeatures,
+  unwrapSourceFeature,
+  unwrapSourceFeatureIndex
+} from '@deck.gl/layers/geojson-layer/geojson';
 
 const TEST_DATA = {
   POINT: {
@@ -76,6 +81,10 @@ const TEST_CASES = [
       lineFeaturesLength: 0,
       polygonFeaturesLength: 0,
       polygonOutlineFeaturesLength: 0,
+      pointSourceFeatures: [TEST_DATA.POINT],
+      lineSourceFeatures: [],
+      polygonSourceFeatures: [],
+      polygonOutlineSourceFeatures: [],
       pointFeatureIndexes: [0],
       lineFeatureIndexes: [],
       polygonFeatureIndexes: [],
@@ -90,6 +99,10 @@ const TEST_CASES = [
       lineFeaturesLength: 2,
       polygonFeaturesLength: 0,
       polygonOutlineFeaturesLength: 0,
+      pointSourceFeatures: [],
+      lineSourceFeatures: [TEST_DATA.MULTI_LINESTRING, TEST_DATA.MULTI_LINESTRING],
+      polygonSourceFeatures: [],
+      polygonOutlineSourceFeatures: [],
       pointFeatureIndexes: [],
       lineFeatureIndexes: [0, 0],
       polygonFeatureIndexes: [],
@@ -104,6 +117,10 @@ const TEST_CASES = [
       lineFeaturesLength: 0,
       polygonFeaturesLength: 1,
       polygonOutlineFeaturesLength: 1,
+      pointSourceFeatures: [],
+      lineSourceFeatures: [],
+      polygonSourceFeatures: [TEST_DATA.POLYGON],
+      polygonOutlineSourceFeatures: [TEST_DATA.POLYGON],
       pointFeatureIndexes: [],
       lineFeatureIndexes: [],
       polygonFeatureIndexes: [0],
@@ -118,6 +135,10 @@ const TEST_CASES = [
       lineFeaturesLength: 1,
       polygonFeaturesLength: 0,
       polygonOutlineFeaturesLength: 0,
+      pointSourceFeatures: [TEST_DATA.GEOMETRY_COLLECTION.geometries[0]],
+      lineSourceFeatures: [TEST_DATA.GEOMETRY_COLLECTION.geometries[1]],
+      polygonSourceFeatures: [],
+      polygonOutlineSourceFeatures: [],
       pointFeatureIndexes: [0],
       lineFeatureIndexes: [1],
       polygonFeatureIndexes: [],
@@ -132,6 +153,10 @@ const TEST_CASES = [
       lineFeaturesLength: 0,
       polygonFeaturesLength: 0,
       polygonOutlineFeaturesLength: 0,
+      pointSourceFeatures: [TEST_DATA.MULTI_POINT, TEST_DATA.MULTI_POINT],
+      lineSourceFeatures: [],
+      polygonSourceFeatures: [],
+      polygonOutlineSourceFeatures: [],
       pointFeatureIndexes: [0, 0],
       lineFeatureIndexes: [],
       polygonFeatureIndexes: [],
@@ -146,6 +171,10 @@ const TEST_CASES = [
       lineFeaturesLength: 1,
       polygonFeaturesLength: 0,
       polygonOutlineFeaturesLength: 0,
+      pointSourceFeatures: [],
+      lineSourceFeatures: [TEST_DATA.LINESTRING],
+      polygonSourceFeatures: [],
+      polygonOutlineSourceFeatures: [],
       pointFeatureIndexes: [],
       lineFeatureIndexes: [0],
       polygonFeatureIndexes: [],
@@ -160,6 +189,14 @@ const TEST_CASES = [
       lineFeaturesLength: 0,
       polygonFeaturesLength: 2,
       polygonOutlineFeaturesLength: 3,
+      pointSourceFeatures: [],
+      lineSourceFeatures: [],
+      polygonSourceFeatures: [TEST_DATA.MULTI_POLYGON, TEST_DATA.MULTI_POLYGON],
+      polygonOutlineSourceFeatures: [
+        TEST_DATA.MULTI_POLYGON,
+        TEST_DATA.MULTI_POLYGON,
+        TEST_DATA.MULTI_POLYGON
+      ],
       pointFeatureIndexes: [],
       lineFeatureIndexes: [],
       polygonFeatureIndexes: [0, 0],
@@ -174,6 +211,10 @@ const TEST_CASES = [
       lineFeaturesLength: 0,
       polygonFeaturesLength: 0,
       polygonOutlineFeaturesLength: 0,
+      pointSourceFeatures: [],
+      lineSourceFeatures: [],
+      polygonSourceFeatures: [],
+      polygonOutlineSourceFeatures: [],
       pointFeatureIndexes: [],
       lineFeatureIndexes: [],
       polygonFeatureIndexes: [],
@@ -198,6 +239,19 @@ const TEST_CASES = [
       lineFeaturesLength: 3,
       polygonFeaturesLength: 3,
       polygonOutlineFeaturesLength: 4,
+      pointSourceFeatures: [TEST_DATA.POINT, TEST_DATA.MULTI_POINT, TEST_DATA.MULTI_POINT],
+      lineSourceFeatures: [
+        TEST_DATA.LINESTRING,
+        TEST_DATA.MULTI_LINESTRING,
+        TEST_DATA.MULTI_LINESTRING
+      ],
+      polygonSourceFeatures: [TEST_DATA.POLYGON, TEST_DATA.MULTI_POLYGON, TEST_DATA.MULTI_POLYGON],
+      polygonOutlineSourceFeatures: [
+        TEST_DATA.POLYGON,
+        TEST_DATA.MULTI_POLYGON,
+        TEST_DATA.MULTI_POLYGON,
+        TEST_DATA.MULTI_POLYGON
+      ],
       pointFeatureIndexes: [0, 1, 1],
       lineFeatureIndexes: [2, 3, 3],
       polygonFeatureIndexes: [4, 5, 5],
@@ -283,10 +337,18 @@ test('geojson#getGeojsonFeatures, separateGeojsonFeatures', t => {
         lineFeaturesLength: result.lineFeatures.length,
         polygonFeaturesLength: result.polygonFeatures.length,
         polygonOutlineFeaturesLength: result.polygonOutlineFeatures.length,
-        pointFeatureIndexes: result.pointFeatures.map(f => f.sourceFeature.index),
-        lineFeatureIndexes: result.lineFeatures.map(f => f.sourceFeature.index),
-        polygonFeatureIndexes: result.polygonFeatures.map(f => f.sourceFeature.index),
-        polygonOutlineFeatureIndexes: result.polygonOutlineFeatures.map(f => f.sourceFeature.index)
+        pointSourceFeatures: result.pointFeatures.map(f => unwrapSourceFeature(f).geometry),
+        lineSourceFeatures: result.lineFeatures.map(f => unwrapSourceFeature(f).geometry),
+        polygonSourceFeatures: result.polygonFeatures.map(f => unwrapSourceFeature(f).geometry),
+        polygonOutlineSourceFeatures: result.polygonOutlineFeatures.map(
+          f => unwrapSourceFeature(f).geometry
+        ),
+        pointFeatureIndexes: result.pointFeatures.map(f => unwrapSourceFeatureIndex(f)),
+        lineFeatureIndexes: result.lineFeatures.map(f => unwrapSourceFeatureIndex(f)),
+        polygonFeatureIndexes: result.polygonFeatures.map(f => unwrapSourceFeatureIndex(f)),
+        polygonOutlineFeatureIndexes: result.polygonOutlineFeatures.map(f =>
+          unwrapSourceFeatureIndex(f)
+        )
       };
       t.deepEquals(
         actual,

--- a/test/modules/core-layers/geojson.spec.js
+++ b/test/modules/core-layers/geojson.spec.js
@@ -283,12 +283,10 @@ test('geojson#getGeojsonFeatures, separateGeojsonFeatures', t => {
         lineFeaturesLength: result.lineFeatures.length,
         polygonFeaturesLength: result.polygonFeatures.length,
         polygonOutlineFeaturesLength: result.polygonOutlineFeatures.length,
-        pointFeatureIndexes: result.pointFeatures.map(f => f.deckPickingInfo.featureIndex),
-        lineFeatureIndexes: result.lineFeatures.map(f => f.deckPickingInfo.featureIndex),
-        polygonFeatureIndexes: result.polygonFeatures.map(f => f.deckPickingInfo.featureIndex),
-        polygonOutlineFeatureIndexes: result.polygonOutlineFeatures.map(
-          f => f.deckPickingInfo.featureIndex
-        )
+        pointFeatureIndexes: result.pointFeatures.map(f => f.sourceFeature.index),
+        lineFeatureIndexes: result.lineFeatures.map(f => f.sourceFeature.index),
+        polygonFeatureIndexes: result.polygonFeatures.map(f => f.sourceFeature.index),
+        polygonOutlineFeatureIndexes: result.polygonOutlineFeatures.map(f => f.sourceFeature.index)
       };
       t.deepEquals(
         actual,


### PR DESCRIPTION
#### Background
The feature passed into accessors isn't the same feature the user passed into the props, and may be missing some properties. Yes, it will include the `properties` property. But, it doesn't include the `id` property (which is valid in GeoJSON), or any other custom properties the user may have (much less likely).

This fixes that issue by using the "wrapped" feature produced by `separateGeojsonFeatures` and "unwrapping" it before calling accessor callbacks.

#### Change List
- `GeoJsonLayer`
