### PR TITLE
ScreenGridLayer: 64-bit support for maxCount and WebGL1 fallback for UBO

### DIFF
--- a/modules/core/src/experimental/utils/gpu-grid-aggregator.js
+++ b/modules/core/src/experimental/utils/gpu-grid-aggregator.js
@@ -125,31 +125,6 @@ void main(void) {
 }
 `;
 
-const AGGREGATE_ALL_VS = `\
-#version 300 es
-
-in vec2 position;
-uniform vec2 gridSize;
-
-out vec2 vTextureCoord;
-void main(void) {
-  // Map each position to single pixel
-  vec2 pos = vec2(-1.0, -1.0);
-
-  // Move to pixel center, pixel-size in screen sapce (2/gridSize) * 0.5 => 1/gridSize
-  vec2 offset = 1.0 / gridSize;
-  pos = pos + offset;
-
-  gl_Position = vec4(pos, 0.0, 1.0);
-
-  float yIndex = floor(float(gl_InstanceID) / gridSize[0]);
-  float xIndex = float(gl_InstanceID) - (yIndex * gridSize[0]);
-
-  vTextureCoord = vec2(yIndex/gridSize[1], xIndex/gridSize[0]);
-  // vTextureCoord = vec2(0.5, 0.5);
-}
-`;
-
 const AGGREGATE_ALL_VS_FP64 = `\
 #version 300 es
 

--- a/modules/core/src/experimental/utils/gpu-grid-aggregator.js
+++ b/modules/core/src/experimental/utils/gpu-grid-aggregator.js
@@ -337,9 +337,9 @@ export default class GPUGridAggregator {
     const {gl, shaderCache} = this;
     return new Model(gl, {
       id: 'All-Aggregation-Model',
-      vs: fp64 ? AGGREGATE_ALL_VS_FP64 : AGGREGATE_ALL_VS,
+      vs: AGGREGATE_ALL_VS_FP64,
       fs: AGGREGATE_ALL_FS,
-      modules: fp64 ? ['fp64'] : [],
+      modules:['fp64'],
       shaderCache,
       vertexCount: 1,
       drawMode: GL.POINTS,

--- a/modules/core/src/experimental/utils/gpu-grid-aggregator.js
+++ b/modules/core/src/experimental/utils/gpu-grid-aggregator.js
@@ -479,7 +479,14 @@ export default class GPUGridAggregator {
     } else {
       maxCountBuffer = new Buffer(this.gl, {data: maxCountBufferData});
     }
-    return {countsBuffer, maxCountBuffer};
+    return {
+      countsBuffer,
+      maxCountBuffer,
+      // Return total aggregaton values to avoid buffer for WebGL1 cases
+      totalCount,
+      totalWeight,
+      maxWeight
+    };
   }
   /* eslint-enable max-statements */
 

--- a/modules/core/src/experimental/utils/gpu-grid-aggregator.js
+++ b/modules/core/src/experimental/utils/gpu-grid-aggregator.js
@@ -314,7 +314,7 @@ export default class GPUGridAggregator {
       id: 'All-Aggregation-Model',
       vs: AGGREGATE_ALL_VS_FP64,
       fs: AGGREGATE_ALL_FS,
-      modules:['fp64'],
+      modules: ['fp64'],
       shaderCache,
       vertexCount: 1,
       drawMode: GL.POINTS,
@@ -457,7 +457,7 @@ export default class GPUGridAggregator {
     return {
       countsBuffer,
       maxCountBuffer,
-      // Return total aggregaton values to avoid buffer for WebGL1 cases
+      // Return total aggregaton values to avoid UBO setup for WebGL1 cases
       totalCount,
       totalWeight,
       maxWeight

--- a/modules/layers/src/screen-grid-layer/screen-grid-layer-fragment-webgl1.glsl.js
+++ b/modules/layers/src/screen-grid-layer/screen-grid-layer-fragment-webgl1.glsl.js
@@ -1,0 +1,34 @@
+// Copyright (c) 2015 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+/* fragment shader for the grid-layer */
+export default `\
+#define SHADER_NAME screen-grid-layer-fragment-shader-webgl1
+
+precision highp float;
+
+varying vec4 vColor;
+
+void main(void) {
+  gl_FragColor = vColor;
+
+  gl_FragColor = picking_filterColor(gl_FragColor);
+}
+`;

--- a/modules/layers/src/screen-grid-layer/screen-grid-layer-vertex-webgl1.glsl.js
+++ b/modules/layers/src/screen-grid-layer/screen-grid-layer-vertex-webgl1.glsl.js
@@ -1,0 +1,79 @@
+// Copyright (c) 2015 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+export default `\
+#define SHADER_NAME screen-grid-layer-vertex-shader-webgl1
+#define RANGE_COUNT 6
+
+attribute vec3 vertices;
+attribute vec3 instancePositions;
+attribute vec4 instanceCounts;
+attribute vec3 instancePickingColors;
+
+uniform float opacity;
+uniform vec3 cellScale;
+uniform vec4 minColor;
+uniform vec4 maxColor;
+uniform float maxWeight;
+uniform vec4 colorRange[RANGE_COUNT];
+uniform vec2 colorDomain;
+uniform bool shouldUseMinMax;
+
+varying vec4 vColor;
+
+vec4 quantizeScale(vec2 domain, vec4 range[RANGE_COUNT], float value) {
+  vec4 outColor = vec4(0., 0., 0., 0.);
+  if (value >= domain.x && value <= domain.y) {
+    float domainRange = domain.y - domain.x;
+    if (domainRange <= 0.) {
+      outColor = colorRange[0];
+    } else {
+      float rangeCount = float(RANGE_COUNT);
+      float rangeStep = domainRange / rangeCount;
+      float idx = floor((value - domain.x) / rangeStep);
+      idx = clamp(idx, 0., rangeCount - 1.);
+      int intIdx = int(idx);
+      outColor = colorRange[intIdx];
+    }
+  }
+  outColor = outColor / 255.;
+  return outColor;
+}
+
+void main(void) {
+  float weight = instanceCounts.g ;
+  float step = weight / maxWeight;
+  vec4 minMaxColor = mix(minColor, maxColor, step) / 255.;
+
+  vec2 domain = colorDomain;
+  float domainMaxValid = float(colorDomain.y != 0.);
+  domain.y = mix(maxWeight, colorDomain.y, domainMaxValid);
+  vec4 rangeColor = quantizeScale(domain, colorRange, weight);
+
+  float rangeMinMax = float(shouldUseMinMax);
+  vec4 color = mix(rangeColor, minMaxColor, rangeMinMax);
+  vColor = vec4(color.rgb, color.a * opacity);
+
+  // Set color to be rendered to picking fbo (also used to check for selection highlight).
+  picking_setPickingColor(instancePickingColors);
+
+  gl_Position = vec4(instancePositions + vertices * cellScale, 1.);
+}
+`;

--- a/modules/layers/src/screen-grid-layer/screen-grid-layer.js
+++ b/modules/layers/src/screen-grid-layer/screen-grid-layer.js
@@ -27,10 +27,12 @@ import {
 const {defaultColorRange} = experimental;
 
 import GL from 'luma.gl/constants';
-import {Model, Geometry, Buffer} from 'luma.gl';
+import {Model, Geometry, Buffer, isWebGL2} from 'luma.gl';
 
 import vs from './screen-grid-layer-vertex.glsl';
+import vs_WebGL1 from './screen-grid-layer-vertex-webgl1.glsl';
 import fs from './screen-grid-layer-fragment.glsl';
+import fs_WebGL1 from './screen-grid-layer-fragment-webgl1.glsl';
 import assert from 'assert';
 
 const DEFAULT_MINCOLOR = [0, 0, 0, 0];
@@ -54,7 +56,9 @@ const defaultProps = {
 
 export default class ScreenGridLayer extends Layer {
   getShaders() {
-    return {vs, fs, modules: ['picking']};
+    const shaders = isWebGL2(this.context.gl) ? {vs, fs} : {vs: vs_WebGL1, fs: fs_WebGL1};
+    shaders.modules = ['picking'];
+    return shaders;
   }
 
   initializeState() {
@@ -109,6 +113,7 @@ export default class ScreenGridLayer extends Layer {
   }
 
   draw({uniforms}) {
+    const {gl} = this.context;
     const {parameters = {}} = this.props;
     const minColor = this.props.minColor || DEFAULT_MINCOLOR;
     const maxColor = this.props.maxColor || DEFAULT_MAXCOLOR;
@@ -116,18 +121,23 @@ export default class ScreenGridLayer extends Layer {
     // If colorDomain not specified we use default domain [1, maxCount]
     // maxCount value will be deduced from aggregated buffer in the vertex shader.
     const colorDomain = this.props.colorDomain || [1, 0];
-    const {model, maxCountBuffer, cellScale, shouldUseMinMax, colorRange} = this.state;
-    uniforms = Object.assign({}, uniforms, {
+    const {model, maxCountBuffer, cellScale, shouldUseMinMax, colorRange, maxWeight} = this.state;
+    const layerUniforms = {
       minColor,
       maxColor,
       cellScale,
       colorRange,
       colorDomain,
       shouldUseMinMax
-    });
+    };
 
-    // TODO: remove index specification (https://github.com/uber/luma.gl/pull/473)
-    maxCountBuffer.bind({index: AGGREGATION_DATA_UBO_INDEX});
+    if (isWebGL2(gl)) {
+      // TODO: remove index specification (https://github.com/uber/luma.gl/pull/473)
+      maxCountBuffer.bind({target: GL.UNIFORM_BUFFER, index: AGGREGATION_DATA_UBO_INDEX});
+    } else {
+      layerUniforms.maxWeight =  maxWeight;
+    }
+    uniforms = Object.assign(layerUniforms, uniforms);
     model.draw({
       uniforms,
       parameters: Object.assign(
@@ -138,7 +148,9 @@ export default class ScreenGridLayer extends Layer {
         parameters
       )
     });
-    maxCountBuffer.unbind({index: AGGREGATION_DATA_UBO_INDEX});
+    if (isWebGL2(gl)) {
+      maxCountBuffer.unbind({target: GL.UNIFORM_BUFFER, index: AGGREGATION_DATA_UBO_INDEX});
+    }
   }
 
   calculateInstancePositions(attribute, {numInstances}) {
@@ -224,7 +236,6 @@ export default class ScreenGridLayer extends Layer {
   // Creates and returns a Uniform Buffer object to hold maxCount value.
   _getMaxCountBuffer(gl) {
     return new Buffer(gl, {
-      target: GL.UNIFORM_BUFFER,
       bytes: 4 * 4, // Four floats
       size: 4,
       index: AGGREGATION_DATA_UBO_INDEX
@@ -250,6 +261,10 @@ export default class ScreenGridLayer extends Layer {
   // Set a binding point for the aggregation uniform block index
   _setupUniformBuffer() {
     const gl = this.context.gl;
+    // For WebGL1, uniform buffer is not used.
+    if (!isWebGL2(gl)) {
+      return;
+    }
     const programHandle = this.state.model.program.handle;
 
     // TODO: Replace with luma.gl api when ready.
@@ -282,7 +297,7 @@ export default class ScreenGridLayer extends Layer {
     const {positions, weights, maxCountBuffer, countsBuffer} = this.state;
 
     const projectPoints = this.context.viewport instanceof WebMercatorViewport;
-    this.state.gpuGridAggregator.run({
+    const results = this.state.gpuGridAggregator.run({
       positions,
       weights,
       cellSize: [cellSizePixels, cellSizePixels],
@@ -294,8 +309,11 @@ export default class ScreenGridLayer extends Layer {
       projectPoints
     });
 
-    // Aggregation changed, enforce reading buffer data for picking.
-    this.setState({aggregationData: null});
+    const {maxWeight = 0} = results;
+    this.setState({
+      aggregationData: null, // Aggregation changed, enforce reading buffer data for picking.
+      maxWeight // uniform to use under WebGL1
+    });
 
     attributeManager.invalidate('instanceCounts');
   }

--- a/modules/layers/src/screen-grid-layer/screen-grid-layer.js
+++ b/modules/layers/src/screen-grid-layer/screen-grid-layer.js
@@ -134,7 +134,7 @@ export default class ScreenGridLayer extends Layer {
     if (isWebGL2(gl)) {
       maxCountBuffer.bind({target: GL.UNIFORM_BUFFER});
     } else {
-      layerUniforms.maxWeight =  maxWeight;
+      layerUniforms.maxWeight = maxWeight;
     }
     uniforms = Object.assign(layerUniforms, uniforms);
     model.draw({

--- a/modules/layers/src/screen-grid-layer/screen-grid-layer.js
+++ b/modules/layers/src/screen-grid-layer/screen-grid-layer.js
@@ -132,8 +132,7 @@ export default class ScreenGridLayer extends Layer {
     };
 
     if (isWebGL2(gl)) {
-      // TODO: remove index specification (https://github.com/uber/luma.gl/pull/473)
-      maxCountBuffer.bind({target: GL.UNIFORM_BUFFER, index: AGGREGATION_DATA_UBO_INDEX});
+      maxCountBuffer.bind({target: GL.UNIFORM_BUFFER});
     } else {
       layerUniforms.maxWeight =  maxWeight;
     }
@@ -149,7 +148,7 @@ export default class ScreenGridLayer extends Layer {
       )
     });
     if (isWebGL2(gl)) {
-      maxCountBuffer.unbind({target: GL.UNIFORM_BUFFER, index: AGGREGATION_DATA_UBO_INDEX});
+      maxCountBuffer.unbind();
     }
   }
 

--- a/test/data/grid-aggregation-data.js
+++ b/test/data/grid-aggregation-data.js
@@ -140,11 +140,10 @@ const viewport2 = new WebMercatorViewport({
   height: 500
 });
 
-const positions2 = dataSamples.points
-  .reduce((acc, point) => {
-    acc.push(...point.COORDINATES);
-    return acc;
-  }, []);
+const positions2 = dataSamples.points.reduce((acc, point) => {
+  acc.push(...point.COORDINATES);
+  return acc;
+}, []);
 
 const positions64xyLow2 = positions2.map(pos => fp64LowPart(pos));
 const weights2 = dataSamples.points.map(_ => 1.0);

--- a/test/data/grid-aggregation-data.js
+++ b/test/data/grid-aggregation-data.js
@@ -1,4 +1,5 @@
 import {WebMercatorViewport} from 'deck.gl';
+import * as dataSamples from '../../examples/layer-browser/src/data-samples';
 import {fp64} from 'luma.gl';
 
 const {fp64LowPart} = fp64;
@@ -129,6 +130,37 @@ positions = [
 ];
 positions64xyLow = positions.map(pos => fp64LowPart(pos));
 
+const viewport2 = new WebMercatorViewport({
+  latitude: 37.751537058389985,
+  longitude: -122.42694203247012,
+  zoom: 11.5,
+  pitch: 0,
+  bearing: 0,
+  width: 500,
+  height: 500
+});
+
+const positions2 = dataSamples.points
+  .reduce((acc, point) => {
+    acc.push(...point.COORDINATES);
+    return acc;
+  }, []);
+
+const positions64xyLow2 = positions2.map(pos => fp64LowPart(pos));
+const weights2 = dataSamples.points.map(_ => 1.0);
+const fixture2 = {
+  positions: positions2,
+  positions64xyLow: positions64xyLow2,
+  weights: weights2,
+  windowSize: [800, 450],
+  cellSize: [40, 40],
+  gridSize: [20, 12],
+  changeFlags: {
+    dataChanged: true
+  },
+  viewport: viewport2
+};
+
 const fixtureWorldSpace = {
   positions,
   positions64xyLow,
@@ -140,6 +172,7 @@ const fixtureWorldSpace = {
 export const GridAggregationData = {
   viewport,
   fixture,
+  fixture2,
   generateRandomGridPoints,
   fixtureWorldSpace
 };

--- a/test/modules/core-layers/core-layers.spec.js
+++ b/test/modules/core-layers/core-layers.spec.js
@@ -26,7 +26,7 @@ import {
   IconLayer,
   ArcLayer,
   LineLayer,
-   ScreenGridLayer,
+  ScreenGridLayer,
   PointCloudLayer,
   PathLayer
   // TextLayer

--- a/test/modules/core-layers/core-layers.spec.js
+++ b/test/modules/core-layers/core-layers.spec.js
@@ -26,7 +26,7 @@ import {
   IconLayer,
   ArcLayer,
   LineLayer,
-  //  ScreenGridLayer,
+   ScreenGridLayer,
   PointCloudLayer,
   PathLayer
   // TextLayer
@@ -36,8 +36,6 @@ import * as FIXTURES from 'deck.gl/test/data';
 
 const getPointPosition = d => d.COORDINATES;
 
-/*
-TODO: https://github.com/uber/deck.gl/issues/1987
 test('ScreenGridLayer#constructor', t => {
   const data = FIXTURES.points;
 
@@ -77,7 +75,6 @@ test('ScreenGridLayer#constructor', t => {
 
   t.end();
 });
-*/
 
 test('ScatterplotLayer#constructor', t => {
   const data = FIXTURES.points;

--- a/test/render/test-cases.js
+++ b/test/render/test-cases.js
@@ -655,27 +655,26 @@ export const TEST_CASES = [
     ],
     referenceImageUrl: './test/render/golden-images/screengrid-lnglat.png'
   },
-  // TODO: https://github.com/uber/deck.gl/issues/1987
-  // {
-  //   name: 'screengrid-lnglat-colorRange',
-  //   viewState: {
-  //     latitude: 37.751537058389985,
-  //     longitude: -122.42694203247012,
-  //     zoom: 11.5,
-  //     pitch: 0,
-  //     bearing: 0
-  //   },
-  //   layers: [
-  //     new ScreenGridLayer({
-  //       id: 'screengrid-lnglat-colorRange',
-  //       data: dataSamples.points,
-  //       getPosition: d => d.COORDINATES,
-  //       cellSizePixels: 40,
-  //       pickable: false
-  //     })
-  //   ],
-  //   referenceImageUrl: './test/render/golden-images/screengrid-lnglat-colorRange.png'
-  // },
+  {
+    name: 'screengrid-lnglat-colorRange',
+    viewState: {
+      latitude: 37.751537058389985,
+      longitude: -122.42694203247012,
+      zoom: 11.5,
+      pitch: 0,
+      bearing: 0
+    },
+    layers: [
+      new ScreenGridLayer({
+        id: 'screengrid-lnglat-colorRange',
+        data: dataSamples.points,
+        getPosition: d => d.COORDINATES,
+        cellSizePixels: 40,
+        pickable: false
+      })
+    ],
+    referenceImageUrl: './test/render/golden-images/screengrid-lnglat-colorRange.png'
+  },
   {
     name: 'hexagoncell-lnglat',
     viewState: {


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #1987 
<!-- For other PRs without open issue -->
#### Background
- Enable 64-bit operations when aggregating to a single cell, for `maxCount` and `maxWeight` by default. Should not impact performance as these are performed per cell and not per data item.
- UBO not supported in WebGL1, add fallback path and set uniform directly when using WebGL1.
- Enable tests cases that were previously disabled.

<!-- For all the PRs -->
#### Change List
- ScreenGridLayer: 64-bit support for maxCount and WebGL1 fallback for UBO
