### PR TITLE
Deck: Add onLoad callback

### DIFF
--- a/docs/api-reference/deck.md
+++ b/docs/api-reference/deck.md
@@ -176,6 +176,10 @@ Callback Arguments:
 * `pickedInfos` - an array of info objects for all pickable layers that are affected.
 * `event` - the original [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) object
 
+##### `onLoad` (Function, optional)
+
+Callback, called once after gl context and Deck components (`ViewManager`, `LayerManager`, etc) are created. Can be used to trigger viewport transitions.
+
 
 ## Methods
 

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -76,6 +76,7 @@ function getPropTypes(PropTypes) {
     onAfterRender: PropTypes.func,
     onLayerClick: PropTypes.func,
     onLayerHover: PropTypes.func,
+    onLoad: PropTypes.func,
 
     // Debug settings
     debug: PropTypes.bool,
@@ -105,6 +106,7 @@ const defaultProps = {
   onAfterRender: noop,
   onLayerClick: null,
   onLayerHover: null,
+  onLoad: noop,
 
   getCursor,
 
@@ -456,6 +458,7 @@ export default class Deck {
     this.setProps(this.props);
 
     this._updateCanvasSize();
+    this.props.onLoad();
   }
 
   _onRenderFrame({gl}) {

--- a/test/apps/viewport-transitions/app.js
+++ b/test/apps/viewport-transitions/app.js
@@ -48,8 +48,7 @@ class Root extends Component {
     this.rotationStep = 0;
     this.state = {
       viewState: INITIAL_VIEW_STATE,
-      data: null,
-      loaded: false
+      data: null
     };
 
     this._onLoad = this._onLoad.bind(this);

--- a/test/apps/viewport-transitions/app.js
+++ b/test/apps/viewport-transitions/app.js
@@ -52,7 +52,7 @@ class Root extends Component {
       loaded: false
     };
 
-    this._onResize = this._onResize.bind(this);
+    this._onLoad = this._onLoad.bind(this);
     this._onViewStateChange = this._onViewStateChange.bind(this);
     this._rotateCamera = this._rotateCamera.bind(this);
 
@@ -64,12 +64,8 @@ class Root extends Component {
     });
   }
 
-  // TODO - this is a hack. Deck does not have an onLoad callback
-  _onResize() {
-    if (!this.state.loaded) {
-      this.setState({loaded: true});
-      this._rotateCamera();
-    }
+  _onLoad() {
+    this._rotateCamera();
   }
 
   _onViewStateChange({viewState}) {
@@ -118,8 +114,8 @@ class Root extends Component {
       <DeckGL
         layers={this._renderLayers()}
         viewState={viewState}
+        onLoad={this._onLoad}
         onViewStateChange={this._onViewStateChange}
-        onResize={this._onResize}
         controller={true}
       >
         <StaticMap mapStyle="mapbox://styles/mapbox/dark-v9" mapboxApiAccessToken={MAPBOX_TOKEN} />


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #2041 
**NOTE** : I will cherry-pick this to 6.0
<!-- For other PRs without open issue -->
#### Background
Add `onLoad` call back.
Replace the `onResize` hack in `viewport-tranisionts` example with `onLoad` callback.
<!-- For all the PRs -->
#### Change List
-  Deck: Add onLoad callback
