### PR TITLE
Fix: Brushing example

### DIFF
--- a/examples/website/brushing/arc-brushing-layer/arc-brushing-layer-vertex.glsl.js
+++ b/examples/website/brushing/arc-brushing-layer/arc-brushing-layer-vertex.glsl.js
@@ -29,15 +29,15 @@ attribute vec4 instanceSourceColors;
 attribute vec4 instanceTargetColors;
 attribute vec4 instancePositions;
 attribute vec3 instancePickingColors;
+attribute float instanceWidths;
 
 uniform float numSegments;
-uniform float strokeWidth;
 uniform float opacity;
 
 // uniform for brushing
 uniform vec2 mousePos;
 uniform float brushRadius;
-uniform float enableBrushing;
+uniform bool enableBrushing;
 uniform float brushSource;
 uniform float brushTarget;
 
@@ -74,7 +74,7 @@ float paraboloid(vec2 source, vec2 target, float ratio) {
   return (dSourceCenter + dXCenter) * (dSourceCenter - dXCenter);
 }
 
-// offset vector by strokeWidth pixels
+// offset vector by instanceWidths pixels
 // offset_direction is -1 (left) or 1 (right)
 vec2 getExtrusionOffset(vec2 line_clipspace, float offset_direction, float strokeWidth) {
   // normalized direction of the line
@@ -109,7 +109,7 @@ void main(void) {
   float isSourceInBrush = isPointInRange(instancePositions.xy, mousePos, brushRadius, brushSource);
   float isTargetInBrush = isPointInRange(instancePositions.zw, mousePos, brushRadius, brushTarget);
 
-  float isInBrush = float(enableBrushing <= 0. ||
+  float isInBrush = float(enableBrushing &&
   (brushSource * isSourceInBrush > 0. || brushTarget * isTargetInBrush > 0.));
 
   float segmentIndex = positions.x;
@@ -125,8 +125,8 @@ void main(void) {
   vec4 curr = project_to_clipspace(vec4(currPos, 1.0));
   vec4 next = project_to_clipspace(vec4(nextPos, 1.0));
 
-  // mix strokeWidth with brush, if not in brush, return 0
-  float finalWidth = mix(0.0, strokeWidth, isInBrush);
+  // mix instanceWidths with brush, if not in brush, return 0
+  float finalWidth = mix(0.0, instanceWidths, isInBrush);
 
   // extrude
   vec2 offset = getExtrusionOffset((next.xy - curr.xy) * indexDir, positions.y, finalWidth);

--- a/examples/website/brushing/arc-brushing-layer/arc-brushing-layer.js
+++ b/examples/website/brushing/arc-brushing-layer/arc-brushing-layer.js
@@ -45,20 +45,19 @@ export default class ArcBrushingLayer extends ArcLayer {
     });
   }
 
-  draw({uniforms}) {
+  draw(opts) {
     // add uniforms
-    super.draw({
-      uniforms: {
-        ...uniforms,
-        brushSource: this.props.brushSource,
-        brushTarget: this.props.brushTarget,
-        brushRadius: this.props.brushRadius,
-        mousePos: this.props.mousePosition
-          ? new Float32Array(this.unproject(this.props.mousePosition))
-          : defaultProps.mousePosition,
-        enableBrushing: this.props.enableBrushing ? 1 : 0
-      }
+    const uniforms = Object.assign({}, opts.uniforms, {
+      brushSource: this.props.brushSource,
+      brushTarget: this.props.brushTarget,
+      brushRadius: this.props.brushRadius,
+      mousePos: this.props.mousePosition
+        ? new Float32Array(this.unproject(this.props.mousePosition))
+        : defaultProps.mousePosition,
+      enableBrushing: this.props.enableBrushing
     });
+    const newOpts = Object.assign({}, opts, {uniforms});
+    super.draw(newOpts);
   }
 }
 

--- a/examples/website/brushing/scatterplot-brushing-layer/scatterplot-brushing-layer-vertex.glsl.js
+++ b/examples/website/brushing/scatterplot-brushing-layer/scatterplot-brushing-layer-vertex.glsl.js
@@ -40,7 +40,7 @@ uniform float strokeWidth;
 // uniform for brushing
 uniform vec2 mousePos;
 uniform float brushRadius;
-uniform float enableBrushing;
+uniform bool enableBrushing;
 uniform float brushTarget;
 
 varying vec4 vColor;
@@ -63,9 +63,9 @@ float distanceBetweenLatLng(vec2 source, vec2 target) {
 }
 
 // range is km
-float isPointInRange(vec2 ptLatLng, vec2 mouseLatLng, float range, float enabled) {
+float isPointInRange(vec2 ptLatLng, vec2 mouseLatLng, float range, bool enabled) {
 
-  return float(enabled <= 0. || distanceBetweenLatLng(ptLatLng, mouseLatLng) <= range);
+  return float(enabled && distanceBetweenLatLng(ptLatLng, mouseLatLng) <= range);
 }
 
 void main(void) {
@@ -75,7 +75,7 @@ void main(void) {
 
   // for use with arc layer, if brushTarget is truthy
   // calculate whether instanceTargetPositions is in range
-  float isTargetInBrush = isPointInRange(instanceTargetPositions.xy, mousePos, brushRadius, 1.);
+  float isTargetInBrush = isPointInRange(instanceTargetPositions.xy, mousePos, brushRadius, true);
 
   // if brushTarget is falsy, when pt is in brush return true
   // if brushTarget is truthy and target is in brush return true

--- a/examples/website/brushing/scatterplot-brushing-layer/scatterplot-brushing-layer.js
+++ b/examples/website/brushing/scatterplot-brushing-layer/scatterplot-brushing-layer.js
@@ -58,19 +58,18 @@ export default class ScatterplotBrushingLayer extends ScatterplotLayer {
     });
   }
 
-  draw({uniforms}) {
+  draw(opts) {
     // add uniforms
-    super.draw({
-      uniforms: {
-        ...uniforms,
-        brushTarget: this.props.brushTarget,
-        brushRadius: this.props.brushRadius,
-        mousePos: this.props.mousePosition
-          ? new Float32Array(this.unproject(this.props.mousePosition))
-          : defaultProps.mousePosition,
-        enableBrushing: Boolean(this.props.enableBrushing)
-      }
+    const uniforms = Object.assign({}, opts.uniforms, {
+      brushTarget: this.props.brushTarget,
+      brushRadius: this.props.brushRadius,
+      mousePos: this.props.mousePosition
+        ? new Float32Array(this.unproject(this.props.mousePosition))
+        : defaultProps.mousePosition,
+      enableBrushing: Boolean(this.props.enableBrushing)
     });
+    const newOpts = Object.assign({}, opts, {uniforms});
+    super.draw(newOpts);
   }
 
   // calculate instanceSourcePositions


### PR DESCRIPTION
For #1873
<!-- For other PRs without open issue -->
#### Background
FIX: Sublayers `draw` method.
FIX: Arc-brush-layer's `instanceWidths` attribute.
FIX: Usage and setting of `enableBrushing` uniform.

<!-- For all the PRs -->
#### Change List
-  Brushing: Fix draw method, arc instanceWidth attribute and enableBrushing uniform.
