### PR TITLE
Restore prop override for regular React children

### DIFF
--- a/examples/website/3d-heatmap/app.js
+++ b/examples/website/3d-heatmap/app.js
@@ -144,16 +144,14 @@ class App extends Component {
         onViewStateChange={onViewStateChange}
         controller={MapController}
       >
-        {!window.demoLauncherActive &&
-          (viewProps => (
-            <StaticMap
-              {...viewProps}
-              reuseMaps
-              mapStyle="mapbox://styles/mapbox/dark-v9"
-              preventStyleDiffing={true}
-              mapboxApiAccessToken={MAPBOX_TOKEN}
-            />
-          ))}
+        {!window.demoLauncherActive && (
+          <StaticMap
+            reuseMaps
+            mapStyle="mapbox://styles/mapbox/dark-v9"
+            preventStyleDiffing={true}
+            mapboxApiAccessToken={MAPBOX_TOKEN}
+          />
+        )}
       </DeckGL>
     );
   }

--- a/modules/react/src/utils/evaluate-children.js
+++ b/modules/react/src/utils/evaluate-children.js
@@ -1,3 +1,5 @@
+import {cloneElement} from 'react';
+
 export default function evaluateChildren(children, childProps) {
   if (!children) {
     return children;
@@ -8,5 +10,5 @@ export default function evaluateChildren(children, childProps) {
   if (Array.isArray(children)) {
     return children.map(child => evaluateChildren(child, childProps));
   }
-  return children;
+  return cloneElement(children, childProps);
 }

--- a/modules/react/src/utils/extract-jsx-layers.js
+++ b/modules/react/src/utils/extract-jsx-layers.js
@@ -8,7 +8,8 @@ function wrapInView(node) {
     return node;
   }
   if (typeof node === 'function') {
-    // All render callbacks must be assigned to a View
+    // React.Children does not traverse functions.
+    // All render callbacks must be protected under a <View>
     return createElement(View, {}, node);
   }
   if (Array.isArray(node)) {


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/1969

#### Change List
- All React children will be positioned inside a specific view
- Any child not wrapped inside a <View> will be positioned inside the default (first) view
- Render callback behavior is not changed
- Regular React children are injected with the following props: `{x, y, width, height, viewState, viewport}`
