### PR TITLE
ScreenGridLayer: deprecate minColor and maxColor props

### DIFF
--- a/docs/layers/screen-grid-layer.md
+++ b/docs/layers/screen-grid-layer.md
@@ -58,19 +58,19 @@ Unit width/height of the bins.
 
 Cell margin size in pixels.
 
-##### `minColor` (Number[4], optional)
+##### `minColor` (Number[4], optional) **DEPRECATED**
 
 * Default: `[0, 0, 0, 255]`
 
 Expressed as an rgba array, minimal color that could be rendered by a tile. This prop is deprecated in version 5.2.0, use `colorRange` and `colorDomain` instead.
 
-##### `maxColor` (Number[4], optional)
+##### `maxColor` (Number[4], optional) **DEPRECATED**
 
 * Default: `[0, 255, 0, 255]`
 
 Expressed as an rgba array, maximal color that could be rendered by a tile.  This prop is deprecated in version 5.2.0, use `colorRange` and `colorDomain` instead.
 
-##### `colorDomain` (Array, optional) **EXPERIMENTAL**
+##### `colorDomain` (Array, optional)
 
 * Default: `[1, max(weight)]`
 
@@ -78,7 +78,7 @@ Color scale input domain. The color scale maps continues numeric domain into
 discrete color range. If not provided, the layer will set `colorDomain` to [1, max-of-all-cell-weights], You can control how the color of cells mapped
 to value of its weight by passing in an arbitrary color domain. This property is extremely handy when you want to render different data input with the same color mapping for comparison.
 
-##### `colorRange` (Array, optional) **EXPERIMENTAL**
+##### `colorRange` (Array, optional)
 
 * Default: <img src="/website/src/static/images/colorbrewer_YlOrRd_6.png"/></a>
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -30,6 +30,12 @@ Some previously deprecated `project` module functions have now been removed.
 Instead use `use64bitProjection` and `use64bitPositions`.
 
 
+#### ScreenGridLayer
+
+`minColor` and `maxColor` props are deprecated. Use `colorRange` and `colorDomain` props.
+
+
+
 ## Upgrading from deck.gl v5.2 to v5.3
 
 ### Viewport classes

--- a/examples/website/screen-grid/app.js
+++ b/examples/website/screen-grid/app.js
@@ -28,7 +28,6 @@ const colorRange = [
   [189, 0, 38, 255]
 ];
 
-
 export class App extends Component {
   _renderLayers() {
     const {data = DATA_URL, cellSize = 20, gpuAggregation = true} = this.props;

--- a/modules/layers/src/screen-grid-layer/screen-grid-layer.js
+++ b/modules/layers/src/screen-grid-layer/screen-grid-layer.js
@@ -22,7 +22,8 @@ import {
   Layer,
   experimental,
   WebMercatorViewport,
-  _GPUGridAggregator as GPUGridAggregator
+  _GPUGridAggregator as GPUGridAggregator,
+  log
 } from '@deck.gl/core';
 const {defaultColorRange} = experimental;
 
@@ -274,6 +275,7 @@ export default class ScreenGridLayer extends Layer {
   _shouldUseMinMax() {
     const {minColor, maxColor, colorDomain, colorRange} = this.props;
     if (minColor || maxColor) {
+      log.deprecated('ScreenGridLayer props: minColor and maxColor', 'colorRange, colorDomain')();
       return true;
     }
     // minColor and maxColor not supplied, check if colorRange or colorDomain supplied.


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #1946
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
- ScreenGridLayer: deprecate minColor and maxColor props
