### PR TITLE
Fix layer constant attributes in safari

### DIFF
--- a/modules/layers/src/point-cloud-layer/point-cloud-layer-vertex.glsl.js
+++ b/modules/layers/src/point-cloud-layer/point-cloud-layer-vertex.glsl.js
@@ -22,11 +22,10 @@ export default `\
 #define SHADER_NAME point-cloud-layer-vertex-shader
 
 attribute vec3 positions;
-
-attribute vec3 instancePositions;
-attribute vec2 instancePositions64xyLow;
 attribute vec3 instanceNormals;
 attribute vec4 instanceColors;
+attribute vec3 instancePositions;
+attribute vec2 instancePositions64xyLow;
 attribute vec3 instancePickingColors;
 
 uniform float opacity;

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -313,7 +313,7 @@ export default class SolidPolygonLayer extends Layer {
           geometry: new Geometry({
             drawMode: GL.TRIANGLES,
             attributes: {
-              vertexPositions: {size: 2, constant: true, value: new Float32Array([0, 1])},
+              vertexPositions: {size: 2, isInstanced: true, value: new Float32Array([0, 1])},
               nextPositions: {size: 3, constant: true, value: new Float32Array(3)},
               nextPositions64xyLow: {size: 2, constant: true, value: new Float32Array(2)}
             }


### PR DESCRIPTION
For #2070	
#### Background
This is a hack to unblock v6 release.
See https://github.com/uber/luma.gl/issues/609 for root cause

#### Change List
- Fix PointCloudLayer
- Fix SolidPolygonLayer
