### PR TITLE
Fix crash in get vendor prefix

### DIFF
--- a/modules/core/src/utils/css-vendor-prefix.js
+++ b/modules/core/src/utils/css-vendor-prefix.js
@@ -22,7 +22,7 @@
 let venderPrefix = '';
 
 // Get CSS vendor prefix
-if (typeof document !== 'undefined') {
+try {
   const styleObj = document.createElement('div').style;
   const prefix = /^(webkit|moz|ms|o)(?=[A-Z])/;
   for (const key in styleObj) {
@@ -31,6 +31,8 @@ if (typeof document !== 'undefined') {
       break;
     }
   }
+} catch (error) {
+  // document not available
 }
 
 export default venderPrefix;

--- a/modules/core/src/utils/css-vendor-prefix.js
+++ b/modules/core/src/utils/css-vendor-prefix.js
@@ -23,7 +23,7 @@ let venderPrefix = '';
 
 // Get CSS vendor prefix
 if (typeof document !== 'undefined') {
-  const styleObj = document.body.style;
+  const styleObj = document.createElement('div').style;
   const prefix = /^(webkit|moz|ms|o)(?=[A-Z])/;
   for (const key in styleObj) {
     if (prefix.test(key)) {


### PR DESCRIPTION
`document.body` may be `null` if deck.gl is loaded in the header

#### Change List
- Remove dependency on `document.body`
