### PR TITLE
Delete controller when view is removed

### DIFF
--- a/modules/core/src/controllers/controller.js
+++ b/modules/core/src/controllers/controller.js
@@ -69,7 +69,14 @@ export default class Controller {
     this.setProps(options);
   }
 
-  finalize() {}
+  finalize() {
+    for (const eventName in this._events) {
+      if (this._events[eventName]) {
+        this.eventManager.off(eventName, this.handleEvent);
+      }
+    }
+    this.transitionManager.finalize();
+  }
 
   /**
    * Callback for events

--- a/modules/core/src/controllers/transition-manager.js
+++ b/modules/core/src/controllers/transition-manager.js
@@ -36,6 +36,10 @@ export default class TransitionManager {
     this._onTransitionUpdate = this._onTransitionUpdate.bind(this);
   }
 
+  finalize() {
+    cancelAnimationFrame(this.animation);
+  }
+
   // Returns current transitioned viewport.
   getViewportInTransition() {
     return this.propsInTransition;


### PR DESCRIPTION
#### Change List
- Fix: first `controller.processViewportChange` throws error for missing width/height
- Delete controller when view is removed
- Move default view state to each view
- Properly finalize controller and transition manager
