### PR TITLE
More Flexible Controller API

### DIFF
--- a/docs/api-reference/map-controller.md
+++ b/docs/api-reference/map-controller.md
@@ -15,6 +15,17 @@ onViewportChange={v => this.setState({viewport: v})}
 />
 ```
 
+## Options
+
+- `scrollZoom` (`Boolean`) - enable zooming with mouse wheel. Default `true`
+- `dragPan` (`Boolean`) - enable panning with pointer drag. Default `true`
+- `dragRotate` (`Boolean`) - enable rotating with pointer drag. Default `true`
+- `doubleClickZoom` (`Boolean`) - enable zooming with double click. Default `true`
+- `touchZoom` (`Boolean`) - enable zooming with multi-touch. Default `true`
+- `touchRotate` (`Boolean`) - enable rotating with multi-touch. Default `false`
+- `keyboard` (`Boolean`) - enable interaction with keyboard. Default `true`
+
+
 ## Methods
 
 Note that the `MapController` class should not be instantiated by the application.

--- a/docs/api-reference/map-controller.md
+++ b/docs/api-reference/map-controller.md
@@ -1,15 +1,34 @@
 # MapController
 
-The `MapController` class can be passed to the `Deck.controller` or `DeckGL.controller` prop to specify that map interaction should be enabled.
+The `MapController` class can be passed to the `Deck.controller` or `View.controller` prop to specify that map interaction should be enabled.
 
+`MapController` is the default controller for `MapView`.
 
 ## Usage
+
+Use with the default view:
 
 ```jsx
 import DeckGL, {MapController} from 'deck.gl';
 
 <DeckGL
-controller={MapController} // NOTE: Constructor is passed. Do not call 'new MapController()'
+controller={{type: MapController, dragRotate: false}}
+viewState={viewState}
+onViewportChange={v => this.setState({viewport: v})}
+/>
+```
+
+Use with multiple views:
+
+```jsx
+import DeckGL, {MapView} from 'deck.gl';
+
+<DeckGL
+views={[
+  new MapView({
+    controller: {doubleClickZoom: false}
+  })
+]}
 viewState={viewState}
 onViewportChange={v => this.setState({viewport: v})}
 />

--- a/docs/api-reference/map-view.md
+++ b/docs/api-reference/map-view.md
@@ -10,6 +10,7 @@ To render, `MapView` requires the application to use a `viewState` that contains
 
 For more information on using `View` classes, consult the [Views](/docs/developer-guide/views.md) article.
 
+The default controller of a `MapView` is [MapController](/docs/api-reference/map-controller.md).
 
 ## Usage
 

--- a/docs/api-reference/react/deckgl.md
+++ b/docs/api-reference/react/deckgl.md
@@ -62,6 +62,12 @@ Default: If the `views` property is not supplied, deck.gl will create a full scr
 
 > deck.gl will render all the views in the provided order. This may not matter as depth testing is enabled by default by deck.gl (unless transparent layers are being rendered, in which case rendering order starts to matter again), but is useful when rendering 2D layers and disabling depth testing.
 
+##### `controller` (Function | Boolean | Object, optional)
+
+Specify the options for viewport interaction. The value is applied to the default (first) view. See [`View`](/docs/api-reference/view.md) for more information.
+
+Default `null`.
+
 
 ### View State Properties
 

--- a/docs/api-reference/view.md
+++ b/docs/api-reference/view.md
@@ -53,6 +53,12 @@ If `projectionMatrix` is not supplied, `Viewport` will build a matrix from the f
 * `focalDistance`=`1` (`Number`) - (orthographic projections only) The distance at which the field-of-view frustum is sampled to extract the extents of the view box. Note: lso used for pixel scale identity distance above.
 * `orthographicFocalDistance` (`Number`) - (orthographic projections only) Can be used to specify different values for pixel scale focal distance and orthographic focal distance.
 
+* `controller` (`Function` | `Boolean` | `Object`) - options for viewport interactivity.
+    - If falsy, this view is not interactive.
+    - If set to `true`, the default controller options are used.
+    - If set to a class construcor, it is used to construct the controller.
+    - If set to an object, it is merged with the default controller options. Use `controller.type` to specify a custom constructor.
+
 
 ## Methods
 

--- a/docs/api-reference/view.md
+++ b/docs/api-reference/view.md
@@ -54,11 +54,14 @@ If `projectionMatrix` is not supplied, `Viewport` will build a matrix from the f
 * `orthographicFocalDistance` (`Number`) - (orthographic projections only) Can be used to specify different values for pixel scale focal distance and orthographic focal distance.
 
 * `controller` (`Function` | `Boolean` | `Object`) - options for viewport interactivity.
-  - If falsy, this view is not interactive.
-  - If set to `true`, the default controller options are used.
-  - If set to a class construcor, it is used to construct the controller.
-  - If set to an object, it is merged with the default controller options. Use `controller.type` to specify a custom constructor.
+  - `null` or `false`: this view is not interactive.
+  - `true`: initiates the default controller with default options.
+  - `Controller` class (not instance): initiates the provided controller with default options.
+  - `Object`: controller options. This will be merged with the default controller options. 
+    + `controller.type`: the controller class
+    + For other options, consult the documentation of each Controller class.
 
+Default `null`.
 
 ## Methods
 

--- a/docs/api-reference/view.md
+++ b/docs/api-reference/view.md
@@ -54,10 +54,10 @@ If `projectionMatrix` is not supplied, `Viewport` will build a matrix from the f
 * `orthographicFocalDistance` (`Number`) - (orthographic projections only) Can be used to specify different values for pixel scale focal distance and orthographic focal distance.
 
 * `controller` (`Function` | `Boolean` | `Object`) - options for viewport interactivity.
-    - If falsy, this view is not interactive.
-    - If set to `true`, the default controller options are used.
-    - If set to a class construcor, it is used to construct the controller.
-    - If set to an object, it is merged with the default controller options. Use `controller.type` to specify a custom constructor.
+  - If falsy, this view is not interactive.
+  - If set to `true`, the default controller options are used.
+  - If set to a class construcor, it is used to construct the controller.
+  - If set to an object, it is merged with the default controller options. Use `controller.type` to specify a custom constructor.
 
 
 ## Methods

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -365,7 +365,7 @@ export default class Deck {
     const views = props.views || [new MapView({id: 'default-view'})];
     if (views.length && props.controller) {
       // Backward compatibility: support controller prop
-      views[0].controller = props.controller;
+      views[0].props.controller = props.controller;
     }
     return views;
   }

--- a/modules/core/src/views/first-person-view.js
+++ b/modules/core/src/views/first-person-view.js
@@ -1,6 +1,7 @@
 import View from './view';
 import Viewport from '../viewports/viewport';
 import {Matrix4, _SphericalCoordinates as SphericalCoordinates} from 'math.gl';
+import FirstPersonController from '../controllers/first-person-controller';
 
 function getDirectionFromBearingAndPitch({bearing, pitch}) {
   const spherical = new SphericalCoordinates({bearing, pitch});
@@ -40,3 +41,7 @@ export default class FirstPersonView extends View {
 }
 
 FirstPersonView.displayName = 'FirstPersonView';
+
+FirstPersonView.defaultController = {
+  type: FirstPersonController
+};

--- a/modules/core/src/views/first-person-view.js
+++ b/modules/core/src/views/first-person-view.js
@@ -10,6 +10,12 @@ function getDirectionFromBearingAndPitch({bearing, pitch}) {
 }
 
 export default class FirstPersonView extends View {
+  get controller() {
+    return this._getControllerProps({
+      type: FirstPersonController
+    });
+  }
+
   _getViewport(props) {
     // TODO - push direction handling into Matrix4.lookAt
     const {
@@ -41,7 +47,3 @@ export default class FirstPersonView extends View {
 }
 
 FirstPersonView.displayName = 'FirstPersonView';
-
-FirstPersonView.defaultController = {
-  type: FirstPersonController
-};

--- a/modules/core/src/views/map-view.js
+++ b/modules/core/src/views/map-view.js
@@ -10,10 +10,12 @@ export default class MapView extends View {
       })
     );
   }
+
+  get controller() {
+    return this._getControllerProps({
+      type: MapController
+    });
+  }
 }
 
 MapView.displayName = 'MapView';
-
-MapView.defaultController = {
-  type: MapController
-};

--- a/modules/core/src/views/map-view.js
+++ b/modules/core/src/views/map-view.js
@@ -1,5 +1,6 @@
 import View from './view';
 import WebMercatorViewport from '../viewports/web-mercator-viewport';
+import MapController from '../controllers/map-controller';
 
 export default class MapView extends View {
   constructor(props) {
@@ -12,3 +13,7 @@ export default class MapView extends View {
 }
 
 MapView.displayName = 'MapView';
+
+MapView.defaultController = {
+  type: MapController
+};

--- a/modules/core/src/views/orbit-view.js
+++ b/modules/core/src/views/orbit-view.js
@@ -11,6 +11,7 @@ import mat4_translate from 'gl-mat4/translate';
 import mat4_rotateX from 'gl-mat4/rotateX';
 import mat4_rotateY from 'gl-mat4/rotateY';
 import mat4_rotateZ from 'gl-mat4/rotateZ';
+import OrbitController from '../controllers/orbit-controller';
 
 const DEGREES_TO_RADIANS = Math.PI / 180;
 
@@ -118,3 +119,7 @@ export default class OrbitView extends View {
 }
 
 OrbitView.displayName = 'OrbitView';
+
+OrbitView.defaultController = {
+  type: OrbitController
+};

--- a/modules/core/src/views/orbit-view.js
+++ b/modules/core/src/views/orbit-view.js
@@ -40,6 +40,12 @@ export default class OrbitView extends View {
     return distance;
   }
 
+  get controller() {
+    return this._getControllerProps({
+      type: OrbitController
+    });
+  }
+
   /* eslint-disable complexity, max-statements */
   _getViewport(props) {
     const {viewState} = props;
@@ -119,7 +125,3 @@ export default class OrbitView extends View {
 }
 
 OrbitView.displayName = 'OrbitView';
-
-OrbitView.defaultController = {
-  type: OrbitController
-};

--- a/modules/core/src/views/view-manager.js
+++ b/modules/core/src/views/view-manager.js
@@ -214,20 +214,16 @@ export default class ViewManager {
   }
 
   _createController(view) {
-    let controller = null;
+    const controllerProps = Object.assign({}, view.controller, {
+      eventManager: this._eventManager,
+      viewState: this.getViewState(view.id),
+      // Set an internal callback that calls the prop callback if provided
+      onViewStateChange: this._onViewStateChange.bind(this, view.id),
+      onStateChange: this._eventCallbacks.onInteractiveStateChange
+    });
+    const Controller = controllerProps.type;
 
-    if (view.controller) {
-      const Controller = view.controller;
-      controller = new Controller({
-        eventManager: this._eventManager,
-        viewState: this.getViewState(view.id),
-        // Set an internal callback that calls the prop callback if provided
-        onViewStateChange: this._onViewStateChange.bind(this, view.id),
-        onStateChange: this._eventCallbacks.onInteractiveStateChange
-      });
-    }
-
-    return controller;
+    return new Controller(controllerProps);
   }
 
   // Rebuilds viewports from descriptors towards a certain window size
@@ -244,7 +240,7 @@ export default class ViewManager {
         // TODO - check for removed view ids?
         if (controller) {
           controller.setProps(
-            Object.assign({}, viewState, {
+            Object.assign({}, view.controller, viewState, {
               x: viewport.x,
               y: viewport.y,
               width: viewport.width,

--- a/modules/core/src/views/view.js
+++ b/modules/core/src/views/view.js
@@ -26,6 +26,7 @@ export default class View {
 
       // A controller class constructor, not an already created instance
       controller = null,
+      defaultController = null,
 
       // Internal: Viewport Type
       type = Viewport // TODO - default to WebMercator?
@@ -33,6 +34,8 @@ export default class View {
 
     assert(!viewportInstance || viewportInstance instanceof Viewport);
     this.viewportInstance = viewportInstance;
+
+    this.defaultController = defaultController;
     this.controller = controller;
 
     // Id
@@ -54,6 +57,17 @@ export default class View {
     this.equals = this.equals.bind(this);
 
     Object.seal(this);
+  }
+
+  get controller() {
+    return this._controller;
+  }
+
+  set controller(value) {
+    if (typeof value === 'function') {
+      value = {type: value};
+    }
+    this._controller = value ? Object.assign({}, this.constructor.defaultController, value) : null;
   }
 
   equals(view) {

--- a/modules/core/src/views/view.js
+++ b/modules/core/src/views/view.js
@@ -24,19 +24,12 @@ export default class View {
       // A View can be a wrapper for a viewport instance
       viewportInstance = null,
 
-      // A controller class constructor, not an already created instance
-      controller = null,
-      defaultController = null,
-
       // Internal: Viewport Type
       type = Viewport // TODO - default to WebMercator?
     } = props;
 
     assert(!viewportInstance || viewportInstance instanceof Viewport);
     this.viewportInstance = viewportInstance;
-
-    this.defaultController = defaultController;
-    this.controller = controller;
 
     // Id
     this.id = id || this.constructor.displayName || 'view';
@@ -57,17 +50,6 @@ export default class View {
     this.equals = this.equals.bind(this);
 
     Object.seal(this);
-  }
-
-  get controller() {
-    return this._controller;
-  }
-
-  set controller(value) {
-    if (typeof value === 'function') {
-      value = {type: value};
-    }
-    this._controller = value ? Object.assign({}, this.constructor.defaultController, value) : null;
   }
 
   equals(view) {
@@ -108,6 +90,22 @@ export default class View {
       width: getPosition(this._width, width),
       height: getPosition(this._height, height)
     };
+  }
+
+  // Used by sub classes to resolve controller props
+  _getControllerProps(defaultOpts) {
+    let opts = this.props.controller;
+
+    if (!opts) {
+      return null;
+    }
+    if (opts === true) {
+      return defaultOpts;
+    }
+    if (typeof opts === 'function') {
+      opts = {type: opts};
+    }
+    return Object.assign({}, defaultOpts, opts);
   }
 
   // Overridable method

--- a/modules/lite/src/deckgl.js
+++ b/modules/lite/src/deckgl.js
@@ -2,7 +2,7 @@
 /* eslint-disable max-statements */
 import Mapbox from 'react-map-gl/src/mapbox/mapbox';
 
-import {Deck, MapController, OrbitView, _OrbitController as OrbitController} from '@deck.gl/core';
+import {Deck} from '@deck.gl/core';
 
 const CANVAS_STYLE = {
   position: 'absolute',
@@ -53,7 +53,7 @@ function createCanvas(props) {
 /**
  * @params container (Element) - DOM element to add deck.gl canvas to
  * @params map (Object) - map API. Set to falsy to disable
- * @params controller (Object) - Controller class. Leave empty for auto detection
+ * @params controller (Object) - Controller options. Leave empty for auto detection
  */
 export default class DeckGL extends Deck {
   constructor(props = {}) {
@@ -66,26 +66,19 @@ export default class DeckGL extends Deck {
 
     normalizeProps(props);
     const isMap = Number.isFinite(props.initialViewState.latitude);
-    const isOrbit = props.views && props.views[0] instanceof OrbitView;
-    let Controller;
-    if (isMap) {
-      Controller = MapController;
-    } else if (isOrbit) {
-      Controller = OrbitController;
-    }
+    const {map = window.mapboxgl, controller = true} = props;
 
     super(
       Object.assign({}, props, {
         width: '100%',
         height: '100%',
         canvas: deckCanvas,
-        controller: props.controller || Controller,
+        controller,
         onViewStateChange: ({viewState}) =>
           this._map && this._map.setProps({viewState}) && viewState
       })
     );
 
-    const {map = window.mapboxgl} = props;
     if (map && map.Map) {
       // Default create mapbox map
       this._map =


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/1422

#### Change List
- Allow View classes to specify default controller
- Accept the following values to be supplied to the `controller` prop:
  + `true` (enable)
  + `{dragRotate: false}` (enable with options)
  + `{type: MyMapController, dragRotate: false}` (custom controller with options)
- Update docs
