### PR TITLE
Fix getCursor bugs

### DIFF
--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -31,11 +31,12 @@ import {Stats} from 'probe.gl';
 import {EventManager} from 'mjolnir.js';
 
 import assert from '../utils/assert';
+import VENDOR_PREFIX from '../utils/css-vendor-prefix';
 /* global document */
 
 function noop() {}
 
-const PREFIX = '-webkit-';
+const PREFIX = VENDOR_PREFIX === '-webkit-' ? VENDOR_PREFIX : '';
 
 const CURSOR = {
   GRABBING: `${PREFIX}grabbing`,
@@ -411,10 +412,11 @@ export default class Deck {
   _onInteractiveStateChange({isDragging = false}) {
     if (isDragging !== this.interactiveState.isDragging) {
       this.interactiveState.isDragging = isDragging;
-      if (this.props.getCursor) {
-        this.canvas.style.cursor = this.props.getCursor(this.interactiveState);
-      }
     }
+  }
+
+  _updateCursor() {
+    this.canvas.style.cursor = this.props.getCursor(this.interactiveState);
   }
 
   _onRendererInitialized({gl, canvas}) {
@@ -465,6 +467,8 @@ export default class Deck {
     }
 
     this._updateCanvasSize();
+
+    this._updateCursor();
 
     // Update layers if needed (e.g. some async prop has loaded)
     this.layerManager.updateLayers();

--- a/modules/core/src/utils/css-vendor-prefix.js
+++ b/modules/core/src/utils/css-vendor-prefix.js
@@ -1,0 +1,36 @@
+// Copyright (c) 2015 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+/* global document */
+let venderPrefix = '';
+
+// Get CSS vendor prefix
+if (typeof document !== 'undefined') {
+  const styleObj = document.body.style;
+  const prefix = /^(webkit|moz|ms|o)(?=[A-Z])/;
+  for (const key in styleObj) {
+    if (prefix.test(key)) {
+      venderPrefix = `-${key.match(prefix)[0]}-`;
+      break;
+    }
+  }
+}
+
+export default venderPrefix;

--- a/test/modules/core/utils/css-vendor-prefix.spec.js
+++ b/test/modules/core/utils/css-vendor-prefix.spec.js
@@ -1,0 +1,12 @@
+import test from 'tape-catch';
+import VENDOR_PREFIX from '@deck.gl/core/utils/css-vendor-prefix';
+import {isBrowser} from '@deck.gl/core/utils/globals';
+
+test('utils#CSS vendor prefix', t => {
+  if (isBrowser) {
+    t.is(VENDOR_PREFIX, '-webkit-', 'returns Chrome CSS prefix');
+  } else {
+    t.is(VENDOR_PREFIX, '', 'does not break in non-browser');
+  }
+  t.end();
+});

--- a/test/modules/core/utils/index.js
+++ b/test/modules/core/utils/index.js
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 
 import './color.spec';
+import './css-vendor-prefix.spec';
 import './deep-equal.spec';
 import './get.spec';
 import './flatten.spec';


### PR DESCRIPTION
#### Background
In React, `props.getCursor` is not called when app state updates

#### Change List
- Update cursor in `renderFrame`
- fix cursor CSS for non-Chrome browsers
