### PR TITLE
 Enable drawing into external gl context, controlled by external software

### DIFF
--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -424,7 +424,7 @@ export default class Deck {
 
     this.props.onWebGLInitialized(gl);
 
-    if (!this._customRender) {
+    if (!this.props._customRender) {
       this.eventManager = new EventManager(gl.canvas, {
         events: {
           click: this._onClick,
@@ -499,11 +499,11 @@ export default class Deck {
   // Callbacks
 
   _onRendererInitialized({gl}) {
-    this.setGLContext(gl);
+    this._setGLContext(gl);
   }
 
   _onRenderFrame({gl}) {
-    this._renderLayers({gl});
+    this._drawLayers({gl});
   }
 
   _onViewStateChange(params) {

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -412,7 +412,7 @@ export default class Deck {
     }
 
     // if external context...
-    trackContextState(gl, {enable: true, copyState : true});
+    trackContextState(gl, {enable: true, copyState: true});
 
     setParameters(gl, {
       blend: true,
@@ -424,13 +424,15 @@ export default class Deck {
 
     this.props.onWebGLInitialized(gl);
 
-    // this.eventManager = new EventManager(gl.canvas, {
-    //   events: {
-    //     click: this._onClick,
-    //     pointermove: this._onPointerMove,
-    //     pointerleave: this._onPointerLeave
-    //   }
-    // });
+    if (!this._customRender) {
+      this.eventManager = new EventManager(gl.canvas, {
+        events: {
+          click: this._onClick,
+          pointermove: this._onPointerMove,
+          pointerleave: this._onPointerLeave
+        }
+      });
+    }
 
     this.viewManager = new ViewManager({
       eventManager: this.eventManager,


### PR DESCRIPTION
# For #2132 

#### Background
- Make it possible to start deck.gl without a gl context and an animation loop.
- Expose initialization and render functions so that they can be called from external code.

#### Change List
- deck.gl component initialization.
