### PR TITLE
Fix attribute transition manager crash when numInstances === 0

### DIFF
--- a/modules/core/src/lib/attribute-transition-manager.js
+++ b/modules/core/src/lib/attribute-transition-manager.js
@@ -236,6 +236,7 @@ export default class AttributeTransitionManager {
       };
     }
     const fromState = transition.buffer || toState;
+    // Rendering to an empty buffer causes WebGL error
     const toLength = (this.numInstances || 1) * size;
     const fromLength = (fromState instanceof Buffer && fromState.getElementCount()) || toLength;
 

--- a/modules/core/src/lib/attribute-transition-manager.js
+++ b/modules/core/src/lib/attribute-transition-manager.js
@@ -236,7 +236,7 @@ export default class AttributeTransitionManager {
       };
     }
     const fromState = transition.buffer || toState;
-    const toLength = this.numInstances * size;
+    const toLength = (this.numInstances || 1) * size;
     const fromLength = (fromState instanceof Buffer && fromState.getElementCount()) || toLength;
 
     // Alternate between two buffers when new transitions start.

--- a/modules/core/src/lib/attribute-transition-manager.js
+++ b/modules/core/src/lib/attribute-transition-manager.js
@@ -109,7 +109,7 @@ export default class AttributeTransitionManager {
   // Called every render cycle, run transform feedback
   // Returns `true` if anything changes
   setCurrentTime(currentTime) {
-    if (!this.transform) {
+    if (!this.transform || this.numInstances === 0) {
       return false;
     }
 
@@ -236,8 +236,7 @@ export default class AttributeTransitionManager {
       };
     }
     const fromState = transition.buffer || toState;
-    // Rendering to an empty buffer causes WebGL error
-    const toLength = (this.numInstances || 1) * size;
+    const toLength = this.numInstances * size;
     const fromLength = (fromState instanceof Buffer && fromState.getElementCount()) || toLength;
 
     // Alternate between two buffers when new transitions start.


### PR DESCRIPTION
Rendering TransformFeedback into an empty buffer causes WebGL to crash.

#### Change List
- Make sure target buffer size is never zero
