### PR TITLE
Wrap longitudes over the 180th meridian

### DIFF
--- a/docs/api-reference/layer.md
+++ b/docs/api-reference/layer.md
@@ -161,11 +161,13 @@ Required when the `coordinateSystem` is set to `COORDINATE_SYSTEM.METER_OFFSETS`
 
 Specifies a longitude and a latitude from which meter offsets are calculated. See the article on Coordinate Systems for details
 
-##### `wrapCoordinates` (Boolean, optional)
+##### `wrapLongitude` (Boolean, optional)
 
-Automatically wraps lnglat coordinates over the 180th meridian for the best placement in the current viewport.
+Automatically wraps longitudes over the 180th antimeridian for the best visibility in the current viewport.
 
-Default `true`.
+This option is applied per vertex by dynamically moving the antimeridian the furthest away from the current center of the viewport. It is useful when viewing local data that cross the 180th meridian. However, path/polygon features that get split by the dynamic antimeridian may still be rendered incorrectly. When viewing at a global zoom level, it is recommended that you disable this option and preprocess the data for their best placement.
+
+Default `false`.
 
 ##### `modelMatrix` (Number[16], optional)
 

--- a/docs/api-reference/layer.md
+++ b/docs/api-reference/layer.md
@@ -161,6 +161,12 @@ Required when the `coordinateSystem` is set to `COORDINATE_SYSTEM.METER_OFFSETS`
 
 Specifies a longitude and a latitude from which meter offsets are calculated. See the article on Coordinate Systems for details
 
+##### `wrapCoordinates` (Boolean, optional)
+
+Automatically wraps lnglat coordinates over the 180th meridian for the best placement in the current viewport.
+
+Default `true`.
+
 ##### `modelMatrix` (Number[16], optional)
 
 An optional 4x4 matrix that is multiplied into the affine projection matrices used by shader `project` GLSL function and the Viewport's `project` and `unproject` JavaScript function.

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -28,6 +28,10 @@ Release date: TBD, Target late Aug, 2018
 
 The projection algorithm used for geospatial coordinates (layers with `coordinateSystem: COORDINATE_SYSTEM.LNGLAT`) has been replaced with a "hybrid" projection/offset based implementation that rivals 64-bit precision at 32-bit speeds. This makes the use of the `fp64` mode unnecessary for most applications, and should increase application performance and avoid issues on untested graphics drivers.
 
+#### Dynamic Meridian
+
+LNGLAT projection modes automatically wrap coordinates over the 180th meridian for the best placement in the current viewport. Set the `wrapLongitude` prop in a layer to `true` to enable this behavior.
+
 
 ### JSON API (Experimental)
 
@@ -37,7 +41,6 @@ A new experimental module `@deck.gl/json` provides a set of classes that allows 
 ### Enhanced Multiview Support
 
 deck.gl's multiview support has been significantly enhanced. New `View` properties give applications more control over rendering, making it possible to implement e.g. overlapping views, partially synchronized views (share some but not all view state props), views with different background colors etc.
-
 
 
 ## deck.gl v6.0

--- a/examples/website/icon/app.js
+++ b/examples/website/icon/app.js
@@ -131,6 +131,7 @@ export class App extends Component {
     const layerProps = {
       data,
       pickable: true,
+      wrapLongitude: true,
       getPosition: d => d.coordinates,
       iconAtlas,
       iconMapping,

--- a/modules/core/src/lib/composite-layer.js
+++ b/modules/core/src/lib/composite-layer.js
@@ -70,6 +70,7 @@ export default class CompositeLayer extends Layer {
       highlightColor,
       coordinateSystem,
       coordinateOrigin,
+      wrapLongitude,
       modelMatrix
     } = this.props;
     const newProps = {
@@ -83,6 +84,7 @@ export default class CompositeLayer extends Layer {
       highlightColor,
       coordinateSystem,
       coordinateOrigin,
+      wrapLongitude,
       modelMatrix
     };
 

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -57,6 +57,7 @@ const defaultProps = {
 
   coordinateSystem: COORDINATE_SYSTEM.LNGLAT,
   coordinateOrigin: [0, 0, 0],
+  wrapCoordinates: true,
 
   parameters: {},
   uniforms: {},

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -57,7 +57,7 @@ const defaultProps = {
 
   coordinateSystem: COORDINATE_SYSTEM.LNGLAT,
   coordinateOrigin: [0, 0, 0],
-  wrapCoordinates: true,
+  wrapLongitude: false,
 
   parameters: {},
   uniforms: {},

--- a/modules/core/src/shaderlib/project/project.glsl.js
+++ b/modules/core/src/shaderlib/project/project.glsl.js
@@ -28,8 +28,8 @@ const float COORDINATE_SYSTEM_LNGLAT_EXPERIMENTAL = 4.;
 
 uniform float project_uCoordinateSystem;
 uniform float project_uScale;
-uniform bool project_uWrapCoordinates;
-uniform vec2 project_uLngLatCenter;
+uniform bool project_uWrapLongitude;
+uniform float project_uAntimeridian;
 uniform vec3 project_uPixelsPerMeter;
 uniform vec3 project_uPixelsPerDegree;
 uniform vec3 project_uPixelsPerUnit;
@@ -92,9 +92,8 @@ vec4 project_offset_(vec4 offset) {
 //
 vec2 project_mercator_(vec2 lnglat) {
   float x = lnglat.x;
-  if (project_uWrapCoordinates) {
-    float minLng = project_uLngLatCenter.x - 180.0;
-    x = mod(x - minLng, 360.0) + minLng;
+  if (project_uWrapLongitude) {
+    x = mod(x - project_uAntimeridian, 360.0) + project_uAntimeridian;
   }
   return vec2(
     radians(x) + PI,

--- a/modules/core/src/shaderlib/project/project.glsl.js
+++ b/modules/core/src/shaderlib/project/project.glsl.js
@@ -28,6 +28,8 @@ const float COORDINATE_SYSTEM_LNGLAT_EXPERIMENTAL = 4.;
 
 uniform float project_uCoordinateSystem;
 uniform float project_uScale;
+uniform bool project_uWrapCoordinates;
+uniform vec2 project_uLngLatCenter;
 uniform vec3 project_uPixelsPerMeter;
 uniform vec3 project_uPixelsPerDegree;
 uniform vec3 project_uPixelsPerUnit;
@@ -89,8 +91,13 @@ vec4 project_offset_(vec4 offset) {
 // Projecting positions - non-linear projection: lnglats => unit tile [0-1, 0-1]
 //
 vec2 project_mercator_(vec2 lnglat) {
+  float x = lnglat.x;
+  if (project_uWrapCoordinates) {
+    float minLng = project_uLngLatCenter.x - 180.0;
+    x = mod(x - minLng, 360.0) + minLng;
+  }
   return vec2(
-    radians(lnglat.x) + PI,
+    radians(x) + PI,
     PI - log(tan_fp32(PI * 0.25 + radians(lnglat.y) * 0.5))
   );
 }

--- a/modules/core/src/shaderlib/project/viewport-uniforms.js
+++ b/modules/core/src/shaderlib/project/viewport-uniforms.js
@@ -135,7 +135,7 @@ export function getUniformsFromViewport({
   // Match Layer.defaultProps
   coordinateSystem = COORDINATE_SYSTEM.LNGLAT,
   coordinateOrigin = DEFAULT_COORDINATE_ORIGIN,
-  wrapCoordinates = true,
+  wrapLongitude = false,
   // Deprecated
   projectionMode,
   positionOrigin
@@ -158,7 +158,7 @@ export function getUniformsFromViewport({
       devicePixelRatio,
       coordinateSystem,
       coordinateOrigin,
-      wrapCoordinates
+      wrapLongitude
     })
   );
 }
@@ -168,7 +168,7 @@ function calculateViewportUniforms({
   devicePixelRatio,
   coordinateSystem,
   coordinateOrigin,
-  wrapCoordinates
+  wrapLongitude
 }) {
   const coordinateZoom = viewport.zoom;
   assert(coordinateZoom >= 0);
@@ -197,10 +197,8 @@ function calculateViewportUniforms({
     // Projection mode values
     project_uCoordinateSystem: shaderCoordinateSystem,
     project_uCenter: projectionCenter,
-    project_uWrapCoordinates: wrapCoordinates,
-    project_uLngLatCenter: wrapCoordinates && viewport.isGeospatial
-      ? [viewport.longitude, viewport.latitude]
-      : DEFAULT_COORDINATE_ORIGIN,
+    project_uWrapLongitude: wrapLongitude,
+    project_uAntimeridian: (viewport.longitude || 0) - 180,
 
     // Screen size
     project_uViewportSize: viewportSize,

--- a/modules/core/src/shaderlib/project/viewport-uniforms.js
+++ b/modules/core/src/shaderlib/project/viewport-uniforms.js
@@ -198,7 +198,7 @@ function calculateViewportUniforms({
     project_uCoordinateSystem: shaderCoordinateSystem,
     project_uCenter: projectionCenter,
     project_uWrapCoordinates: wrapCoordinates,
-    project_uLngLatCenter: wrapCoordinates
+    project_uLngLatCenter: wrapCoordinates && viewport.isGeospatial
       ? [viewport.longitude, viewport.latitude]
       : DEFAULT_COORDINATE_ORIGIN,
 

--- a/modules/core/src/shaderlib/project/viewport-uniforms.js
+++ b/modules/core/src/shaderlib/project/viewport-uniforms.js
@@ -135,6 +135,7 @@ export function getUniformsFromViewport({
   // Match Layer.defaultProps
   coordinateSystem = COORDINATE_SYSTEM.LNGLAT,
   coordinateOrigin = DEFAULT_COORDINATE_ORIGIN,
+  wrapCoordinates = true,
   // Deprecated
   projectionMode,
   positionOrigin
@@ -152,7 +153,13 @@ export function getUniformsFromViewport({
     {
       project_uModelMatrix: modelMatrix || IDENTITY_MATRIX
     },
-    getMemoizedViewportUniforms({viewport, devicePixelRatio, coordinateSystem, coordinateOrigin})
+    getMemoizedViewportUniforms({
+      viewport,
+      devicePixelRatio,
+      coordinateSystem,
+      coordinateOrigin,
+      wrapCoordinates
+    })
   );
 }
 
@@ -160,7 +167,8 @@ function calculateViewportUniforms({
   viewport,
   devicePixelRatio,
   coordinateSystem,
-  coordinateOrigin
+  coordinateOrigin,
+  wrapCoordinates
 }) {
   const coordinateZoom = viewport.zoom;
   assert(coordinateZoom >= 0);
@@ -189,6 +197,10 @@ function calculateViewportUniforms({
     // Projection mode values
     project_uCoordinateSystem: shaderCoordinateSystem,
     project_uCenter: projectionCenter,
+    project_uWrapCoordinates: wrapCoordinates,
+    project_uLngLatCenter: wrapCoordinates
+      ? [viewport.longitude, viewport.latitude]
+      : DEFAULT_COORDINATE_ORIGIN,
 
     // Screen size
     project_uViewportSize: viewportSize,


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/2051

Before:
![wrapping-1](https://user-images.githubusercontent.com/2059298/43546384-55383440-958d-11e8-82da-f113ff3e65b2.gif)

After:
![wrapping-0](https://user-images.githubusercontent.com/2059298/43546380-505f56ce-958d-11e8-80d5-4dcb6f85ed22.gif)

#### Change List
- By default, wrap longitude around the viewport center.
- Add a `wrapCoordinates` prop to layers. If set to `false`, fallback to the old projection behavior.
