### PR TITLE
 GPUScreenGridLayer: Add colorRange and colorDomain support.

### DIFF
--- a/modules/experimental-layers/src/gpu-screen-grid-layer/gpu-screen-grid-layer-fragment.glsl.js
+++ b/modules/experimental-layers/src/gpu-screen-grid-layer/gpu-screen-grid-layer-fragment.glsl.js
@@ -31,8 +31,6 @@ out vec4 fragColor;
 void main(void) {
   fragColor = vColor;
 
-  // TODO: Enable picking (https://github.com/uber/deck.gl/issues/1592)
-  // fragColor = picking_filterHighlightColor(fragColor);
-  // fragColor = picking_filterPickingColor(fragColor);
+  fragColor = picking_filterColor(fragColor);
 }
 `;

--- a/modules/experimental-layers/src/gpu-screen-grid-layer/gpu-screen-grid-layer-vertex.glsl.js
+++ b/modules/experimental-layers/src/gpu-screen-grid-layer/gpu-screen-grid-layer-vertex.glsl.js
@@ -54,8 +54,7 @@ vec4 quantizeScale(vec2 domain, vec4 range[RANGE_COUNT], float value) {
       float rangeCount = float(RANGE_COUNT);
       float rangeStep = domainRange / rangeCount;
       float idx = floor((value - domain.x) / rangeStep);
-      idx = min(idx, rangeCount - 1.);
-      idx = max(idx, 0.);
+      idx = clamp(idx, 0., rangeCount - 1.);
       int intIdx = int(idx);
       outColor = colorRange[intIdx];
     }

--- a/modules/experimental-layers/src/gpu-screen-grid-layer/gpu-screen-grid-layer.js
+++ b/modules/experimental-layers/src/gpu-screen-grid-layer/gpu-screen-grid-layer.js
@@ -29,6 +29,8 @@ import assert from 'assert';
 const DEFAULT_MINCOLOR = [0, 0, 0, 0];
 const DEFAULT_MAXCOLOR = [0, 255, 0, 255];
 const AGGREGATION_DATA_UBO_INDEX = 0;
+const COLOR_PROPS = [`minColor`, `maxColor`, `colorRange`, `colorDomain`];
+const COLOR_RANGE_LENGTH = 6;
 
 const defaultProps = {
   cellSizePixels: 100,
@@ -259,19 +261,15 @@ export default class GPUScreenGridLayer extends Layer {
   }
 
   _updateColorUniforms({oldProps, props}) {
-    const colorProps = [`minColor`, `maxColor`, `colorRange`, `colorDomain`];
-    if (
-      colorProps.some(key => {
-        return oldProps[key] !== props[key];
-      })
-    ) {
+
+    if (this._updateMinMaxUniform({oldProps, props})) {
       const shouldUseMinMax = this._shouldUseMinMax();
       this.setState({shouldUseMinMax});
     }
+
     if (oldProps.colorRange !== props.colorRange) {
-      // const colorRangeUniform = [].concat(...props.colorRange);
       const colorRangeUniform = [];
-      assert(props.colorRange && props.colorRange.length === 6);
+      assert(props.colorRange && props.colorRange.length === COLOR_RANGE_LENGTH);
       props.colorRange.forEach(color => {
         colorRangeUniform.push(color[0], color[1], color[2], color[3] || 255);
       });
@@ -314,6 +312,18 @@ export default class GPUScreenGridLayer extends Layer {
       countsBuffer
     });
   }
+
+  _updateMinMaxUniform({oldProps, props}) {
+    if (
+      COLOR_PROPS.some(key => {
+        return oldProps[key] !== props[key];
+      })
+    ) {
+      return true;
+    }
+    return false;
+  }
+
 }
 
 GPUScreenGridLayer.layerName = 'GPUScreenGridLayer';


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #1931
<!-- For other PRs without open issue -->
#### Background
- Add shader instructions to do quantize-scale for color.
- Feature wise, this makes `GPUScreenGridLayer` on par with `ScreenGridLayer`, and ready to be replaced.

<!-- For all the PRs -->
#### Change List
- GPUScreenGridLayer: Add colorRange and colorDomain support.
