### PR TITLE
Minimal example of mapbox custom layers integration

### DIFF
--- a/examples/experimental/custom-layers/README.md
+++ b/examples/experimental/custom-layers/README.md
@@ -1,0 +1,5 @@
+Experimental integration with mapbox-layer API
+
+```js
+yarn start-local
+```

--- a/examples/experimental/custom-layers/app.js
+++ b/examples/experimental/custom-layers/app.js
@@ -28,32 +28,32 @@ const map = new mapboxgl.Map({
 });
 
 map.on('load', () => {
-
   map.addLayer({
-    'id': '3d-buildings',
-    'source': 'composite',
+    id: '3d-buildings',
+    source: 'composite',
     'source-layer': 'building',
-    'filter': ['==', 'extrude', 'true'],
-    'type': 'fill-extrusion',
-    'minzoom': 15,
-    'paint': {
+    filter: ['==', 'extrude', 'true'],
+    type: 'fill-extrusion',
+    minzoom: 15,
+    paint: {
       'fill-extrusion-color': '#ccc',
-      'fill-extrusion-height': ["get", "height"]
+      'fill-extrusion-height': ['get', 'height']
     }
   });
 
-  map.addLayer(new DeckLayer({
-    layers: [
-      new GeoJsonLayer({
-        data: GEOJSON,
-        stroked: true,
-        filled: true,
-        lineWidthMinPixels: 2,
-        opacity: 0.4,
-        getLineColor: () => [255, 100, 100],
-        getFillColor: () => [200, 160, 0, 180]
-      })
-    ]
-  }));
-
+  map.addLayer(
+    new DeckLayer({
+      layers: [
+        new GeoJsonLayer({
+          data: GEOJSON,
+          stroked: true,
+          filled: true,
+          lineWidthMinPixels: 2,
+          opacity: 0.4,
+          getLineColor: () => [255, 100, 100],
+          getFillColor: () => [200, 160, 0, 180]
+        })
+      ]
+    })
+  );
 });

--- a/examples/experimental/custom-layers/app.js
+++ b/examples/experimental/custom-layers/app.js
@@ -1,0 +1,59 @@
+import mapboxgl from './mapbox-gl-dev';
+import DeckLayer from './deck-layer';
+import {GeoJsonLayer} from '@deck.gl/layers';
+
+// source: Natural Earth http://www.naturalearthdata.com/ via geojson.xyz
+const GEOJSON =
+  'https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_110m_admin_1_states_provinces_shp.geojson'; //eslint-disable-line
+// Set your mapbox token here
+const MAPBOX_TOKEN = process.env.MapboxAccessToken; // eslint-disable-line
+
+const INITIAL_VIEW_STATE = {
+  latitude: 40.70708981756565,
+  longitude: -74.01194070150844,
+  zoom: 15.2,
+  bearing: 20,
+  pitch: 60
+};
+
+mapboxgl.accessToken = process.env.MapboxAccessToken; // eslint-disable-line
+
+const map = new mapboxgl.Map({
+  container: 'map',
+  style: 'mapbox://styles/mapbox/light-v9',
+  center: [INITIAL_VIEW_STATE.longitude, INITIAL_VIEW_STATE.latitude],
+  zoom: INITIAL_VIEW_STATE.zoom,
+  bearing: INITIAL_VIEW_STATE.bearing,
+  pitch: INITIAL_VIEW_STATE.pitch
+});
+
+map.on('load', () => {
+
+  map.addLayer({
+    'id': '3d-buildings',
+    'source': 'composite',
+    'source-layer': 'building',
+    'filter': ['==', 'extrude', 'true'],
+    'type': 'fill-extrusion',
+    'minzoom': 15,
+    'paint': {
+      'fill-extrusion-color': '#ccc',
+      'fill-extrusion-height': ["get", "height"]
+    }
+  });
+
+  map.addLayer(new DeckLayer({
+    layers: [
+      new GeoJsonLayer({
+        data: GEOJSON,
+        stroked: true,
+        filled: true,
+        lineWidthMinPixels: 2,
+        opacity: 0.4,
+        getLineColor: () => [255, 100, 100],
+        getFillColor: () => [200, 160, 0, 180]
+      })
+    ]
+  }));
+
+});

--- a/examples/experimental/custom-layers/deck-layer.js
+++ b/examples/experimental/custom-layers/deck-layer.js
@@ -18,11 +18,11 @@ export default class DeckLayer {
       zoom: this.map.getZoom(),
       bearing: this.map.getBearing(),
       pitch: this.map.getPitch()
-    }
+    };
   }
 
   onAdd(map, gl) {
-    console.log('onAdd', map, gl);
+    // console.log('onAdd', map, gl);
 
     this.map = map;
     this.deck = new Deck({
@@ -39,7 +39,7 @@ export default class DeckLayer {
 
   render3D(gl, matrix) {
     const viewState = this._getViewState();
-    console.log('render3D', viewState, matrix);
+    // console.log('render3D', viewState, matrix);
 
     this.deck.setProps({viewState});
     this.deck._drawLayers();

--- a/examples/experimental/custom-layers/deck-layer.js
+++ b/examples/experimental/custom-layers/deck-layer.js
@@ -1,0 +1,48 @@
+import {Deck} from '@deck.gl/core';
+
+export default class DeckLayer {
+  constructor({id = 'deck-layer', layers}) {
+    this.id = id;
+    this.type = 'custom';
+
+    this.deck = null;
+
+    this.layers = layers;
+  }
+
+  _getViewState() {
+    const {lng, lat} = this.map.getCenter();
+    return {
+      longitude: lng,
+      latitude: lat,
+      zoom: this.map.getZoom(),
+      bearing: this.map.getBearing(),
+      pitch: this.map.getPitch()
+    }
+  }
+
+  onAdd(map, gl) {
+    console.log('onAdd', map, gl);
+
+    this.map = map;
+    this.deck = new Deck({
+      canvas: 'deck-canvas',
+      width: '100%',
+      height: '100%',
+      viewState: this._getViewState(),
+      controller: false,
+      customRender: true
+    });
+    this.deck._setGLContext(gl);
+    this.deck.setProps({layers: this.layers});
+  }
+
+  render3D(gl, matrix) {
+    const viewState = this._getViewState();
+    console.log('render3D', viewState, matrix);
+
+    this.deck.setProps({viewState});
+    this.deck._drawLayers();
+    this.map.triggerRepaint();
+  }
+}

--- a/examples/experimental/custom-layers/index.html
+++ b/examples/experimental/custom-layers/index.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset='UTF-8' />
+    <title>deck.gl example</title>
+    <style>
+    #container {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+    }
+    #container > * {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+    }
+    </style>
+    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.44.2/mapbox-gl.css' rel='stylesheet' />
+  </head>
+  <body>
+    <div id="container">
+      <div id="map"></div>
+      <canvas id="deck-canvas" style="pointer-events: none"></canvas>
+    </div>
+    <script src='app.js'></script>
+  </body>
+</html>

--- a/examples/experimental/custom-layers/package.json
+++ b/examples/experimental/custom-layers/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "pure-js",
+  "version": "0.0.0",
+  "license": "MIT",
+  "scripts": {
+    "start": "webpack-dev-server --progress --hot --open",
+    "start-local": "webpack-dev-server --env.local --progress --hot --open",
+    "build": "NODE_ENV=production webpack --env.prod=true"
+  },
+  "dependencies": {
+    "@deck.gl/core": "^6.0.0",
+    "@deck.gl/layers": "^6.0.0",
+    "mapbox-gl": "~0.44.2"
+  },
+  "devDependencies": {
+    "buble": "^0.19.3",
+    "buble-loader": "^0.5.0",
+    "webpack": "^4.3.0",
+    "webpack-cli": "^2.0.13",
+    "webpack-dev-server": "^3.1.1"
+  }
+}

--- a/examples/experimental/custom-layers/webpack.config.js
+++ b/examples/experimental/custom-layers/webpack.config.js
@@ -1,0 +1,27 @@
+// NOTE: To use this example standalone (e.g. outside of deck.gl repo)
+// delete the local development overrides at the bottom of this file
+
+// avoid destructuring for older Node version support
+const resolve = require('path').resolve;
+const webpack = require('webpack');
+
+const CONFIG = {
+  mode: 'development',
+
+  entry: {
+    app: resolve('./app.js')
+  },
+
+  resolve: {
+    alias: {
+      // From mapbox-gl-js README. Required for non-browserify bundlers (e.g. webpack):
+      'mapbox-gl$': resolve('./node_modules/mapbox-gl/dist/mapbox-gl.js')
+    }
+  },
+
+  // Optional: Enables reading mapbox token from environment variable
+  plugins: [new webpack.EnvironmentPlugin(['MapboxAccessToken'])]
+};
+
+// This line enables bundling against src in this repo rather than installed module
+module.exports = env => (env ? require('../../webpack.config.local')(CONFIG)(env) : CONFIG);

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -26,7 +26,7 @@ import Effect from '../experimental/lib/effect';
 import log from '../utils/log';
 
 import GL from 'luma.gl/constants';
-import {AnimationLoop, createGLContext, setParameters} from 'luma.gl';
+import {AnimationLoop, createGLContext, trackContextState, setParameters} from 'luma.gl';
 import {Stats} from 'probe.gl';
 import {EventManager} from 'mjolnir.js';
 
@@ -147,11 +147,14 @@ export default class Deck {
 
     // Note: LayerManager creation deferred until gl context available
     this.canvas = this._createCanvas(props);
+
     this.animationLoop = this._createAnimationLoop(props);
 
     this.setProps(props);
 
-    this.animationLoop.start();
+    if (!props.customRender) {
+      this.animationLoop.start();
+    }
   }
 
   finalize() {
@@ -397,30 +400,20 @@ export default class Deck {
     }
   }
 
-  // Callbacks
-
-  _onViewStateChange(params) {
-    // Let app know that view state is changing, and give it a chance to change it
-    const viewState = this.props.onViewStateChange(params) || params.viewState;
-
-    // If initialViewState was set on creation, auto track position
-    if (this.viewState) {
-      this.viewState[params.viewId] = viewState;
-      this.viewManager.setProps({viewState});
-    }
-  }
-
-  _onInteractiveStateChange({isDragging = false}) {
-    if (isDragging !== this.interactiveState.isDragging) {
-      this.interactiveState.isDragging = isDragging;
-    }
-  }
-
   _updateCursor() {
     this.canvas.style.cursor = this.props.getCursor(this.interactiveState);
   }
 
-  _onRendererInitialized({gl, canvas}) {
+  // Deep integration (Mapbox styles)
+
+  _setGLContext(gl) {
+    if (this.layerManager) {
+      return;
+    }
+
+    // if external context...
+    trackContextState(gl, {enable: true, copyState : true});
+
     setParameters(gl, {
       blend: true,
       blendFunc: [GL.SRC_ALPHA, GL.ONE_MINUS_SRC_ALPHA, GL.ONE, GL.ONE_MINUS_SRC_ALPHA],
@@ -431,13 +424,13 @@ export default class Deck {
 
     this.props.onWebGLInitialized(gl);
 
-    this.eventManager = new EventManager(canvas, {
-      events: {
-        click: this._onClick,
-        pointermove: this._onPointerMove,
-        pointerleave: this._onPointerLeave
-      }
-    });
+    // this.eventManager = new EventManager(gl.canvas, {
+    //   events: {
+    //     click: this._onClick,
+    //     pointermove: this._onPointerMove,
+    //     pointerleave: this._onPointerLeave
+    //   }
+    // });
 
     this.viewManager = new ViewManager({
       eventManager: this.eventManager,
@@ -460,7 +453,9 @@ export default class Deck {
     this.props.onLoad();
   }
 
-  _onRenderFrame({gl}) {
+  _drawLayers() {
+    const {gl} = this.layerManager.context;
+
     // Log perf stats every second
     if (this.stats.oneSecondPassed()) {
       const table = this.stats.getStatsTable();
@@ -497,6 +492,33 @@ export default class Deck {
     });
 
     this.props.onAfterRender({gl});
+  }
+
+  // Callbacks
+
+  _onRendererInitialized({gl}) {
+    this.setGLContext(gl);
+  }
+
+  _onRenderFrame({gl}) {
+    this._renderLayers({gl});
+  }
+
+  _onViewStateChange(params) {
+    // Let app know that view state is changing, and give it a chance to change it
+    const viewState = this.props.onViewStateChange(params) || params.viewState;
+
+    // If initialViewState was set on creation, auto track position
+    if (this.viewState) {
+      this.viewState[params.viewId] = viewState;
+      this.viewManager.setProps({viewState});
+    }
+  }
+
+  _onInteractiveStateChange({isDragging = false}) {
+    if (isDragging !== this.interactiveState.isDragging) {
+      this.interactiveState.isDragging = isDragging;
+    }
   }
 
   // Route move events to layers. call the `onHover` prop of any picked layer,

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -412,7 +412,7 @@ export default class Deck {
     }
 
     // if external context...
-    trackContextState(gl, {enable: true, copyState : true});
+    trackContextState(gl, {enable: true, copyState: true});
 
     setParameters(gl, {
       blend: true,
@@ -424,13 +424,15 @@ export default class Deck {
 
     this.props.onWebGLInitialized(gl);
 
-    // this.eventManager = new EventManager(gl.canvas, {
-    //   events: {
-    //     click: this._onClick,
-    //     pointermove: this._onPointerMove,
-    //     pointerleave: this._onPointerLeave
-    //   }
-    // });
+    if (this.props._customRender) {
+      this.eventManager = new EventManager(gl.canvas, {
+        events: {
+          click: this._onClick,
+          pointermove: this._onPointerMove,
+          pointerleave: this._onPointerLeave
+        }
+      });
+    }
 
     this.viewManager = new ViewManager({
       eventManager: this.eventManager,


### PR DESCRIPTION
For #2132 
#### Background
- Allows a deck.gl instance with all its layers to be rendered from a custom mapbox style
- Renders into mapbox context
- Rendering controller by mapbox layer (no deck.gl animation loop)

#### Change List
- new example `examples/experimental/custom-layers`
- `Deck` changes as per #2133 
