### PR TITLE
Perf: skip draw call for composite layers

### DIFF
--- a/modules/core/src/lib/draw-layers.js
+++ b/modules/core/src/lib/draw-layers.js
@@ -190,7 +190,7 @@ function drawLayersInViewport(
   // render layers in normal colors
   layers.forEach((layer, layerIndex) => {
     // Check if we should draw layer
-    let shouldDrawLayer = layer.props.visible;
+    let shouldDrawLayer = !layer.isComposite && layer.props.visible;
     if (drawPickingColors) {
       shouldDrawLayer = shouldDrawLayer && layer.props.pickable;
     }
@@ -208,9 +208,7 @@ function drawLayersInViewport(
 
     // Draw the layer
     if (shouldDrawLayer) {
-      if (!layer.isComposite) {
-        renderStats.visibleCount++;
-      }
+      renderStats.visibleCount++;
 
       drawLayerInViewport({
         gl,


### PR DESCRIPTION
#### Background
Although composite layers do not render anything, `setUniforms` and `setParameters` are still called when they are "drawn".

This is technically a bug since it's stated otherwise in the [docs](https://github.com/uber/deck.gl/blob/master/docs/api-reference/composite-layer.md#draw):

> A composite layer does not render directly into the WebGL context. The draw method inherited from the base class is therefore never called.

#### Change List
- Do not call `drawLayer` on composite layers
