### PR TITLE
Fix dashed lines for `GeoJsonLayer`

### DIFF
--- a/examples/layer-browser/src/examples/core-layers.js
+++ b/examples/layer-browser/src/examples/core-layers.js
@@ -147,12 +147,23 @@ const PolygonLayerExample = {
 const PathLayerExample = {
   layer: PathLayer,
   getData: () => dataSamples.zigzag,
+  propTypes: {
+    getDashArray: {type: 'compound', elements: ['dashSizeLine']},
+    dashSizeLine: {
+      type: 'number',
+      max: 20,
+      onUpdate: (newValue, newSettings, change) => {
+        change('getDashArray', [newValue, 20 - newValue]);
+      }
+    }
+  },
   props: {
     id: 'pathLayer',
     opacity: 0.6,
     getPath: f => f.path,
     getColor: f => [128, 0, 0],
     getWidth: f => 10,
+    getDashArray: f => [20, 0],
     widthMinPixels: 1,
     pickable: true
   }

--- a/modules/layers/src/geojson-layer/geojson-layer.js
+++ b/modules/layers/src/geojson-layer/geojson-layer.js
@@ -223,7 +223,6 @@ export default class GeoJsonLayer extends CompositeLayer {
           dashJustified: lineDashJustified,
 
           getPath: getCoordinates,
-
           getColor: unwrappingAccessor(getLineColor),
           getWidth: unwrappingAccessor(getLineWidth),
           getDashArray: unwrappingAccessor(getLineDashArray),
@@ -243,7 +242,8 @@ export default class GeoJsonLayer extends CompositeLayer {
           id: 'line-paths',
           updateTriggers: {
             getColor: updateTriggers.getLineColor,
-            getWidth: updateTriggers.getLineWidth
+            getWidth: updateTriggers.getLineWidth,
+            getDashArray: updateTriggers.getLineDashArray
           }
         }),
         {
@@ -255,6 +255,7 @@ export default class GeoJsonLayer extends CompositeLayer {
           widthMaxPixels: lineWidthMaxPixels,
           rounded: lineJointRounded,
           miterLimit: lineMiterLimit,
+          dashJustified: lineDashJustified,
 
           getPath: getCoordinates,
           getColor: unwrappingAccessor(getLineColor),


### PR DESCRIPTION
Fixed the `updateTriggers` for dashed lines for `LineString` features.