### PR TITLE
 ScreenGridLayer: Fix cell margin

### DIFF
--- a/modules/experimental-layers/src/gpu-screen-grid-layer/gpu-screen-grid-layer.js
+++ b/modules/experimental-layers/src/gpu-screen-grid-layer/gpu-screen-grid-layer.js
@@ -188,7 +188,8 @@ export default class GPUScreenGridLayer extends Layer {
   // HELPER Methods
 
   _getAggregationChangeFlags({oldProps, props, changeFlags}) {
-    const cellSizeChanged = props.cellSizePixels !== oldProps.cellSizePixels ||
+    const cellSizeChanged =
+      props.cellSizePixels !== oldProps.cellSizePixels ||
       props.cellMarginSizePixels !== oldProps.cellMarginSizePixels;
     const dataChanged = changeFlags.dataChanged;
     const viewportChanged = changeFlags.viewportChanged;
@@ -308,22 +309,23 @@ export default class GPUScreenGridLayer extends Layer {
       props.colorRange.forEach(color => {
         colorRangeUniform.push(color[0], color[1], color[2], color[3] || 255);
       });
-      newState.colorRange =  colorRangeUniform;
+      newState.colorRange = colorRangeUniform;
     }
 
-    if (oldProps.cellMarginSizePixels !== props.cellMarginSizePixels ||
-        oldProps.cellSizePixels !== props.cellSizePixels ||
-        changeFlags.viewportChanged ) {
+    if (
+      oldProps.cellMarginSizePixels !== props.cellMarginSizePixels ||
+      oldProps.cellSizePixels !== props.cellSizePixels ||
+      changeFlags.viewportChanged
+    ) {
+      const {width, height} = this.context.viewport;
+      const {cellSizePixels, cellMarginSizePixels} = this.props;
+      const margin = cellSizePixels > cellMarginSizePixels ? cellMarginSizePixels : 0;
 
-        const {width, height} = this.context.viewport;
-        const {cellSizePixels, cellMarginSizePixels} = this.props;
-        const margin = cellSizePixels > cellMarginSizePixels ? cellMarginSizePixels : 0;
-
-        newState.cellScale = new Float32Array([
-          ((cellSizePixels - margin) / width) * 2,
-          (-(cellSizePixels - margin) / height) * 2,
-          1
-        ]);
+      newState.cellScale = new Float32Array([
+        ((cellSizePixels - margin) / width) * 2,
+        (-(cellSizePixels - margin) / height) * 2,
+        1
+      ]);
     }
     this.setState(newState);
   }

--- a/modules/experimental-layers/src/gpu-screen-grid-layer/gpu-screen-grid-layer.js
+++ b/modules/experimental-layers/src/gpu-screen-grid-layer/gpu-screen-grid-layer.js
@@ -38,7 +38,7 @@ const COLOR_RANGE_LENGTH = 6;
 
 const defaultProps = {
   cellSizePixels: {value: 100, min: 1},
-  cellMarginSizePixels: {value: 2, min: 0, max: 5},
+  cellMarginPixels: {value: 2, min: 0, max: 5},
 
   colorDomain: null,
   colorRange: defaultColorRange,
@@ -190,7 +190,7 @@ export default class GPUScreenGridLayer extends Layer {
   _getAggregationChangeFlags({oldProps, props, changeFlags}) {
     const cellSizeChanged =
       props.cellSizePixels !== oldProps.cellSizePixels ||
-      props.cellMarginSizePixels !== oldProps.cellMarginSizePixels;
+      props.cellMarginPixels !== oldProps.cellMarginPixels;
     const dataChanged = changeFlags.dataChanged;
     const viewportChanged = changeFlags.viewportChanged;
 
@@ -299,7 +299,7 @@ export default class GPUScreenGridLayer extends Layer {
 
   _updateUniforms({oldProps, props, changeFlags}) {
     const newState = {};
-    if (this._updateMinMaxUniform({oldProps, props})) {
+    if (COLOR_PROPS.some(key => oldProps[key] !== props[key])) {
       newState.shouldUseMinMax = this._shouldUseMinMax();
     }
 
@@ -313,13 +313,13 @@ export default class GPUScreenGridLayer extends Layer {
     }
 
     if (
-      oldProps.cellMarginSizePixels !== props.cellMarginSizePixels ||
+      oldProps.cellMarginPixels !== props.cellMarginPixels ||
       oldProps.cellSizePixels !== props.cellSizePixels ||
       changeFlags.viewportChanged
     ) {
       const {width, height} = this.context.viewport;
-      const {cellSizePixels, cellMarginSizePixels} = this.props;
-      const margin = cellSizePixels > cellMarginSizePixels ? cellMarginSizePixels : 0;
+      const {cellSizePixels, cellMarginPixels} = this.props;
+      const margin = cellSizePixels > cellMarginPixels ? cellMarginPixels : 0;
 
       newState.cellScale = new Float32Array([
         ((cellSizePixels - margin) / width) * 2,
@@ -357,17 +357,6 @@ export default class GPUScreenGridLayer extends Layer {
       numInstances,
       countsBuffer
     });
-  }
-
-  _updateMinMaxUniform({oldProps, props}) {
-    if (
-      COLOR_PROPS.some(key => {
-        return oldProps[key] !== props[key];
-      })
-    ) {
-      return true;
-    }
-    return false;
   }
 }
 

--- a/modules/experimental-layers/src/gpu-screen-grid-layer/gpu-screen-grid-layer.js
+++ b/modules/experimental-layers/src/gpu-screen-grid-layer/gpu-screen-grid-layer.js
@@ -37,7 +37,8 @@ const COLOR_PROPS = [`minColor`, `maxColor`, `colorRange`, `colorDomain`];
 const COLOR_RANGE_LENGTH = 6;
 
 const defaultProps = {
-  cellSizePixels: 100,
+  cellSizePixels: {value: 100, min: 1},
+  cellMarginSizePixels: {value: 2, min: 0, max: 5},
 
   colorDomain: null,
   colorRange: defaultColorRange,
@@ -312,13 +313,13 @@ export default class GPUScreenGridLayer extends Layer {
 
   _updateGridParams() {
     const {width, height} = this.context.viewport;
-    const {cellSizePixels} = this.props;
+    const {cellSizePixels, cellMarginSizePixels} = this.props;
     const {gl} = this.context;
 
-    const MARGIN = 2;
+    const margin = cellSizePixels > cellMarginSizePixels ? cellMarginSizePixels : 0;
     const cellScale = new Float32Array([
-      ((cellSizePixels - MARGIN) / width) * 2,
-      (-(cellSizePixels - MARGIN) / height) * 2,
+      ((cellSizePixels - margin) / width) * 2,
+      (-(cellSizePixels - margin) / height) * 2,
       1
     ]);
     const numCol = Math.ceil(width / cellSizePixels);

--- a/modules/layers/src/screen-grid-layer/screen-grid-layer.js
+++ b/modules/layers/src/screen-grid-layer/screen-grid-layer.js
@@ -30,7 +30,8 @@ const DEFAULT_MINCOLOR = [0, 0, 0, 255];
 const DEFAULT_MAXCOLOR = [0, 255, 0, 255];
 
 const defaultProps = {
-  cellSizePixels: 100,
+  cellSizePixels: {value: 100, min: 1},
+  cellMarginSizePixels: {value: 2, min: 0, max: 5},
 
   colorDomain: null,
   colorRange: defaultColorRange,
@@ -112,12 +113,12 @@ export default class ScreenGridLayer extends Layer {
 
   updateCell() {
     const {width, height} = this.context.viewport;
-    const {cellSizePixels} = this.props;
+    const {cellSizePixels, cellMarginSizePixels} = this.props;
 
-    const MARGIN = 2;
+    const margin = cellSizePixels > cellMarginSizePixels ? cellMarginSizePixels : 0;
     const cellScale = new Float32Array([
-      ((cellSizePixels - MARGIN) / width) * 2,
-      (-(cellSizePixels - MARGIN) / height) * 2,
+      ((cellSizePixels - margin) / width) * 2,
+      (-(cellSizePixels - margin) / height) * 2,
       1
     ]);
     const numCol = Math.ceil(width / cellSizePixels);

--- a/modules/layers/src/screen-grid-layer/screen-grid-layer.js
+++ b/modules/layers/src/screen-grid-layer/screen-grid-layer.js
@@ -72,9 +72,14 @@ export default class ScreenGridLayer extends Layer {
   updateState({oldProps, props, changeFlags}) {
     super.updateState({props, oldProps, changeFlags});
     const cellSizeChanged = props.cellSizePixels !== oldProps.cellSizePixels;
+    const cellMarginChanged = props.cellMarginSizePixels !== oldProps.cellMarginSizePixels;
 
     if (cellSizeChanged || changeFlags.viewportChanged) {
       this.updateCell();
+    }
+
+    if (cellSizeChanged || cellMarginChanged || changeFlags.viewportChanged) {
+      this.updateCellScale();
     }
   }
 
@@ -113,19 +118,12 @@ export default class ScreenGridLayer extends Layer {
 
   updateCell() {
     const {width, height} = this.context.viewport;
-    const {cellSizePixels, cellMarginSizePixels} = this.props;
+    const {cellSizePixels} = this.props;
 
-    const margin = cellSizePixels > cellMarginSizePixels ? cellMarginSizePixels : 0;
-    const cellScale = new Float32Array([
-      ((cellSizePixels - margin) / width) * 2,
-      (-(cellSizePixels - margin) / height) * 2,
-      1
-    ]);
     const numCol = Math.ceil(width / cellSizePixels);
     const numRow = Math.ceil(height / cellSizePixels);
 
     this.setState({
-      cellScale,
       numCol,
       numRow,
       numInstances: numCol * numRow
@@ -133,6 +131,18 @@ export default class ScreenGridLayer extends Layer {
 
     const attributeManager = this.getAttributeManager();
     attributeManager.invalidateAll();
+  }
+
+  updateCellScale() {
+    const {width, height} = this.context.viewport;
+    const {cellSizePixels, cellMarginSizePixels} = this.props;
+    const margin = cellSizePixels > cellMarginSizePixels ? cellMarginSizePixels : 0;
+    const cellScale = new Float32Array([
+      ((cellSizePixels - margin) / width) * 2,
+      (-(cellSizePixels - margin) / height) * 2,
+      1
+    ]);
+    this.setState({cellScale});
   }
 
   calculateInstancePositions(attribute, {numInstances}) {

--- a/modules/layers/src/screen-grid-layer/screen-grid-layer.js
+++ b/modules/layers/src/screen-grid-layer/screen-grid-layer.js
@@ -31,7 +31,7 @@ const DEFAULT_MAXCOLOR = [0, 255, 0, 255];
 
 const defaultProps = {
   cellSizePixels: {value: 100, min: 1},
-  cellMarginSizePixels: {value: 2, min: 0, max: 5},
+  cellMarginPixels: {value: 2, min: 0, max: 5},
 
   colorDomain: null,
   colorRange: defaultColorRange,
@@ -72,7 +72,7 @@ export default class ScreenGridLayer extends Layer {
   updateState({oldProps, props, changeFlags}) {
     super.updateState({props, oldProps, changeFlags});
     const cellSizeChanged = props.cellSizePixels !== oldProps.cellSizePixels;
-    const cellMarginChanged = props.cellMarginSizePixels !== oldProps.cellMarginSizePixels;
+    const cellMarginChanged = props.cellMarginPixels !== oldProps.cellMarginPixels;
 
     if (cellSizeChanged || changeFlags.viewportChanged) {
       this.updateCell();
@@ -116,6 +116,7 @@ export default class ScreenGridLayer extends Layer {
     );
   }
 
+  // Update cell size parameters and invalidated attributes for re-calculation.
   updateCell() {
     const {width, height} = this.context.viewport;
     const {cellSizePixels} = this.props;
@@ -133,10 +134,11 @@ export default class ScreenGridLayer extends Layer {
     attributeManager.invalidateAll();
   }
 
+  // update cellScale uniform used in vertex shader.
   updateCellScale() {
     const {width, height} = this.context.viewport;
-    const {cellSizePixels, cellMarginSizePixels} = this.props;
-    const margin = cellSizePixels > cellMarginSizePixels ? cellMarginSizePixels : 0;
+    const {cellSizePixels, cellMarginPixels} = this.props;
+    const margin = cellSizePixels > cellMarginPixels ? cellMarginPixels : 0;
     const cellScale = new Float32Array([
       ((cellSizePixels - margin) / width) * 2,
       (-(cellSizePixels - margin) / height) * 2,


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #1976 
<!-- For other PRs without open issue -->
#### Background
- Add new prop, `cellMarginPixels`, so users can provide 0 or higher value. Default value `2`, matches with old behavior. (non breaking change)
- Use `0` for margin when the cellSize is less than are equal to margin.
<!-- For all the PRs -->
#### Change List
- ScreenGridLayer: Fix cell margin

cellMarginSizePixels = 2 :
<img width="579" alt="screen shot 2018-06-27 at 9 03 26 pm" src="https://user-images.githubusercontent.com/9502731/42012543-a69b98be-7a4d-11e8-8858-0a53368ab0aa.png">

cellMarginSizePixels = 0 :
<img width="584" alt="screen shot 2018-06-27 at 9 03 36 pm" src="https://user-images.githubusercontent.com/9502731/42012567-c0dcf010-7a4d-11e8-836b-eaacfeef9da2.png">

