### PR TITLE
React: JSX view bug fixes

### DIFF
--- a/modules/react/src/deckgl.js
+++ b/modules/react/src/deckgl.js
@@ -158,7 +158,7 @@ export default class DeckGL extends React.PureComponent {
       if (child.props.viewportId) {
         log.removed('viewportId', '<View>')();
       }
-      if (child.props.viewportId) {
+      if (child.props.viewId) {
         log.removed('viewId', '<View>')();
       }
 

--- a/modules/react/src/utils/extract-jsx-layers.js
+++ b/modules/react/src/utils/extract-jsx-layers.js
@@ -40,7 +40,7 @@ export default function extractJSXLayers({children, layers, views}) {
       }
 
       // empty id => default view
-      if (inheritsFrom(ElementType, View) && reactElement.props.id) {
+      if (ElementType !== View && inheritsFrom(ElementType, View) && reactElement.props.id) {
         const view = new ElementType(reactElement.props);
         jsxViews[view.id] = view;
       }

--- a/test/modules/react/utils/extract-jsx-layers.spec.js
+++ b/test/modules/react/utils/extract-jsx-layers.spec.js
@@ -108,6 +108,19 @@ const TEST_CASES = [
   },
   {
     input: {
+      children: createElement(View, {id: 'not-map'}, noop),
+      views: mapView,
+      layers: []
+    },
+    output: {
+      children: [createElement(View, {id: 'not-map'}, noop)],
+      views: mapView,
+      layers: []
+    },
+    title: 'JSX views with views prop'
+  },
+  {
+    input: {
       children: reactLineLayer,
       views: null,
       layers: []


### PR DESCRIPTION
#### Background
DeckGL React syntax allows for auto showing/hiding UI of a view by wrapping children in a `<View id="...">` tag. The JSX multi-view syntax allows for adding a view by wrapping children in a e.g. `<MapView ...>` tag. The bug is that we currently extract all React children that is/inherits the `View` type to the views list, while the base View class should not be instantiated.

#### Change List
- Fix deprecation warning
- Do not extract view from JSX if type is base View class
