### PR TITLE
Consolidate module parameter handling

### DIFF
--- a/docs/api-reference/layer.md
+++ b/docs/api-reference/layer.md
@@ -317,6 +317,9 @@ The state object allows a layer to store persistent information cross rendering 
 
 Used to update the layers [`state`](/docs/api-reference/layer.md#-state-object-) object. Calling this method will also cause the layer to rerender.
 
+##### `setModuleParameters`
+
+Used to update the settings of shader modules.
 
 ### Layer Lifecycle Methods
 

--- a/examples/layer-browser/src/components/color-picker.js
+++ b/examples/layer-browser/src/components/color-picker.js
@@ -42,7 +42,8 @@ export function getColorArray(str) {
   return [
     parseInt(str.slice(1, 3), 16),
     parseInt(str.slice(3, 5), 16),
-    parseInt(str.slice(5, 7), 16)
+    parseInt(str.slice(5, 7), 16),
+    255
   ];
 }
 

--- a/modules/core/src/lib/draw-layers.js
+++ b/modules/core/src/lib/draw-layers.js
@@ -236,11 +236,11 @@ function drawLayerInViewport({
   glViewport,
   parameters
 }) {
-  const moduleParameters = Object.assign(Object.create(layer.props), {
+  const moduleParameters = {
     viewport: layer.context.viewport,
     pickingActive: drawPickingColors ? 1 : 0,
     devicePixelRatio: pixelRatio
-  });
+  };
 
   const uniforms = Object.assign({}, layer.context.uniforms, {layerIndex});
 

--- a/modules/core/src/lib/draw-layers.js
+++ b/modules/core/src/lib/draw-layers.js
@@ -236,11 +236,11 @@ function drawLayerInViewport({
   glViewport,
   parameters
 }) {
-  const moduleParameters = {
+  const moduleParameters = Object.assign(Object.create(layer.props), {
     viewport: layer.context.viewport,
     pickingActive: drawPickingColors ? 1 : 0,
     devicePixelRatio: pixelRatio
-  };
+  });
 
   const uniforms = Object.assign({}, layer.context.uniforms, {layerIndex});
 
@@ -308,8 +308,9 @@ function getObjectHighlightParameters(layer) {
 
   // Update picking module settings if highlightedObjectIndex is set.
   // This will overwrite any settings from auto highlighting.
-  if (Number.isInteger(highlightedObjectIndex) && highlightedObjectIndex >= 0) {
-    parameters.pickingSelectedColor = layer.encodePickingColor(highlightedObjectIndex);
+  if (Number.isInteger(highlightedObjectIndex)) {
+    parameters.pickingSelectedColor =
+      highlightedObjectIndex >= 0 ? layer.encodePickingColor(highlightedObjectIndex) : null;
   }
   return parameters;
 }

--- a/modules/core/src/lib/draw-layers.js
+++ b/modules/core/src/lib/draw-layers.js
@@ -301,18 +301,15 @@ function getViewportFromDescriptor(viewportOrDescriptor) {
 function getObjectHighlightParameters(layer) {
   // TODO - inefficient to update settings every render?
   // TODO: Add warning if 'highlightedObjectIndex' is > numberOfInstances of the model.
+  const {highlightedObjectIndex, highlightColor} = layer.props;
+  const parameters = {
+    pickingHighlightColor: highlightColor
+  };
 
   // Update picking module settings if highlightedObjectIndex is set.
   // This will overwrite any settings from auto highlighting.
-  if (Number.isInteger(layer.props.highlightedObjectIndex)) {
-    const pickingSelectedColor =
-      layer.props.highlightedObjectIndex >= 0
-        ? layer.encodePickingColor(layer.props.highlightedObjectIndex)
-        : null;
-
-    return {
-      pickingSelectedColor
-    };
+  if (Number.isInteger(highlightedObjectIndex) && highlightedObjectIndex >= 0) {
+    parameters.pickingSelectedColor = layer.encodePickingColor(highlightedObjectIndex);
   }
-  return null;
+  return parameters;
 }

--- a/modules/core/src/lib/layer-state.js
+++ b/modules/core/src/lib/layer-state.js
@@ -7,6 +7,7 @@ export default class LayerState extends ComponentState {
     this.model = null;
     this.needsRedraw = true;
     this.subLayers = null; // reference to sublayers rendered in a previous cycle
+    this.moduleParameters = {};
   }
 
   get layer() {

--- a/modules/core/src/lib/layer-state.js
+++ b/modules/core/src/lib/layer-state.js
@@ -7,7 +7,6 @@ export default class LayerState extends ComponentState {
     this.model = null;
     this.needsRedraw = true;
     this.subLayers = null; // reference to sublayers rendered in a previous cycle
-    this.moduleParameters = {};
   }
 
   get layer() {

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -534,12 +534,12 @@ export default class Layer extends Component {
       this.updateTransition();
     }
 
-    if (moduleParameters) {
-      // moduleParameters extend layer.props, cannot be used to extend other objects
-      Object.assign(moduleParameters, this._getModuleParameters());
-    } else {
-      moduleParameters = this._getModuleParameters();
-    }
+    moduleParameters = Object.assign(
+      // Extending Props object directly will lose inherited keys
+      Object.create(this.props),
+      this._getModuleParameters(),
+      moduleParameters
+    );
     for (const model of this.getModels()) {
       model.updateModuleSettings(moduleParameters);
     }
@@ -552,12 +552,7 @@ export default class Layer extends Component {
 
     // Call subclass lifecycle method
     withParameters(this.context.gl, parameters, () => {
-      this.draw({
-        moduleParameters,
-        uniforms,
-        parameters,
-        context: this.context
-      });
+      this.draw({moduleParameters, uniforms, parameters, context: this.context});
     });
     // End lifecycle method
   }

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -534,14 +534,9 @@ export default class Layer extends Component {
       this.updateTransition();
     }
 
-    moduleParameters = Object.assign(
-      // Extending Props object directly will lose inherited keys
-      Object.create(this.props),
-      this._getModuleParameters(),
-      moduleParameters
-    );
-    for (const model of this.getModels()) {
-      model.updateModuleSettings(moduleParameters);
+    // TODO/ib - hack move to luma Model.draw
+    if (moduleParameters) {
+      this.setModuleParameters(moduleParameters);
     }
 
     // Apply polygon offset to avoid z-fighting
@@ -665,10 +660,9 @@ ${flags.viewportChanged ? 'viewport' : ''}\
   }
 
   setModuleParameters(moduleParameters) {
-    if (this.internalState) {
-      Object.assign(this.internalState.moduleParameters, moduleParameters);
+    for (const model of this.getModels()) {
+      model.updateModuleSettings(moduleParameters);
     }
-    this.setNeedsRedraw();
   }
 
   // PRIVATE METHODS
@@ -818,10 +812,6 @@ ${flags.viewportChanged ? 'viewport' : ''}\
 
     // TODO - set needsRedraw on the model(s)?
     this.setNeedsRedraw();
-  }
-
-  _getModuleParameters() {
-    return this.internalState && this.internalState.moduleParameters;
   }
 
   // DEPRECATED METHODS

--- a/modules/core/src/lib/pick-layers.js
+++ b/modules/core/src/lib/pick-layers.js
@@ -362,13 +362,9 @@ function processPickInfo({
     const pickingSelectedColor =
       layer.props.autoHighlight && pickedLayer === layer ? pickedColor : null;
 
-    const pickingParameters = {
+    layer.setModuleParameters({
       pickingSelectedColor
-    };
-
-    for (const model of layer.getModels()) {
-      model.updateModuleSettings(pickingParameters);
-    }
+    });
   });
 
   const unhandledPickInfos = callLayerPickingCallbacks(infos, mode);


### PR DESCRIPTION
General code quality issues encountered as I'm working on custom shader modules.

#### Change List
- Add `layer.setModuleParameters` method
- Remove direct `model.updateModuleSettings` calls from `drawLayer` and `pickLayer`
