### PR TITLE
Support iterables in grid and hexagonal aggregators

### DIFF
--- a/modules/layers/src/hexagon-layer/hexagon-aggregator.js
+++ b/modules/layers/src/hexagon-layer/hexagon-aggregator.js
@@ -22,7 +22,7 @@ import {hexbin} from 'd3-hexbin';
 
 /**
  * Use d3-hexbin to performs hexagonal binning from geo points to hexagons
- * @param {Array} data - array of points
+ * @param {Iterable} data - array of points
  * @param {Number} radius - hexagon radius in meter
  * @param {function} getPosition - get points lon lat
  * @param {Object} viewport - current viewport object
@@ -34,14 +34,17 @@ export function pointToHexbin({data, radius, getPosition}, viewport) {
   const radiusInPixel = getRadiusInPixel(radius, viewport);
 
   // add world space coordinates to points
-  const screenPoints = data.map(pt =>
-    Object.assign(
-      {
-        screenCoord: viewport.projectFlat(getPosition(pt))
-      },
-      pt
-    )
-  );
+  const screenPoints = [];
+  for (const pt of data) {
+    screenPoints.push(
+      Object.assign(
+        {
+          screenCoord: viewport.projectFlat(getPosition(pt))
+        },
+        pt
+      )
+    );
+  }
 
   const newHexbin = hexbin()
     .radius(radiusInPixel)

--- a/test/modules/layers/grid-aggregator.spec.js
+++ b/test/modules/layers/grid-aggregator.spec.js
@@ -18,14 +18,20 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import './polygon-tesselation.spec';
-import './core-layers.spec';
-import './polygon-layer.spec';
-import './geojson.spec';
-import './geojson-layer.spec';
-import './grid-cell-layer.spec';
-import './grid-layer.spec';
-import './grid-aggregator.spec';
-import './hexagon-cell-layer.spec';
-import './hexagon-layer.spec';
-import './hexagon-aggregator.spec';
+import test from 'tape-catch';
+
+import * as FIXTURES from 'deck.gl/test/data';
+
+import {pointToDensityGridData} from '@deck.gl/layers/grid-layer/grid-aggregator';
+
+const getPosition = d => d.COORDINATES;
+const iterableData = new Set(FIXTURES.points);
+const cellSize = 500;
+
+test('pointToDensityGridData', t => {
+  t.ok(
+    typeof pointToDensityGridData(iterableData, cellSize, getPosition) === 'object',
+    'should work with iterables'
+  );
+  t.end();
+});

--- a/test/modules/layers/hexagon-aggregator.spec.js
+++ b/test/modules/layers/hexagon-aggregator.spec.js
@@ -18,14 +18,21 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import './polygon-tesselation.spec';
-import './core-layers.spec';
-import './polygon-layer.spec';
-import './geojson.spec';
-import './geojson-layer.spec';
-import './grid-cell-layer.spec';
-import './grid-layer.spec';
-import './grid-aggregator.spec';
-import './hexagon-cell-layer.spec';
-import './hexagon-layer.spec';
-import './hexagon-aggregator.spec';
+import test from 'tape-catch';
+
+import * as FIXTURES from 'deck.gl/test/data';
+
+import {pointToHexbin} from '@deck.gl/layers/hexagon-layer/hexagon-aggregator';
+
+const getPosition = d => d.COORDINATES;
+const iterableData = new Set(FIXTURES.points);
+const radius = 500;
+const viewport = FIXTURES.sampleViewport;
+
+test('pointToHexbin', t => {
+  t.ok(
+    typeof pointToHexbin({data: iterableData, radius, getPosition}, viewport) === 'object',
+    'should work with iterables'
+  );
+  t.end();
+});


### PR DESCRIPTION
#### Background

Usage of iterable data types with deck.gl works most of the time, but the grid and hexagonal aggregators use `.map`, `.reduce` and `for in` which cause errors.

<!-- For all the PRs -->
#### Change List
- change hexagon-aggregator to use `for of` instead of `.map`
- change grid-aggregator to use `for of` instead of `.reduce` or `for in`
