### PR TITLE
GPUScreenGridLayer: Provide aggregated data as picking information.

### DIFF
--- a/modules/experimental-layers/src/utils/gpu-grid-aggregator.js
+++ b/modules/experimental-layers/src/utils/gpu-grid-aggregator.js
@@ -5,6 +5,7 @@ import {fp64 as fp64Utils} from 'luma.gl';
 import {worldToPixels} from 'viewport-mercator-project';
 const {fp64ifyMatrix4} = fp64Utils;
 const IDENTITY_MATRIX = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+const PIXEL_SIZE = 4; // RGBA32F
 const AGGREGATE_TO_GRID_VS = `\
 attribute vec2 positions;
 attribute vec2 positions64xyLow;
@@ -201,6 +202,20 @@ const DEFAULT_CHANGE_FLAGS = {
 };
 
 export default class GPUGridAggregator {
+  // Decode and return aggregation data of given pixel.
+  static getAggregationData({countsData, maxCountData, pixelIndex}) {
+    assert(countsData.length >= ((pixelIndex + 1) * PIXEL_SIZE));
+    assert(maxCountData.length === PIXEL_SIZE);
+    const index = pixelIndex * PIXEL_SIZE;
+    const cellCount = countsData[index];
+    const cellWeight = countsData[index + 1];
+    const totalCount = maxCountData[0];
+    const totalWeight = maxCountData[1];
+    const maxCellWieght = maxCountData[3];
+    return {
+      cellCount, cellWeight, totalCount, totalWeight, maxCellWieght
+    };
+  }
   constructor(gl, opts = {}) {
     this.id = opts.id || 'gpu-grid-aggregator';
     this.shaderCache = opts.shaderCache || null;


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #1931 
<!-- For other PRs without open issue -->
#### Background
Provide aggregation details of selected grid-cell as picking information. When users are using aggregation layers, this data provides more information on selected grid-cell.

<img width="1159" alt="screen shot 2018-06-21 at 2 18 08 pm" src="https://user-images.githubusercontent.com/9502731/41746087-feb448b0-755d-11e8-9d75-53b85108c5ed.png">
<img width="1158" alt="screen shot 2018-06-21 at 2 18 20 pm" src="https://user-images.githubusercontent.com/9502731/41746092-0355a03a-755e-11e8-9b39-0c0b7c9cf486.png">



<!-- For all the PRs -->
#### Change List
-  GPUScreenGridLayer: Provide aggregated data as picking information.
