### PR TITLE
Per-view controller

### DIFF
--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -243,16 +243,25 @@ export default class App extends PureComponent {
     } = this.state;
 
     if (infovis) {
-      return new OrbitView({id: 'infovis'});
+      return new OrbitView({
+        id: 'infovis',
+        controller: OrbitController
+      });
     }
 
     if (multiview) {
       return [
         new FirstPersonView({id: 'first-person', height: '50%'}),
-        new MapView({id: 'basemap', y: '50%', height: '50%', orthographic})
+        new MapView({
+          id: 'basemap',
+          controller: MapController,
+          y: '50%',
+          height: '50%',
+          orthographic
+        })
       ];
     }
-    return new MapView({id: 'basemap', orthographic});
+    return new MapView({id: 'basemap', controller: MapController, orthographic});
   }
 
   // Only show infovis layers in infovis mode and vice versa
@@ -277,7 +286,6 @@ export default class App extends PureComponent {
           layerFilter={this._layerFilter}
           views={views}
           viewState={infovis ? orbitViewState : {...mapViewState, position: [0, 0, 50]}}
-          controller={infovis ? OrbitController : MapController}
           onViewStateChange={this._onViewStateChange}
           effects={effects ? this._effects : []}
           pickingRadius={pickingRadius}

--- a/modules/core/src/controllers/first-person-controller.js
+++ b/modules/core/src/controllers/first-person-controller.js
@@ -95,6 +95,8 @@ class FirstPersonState extends ViewState {
   pan({pos, startPos}) {
     const startPanEventPosition = this._interactiveState.startPanEventPosition || startPos;
 
+    // when the mouse starts dragging outside of this viewport, then drags over it.
+    // TODO - use interactionState flag instead
     if (!startPanEventPosition) {
       return this;
     }
@@ -139,6 +141,8 @@ class FirstPersonState extends ViewState {
    * @param {[Number, Number]} pos - position on screen where the pointer is
    */
   rotate({deltaScaleX, deltaScaleY}) {
+    // when the mouse starts dragging outside of this viewport, then drags over it.
+    // TODO - use interactionState flag instead
     if (!this._interactiveState.startRotateCenter) {
       return this;
     }

--- a/modules/core/src/controllers/first-person-controller.js
+++ b/modules/core/src/controllers/first-person-controller.js
@@ -2,7 +2,6 @@ import Controller from './controller';
 import ViewState from './view-state';
 
 import {Vector3, clamp} from 'math.gl';
-import assert from '../utils/assert';
 
 const MOVEMENT_SPEED = 1; // 1 meter per keyboard click
 const ROTATION_STEP_DEGREES = 2;
@@ -95,7 +94,10 @@ class FirstPersonState extends ViewState {
    */
   pan({pos, startPos}) {
     const startPanEventPosition = this._interactiveState.startPanEventPosition || startPos;
-    assert(startPanEventPosition, '`startPanEventPosition` props is required');
+
+    if (!startPanEventPosition) {
+      return this;
+    }
 
     let [translationX, translationY] = this._interactiveState.startPanPosition || [];
     translationX = ensureFinite(translationX, this._viewportProps.translationX);
@@ -137,6 +139,10 @@ class FirstPersonState extends ViewState {
    * @param {[Number, Number]} pos - position on screen where the pointer is
    */
   rotate({deltaScaleX, deltaScaleY}) {
+    if (!this._interactiveState.startRotateCenter) {
+      return this;
+    }
+
     const {bearing, pitch} = this._viewportProps;
 
     return this._getUpdatedState({

--- a/modules/core/src/controllers/transition-manager.js
+++ b/modules/core/src/controllers/transition-manager.js
@@ -162,7 +162,10 @@ export default class TransitionManager {
       this.props.onViewportChange(this.propsInTransition, {inTransition: true});
     }
     if (this.props.onViewStateChange) {
-      this.props.onViewStateChange({viewState: this.propsInTransition}, {inTransition: true});
+      this.props.onViewStateChange({
+        viewState: this.propsInTransition,
+        interactionState: {inTransition: true}
+      });
     }
   }
 }

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -32,10 +32,17 @@ import {EventManager} from 'mjolnir.js';
 import assert from '../utils/assert';
 /* global document */
 
-// TODO - move into Controller classes
-import {MAPBOX_LIMITS} from '../controllers/map-controller';
-
 function noop() {}
+
+const PREFIX = '-webkit-';
+
+const CURSOR = {
+  GRABBING: `${PREFIX}grabbing`,
+  GRAB: `${PREFIX}grab`,
+  POINTER: 'pointer'
+};
+
+const getCursor = ({isDragging}) => (isDragging ? CURSOR.GRABBING : CURSOR.GRAB);
 
 function getPropTypes(PropTypes) {
   // Note: Arrays (layers, views, ) can contain falsy values
@@ -97,29 +104,11 @@ const defaultProps = {
   onLayerClick: null,
   onLayerHover: null,
 
+  getCursor,
+
   debug: false,
   drawPickingColors: false
 };
-
-const PREFIX = '-webkit-';
-
-const CURSOR = {
-  GRABBING: `${PREFIX}grabbing`,
-  GRAB: `${PREFIX}grab`,
-  POINTER: 'pointer'
-};
-
-const getCursor = ({isDragging}) => (isDragging ? CURSOR.GRABBING : CURSOR.GRAB);
-
-// TODO - move into Controller classes
-const defaultControllerProps = Object.assign({}, MAPBOX_LIMITS, {
-  scrollZoom: true,
-  dragPan: true,
-  dragRotate: true,
-  doubleClickZoom: true,
-  touchZoomRotate: true,
-  getCursor
-});
 
 export default class Deck {
   constructor(props) {
@@ -129,10 +118,10 @@ export default class Deck {
     this.height = 0; // "read-only", auto-updated from canvas
 
     // Maps view descriptors to vieports, rebuilds when width/height/viewState/views change
-    this.viewManager = new ViewManager();
+    this.viewManager = null;
     this.layerManager = null;
     this.effectManager = null;
-    this.controller = null;
+
     this.stats = new Stats({id: 'deck.gl'});
 
     this._needsRedraw = true;
@@ -154,7 +143,6 @@ export default class Deck {
 
     // Note: LayerManager creation deferred until gl context available
     this.canvas = this._createCanvas(props);
-    this.controller = this._createController(props);
     this.animationLoop = this._createAnimationLoop(props);
 
     this.setProps(props);
@@ -171,9 +159,9 @@ export default class Deck {
       this.layerManager = null;
     }
 
-    if (this.controller) {
-      this.controller.finalize();
-      this.controller = null;
+    if (this.viewManager) {
+      this.viewManager.finalize();
+      this.viewManager = null;
     }
 
     if (this.eventManager) {
@@ -212,14 +200,6 @@ export default class Deck {
       this.animationLoop.setProps(newProps);
     }
 
-    // Update controller props
-    if (this.controller) {
-      this.controller.setProps(
-        Object.assign(newProps, {
-          onViewStateChange: this._onViewStateChange
-        })
-      );
-    }
     this.stats.timeEnd('deck.setProps');
   }
 
@@ -340,13 +320,6 @@ export default class Deck {
     if (this._checkForCanvasSizeChange()) {
       const {width, height} = this;
       this.viewManager.setProps({width, height});
-      if (this.controller) {
-        this.controller.setProps({
-          viewState: this._getViewState(this.props),
-          width: this.width,
-          height: this.height
-        });
-      }
       this.props.onResize({width: this.width, height: this.height});
     }
   }
@@ -360,27 +333,6 @@ export default class Deck {
       return true;
     }
     return false;
-  }
-
-  // Note: props.controller must be a class constructor, not an already created instance
-  _createController(props) {
-    let controller = null;
-
-    if (props.controller) {
-      const Controller = props.controller;
-      controller = new Controller(props);
-      controller.setProps(
-        Object.assign({}, this.props, defaultControllerProps, {
-          eventManager: this.eventManager,
-          viewState: this._getViewState(props),
-          // Set an internal callback that calls the prop callback if provided
-          onViewStateChange: this._onViewStateChange,
-          onStateChange: this._onInteractiveStateChange
-        })
-      );
-    }
-
-    return controller;
   }
 
   _createAnimationLoop(props) {
@@ -403,16 +355,18 @@ export default class Deck {
   // Get the most relevant view state: props.viewState, if supplied, shadows internal viewState
   // TODO: For backwards compatibility ensure numeric width and height is added to the viewState
   _getViewState(props) {
-    return Object.assign({}, props.viewState || this.viewState || {}, {
-      width: this.width,
-      height: this.height
-    });
+    return props.viewState || this.viewState || {};
   }
 
   // Get the view descriptor list
   _getViews(props) {
     // Default to a full screen map view port
-    return props.views || [new MapView({id: 'default-view'})];
+    const views = props.views || [new MapView()];
+    if (views.length && props.controller) {
+      // Backward compatibility: support controller prop
+      views[0].controller = props.controller;
+    }
+    return views;
   }
 
   _pickAndCallback(options) {
@@ -434,15 +388,19 @@ export default class Deck {
 
   // Callbacks
 
-  _onViewStateChange({viewState}, ...args) {
+  _onViewStateChange(event) {
     // Let app know that view state is changing, and give it a chance to change it
-    viewState = this.props.onViewStateChange({viewState}, ...args) || viewState;
+    const viewState = this.props.onViewStateChange(event) || event.viewState;
+
+    // TODO - deprecate?
+    if (this.props.onViewportChange) {
+      this.props.onViewportChange(event.viewState, event.interactionState, event.oldViewState);
+    }
 
     // If initialViewState was set on creation, auto track position
     if (this.viewState) {
-      this.viewState = viewState;
+      this.viewState[event.viewId] = viewState;
       this.viewManager.setProps({viewState});
-      this.controller.setProps({viewState});
     }
   }
 
@@ -474,9 +432,11 @@ export default class Deck {
       }
     });
 
-    if (this.controller) {
-      this.controller.setProps({eventManager: this.eventManager});
-    }
+    this.viewManager = new ViewManager({
+      eventManager: this.eventManager,
+      onViewStateChange: this._onViewStateChange,
+      onInteractiveStateChange: this._onInteractiveStateChange
+    });
 
     // Note: avoid React setState due GL animation loop / setState timing issue
     this.layerManager = new LayerManager(gl, {stats: this.stats});

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -388,18 +388,18 @@ export default class Deck {
 
   // Callbacks
 
-  _onViewStateChange(event) {
+  _onViewStateChange(params) {
     // Let app know that view state is changing, and give it a chance to change it
-    const viewState = this.props.onViewStateChange(event) || event.viewState;
+    const viewState = this.props.onViewStateChange(params) || params.viewState;
 
     // TODO - deprecate?
     if (this.props.onViewportChange) {
-      this.props.onViewportChange(event.viewState, event.interactionState, event.oldViewState);
+      this.props.onViewportChange(params.viewState, params.interactionState, params.oldViewState);
     }
 
     // If initialViewState was set on creation, auto track position
     if (this.viewState) {
-      this.viewState[event.viewId] = viewState;
+      this.viewState[params.viewId] = viewState;
       this.viewManager.setProps({viewState});
     }
   }

--- a/modules/core/src/views/view-manager.js
+++ b/modules/core/src/views/view-manager.js
@@ -236,6 +236,7 @@ export default class ViewManager {
         const viewport = view.makeViewport({width, height, viewState});
 
         const controller = this.controllers[view.id];
+        // TODO - check for removed view ids?
         if (controller) {
           controller.setProps(
             Object.assign({}, viewState, {

--- a/modules/core/src/views/view-manager.js
+++ b/modules/core/src/views/view-manager.js
@@ -34,11 +34,18 @@ export default class ViewManager {
     this.width = 100;
     this.height = 100;
     this.viewState = INITIAL_VIEW_STATE;
+    this.controllers = {};
 
     this._viewports = []; // Generated viewports
     this._viewportMap = {};
     this._needsRedraw = 'Initial render';
     this._needsUpdate = true;
+
+    this._eventManager = props.eventManager;
+    this._eventCallbacks = {
+      onViewStateChange: props.onViewStateChange,
+      onInteractiveStateChange: props.onInteractiveStateChange
+    };
 
     Object.seal(this);
 
@@ -46,7 +53,12 @@ export default class ViewManager {
     this.setProps(props);
   }
 
-  finalize() {}
+  finalize() {
+    for (const key in this.controllers) {
+      this.controllers[key].finalize();
+    }
+    this.controllers = {};
+  }
 
   // Check if a redraw is needed
   needsRedraw({clearRedrawFlags = true} = {}) {
@@ -72,12 +84,10 @@ export default class ViewManager {
   // Get a set of viewports for a given width and height
   // TODO - Intention is for deck.gl to autodeduce width and height and drop the need for props
   getViewports() {
-    this._rebuildViewportsFromViews();
     return this._viewports;
   }
 
   getViewport(viewId) {
-    this._rebuildViewportsFromViews();
     return this._viewportMap[viewId];
   }
 
@@ -128,21 +138,23 @@ export default class ViewManager {
   /* eslint-disable complexity */
   setProps(props) {
     if ('views' in props) {
-      this.setViews(props.views);
+      this._setViews(props.views);
     }
 
     // TODO - support multiple view states
     if ('viewState' in props) {
-      this.setViewState(props.viewState);
+      this._setViewState(props.viewState);
     }
 
     if ('width' in props || 'height' in props) {
-      this.setSize(props.width, props.height);
+      this._setSize(props.width, props.height);
     }
+
+    this._rebuildViewportsFromViews();
   }
   /* eslint-enable complexity */
 
-  setSize(width, height) {
+  _setSize(width, height) {
     assert(Number.isFinite(width) && Number.isFinite(height));
     if (width !== this.width || height !== this.height) {
       this.width = width;
@@ -153,11 +165,17 @@ export default class ViewManager {
 
   // Update the view descriptor list and set change flag if needed
   // Does not actually rebuild the `Viewport`s until `getViewports` is called
-  setViews(views) {
+  _setViews(views) {
     // DEPRECATED: Ensure any "naked" Viewports are wrapped in View instances
     views = flatten(views, {filter: Boolean}).map(
       view => (view instanceof Viewport ? new View({viewportInstance: view}) : view)
     );
+
+    views.forEach(view => {
+      if (view.controller && !this.controllers[view.id]) {
+        this.controllers[view.id] = this._createController(view);
+      }
+    });
 
     const viewsChanged = this._diffViews(views, this.views);
     if (viewsChanged) {
@@ -167,7 +185,7 @@ export default class ViewManager {
     this.views = views;
   }
 
-  setViewState(viewState) {
+  _setViewState(viewState) {
     if (viewState) {
       const viewStateChanged = deepEqual(viewState, this.viewState);
 
@@ -185,13 +203,52 @@ export default class ViewManager {
   // PRIVATE METHODS
   //
 
+  _onViewStateChange(viewId, event) {
+    event.viewId = viewId;
+    this._eventCallbacks.onViewStateChange(event);
+  }
+
+  _createController(view) {
+    let controller = null;
+
+    if (view.controller) {
+      const Controller = view.controller;
+      controller = new Controller({
+        eventManager: this._eventManager,
+        viewState: this._getViewState(view.id),
+        // Set an internal callback that calls the prop callback if provided
+        onViewStateChange: this._onViewStateChange.bind(this, view.id),
+        onStateChange: this._eventCallbacks.onInteractiveStateChange
+      });
+    }
+
+    return controller;
+  }
+
   // Rebuilds viewports from descriptors towards a certain window size
   _rebuildViewportsFromViews() {
     const updateReason = this._needsUpdate;
     if (updateReason) {
-      const {width, height, views, viewState} = this;
+      const {width, height, views} = this;
 
-      this._viewports = views.map(view => view.makeViewport({width, height, viewState}));
+      this._viewports = views.map(view => {
+        const viewState = this._getViewState(view.id);
+        const viewport = view.makeViewport({width, height, viewState});
+
+        const controller = this.controllers[view.id];
+        if (controller) {
+          controller.setProps(
+            Object.assign({}, viewState, {
+              x: viewport.x,
+              y: viewport.y,
+              width: viewport.width,
+              height: viewport.height
+            })
+          );
+        }
+
+        return viewport;
+      });
 
       this._buildViewportMap();
 
@@ -210,6 +267,11 @@ export default class ViewManager {
         this._viewportMap[viewport.id] = this._viewportMap[viewport.id] || viewport;
       }
     });
+  }
+
+  _getViewState(viewId) {
+    // Backward compatibility: view state for single view
+    return this.viewState[viewId] || this.viewState;
   }
 
   // Check if viewport array has changed, returns true if any change

--- a/modules/core/src/views/view.js
+++ b/modules/core/src/views/view.js
@@ -6,7 +6,7 @@ import assert from '../utils/assert';
 export default class View {
   constructor(props = {}) {
     const {
-      id = null,
+      id = 'default-view',
 
       // Window width/height in pixels (for pixel projection)
       x = 0,
@@ -24,12 +24,16 @@ export default class View {
       // A View can be a wrapper for a viewport instance
       viewportInstance = null,
 
+      // A controller class constructor, not an already created instance
+      controller = null,
+
       // Internal: Viewport Type
       type = Viewport // TODO - default to WebMercator?
     } = props;
 
     assert(!viewportInstance || viewportInstance instanceof Viewport);
     this.viewportInstance = viewportInstance;
+    this.controller = controller;
 
     // Id
     this.id = id || this.constructor.displayName || 'view';

--- a/modules/lite/src/deckgl.js
+++ b/modules/lite/src/deckgl.js
@@ -68,6 +68,7 @@ export default class DeckGL extends Deck {
     const isMap = Number.isFinite(props.initialViewState.latitude);
     const isOrbit = props.views && props.views[0] instanceof OrbitView;
     let Controller;
+
     if (isMap) {
       Controller = MapController;
     } else if (isOrbit) {

--- a/modules/lite/src/deckgl.js
+++ b/modules/lite/src/deckgl.js
@@ -68,7 +68,6 @@ export default class DeckGL extends Deck {
     const isMap = Number.isFinite(props.initialViewState.latitude);
     const isOrbit = props.views && props.views[0] instanceof OrbitView;
     let Controller;
-
     if (isMap) {
       Controller = MapController;
     } else if (isOrbit) {

--- a/test/apps/multi-viewport/index.html
+++ b/test/apps/multi-viewport/index.html
@@ -4,7 +4,7 @@
     <meta charset='UTF-8' />
     <title>deck.gl example</title>
     <style>
-      body {margin: 0; padding: 0; overflow: hidden;}
+      body {margin: 0; padding: 0; overflow: hidden; background: #000;}
     </style>
     <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.42.2/mapbox-gl.css' rel='stylesheet' />
   </head>

--- a/test/modules/lite/deckgl.spec.js
+++ b/test/modules/lite/deckgl.spec.js
@@ -40,14 +40,18 @@ test('standalone#DeckGL', t => {
       new deckgl.ScatterplotLayer({
         data: [{position: [-122.45, 37.8], color: [255, 0, 0], radius: 100}]
       })
-    ]
+    ],
+    onAfterRender: () => {
+      t.ok(Object.keys(deck.viewManager.controllers).length > 0, 'component has controller');
+
+      deck.finalize();
+
+      t.notOk(deck.layerManager, 'component is finalized');
+      t.notOk(deck.viewManager, 'component is finalized');
+
+      t.end();
+    }
   });
 
   t.ok(deck, 'DeckGL constructor does not throw error');
-  t.ok(deck.controller, 'component has controller');
-
-  deck.finalize();
-  t.notOk(deck.controller, 'component is finalized');
-
-  t.end();
 });


### PR DESCRIPTION
For
https://github.com/uber/deck.gl/issues/1422
https://github.com/uber/deck.gl/issues/1668

#### Change List
- Move controllers from Deck into ViewManager class
- Add `controller` option to View class
- Support per-view viewState: the `viewState` prop may be a view id to view state map. Fallback to the old viewState format if a view id is not found.
- Support per-view controller. The `controller` prop applies to the first view if specified.
- Clean up the multi-viewport test app, add controllers to each view
- Update controllers to handle events outside of viewport bounds

Tested applications:
Layer-browser, viewport-transitions-flyto, multi-viewport, pure-js, standalone