### PR TITLE
Make doubleTap and keyboard transitions exlusive to MapController

### DIFF
--- a/modules/core/src/controllers/controller.js
+++ b/modules/core/src/controllers/controller.js
@@ -18,19 +18,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import LinearInterpolator from '../transitions/linear-interpolator';
-import TransitionManager, {TRANSITION_EVENTS} from './transition-manager';
+import TransitionManager from './transition-manager';
 import assert from '../utils/assert';
 
 const NO_TRANSITION_PROPS = {
   transitionDuration: 0
-};
-
-const LINEAR_TRANSITION_PROPS = {
-  transitionDuration: 300,
-  transitionEasing: t => t,
-  transitionInterpolator: new LinearInterpolator(),
-  transitionInterruption: TRANSITION_EVENTS.BREAK
 };
 
 // EVENT HANDLING PARAMETERS
@@ -65,6 +57,7 @@ export default class Controller {
     this.invertPan = false;
 
     this.handleEvent = this.handleEvent.bind(this);
+    this._transitionProps = this._getTransitionProps();
 
     this.setProps(options);
   }
@@ -383,7 +376,7 @@ export default class Controller {
     const isZoomOut = this.isFunctionKeyPressed(event);
 
     const newControllerState = this.controllerState.zoom({pos, scale: isZoomOut ? 0.5 : 2});
-    return this.updateViewport(newControllerState, LINEAR_TRANSITION_PROPS);
+    return this.updateViewport(newControllerState, this._transitionProps);
   }
 
   /* eslint-disable complexity */
@@ -420,7 +413,12 @@ export default class Controller {
       default:
         return false;
     }
-    return this.updateViewport(newControllerState, LINEAR_TRANSITION_PROPS);
+    return this.updateViewport(newControllerState, this._transitionProps);
   }
   /* eslint-enable complexity */
+
+  _getTransitionProps() {
+    // Transitions on double-tap and key-down are only supported by MapController
+    return NO_TRANSITION_PROPS;
+  }
 }

--- a/modules/core/src/controllers/controller.js
+++ b/modules/core/src/controllers/controller.js
@@ -57,7 +57,6 @@ export default class Controller {
     this.invertPan = false;
 
     this.handleEvent = this.handleEvent.bind(this);
-    this._transitionProps = this._getTransitionProps();
 
     this.setProps(options);
   }
@@ -376,7 +375,7 @@ export default class Controller {
     const isZoomOut = this.isFunctionKeyPressed(event);
 
     const newControllerState = this.controllerState.zoom({pos, scale: isZoomOut ? 0.5 : 2});
-    return this.updateViewport(newControllerState, this._transitionProps);
+    return this.updateViewport(newControllerState, this._getTransitionProps());
   }
 
   /* eslint-disable complexity */
@@ -413,7 +412,7 @@ export default class Controller {
       default:
         return false;
     }
-    return this.updateViewport(newControllerState, this._transitionProps);
+    return this.updateViewport(newControllerState, this._getTransitionProps());
   }
   /* eslint-enable complexity */
 

--- a/modules/core/src/controllers/map-controller.js
+++ b/modules/core/src/controllers/map-controller.js
@@ -3,6 +3,17 @@ import Controller from './controller';
 import ViewState from './view-state';
 import WebMercatorViewport, {normalizeViewportProps} from 'viewport-mercator-project';
 import assert from '../utils/assert';
+import LinearInterpolator from '../transitions/linear-interpolator';
+import {TRANSITION_EVENTS} from './transition-manager';
+
+
+const LINEAR_TRANSITION_PROPS = {
+  transitionDuration: 300,
+  transitionEasing: t => t,
+  transitionInterpolator: new LinearInterpolator(),
+  transitionInterruption: TRANSITION_EVENTS.BREAK
+};
+
 
 // MAPBOX LIMITS
 export const MAPBOX_LIMITS = {
@@ -404,6 +415,11 @@ export default class MapController extends Controller {
   constructor(props) {
     super(MapState, props);
     this.invertPan = true;
+  }
+
+  _getTransitionProps() {
+    // Transitions on double-tap and key-down are only supported by MapController
+    return LINEAR_TRANSITION_PROPS;
   }
 }
 

--- a/modules/core/src/controllers/map-controller.js
+++ b/modules/core/src/controllers/map-controller.js
@@ -6,14 +6,12 @@ import assert from '../utils/assert';
 import LinearInterpolator from '../transitions/linear-interpolator';
 import {TRANSITION_EVENTS} from './transition-manager';
 
-
 const LINEAR_TRANSITION_PROPS = {
   transitionDuration: 300,
   transitionEasing: t => t,
   transitionInterpolator: new LinearInterpolator(),
   transitionInterruption: TRANSITION_EVENTS.BREAK
 };
-
 
 // MAPBOX LIMITS
 export const MAPBOX_LIMITS = {


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #2001 

**NOTE**: I will port the changes to 6.0 and master.
<!-- For other PRs without open issue -->
#### Background
Make doubleTap and keyboard transitions exlusive to MapController
<!-- For all the PRs -->
#### Change List
- Make doubleTap and keyboard transitions exlusive to MapController
