### PR TITLE
Multi-view picking perf: filter viewports by pointer position

### DIFF
--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -225,9 +225,8 @@ export default class Deck {
   }
 
   // Get a set of viewports for a given width and height
-  getViewports() {
-    const viewports = this.viewManager.getViewports();
-    return viewports;
+  getViewports(rect) {
+    return this.viewManager.getViewports(rect);
   }
 
   pickObject({x, y, radius = 0, layerIds = null}) {
@@ -237,7 +236,7 @@ export default class Deck {
       y,
       radius,
       layerIds,
-      viewports: this.getViewports(),
+      viewports: this.getViewports({x, y}),
       mode: 'query',
       depth: 1
     });
@@ -252,7 +251,7 @@ export default class Deck {
       y,
       radius,
       layerIds,
-      viewports: this.getViewports(),
+      viewports: this.getViewports({x, y}),
       mode: 'query',
       depth
     });
@@ -268,7 +267,7 @@ export default class Deck {
       width,
       height,
       layerIds,
-      viewports: this.getViewports()
+      viewports: this.getViewports({x, y, width, height})
     });
     this.stats.timeEnd('deck.pickObjects');
     return infos;
@@ -385,7 +384,7 @@ export default class Deck {
       x: pos.x,
       y: pos.y,
       radius,
-      viewports: this.getViewports(),
+      viewports: this.getViewports(pos),
       mode: options.mode,
       depth: 1
     });
@@ -524,7 +523,7 @@ export default class Deck {
     this.layerManager.pickObject({
       x: -1,
       y: -1,
-      viewports: this.getViewports(),
+      viewports: [],
       radius: 1,
       mode: 'hover'
     });

--- a/modules/core/src/lib/pick-layers.js
+++ b/modules/core/src/lib/pick-layers.js
@@ -331,7 +331,7 @@ function processPickInfo({
     x,
     y,
     pixel: [x, y],
-    lngLat: viewport.unproject([x, y]),
+    lngLat: viewport && viewport.unproject([x, y]),
     devicePixel: [deviceX, deviceY],
     pixelRatio
   };

--- a/modules/core/src/viewports/viewport.js
+++ b/modules/core/src/viewports/viewport.js
@@ -233,6 +233,15 @@ export default class Viewport {
     return matrices;
   }
 
+  containsPixel({x, y, width = 1, height = 1}) {
+    return (
+      x < this.x + this.width &&
+      this.x < x + width &&
+      y < this.y + this.height &&
+      this.y < y + height
+    );
+  }
+
   // EXPERIMENTAL METHODS
 
   getCameraPosition() {

--- a/modules/core/src/views/view-manager.js
+++ b/modules/core/src/views/view-manager.js
@@ -81,7 +81,11 @@ export default class ViewManager {
 
   // Get a set of viewports for a given width and height
   // TODO - Intention is for deck.gl to autodeduce width and height and drop the need for props
-  getViewports() {
+  // @param rect ([object]) - x, y, [width], [height] of the pixel/area that the viewports should cover
+  getViewports(rect) {
+    if (rect) {
+      return this._viewports.filter(viewport => viewport.containsPixel(rect));
+    }
     return this._viewports;
   }
 

--- a/modules/core/src/views/view-manager.js
+++ b/modules/core/src/views/view-manager.js
@@ -79,9 +79,13 @@ export default class ViewManager {
     this._needsRedraw = this._needsRedraw || reason;
   }
 
-  // Get a set of viewports for a given width and height
-  // TODO - Intention is for deck.gl to autodeduce width and height and drop the need for props
-  // @param rect ([object]) - x, y, [width], [height] of the pixel/area that the viewports should cover
+  /** Get a set of viewports for a given width and height
+   * TODO - Intention is for deck.gl to autodeduce width and height and drop the need for props
+   * @param rect (object, optional) - filter the viewports
+   *   + not provided - return all viewports
+   *   + {x, y} - only return viewports that contain this pixel
+   *   + {x, y, width, height} - only return viewports that overlap with this rectangle
+   */
   getViewports(rect) {
     if (rect) {
       return this._viewports.filter(viewport => viewport.containsPixel(rect));

--- a/test/modules/core/viewports/viewport.spec.js
+++ b/test/modules/core/viewports/viewport.spec.js
@@ -84,3 +84,18 @@ test('Viewport.getScales', t => {
   }
   t.end();
 });
+
+test('Viewport.containsPixel', t => {
+  const viewport = new Viewport({x: 0, y: 0, width: 10, height: 10});
+
+  t.ok(viewport.containsPixel({x: 5, y: 5}), 'pixel is inside');
+  t.ok(viewport.containsPixel({x: 0, y: 0}), 'pixel is inside');
+  t.notOk(viewport.containsPixel({x: 10, y: 10}), 'pixel is outside');
+  t.ok(viewport.containsPixel({x: -1, y: -1, width: 2, height: 2}), 'rectangle overlaps');
+  t.notOk(viewport.containsPixel({x: -3, y: -3, width: 2, height: 2}), 'rectangle is outside');
+  t.ok(viewport.containsPixel({x: 9, y: 0, width: 2, height: 2}), 'rectangle overlaps');
+  t.ok(viewport.containsPixel({x: 0, y: 9, width: 2, height: 2}), 'rectangle overlaps');
+  t.notOk(viewport.containsPixel({x: 11, y: 11, width: 2, height: 2}), 'rectangle is outside');
+
+  t.end();
+});

--- a/test/modules/core/views/view-manager.spec.js
+++ b/test/modules/core/views/view-manager.spec.js
@@ -24,7 +24,7 @@ test('ViewManager#getViewports', t => {
     height: 100
   });
 
-  const viewports = viewManager.getViewports();
+  let viewports = viewManager.getViewports();
   t.equals(viewports.length, 2, 'Correct number of viewports returned');
   t.ok(viewports[0] instanceof Viewport, 'Viewport 0 of corrrect type');
   t.ok(viewports[1] instanceof Viewport, 'Viewport 1 of corrrect type');
@@ -33,6 +33,16 @@ test('ViewManager#getViewports', t => {
   t.equals(viewports[0].y, 0, 'viewport dimensions correct');
   t.equals(viewports[1].height, 50, 'viewport dimensions correct');
   t.equals(viewports[1].y, 50, 'viewport dimensions correct');
+
+  viewports = viewManager.getViewports({x: 40, y: 40});
+  t.is(viewports.length, 1, 'Correct number of viewports returned');
+  t.is(viewports[0].y, 0, 'Correct viewport returned');
+
+  viewports = viewManager.getViewports({x: 40, y: 40, width: 20, height: 20});
+  t.is(viewports.length, 2, 'Correct number of viewports returned');
+
+  viewports = viewManager.getViewports({x: -1, y: -1});
+  t.is(viewports.length, 0, 'Correct number of viewports returned');
 
   t.end();
 });


### PR DESCRIPTION
#### Background
`pickLayers` should only render the views that contain the picked position

#### Change List
- Add `viewport.containsPixel` method
- `viewManager.getViewports` accepts an optional pixel/rect as filter
- Tests
