### PR TITLE
Add enter parameter for transitions

### DIFF
--- a/docs/api-reference/layer.md
+++ b/docs/api-reference/layer.md
@@ -259,7 +259,8 @@ new Layer({
     getPositions: 600,
     getColors: {
       duration: 300,
-      easing: d3.easeCubicInOut
+      easing: d3.easeCubicInOut,
+      enter: value => [value[0], value[1], value[2], 0] // fade in
     }
   }
 });
@@ -269,6 +270,7 @@ new Layer({
 | ---------     | --------   | ----------- | ----------- |
 | `duration`    | `Number`   | `0`         | Duration of the transition animation, in milliseconds |
 | `easing`      | `Function` | LINEAR (`t => t`) | Easing function that maps a value from [0, 1] to [0, 1], see [http://easings.net/](http://easings.net/)  |
+| `enter`      | `Function` | APPEARANCE (`x => x`) | Callback to get the value that the entering vertices are transitioning from. |
 | `onStart`     | `Function` | `null`      | Callback when the transition is started |
 | `onEnd`       | `Function` | `null`      | Callback when the transition is done |
 | `onInterrupt` | `Function` | `null`      | Callback when the transition is interrupted |

--- a/docs/api-reference/layer.md
+++ b/docs/api-reference/layer.md
@@ -270,12 +270,17 @@ new Layer({
 | ---------     | --------   | ----------- | ----------- |
 | `duration`    | `Number`   | `0`         | Duration of the transition animation, in milliseconds |
 | `easing`      | `Function` | LINEAR (`t => t`) | Easing function that maps a value from [0, 1] to [0, 1], see [http://easings.net/](http://easings.net/)  |
-| `enter`      | `Function` | APPEARANCE (`x => x`) | Callback to get the value that the entering vertices are transitioning from. |
+| `enter`      | `Function` | APPEARANCE (`value => value`) | Callback to get the value that the entering vertices are transitioning from. See notes below |
 | `onStart`     | `Function` | `null`      | Callback when the transition is started |
 | `onEnd`       | `Function` | `null`      | Callback when the transition is done |
 | `onInterrupt` | `Function` | `null`      | Callback when the transition is interrupted |
 
-As a shorthand, if an accessor key maps to a number rather than an object, then the number is assigned to the `duration` parameter.
+Notes: 
+* As a shorthand, if an accessor key maps to a number rather than an object, then the number is assigned to the `duration` parameter.
+* Attribute transition is performed between the values at the same index. If the new data is larger, `enter` callback is called for each new vertex to backfill the values to transition from.
+* `enter` should return the value to transition from. for the current vertex. It receives two arguments:
+  - `toValue` (TypedArray) - the new value to transition to, for the current vertex
+  - `fromChunk` (Array | TypedArray) - the existing value to transition from, for the chunk that the current vertex belongs to. A "chunk" is a group of vertices that help the callback determine the context of this transition. For most layers, all objects are in one chunk. For PathLayer and PolygonLayer, each path/polygon is a chunk.
 
 
 ## Members

--- a/modules/core/src/lib/attribute.js
+++ b/modules/core/src/lib/attribute.js
@@ -78,6 +78,28 @@ export default class LayerAttribute extends Attribute {
     return this.userData.transition;
   }
 
+  // Resolve transition settings object if transition is enabled, otherwise `null`
+  getTransitionSetting(opts) {
+    const {transition, accessor} = this.userData;
+    if (!transition) {
+      return null;
+    }
+    let settings = Array.isArray(accessor)
+      ? accessor.map(a => opts[a]).find(Boolean)
+      : opts[accessor];
+
+    // Shorthand: use duration instead of parameter object
+    if (Number.isFinite(settings)) {
+      settings = {duration: settings};
+    }
+
+    if (settings && settings.duration > 0) {
+      return Object.assign({}, transition, settings);
+    }
+
+    return null;
+  }
+
   // Checks that typed arrays for attributes are big enough
   // sets alloc flag if not
   // @return {Boolean} whether any updates are needed

--- a/modules/core/src/lib/attribute.js
+++ b/modules/core/src/lib/attribute.js
@@ -84,9 +84,7 @@ export default class LayerAttribute extends Attribute {
     if (!transition) {
       return null;
     }
-    let settings = Array.isArray(accessor)
-      ? accessor.map(a => opts[a]).find(Boolean)
-      : opts[accessor];
+    let settings = Array.isArray(accessor) ? opts[accessor.find(a => opts[a])] : opts[accessor];
 
     // Shorthand: use duration instead of parameter object
     if (Number.isFinite(settings)) {

--- a/modules/layers/src/path-layer/path-layer.js
+++ b/modules/layers/src/path-layer/path-layer.js
@@ -54,6 +54,15 @@ const isClosed = path => {
   );
 };
 
+const ATTRIBUTE_TRANSITION = {
+  enter: (value, chunk) => {
+    if (chunk.length) {
+      return chunk.subarray(chunk.length - value.length);
+    }
+    return value;
+  }
+};
+
 export default class PathLayer extends Layer {
   getShaders() {
     return this.use64bitProjection()
@@ -67,13 +76,13 @@ export default class PathLayer extends Layer {
     attributeManager.addInstanced({
       instanceStartPositions: {
         size: 3,
-        transition: true,
+        transition: ATTRIBUTE_TRANSITION,
         accessor: 'getPath',
         update: this.calculateStartPositions
       },
       instanceEndPositions: {
         size: 3,
-        transition: true,
+        transition: ATTRIBUTE_TRANSITION,
         accessor: 'getPath',
         update: this.calculateEndPositions
       },
@@ -82,7 +91,7 @@ export default class PathLayer extends Layer {
       instanceStrokeWidths: {
         size: 1,
         accessor: 'getWidth',
-        transition: true,
+        transition: ATTRIBUTE_TRANSITION,
         update: this.calculateStrokeWidths,
         defaultValue: 1
       },
@@ -91,7 +100,7 @@ export default class PathLayer extends Layer {
         size: 4,
         type: GL.UNSIGNED_BYTE,
         accessor: 'getColor',
-        transition: true,
+        transition: ATTRIBUTE_TRANSITION,
         update: this.calculateColors,
         defaultValue: DEFAULT_COLOR
       },

--- a/modules/layers/src/path-layer/path-layer.js
+++ b/modules/layers/src/path-layer/path-layer.js
@@ -56,10 +56,7 @@ const isClosed = path => {
 
 const ATTRIBUTE_TRANSITION = {
   enter: (value, chunk) => {
-    if (chunk.length) {
-      return chunk.subarray(chunk.length - value.length);
-    }
-    return value;
+    return chunk.length ? chunk.subarray(chunk.length - value.length) : value;
   }
 };
 

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -120,6 +120,15 @@ const ATTRIBUTE_MAPS = {
   }
 };
 
+const ATTRIBUTE_TRANSITION = {
+  enter: (value, chunk) => {
+    if (chunk.length) {
+      return chunk.subarray(chunk.length - value.length);
+    }
+    return value;
+  }
+};
+
 export default class SolidPolygonLayer extends Layer {
   getShaders() {
     const projectModule = this.use64bitProjection() ? 'project64' : 'project32';
@@ -140,7 +149,7 @@ export default class SolidPolygonLayer extends Layer {
       indices: {size: 1, isIndexed: true, update: this.calculateIndices, noAlloc},
       positions: {
         size: 3,
-        transition: true,
+        transition: ATTRIBUTE_TRANSITION,
         accessor: 'getPolygon',
         update: this.calculatePositions,
         noAlloc
@@ -148,7 +157,7 @@ export default class SolidPolygonLayer extends Layer {
       positions64xyLow: {size: 2, update: this.calculatePositionsLow},
       nextPositions: {
         size: 3,
-        transition: true,
+        transition: ATTRIBUTE_TRANSITION,
         accessor: 'getPolygon',
         update: this.calculateNextPositions,
         noAlloc
@@ -156,7 +165,7 @@ export default class SolidPolygonLayer extends Layer {
       nextPositions64xyLow: {size: 2, update: this.calculateNextPositionsLow},
       elevations: {
         size: 1,
-        transition: true,
+        transition: ATTRIBUTE_TRANSITION,
         accessor: 'getElevation',
         update: this.calculateElevations,
         noAlloc
@@ -165,7 +174,7 @@ export default class SolidPolygonLayer extends Layer {
         alias: 'colors',
         size: 4,
         type: GL.UNSIGNED_BYTE,
-        transition: true,
+        transition: ATTRIBUTE_TRANSITION,
         accessor: 'getFillColor',
         update: this.calculateFillColors,
         defaultValue: defaultFillColor,
@@ -175,7 +184,7 @@ export default class SolidPolygonLayer extends Layer {
         alias: 'colors',
         size: 4,
         type: GL.UNSIGNED_BYTE,
-        transition: true,
+        transition: ATTRIBUTE_TRANSITION,
         accessor: 'getLineColor',
         update: this.calculateLineColors,
         defaultValue: defaultLineColor,

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -122,10 +122,7 @@ const ATTRIBUTE_MAPS = {
 
 const ATTRIBUTE_TRANSITION = {
   enter: (value, chunk) => {
-    if (chunk.length) {
-      return chunk.subarray(chunk.length - value.length);
-    }
-    return value;
+    return chunk.length ? chunk.subarray(chunk.length - value.length) : value;
   }
 };
 


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/1905

Most layer attributes have the default enter as "appearance" (no transition)
PathLayer and SolidPolygonLayer need them to use the last value of the chunk.

#### Change List
- Add `enter` callback to transition settings
- Allow each attribute to define its own default transition settings
- Update PathLayer and SolidPolygonLayer