### PR TITLE
Add progress bar to website demos

### DIFF
--- a/website/src/components/demos/point-cloud-demo.js
+++ b/website/src/components/demos/point-cloud-demo.js
@@ -26,7 +26,6 @@ export default class PointCloudDemo extends Component {
         <div className="stat">No. of Points
           <b>{ readableInteger(meta.count) }</b>
         </div>
-        {meta.progress < 1 && <p>Loading {(meta.progress * 100).toFixed(2)}%</p>}
       </div>
     );
   }

--- a/website/src/components/info-panel.js
+++ b/website/src/components/info-panel.js
@@ -4,6 +4,7 @@ import {connect} from 'react-redux';
 import autobind from 'autobind-decorator';
 
 import GenericInput from './input';
+import Spinner from './spinner';
 import * as Demos from './demos';
 import {updateParam} from '../actions/app-actions';
 
@@ -53,6 +54,7 @@ class InfoPanel extends Component {
 
         {this.props.children}
 
+        <Spinner meta={metaLoaded} />
       </div>
     );
   }

--- a/website/src/components/spinner.js
+++ b/website/src/components/spinner.js
@@ -1,0 +1,26 @@
+import React, {PureComponent} from 'react';
+
+export default class Spinner extends PureComponent {
+
+  render() {
+    const {meta} = this.props;
+    
+    if (!Number.isFinite(meta.progress) && !Number.isFinite(meta.progressAlt)) {
+      return null;
+    }
+
+    const progress = (meta.progress || 0) + (meta.progressAlt || 0);
+    const percentage = Math.round(progress * 1000) / 10;
+    const text = `Loading... ${percentage}%`;
+
+    return (
+      <div className={`spinner ${progress >= 1 ? 'done' : ''}`}>
+        <div className="spinner--text" >{text}</div>
+        <div className="spinner--fill" style={{width: `${percentage}%`}} >
+          {text}
+        </div>
+      </div>
+    );
+  }
+
+}

--- a/website/src/static/workers/building-data-decoder.js
+++ b/website/src/static/workers/building-data-decoder.js
@@ -42,7 +42,7 @@ function flush() {
   postMessage({
     action: 'add',
     data: result,
-    meta: {buildings: count, triangles: triangleCount}
+    meta: {buildings: count, triangles: triangleCount, progressAlt: count / 3895 * 0.2}
   });
   result = [];
 }

--- a/website/src/static/workers/screen-grid-data-decoder.js
+++ b/website/src/static/workers/screen-grid-data-decoder.js
@@ -1,9 +1,9 @@
 importScripts('./util.js');
 let total = 0;
+const result = [];
 
 onmessage = function(e) {
   const lines = e.data.text.split('\n');
-  const result = [];
 
   lines.forEach(function(line) {
     if (!line) {
@@ -19,9 +19,13 @@ onmessage = function(e) {
       }
     }
   });
-  postMessage({
-    action: 'add',
-    data: result,
-    meta: {count: total}
-  });
+
+  if (e.data.event === 'load') {
+    postMessage({
+      action: 'add',
+      data: result,
+      meta: {count: total, progress: 1}
+    });
+    postMessage({action: 'end'});
+  }
 };

--- a/website/src/static/workers/trips-data-decoder.js
+++ b/website/src/static/workers/trips-data-decoder.js
@@ -62,7 +62,7 @@ function flush() {
   postMessage({
     action: 'add',
     data: result,
-    meta: {trips: tripsCount, vertices: vertexCount}
+    meta: {trips: tripsCount, vertices: vertexCount, progress: tripsCount / 9970 / * 0.8}
   });
   result = [];
 }

--- a/website/src/static/workers/trips-data-decoder.js
+++ b/website/src/static/workers/trips-data-decoder.js
@@ -62,7 +62,7 @@ function flush() {
   postMessage({
     action: 'add',
     data: result,
-    meta: {trips: tripsCount, vertices: vertexCount, progress: tripsCount / 9970 / * 0.8}
+    meta: {trips: tripsCount, vertices: vertexCount, progress: tripsCount / 9970 * 0.8}
   });
   result = [];
 }

--- a/website/src/stylesheets/_gallery.scss
+++ b/website/src/stylesheets/_gallery.scss
@@ -111,6 +111,7 @@
   pointer-events: none;
 }
 .options-panel {
+  position: relative;
   width: 284px;
   background: #fff;
   box-shadow: 0 0 4px rgba(0, 0, 0, 0.15);
@@ -194,6 +195,41 @@
     width: 12px;
     height: 12px;
   }
+  .spinner {
+    height: 18px;
+    line-height: 18px;
+    font-size: 10px;
+
+    >div {
+      white-space: nowrap;
+      left: 0;
+      bottom: 0;
+      position: absolute;
+      height: 18px;
+      padding-left: 20px;
+      transition: width 0.5s;
+    }
+    .spinner--fill {
+      background: $primary;
+      color: $white;
+      overflow: hidden;
+    }
+    .spinner--text {
+      color: $black-40;
+    }
+
+    &.done {
+      height: 0 !important;
+      line-height: 0;
+      font-size: 0;
+      transition: height 0.5s 1s;
+
+      >div {
+        height: 0 !important;
+        transition: height 0.5s 1s;
+      }
+    }
+  }
 }
 code {
   font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace !important;
@@ -261,7 +297,7 @@ code {
     >div > *, hr, .input {
       display: none;
     }
-    >div:before {
+    &:before {
       position: absolute;
       top: 12px;
       right: 12px;
@@ -269,6 +305,16 @@ code {
       font-size: 24px;
       font-family: 'deckgl';
       content: "\e906";
+    }
+    >.spinner {
+      height: 3px;
+      line-height: 0;
+      font-size: 0;
+
+      .spinner--fill {
+        height: 3px;
+        display: block;
+      }
     }
     h3 {
       display: block;


### PR DESCRIPTION
#### Change List
- Add progress bar for point cloud and trips data
- Remove progressive loading for screen grid layer (perf)

Full size:
<img width="379" alt="screen shot 2018-07-13 at 4 46 09 pm" src="https://user-images.githubusercontent.com/2059298/42718331-c4114a1c-86bc-11e8-8e70-a37fb06de1f6.png">

Mobile:
<img width="469" alt="screen shot 2018-07-13 at 4 46 38 pm" src="https://user-images.githubusercontent.com/2059298/42718333-c5b75988-86bc-11e8-9924-0fd458884988.png">

