### PR TITLE
fix pointer leave callback

### DIFF
--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -521,13 +521,14 @@ export default class Deck {
   }
 
   _onPointerLeave(event) {
-    this.pickObject({
+    this.layerManager.pickObject({
       x: -1,
       y: -1,
       viewports: this.getViewports(),
-      radius: this.props.pickingRadius,
+      radius: 1,
       mode: 'hover'
     });
+    this.props.onLayerHover(null, [], event.srcEvent);
   }
 }
 


### PR DESCRIPTION
#### Background
`pointerLeave` event is not invoking `onHover`/`onLayerHover` callbacks

https://github.com/uber/deck.gl/issues/2027 may be related

#### Change List
- Fix pointer leave event handling
