### PR TITLE
3DSurfaceExplorer Demo: fix crash

### DIFF
--- a/website/src/components/demos/plot-demo.js
+++ b/website/src/components/demos/plot-demo.js
@@ -12,7 +12,7 @@ export default class PlotDemo extends Component {
   static get parameters() {
     return {
       equation: {displayName: 'Z = f(x, y)', type: 'text', value: 'sin(x ^ 2 + y ^ 2) * x / 3.14'},
-      resolution: {displayName: 'Resolution', type: 'number',
+      resolution: {displayName: 'Resolution', type: 'range',
         value: 200, step: 10, min: 10, max: 1000},
       showAxis: {displayName: 'Grid', type: 'checkbox', value: true}
     };


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #2070 
<!-- For other PRs without open issue -->
#### Background
A string value used to define resolution causing a crash in WebGL for vertex count. Use correct paramter type.

<!-- For all the PRs -->
#### Change List
-
