### PR TITLE
GPUAggregator: Set ONE uniform for fp64 module

### DIFF
--- a/modules/core/src/experimental/utils/gpu-grid-aggregator.js
+++ b/modules/core/src/experimental/utils/gpu-grid-aggregator.js
@@ -372,7 +372,8 @@ export default class GPUGridAggregator {
         gridSize,
         uProjectionMatrix: gridTransformMatrix,
         uProjectionMatrixFP64,
-        projectPoints
+        projectPoints,
+        ONE: 1.0
       }
     });
     gridAggregationFramebuffer.unbind();
@@ -391,7 +392,8 @@ export default class GPUGridAggregator {
       },
       uniforms: {
         uSampler: gridAggregationFramebuffer.texture,
-        gridSize
+        gridSize,
+        ONE: 1.0
       }
     });
     allAggregrationFramebuffer.unbind();


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #2121
<!-- For other PRs without open issue -->
#### Background
On Intel GPUs `fp64` shader module uses `LUMA_FP64_CODE_ELIMINATION_WORKAROUND`, which uses a const uniform `ONE` always. For all layers this is provided as part of base `Layer` class. Set this uniform explicitly for GPU Aggregation path. 
<!-- For all the PRs -->
#### Change List
- GPUAggregator: Set ONE uniform for fp64 module
