### PR TITLE
Fix: transition breaks map interaction

### DIFF
--- a/modules/core/src/views/view-manager.js
+++ b/modules/core/src/views/view-manager.js
@@ -162,7 +162,7 @@ export default class ViewManager {
     }
 
     // Important: avoid invoking _update() inside itself
-    // Nested updates result in unexpected side effects inside _rebuildViewportsFromViews()
+    // Nested updates result in unexpected side effects inside _rebuildViewports()
     // when using auto control in pure-js
     if (!this._isUpdating) {
       this._update();
@@ -175,14 +175,14 @@ export default class ViewManager {
     // Only rebuild viewports if the update flag is set
     if (this._needsUpdate) {
       this._needsUpdate = false;
-      this._rebuildViewportsFromViews();
+      this._rebuildViewports();
     }
 
     // If viewport transition(s) are triggered during viewports update, controller(s)
     // will immediately call `onViewStateChange` which calls `viewManager.setProps` again.
     if (this._needsUpdate) {
       this._needsUpdate = false;
-      this._rebuildViewportsFromViews();
+      this._rebuildViewports();
     }
 
     this._isUpdating = false;
@@ -255,7 +255,7 @@ export default class ViewManager {
   }
 
   // Rebuilds viewports from descriptors towards a certain window size
-  _rebuildViewportsFromViews() {
+  _rebuildViewports() {
     const {width, height, views} = this;
 
     const oldControllers = this.controllers;

--- a/test/apps/viewport-transitions-flyTo/package.json
+++ b/test/apps/viewport-transitions-flyTo/package.json
@@ -4,11 +4,10 @@
     "start-local": "webpack-dev-server --env.local --progress --hot --open"
   },
   "dependencies": {
-    "deck.gl": ">=5.2.0-alpha.7",
-    "immutable": "^3.8.1",
+    "deck.gl": "^6.0.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
-    "react-map-gl": "^3.2.0"
+    "react-map-gl": "^3.3.0"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.18.0",

--- a/test/apps/viewport-transitions/package.json
+++ b/test/apps/viewport-transitions/package.json
@@ -5,8 +5,7 @@
   },
   "dependencies": {
     "d3-request": "^1.0.5",
-    "deck.gl": ">=6.0.0-beta",
-    "luma.gl": ">=6.0.0-beta",
+    "deck.gl": "^6.0.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-map-gl": "^3.3.0"


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/2102

#### Background

This bug was introduced by the implementation of per-view controller.

Inside `viewManager.setProps`, all viewports are updated. If a viewport transition is triggered during this update, the controller immediately calls `onViewStateChange` callback which calls `viewManager.setProps` again. The nested updates result in an incomplete `controllers` map.

#### Change List
- Avoid invoking `_rebuildViewportsFromViews` inside itself
