### PR TITLE
upgrade guide

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -15,6 +15,7 @@ Pixel sizes in line, icon and text layers now match their HTML/SVG counterparts.
 
 #### Views and Controllers
 
+* Viewport constraint props: `maxZoom`, `minZoom`, `maxPitch`, `minPitch` are no longer supported by the React component. They must be specified as part of the `viewState` object.
 * `ViewportController` React component has been removed. The functionality is now built in to the `Deck` and `DeckGL` classes.
 * `Deck.onViewportChange(viewport)` etc callbacks are no longer supported. Use `Deck.onViewStateChange({viewState})`
 * `DeckGL.viewport` and `DeckGL.viewports` props are no longer supported. Use `DeckGL.views`.

--- a/modules/react/src/deckgl.js
+++ b/modules/react/src/deckgl.js
@@ -137,6 +137,12 @@ export default class DeckGL extends React.PureComponent {
   // Supports old "geospatial view state as separate props" style (React only!)
   _getViewState(props) {
     if (!props.viewState && 'latitude' in props && 'longitude' in props && 'zoom' in props) {
+      if ('maxZoom' in props) {
+        log.removed('maxZoom', 'viewState');
+      }
+      if ('minZoom' in props) {
+        log.removed('minZoom', 'viewState');
+      }
       const {latitude, longitude, zoom, pitch = 0, bearing = 0} = props;
       return {latitude, longitude, zoom, pitch, bearing};
     }


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/2071

#### Change List
- Deprecation warning for `maxZoom` and `minZoom`. These are not all of the props but will be present if the user uses the old `<DeckGL {...viewState} />` pattern
- Update upgrade guide
