### PR TITLE
PATCH (v6.0.x): Bump probe.gl version to avoid issues with changed webpack behavior

### DIFF
--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -35,7 +35,7 @@
     "luma.gl": "^6.0.0",
     "math.gl": "^2.0.0",
     "mjolnir.js": "^1.0.0",
-    "probe.gl": "^1.0.0",
+    "probe.gl": "^1.0.4",
     "seer": "^0.2.4",
     "viewport-mercator-project": "^5.2.0"
   }

--- a/modules/test-utils/package.json
+++ b/modules/test-utils/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "deck.gl": "^6.0.2",
     "pixelmatch": "^4.0.2",
-    "probe.gl": "^1.0.0"
+    "probe.gl": "^1.0.4"
   },
   "scripts": {
     "build-clean": "rm -fr dist dist-es6 && mkdir -p dist dist-es6",


### PR DESCRIPTION
For #
#### Background
- Webpack made a big change (starting to bundle dynamic requires) in a minor version.
- The updated probe.gl prevents node modules from being pulled into browser builds.

#### Change List
- Bump probe.gl
