### PR TITLE
Fix attribute transition

### DIFF
--- a/docs/api-reference/attribute-manager.md
+++ b/docs/api-reference/attribute-manager.md
@@ -69,7 +69,7 @@ Takes a single parameter as a map of attribute descriptor objects:
     (a.k.a. divisor). Default to `false`.
   + `isIndexed` (Boolean, optional) - if this is an index attribute
     (a.k.a. indices). Default to `false`.
-  + `isGeneric` (Boolean, optional) - if this is a generic attribute
+  + `constant` (Boolean, optional) - if this is a generic attribute
     (same value applied to every vertex). Default to `false`.
   + `noAlloc` (Boolean, optional) - if this attribute should not be
     automatically allocated. Default to `false`.

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -32,7 +32,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "luma.gl": ">=6.0.0-alpha.5",
+    "luma.gl": "^6.0.0-alpha.6",
     "math.gl": "^2.0.0",
     "mjolnir.js": "^1.0.0",
     "probe.gl": "^1.0.0",

--- a/modules/core/src/lib/attribute-manager.js
+++ b/modules/core/src/lib/attribute-manager.js
@@ -319,7 +319,7 @@ export default class AttributeManager {
         Object.assign({}, attribute, {
           id: attributeName,
           // Luma fields
-          isGeneric: attribute.isGeneric || false,
+          constant: attribute.constant || false,
           isIndexed: attribute.isIndexed || attribute.elements,
           size: (attribute.elements && 1) || attribute.size,
           value: attribute.value || null,

--- a/modules/core/src/lib/attribute-transition-manager.js
+++ b/modules/core/src/lib/attribute-transition-manager.js
@@ -216,10 +216,10 @@ export default class AttributeTransitionManager {
     const {size} = attribute;
 
     let toState;
-    if (attribute.isGeneric) {
-      toState = {isGeneric: true, value: attribute.value, size};
+    if (attribute.constant) {
+      toState = {constant: true, value: attribute.value, size};
     } else {
-      toState = {isGeneric: false, buffer: attribute.getBuffer(), size};
+      toState = {constant: false, buffer: attribute.getBuffer(), size};
     }
     const fromState = transition.buffer || toState;
     const toLength = this.numInstances * size;
@@ -238,7 +238,7 @@ export default class AttributeTransitionManager {
       });
     }
 
-    transition.attributeInTransition.update({isGeneric: false, buffer});
+    transition.attributeInTransition.update({buffer});
 
     // Pad buffers to be the same length
     if (buffer.data.length < toLength) {

--- a/modules/core/src/lib/attribute-transition-utils.js
+++ b/modules/core/src/lib/attribute-transition-utils.js
@@ -61,14 +61,14 @@ void main(void) {
 
 export function getBuffers(transitions) {
   const sourceBuffers = {};
-  const destinationBuffers = {};
+  const feedbackBuffers = {};
   for (const attributeName in transitions) {
     const {fromState, toState, buffer} = transitions[attributeName];
     sourceBuffers[`${attributeName}From`] = fromState;
     sourceBuffers[`${attributeName}To`] = toState;
-    destinationBuffers[`${attributeName}`] = buffer;
+    feedbackBuffers[`${attributeName}`] = buffer;
   }
-  return {sourceBuffers, destinationBuffers};
+  return {sourceBuffers, feedbackBuffers};
 }
 
 export function padBuffer({fromState, toState, fromLength, toLength, context}) {

--- a/modules/core/src/lib/attribute-transition-utils.js
+++ b/modules/core/src/lib/attribute-transition-utils.js
@@ -81,7 +81,7 @@ export function padBuffer({fromState, toState, fromLength, toLength, context}) {
   // copy the currect values
   data.set(fromState.getData({}));
 
-  if (toState.isGeneric) {
+  if (toState.constant) {
     fillArray({
       target: data,
       source: toState.value,

--- a/modules/core/src/lib/attribute.js
+++ b/modules/core/src/lib/attribute.js
@@ -96,7 +96,7 @@ export default class LayerAttribute extends Attribute {
       const allocCount = Math.max(numInstances, 1);
       const ArrayType = glArrayFromType(this.type || GL.FLOAT);
 
-      this.isGeneric = false;
+      this.constant = false;
       this.value = new ArrayType(this.size * allocCount);
       state.needsUpdate = true;
       state.allocedInstances = allocCount;
@@ -121,7 +121,7 @@ export default class LayerAttribute extends Attribute {
       update.call(context, this, {data, props, numInstances});
       this.update({
         value: this.value,
-        isGeneric: this.isGeneric
+        constant: this.constant
       });
       this._checkAttributeArray();
     } else if (accessor) {
@@ -151,10 +151,10 @@ export default class LayerAttribute extends Attribute {
     }
 
     value = this._normalizeValue(value);
-    const hasChanged = !this.isGeneric || !this._areValuesEqual(value, this.value);
+    const hasChanged = !this.constant || !this._areValuesEqual(value, this.value);
 
     if (hasChanged) {
-      this.update({isGeneric: true, value});
+      this.update({constant: true, value});
     }
     state.needsRedraw = state.needsUpdate || hasChanged;
     state.needsUpdate = false;
@@ -173,7 +173,7 @@ export default class LayerAttribute extends Attribute {
 
       if (buffer instanceof Buffer) {
         if (this.externalBuffer !== buffer) {
-          this.update({isGeneric: false, buffer});
+          this.update({constant: false, buffer});
           state.needsRedraw = true;
         }
       } else {
@@ -185,7 +185,7 @@ export default class LayerAttribute extends Attribute {
           throw new Error('Attribute prop array must match length and size');
         }
         if (this.value !== buffer) {
-          this.update({isGeneric: false, value: buffer});
+          this.update({constant: false, value: buffer});
           state.needsRedraw = true;
         }
       }

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -476,7 +476,6 @@ export default class Layer extends Component {
       model.id = this.props.id;
       model.program.id = `${this.props.id}-program`;
       model.geometry.id = `${this.props.id}-geometry`;
-      model.setAttributes(this.getAttributeManager().getAttributes());
     }
   }
 

--- a/modules/experimental-layers/src/mesh-layer/mesh-layer.js
+++ b/modules/experimental-layers/src/mesh-layer/mesh-layer.js
@@ -231,7 +231,7 @@ export default class MeshLayer extends Layer {
 
   calculateInstancePositions64xyLow(attribute) {
     const isFP64 = this.use64bitPositions();
-    attribute.isGeneric = !isFP64;
+    attribute.constant = !isFP64;
 
     if (!isFP64) {
       attribute.value = new Float32Array(2);

--- a/modules/layers/src/grid-cell-layer/grid-cell-layer.js
+++ b/modules/layers/src/grid-cell-layer/grid-cell-layer.js
@@ -129,7 +129,7 @@ export default class GridCellLayer extends Layer {
 
   calculateInstancePositions64xyLow(attribute) {
     const isFP64 = this.use64bitPositions();
-    attribute.isGeneric = !isFP64;
+    attribute.constant = !isFP64;
 
     if (!isFP64) {
       attribute.value = new Float32Array(2);

--- a/modules/layers/src/hexagon-cell-layer/hexagon-cell-layer.js
+++ b/modules/layers/src/hexagon-cell-layer/hexagon-cell-layer.js
@@ -204,7 +204,7 @@ export default class HexagonCellLayer extends Layer {
 
   calculateInstancePositions64xyLow(attribute) {
     const isFP64 = this.use64bitPositions();
-    attribute.isGeneric = !isFP64;
+    attribute.constant = !isFP64;
 
     if (!isFP64) {
       attribute.value = new Float32Array(2);

--- a/modules/layers/src/icon-layer/icon-layer.js
+++ b/modules/layers/src/icon-layer/icon-layer.js
@@ -196,7 +196,7 @@ export default class IconLayer extends Layer {
 
   calculateInstancePositions64xyLow(attribute) {
     const isFP64 = this.use64bitPositions();
-    attribute.isGeneric = !isFP64;
+    attribute.constant = !isFP64;
 
     if (!isFP64) {
       attribute.value = new Float32Array(2);

--- a/modules/layers/src/line-layer/line-layer.js
+++ b/modules/layers/src/line-layer/line-layer.js
@@ -132,7 +132,7 @@ export default class LineLayer extends Layer {
 
   calculateInstanceSourceTargetPositions64xyLow(attribute) {
     const isFP64 = this.use64bitPositions();
-    attribute.isGeneric = !isFP64;
+    attribute.constant = !isFP64;
 
     if (!isFP64) {
       attribute.value = new Float32Array(4);

--- a/modules/layers/src/point-cloud-layer/point-cloud-layer.js
+++ b/modules/layers/src/point-cloud-layer/point-cloud-layer.js
@@ -122,7 +122,7 @@ export default class PointCloudLayer extends Layer {
 
   calculateInstancePositions64xyLow(attribute) {
     const isFP64 = this.use64bitPositions();
-    attribute.isGeneric = !isFP64;
+    attribute.constant = !isFP64;
 
     if (!isFP64) {
       attribute.value = new Float32Array(2);

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer.js
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer.js
@@ -122,7 +122,7 @@ export default class ScatterplotLayer extends Layer {
 
   calculateInstancePositions64xyLow(attribute) {
     const isFP64 = this.use64bitPositions();
-    attribute.isGeneric = !isFP64;
+    attribute.constant = !isFP64;
 
     if (!isFP64) {
       attribute.value = new Float32Array(2);

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -282,7 +282,7 @@ export default class SolidPolygonLayer extends Layer {
           // otherwise it is an Attribute object
           newAttributes[attributeName] = attributeOverride
             ? Object.assign({}, attribute, attributeOverride, {
-                buffer: attribute instanceof Buffer ? attribute : attribute.getBuffer()
+                buffer: attribute.getBuffer()
               })
             : attribute;
         }

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -304,9 +304,9 @@ export default class SolidPolygonLayer extends Layer {
           geometry: new Geometry({
             drawMode: GL.TRIANGLES,
             attributes: {
-              vertexPositions: {size: 2, isGeneric: true, value: new Float32Array([0, 1])},
-              nextPositions: {size: 3, isGeneric: true, value: new Float32Array(3)},
-              nextPositions64xyLow: {size: 2, isGeneric: true, value: new Float32Array(2)}
+              vertexPositions: {size: 2, constant: true, value: new Float32Array([0, 1])},
+              nextPositions: {size: 3, constant: true, value: new Float32Array(3)},
+              nextPositions64xyLow: {size: 2, constant: true, value: new Float32Array(2)}
             }
           }),
           uniforms: {
@@ -376,7 +376,7 @@ export default class SolidPolygonLayer extends Layer {
   }
   calculatePositionsLow(attribute) {
     const isFP64 = this.use64bitPositions();
-    attribute.isGeneric = !isFP64;
+    attribute.constant = !isFP64;
 
     if (!isFP64) {
       attribute.value = new Float32Array(2);
@@ -391,7 +391,7 @@ export default class SolidPolygonLayer extends Layer {
   }
   calculateNextPositionsLow(attribute) {
     const isFP64 = this.use64bitPositions();
-    attribute.isGeneric = !isFP64;
+    attribute.constant = !isFP64;
 
     if (!isFP64) {
       attribute.value = new Float32Array(2);
@@ -404,13 +404,13 @@ export default class SolidPolygonLayer extends Layer {
   calculateElevations(attribute) {
     const {extruded, getElevation} = this.props;
     if (extruded && typeof getElevation === 'function') {
-      attribute.isGeneric = false;
+      attribute.constant = false;
       attribute.value = this.state.polygonTesselator.elevations({
         getElevation: polygonIndex => getElevation(this.props.data[polygonIndex])
       });
     } else {
       const elevation = extruded ? getElevation : 0;
-      attribute.isGeneric = true;
+      attribute.constant = true;
       attribute.value = new Float32Array([elevation]);
     }
   }

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -20,7 +20,7 @@
 
 import {Layer} from '@deck.gl/core';
 import GL from 'luma.gl/constants';
-import {Model, Buffer, Geometry, hasFeature, FEATURES} from 'luma.gl';
+import {Model, Geometry, hasFeature, FEATURES} from 'luma.gl';
 
 // Polygon geometry generation is managed by the polygon tesselator
 import {PolygonTesselator} from './polygon-tesselator';
@@ -278,8 +278,6 @@ export default class SolidPolygonLayer extends Layer {
 
         if (attribute) {
           // Apply layout override to the attribute.
-          // If the attribute is being animated, it is a Buffer object
-          // otherwise it is an Attribute object
           newAttributes[attributeName] = attributeOverride
             ? Object.assign({}, attribute, attributeOverride, {
                 buffer: attribute.getBuffer()

--- a/test/modules/core-layers/grid-layer.spec.js
+++ b/test/modules/core-layers/grid-layer.spec.js
@@ -173,7 +173,10 @@ test('GridLayer#updates', t => {
           getPosition: d => d.COORDINATES
         },
         assert({layer, oldState}) {
-          t.ok(oldState.layerData !== layer.state.layerData, 'getPosition prop change should update layer data');
+          t.ok(
+            oldState.layerData !== layer.state.layerData,
+            'getPosition prop change should update layer data'
+          );
 
           t.ok(
             oldState.sortedColorBins !== layer.state.sortedColorBins,

--- a/test/modules/core/lib/attribute-transition-manager.spec.js
+++ b/test/modules/core/lib/attribute-transition-manager.spec.js
@@ -89,7 +89,7 @@ if (isWebGL2(gl)) {
     t.deepEquals(sizeTransition.fromState.data, [0, 0, 0, 0, 1], 'from buffer is extended');
     t.is(sizeTransition.buffer.data.length, 5, 'buffer has correct size');
 
-    attributes.instanceSizes.update({isGeneric: true, value: [2]});
+    attributes.instanceSizes.update({constant: true, value: [2]});
     manager.update({attributes, transitions: {getSize: 1000}, numInstances: 6});
     t.deepEquals(sizeTransition.fromState.data, [0, 0, 0, 0, 0, 2], 'from buffer is extended');
     t.is(sizeTransition.buffer.data.length, 6, 'buffer has correct size');

--- a/yarn.lock
+++ b/yarn.lock
@@ -5985,9 +5985,9 @@ lru-cache@^4.0.1, lru-cache@^4.1.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
-luma.gl@>=6.0.0-alpha.3:
-  version "6.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/luma.gl/-/luma.gl-6.0.0-alpha.3.tgz#add08366fe617361dce92df99e2b45d74b69c116"
+luma.gl@^6.0.0-alpha.6:
+  version "6.0.0-alpha.6"
+  resolved "https://registry.yarnpkg.com/luma.gl/-/luma.gl-6.0.0-alpha.6.tgz#5f1718b0dee17e4c51f828ffbe8204d97f0835af"
   dependencies:
     math.gl "^2.0.0"
     probe.gl "^1.0.0"


### PR DESCRIPTION
#### Background
Attribute transition is broken after upgrading to luma v6.

#### Change List
- `attributeTransitionManager.getAttributes()` now returns Attribute objects instead of Buffer
- Update `Transform` usage to v6 API