### PR TITLE
rerender sublayers when state change

### DIFF
--- a/modules/core/src/lib/composite-layer.js
+++ b/modules/core/src/lib/composite-layer.js
@@ -38,6 +38,12 @@ export default class CompositeLayer extends Layer {
   // Provide empty definition to disable check for missing definition
   initializeState() {}
 
+  // Updates selected state members and marks the composite layer to need rerender
+  setState(updateObject) {
+    super.setState(updateObject);
+    this.setLayerNeedsUpdate();
+  }
+
   // called to augment the info object that is bubbled up from a sublayer
   // override Layer.getPickingInfo() because decoding / setting uniform do
   // not apply to a composite layer.

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -85,6 +85,7 @@ export default class Layer extends Component {
 
   // Updates selected state members and marks the object for redraw
   setState(updateObject) {
+    this.setChangeFlags({stateChanged: true});
     Object.assign(this.state, updateObject);
     this.setNeedsRedraw();
   }
@@ -597,13 +598,20 @@ export default class Layer extends Component {
         () => `viewportChanged: ${flags.viewportChanged} in ${this.id}`
       )();
     }
+    if (flags.stateChanged && !changeFlags.stateChanged) {
+      changeFlags.stateChanged = flags.stateChanged;
+      log.log(LOG_PRIORITY_UPDATE + 1, () => `stateChanged: ${flags.stateChanged} in ${this.id}`)();
+    }
 
     // Update composite flags
     const propsOrDataChanged =
       flags.dataChanged || flags.updateTriggersChanged || flags.propsChanged;
     changeFlags.propsOrDataChanged = changeFlags.propsOrDataChanged || propsOrDataChanged;
     changeFlags.somethingChanged =
-      changeFlags.somethingChanged || propsOrDataChanged || flags.viewportChanged;
+      changeFlags.somethingChanged ||
+      propsOrDataChanged ||
+      flags.viewportChanged ||
+      flags.stateChanged;
   }
   /* eslint-enable complexity */
 
@@ -615,6 +623,7 @@ export default class Layer extends Component {
       propsChanged: false,
       updateTriggersChanged: false,
       viewportChanged: false,
+      stateChanged: false,
 
       // Derived changeFlags
       propsOrDataChanged: false,


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/1993

#### Change List
- add `stateChanged` to change flags
- composite layer marks as needs update when `setState` is called
- default layer behavior is not affected
