### PR TITLE
Scripting example fixes

### DIFF
--- a/examples/gallery/src/boiler-plate.html
+++ b/examples/gallery/src/boiler-plate.html
@@ -23,12 +23,17 @@
           data: [
             {position: [-122.402, 37.79], color: [255, 0, 0], radius: 1000}
           ],
+          getPosition: d => d.position,
+          getColor: d => d.color,
+          getRadius: d => d.radius,
           opacity: 0.3
         }),
         new TextLayer({
           data: [
             {position: [-122.402, 37.79], text: 'Hello World'}
-          ]
+          ],
+          getPosition: d => d.position,
+          getText: d => d.text
         })
       ]
     });

--- a/examples/gallery/src/hexagon-layer.html
+++ b/examples/gallery/src/hexagon-layer.html
@@ -100,7 +100,7 @@
       OPTIONS.forEach(key => {
         const value = document.getElementById(key).value;
         document.getElementById(key + '-value').innerHTML = value;
-        options[key] = value;
+        options[key] = Number(value);
       });
 
       const hexagonLayer = new HexagonLayer({

--- a/examples/gallery/src/point-cloud-layer.html
+++ b/examples/gallery/src/point-cloud-layer.html
@@ -71,6 +71,9 @@
           coordinateSystem: COORDINATE_SYSTEM.IDENTITY,
           opacity: 1,
           data: points,
+          getPosition: d => d.position,
+          getNormal: d => d.normal,
+          getColor: d => d.color,
           radiusPixels: 10,
           lightSettings: {
             coordinateSystem: COORDINATE_SYSTEM.IDENTITY,

--- a/modules/lite/src/deckgl.js
+++ b/modules/lite/src/deckgl.js
@@ -118,11 +118,6 @@ export default class DeckGL extends Deck {
   }
 
   setProps(props) {
-    const viewState = getViewState(props);
-    if (viewState) {
-      props.viewState = viewState;
-    }
-
     // this._updateViewState must be bound to `this`
     // but we don't have access to the current instance before calling super().
     if ('onViewStateChange' in props && this._updateViewState) {

--- a/modules/lite/test/index.js
+++ b/modules/lite/test/index.js
@@ -49,7 +49,9 @@ const nonGeoExample = new deck.DeckGL({
       coordinateSystem: deck.COORDINATE_SYSTEM.IDENTITY,
       opacity: 1,
       data: points,
-      getNormal: d => [0, 0, 1],
+      getPosition: d => d.position,
+      getColor: d => d.color,
+      getNormal: [0, 0, 1],
       radiusPixels: 10,
       lightSettings: {
         coordinateSystem: deck.COORDINATE_SYSTEM.IDENTITY,

--- a/test/apps/mapbox-custom-layers/deck-layer.js
+++ b/test/apps/mapbox-custom-layers/deck-layer.js
@@ -1,4 +1,4 @@
-import {Deck, MapView} from '@deck.gl/core';
+import {Deck} from '@deck.gl/core';
 
 export default class DeckLayer {
   constructor({id = 'deck-layer', layers}) {


### PR DESCRIPTION
#### Change List
- Add missing accessors (due to v6 accessor default value change)
- Fix an issue in standalone bundle where calling `setProps` without `viewState` resets the viewport
