### PR TITLE
Fix callback error on pointer leave

### DIFF
--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -528,7 +528,9 @@ export default class Deck {
       radius: 1,
       mode: 'hover'
     });
-    this.props.onLayerHover(null, [], event.srcEvent);
+    if (this.props.onLayerHover) {
+      this.props.onLayerHover(null, [], event.srcEvent);
+    }
   }
 }
 


### PR DESCRIPTION
#### Change List
- Check if `props.onLayerHover` is empty
