### PR TITLE
No attribute manager for composite layers

### DIFF
--- a/modules/core/src/lib/attribute-manager.js
+++ b/modules/core/src/lib/attribute-manager.js
@@ -362,9 +362,9 @@ export default class AttributeManager {
         }
       });
     } else {
-      // let message = `invalidating non-existent trigger ${triggerName} for ${this.id}\n`;
-      // message += `Valid triggers: ${Object.keys(attributes).join(', ')}`;
-      // log.warn(message, invalidatedAttributes)();
+      let message = `invalidating non-existent trigger ${triggerName} for ${this.id}\n`;
+      message += `Valid triggers: ${Object.keys(attributes).join(', ')}`;
+      log.warn(message, invalidatedAttributes)();
     }
     return invalidatedAttributes;
   }

--- a/modules/core/src/lib/composite-layer.js
+++ b/modules/core/src/lib/composite-layer.js
@@ -101,6 +101,10 @@ export default class CompositeLayer extends Layer {
     return newProps;
   }
 
+  _getAttributeManager() {
+    return null;
+  }
+
   // Called by layer manager to render subLayers
   _renderLayers() {
     let {subLayers} = this.internalState;

--- a/modules/layers/src/grid-cell-layer/grid-cell-layer.js
+++ b/modules/layers/src/grid-cell-layer/grid-cell-layer.js
@@ -98,7 +98,7 @@ export default class GridCellLayer extends Layer {
         this.state.model.delete();
       }
       this.setState({model: this._getModel(gl)});
-      this.state.attributeManager.invalidateAll();
+      this.getAttributeManager().invalidateAll();
     }
   }
 

--- a/modules/layers/src/hexagon-cell-layer/hexagon-cell-layer.js
+++ b/modules/layers/src/hexagon-cell-layer/hexagon-cell-layer.js
@@ -119,7 +119,7 @@ export default class HexagonCellLayer extends Layer {
         this.state.model.delete();
       }
       this.setState({model: this._getModel(gl)});
-      this.state.attributeManager.invalidateAll();
+      this.getAttributeManager().invalidateAll();
     }
 
     if (

--- a/modules/layers/src/icon-layer/icon-layer.js
+++ b/modules/layers/src/icon-layer/icon-layer.js
@@ -156,7 +156,7 @@ export default class IconLayer extends Layer {
         this.state.model.delete();
       }
       this.setState({model: this._getModel(gl)});
-      this.state.attributeManager.invalidateAll();
+      this.getAttributeManager().invalidateAll();
     }
   }
 

--- a/modules/layers/src/line-layer/line-layer.js
+++ b/modules/layers/src/line-layer/line-layer.js
@@ -100,7 +100,7 @@ export default class LineLayer extends Layer {
         this.state.model.delete();
       }
       this.setState({model: this._getModel(gl)});
-      this.state.attributeManager.invalidateAll();
+      this.getAttributeManager().invalidateAll();
     }
   }
 

--- a/modules/layers/src/point-cloud-layer/point-cloud-layer.js
+++ b/modules/layers/src/point-cloud-layer/point-cloud-layer.js
@@ -47,7 +47,7 @@ export default class PointCloudLayer extends Layer {
 
   initializeState() {
     /* eslint-disable max-len */
-    this.state.attributeManager.addInstanced({
+    this.getAttributeManager().addInstanced({
       instancePositions: {
         size: 3,
         transition: true,
@@ -83,7 +83,7 @@ export default class PointCloudLayer extends Layer {
         this.state.model.delete();
       }
       this.setState({model: this._getModel(gl)});
-      this.state.attributeManager.invalidateAll();
+      this.getAttributeManager().invalidateAll();
     }
   }
 

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer.js
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer.js
@@ -48,7 +48,7 @@ export default class ScatterplotLayer extends Layer {
   }
 
   initializeState() {
-    this.state.attributeManager.addInstanced({
+    this.getAttributeManager().addInstanced({
       instancePositions: {
         size: 3,
         transition: true,
@@ -83,7 +83,7 @@ export default class ScatterplotLayer extends Layer {
         this.state.model.delete();
       }
       this.setState({model: this._getModel(gl)});
-      this.state.attributeManager.invalidateAll();
+      this.getAttributeManager().invalidateAll();
     }
   }
 


### PR DESCRIPTION
Fix https://github.com/uber/deck.gl/pull/2036 properly:

Do not create attribute manager for composite layers. This avoids generating warnings that only apply to primitive layers, and improves performance by skipping attribute update checks and picking color generation.

#### Change List
- Do not create attribute manager for composite layers
