### PR TITLE
RFC: View Class Extensions

### DIFF
--- a/dev-docs/RFCs/README.md
+++ b/dev-docs/RFCs/README.md
@@ -71,7 +71,7 @@ These RFCS are currently targeted for v6.1 Also see [luma.gl RFCs](https://githu
 | RFC | Author | Status | Description |
 | --- | ---    | ---    | ---         |
 | [**JSON Layers**](v6.1/json-layers-rfc.md) | @ibgreen| **Preliminary Approval** | Allow partial updates of vertex attributes to support high-performance editing. |
-| [**View Class Extensions**](v6.1/view-class-extension-rfc.md) | @ibgreen| **Review** | Allow partial updates of vertex attributes to support high-performance editing. |
+| [**View Class Extensions**](v6.1/view-class-extension-rfc.md) | @ibgreen| **Review** | Additional View Class properties that enable e.g. "nested" maps (minimap on top of main map). |
 | [**Partial Updates**](v6.1/partial-updates-rfc.md) | @ibgreen @georgios-uber | **draft** | Allow partial updates of vertex attributes to support high-performance editing. |
 | [**Property Animation (Phase 1)**](v6.x/property-animation-rfc.md) | @ibgreen | Draft | Allow Layer props and GL parameters to accept functions in addition to values and call these on every render to update values |
 | [**Contour Layer**](v6.1/contour-layer-rfc.md) | @1chandy | **Preliminary Approval** | Contour detecting aggregating layer. |

--- a/dev-docs/RFCs/v6.1/json-layers-rfc.md
+++ b/dev-docs/RFCs/v6.1/json-layers-rfc.md
@@ -9,6 +9,13 @@
 
 This RFC proposes adding adaptor classes that accept JSON descriptions of views and layers and convert them to deck.gl views and layers. The JSON schema is proposed to be a "minimal" mapping of the current declarative deck.gl API.
 
+<div align="center">
+  <div>
+    <img src="https://raw.github.com/uber-common/deck.gl-data/master/images/docs/json-layers.gif" />
+    <p><i>PoC: JSON layer browser built on new @deck.gl/json module.</i></p>
+  </div>
+</div>
+
 
 ## Background
 

--- a/dev-docs/RFCs/v6.1/view-class-extension-rfc.md
+++ b/dev-docs/RFCs/v6.1/view-class-extension-rfc.md
@@ -53,7 +53,7 @@ The `viewState` property, while optional, enables a number of use cases:
 
 * `null` (default): Will select a view state based on `view.id`, falling back to using the first view state.
 * `String`: Will attempt to match the indicated 	view state.
-* `Object` (with `id` field): if the object contains an `id` field which matches a dynamic view state, the remaining fields will override fields in that view state.
+* `Object` (with `id` field): if the object contains an `id` field which matches a dynamic view state, the remaining fields will extend the specified dynamic view state.
 * `Object` (with no `id` field): If no `id` is provided, the `View.viewState` object will be used directly as the view state, essentially representing a fixed or constant view state.
 
 Note that specifying both `id` and `viewState` effectively allows the View to modify a view state before using it. This is useful in multiview situations where it enables having one view that fixes some parameters (eg. zoom, pitch and bearing to show an overview map).

--- a/dev-docs/RFCs/v6.1/view-class-extension-rfc.md
+++ b/dev-docs/RFCs/v6.1/view-class-extension-rfc.md
@@ -2,7 +2,7 @@
 
 * **Author**: Ib Green
 * **Date**: August, 2018
-* **Status**: **Draft**
+* **Status**: **Implemented**
 
 References:
 * [View Class RFC](../v5.2/view-class-rfc.md) for deck.gl v5.
@@ -10,7 +10,14 @@ References:
 
 ## Summary
 
-This RFC proposes to extend the functionality of the recently added `View` classes along the lines that were suggested as future extensions in the original proposal, to supporting things such as advance controls of view state (selection and filtering), layer filtering, support for overlapping viewports through background clearing and scissoring, and advanced render parameters.
+This RFC proposes to extend the functionality of `View` class hinted at in the original `View` proposal, primarily to support overlapping viewports through background clearing and scissoring and improved control of view state (selection and "filtering").
+
+<div align="center">
+  <div>
+    <img src="https://raw.github.com/uber-common/deck.gl-data/master/images/docs/minimap.gif" />
+    <p><i>PoC: Minimap implemented declaratively using the enhanced View Class API</i></p>
+  </div>
+</div>
 
 
 ## Motivation
@@ -22,9 +29,6 @@ The new `View` descriptor classes were introduced partly because they provide a 
 
 * Support for overlapping views (clearing background, scissoring)
 * More control over viewState selection and filtering
-* More control over layer filtering
-* More control over rendering setup/teardown (onBeforeRender, onAfterRender callbacks)
-* More control over advanced rendering aspects
 
 
 ### Marking Pitch (deck.gl What's New Page)
@@ -34,81 +38,48 @@ The new `View` descriptor classes were introduced partly because they provide a 
 
 ## Proposed Documentation Additions
 
-
 ### New `View` Class Properties
 
 
-##### `layerFilter` : Function | String[] | `null`
+##### `viewState` : String | Object | null
 
-Restricts what layers will be rendererd in this view.
+Used to specify what view state that should be used by this `View` when rendering, picking or projecting coordinates.
 
-* `Function`: function will be called with the following arguments: `layerFilter({layer, view, isPicking})`
-* `Array`: array of layer ids. Layer id's will be matched from with initial substring of layer ids, allowing nested layers to be matched.
-* `null` (default): All layers will be rendered.
+The `viewState` property, while optional, enables a number of use cases:
 
+* Sharing view states between multiple views - If a `View` id is different from the designed view state's id.
+* specify a complete, constant (fixed) view state directly in the view
+* Overriding a partial set of view state properties from a selected view state.
 
-##### `viewStateId` : String | null
+* `null` (default): Will select a view state based on `view.id`, falling back to using the first view state.
+* `String`: Will attempt to match the indicated 	view state.
+* `Object` (with `id` field): if the object contains an `id` field which matches a dynamic view state, the remaining fields will override fields in that view state.
+* `Object` (with no `id` field): If no `id` is provided, the `View.viewState` object will be used directly as the view state, essentially representing a fixed or constant view state.
 
-Used to select a specific view state (necessary if the viewState id is different than the view's id).
+Note that specifying both `id` and `viewState` effectively allows the View to modify a view state before using it. This is useful in multiview situations where it enables having one view that fixes some parameters (eg. zoom, pitch and bearing to show an overview map).
 
-
-##### `viewStateFilter` : Function | Object | `null`
-
-Allows the View to modify a view state before using it. Useful in multiview situations where it enables having one view that fixes some parameters (eg. zoom, pitch and bearing to show an overview map).
-
-* `Function`: will be called with `viewStateFilter(viewState)`. if it returns a value, it will be used as the modified viewState.
-* `Object`: will be merged with viewState and override any supplied fields.
-* `null`: the selected `viewState`
-
-
-##### `clear`: ...
-
-TODO - align argument with luma.gl `clear` function. Should allow for specification of `color` etc. Assuming we don't need
-* `color` - Background color
-* `onClear({gl, view, viewport, ...})` - Customize what is cleared (color, depth, stencil etc)
-
-
-##### `onBeforeRender({gl, view, viewport, viewState,...})`
-
-If supplied, called on every render, just before this view is rendered. However, note that a view that does not intersect the current update rect may not be rendered during that render frame, in which case the callback will not be called.
-
-
-##### `onAfterRender({gl, view, viewport, viewState,...})`
-
-If supplied, called on every render, just after this view was rendered. Note that a view that does not intersect the current update rect may not be rendered during that render frame, in which case the callback will not be called.
+TBD impact on controller? Can the controller make sense of what view state properties it can/should update when properties are overridden?
 
 
 
-## New Properties that Need More Study
+##### `clear`: Boolean | Object
+
+Clears the contents (pixels) of the viewport. If `true` clears color and depth buffers.
+
+* `color` (Boolean or Array) - if not `false`, clears all active color buffers with either the provided color or the currently set clear color.
+* `depth` (Boolean)  - if `true`, clears the depth buffer.
+* `stencil` (Boolean) - if `true` clears the stencil buffer.
+
+Note that the screen is cleared before each render, and viewports should only clear if they are e.g. rendering on top of another viewport, want to change the background coloer etc. Clearing, while cheap, is not totally free.
 
 
-##### `parameters`
-
-Enables the application to provide a full set of GL parameters, perhaps most importantly, selecting framebuffer. Note that 
-
-* `framebuffer` - makes this view render into a framebuffer
-* `parameters`: {blendMode, ...}
+* The value of the `View.clear` property is used as argument to the luma.gl `clear` function:
+* The view's scissor box bounds the cleared region.
+* The pixel ownership test, the scissor test, dithering, and the buffer writemasks affect the operation of `clear`.
+* Alpha function, blend function, logical operation, stenciling, texture mapping, and depth-buffering are ignored by `clear`.
 
 
-##### `framebuffer` : `Framebuffer` | `null`
 
-* Rendering to offscreen framebuffers
+## Future Extensions
 
-If supplied, controls which framebuffer will be the default render target for the layers rendered in this view. Enables vertain views to be rendered to offscreen framebuffers.
-
-TODO: investigate implications
-* relative viewport sizes will be resolved against the framebuffer size.
-* viewports with framebuffers will not be involved in picking.
-* ...
-
-
-## More Advanced Features
-
-We could address use cases beyond simply rendering multiple views:
-More ambitous extensions:
-* Each descriptor can provide its own layer and effects lists...
-* Multiple render passes over the same viewport - avoid clearing background
-
-A viewport descriptor could specify additional information like:
-* a named renderbuffer from a previous stage (viewport descriptor) to be used as input for effects, stencil buffering etc.
-* a `context object` with parameters that get passed to property animation functions.
+See separate [RFC: View Class Extensions 2]().

--- a/dev-docs/RFCs/v6.x/view-class-extensions-2-rfc.md
+++ b/dev-docs/RFCs/v6.x/view-class-extensions-2-rfc.md
@@ -1,0 +1,88 @@
+# RFC - View Class Extensions 2
+
+* **Author**: Ib Green
+* **Date**: August, 2018
+* **Status**: **Draft**
+
+References:
+* [View Class RFC](../v6.1/view-class-extension-rfc.md) for deck.gl v5.
+* [View Class RFC](../v5.2/view-class-rfc.md) for deck.gl v5.
+
+
+## Summary
+
+This RFC proposes to extend the functionality of `View` class hinted at in the original `View` proposal, such as advanced render parameters.
+
+
+## Motivation
+
+The new `View` descriptor classes were introduced partly because they provide a highly extensible API for the future.
+
+
+## Requirements
+
+* More control over layer filtering
+* More control over rendering setup/teardown (onBeforeRender, onAfterRender callbacks)
+* More control over advanced rendering aspects
+
+
+### Marking Pitch (deck.gl What's New Page)
+
+TBA..
+
+
+## Proposed Documentation Additions
+
+
+### New `View` Class Properties
+
+
+##### `layerFilter` : Function | String[] | `null`
+
+Restricts what layers will be rendererd in this view.
+
+* `Function`: function will be called with the following arguments: `layerFilter({layer, view, isPicking})`
+* `Array`: array of layer ids. Layer id's will be matched from with initial substring of layer ids, allowing nested layers to be matched.
+* `null` (default): All layers will be rendered.
+
+
+##### `onBeforeRender({gl, view, viewport, viewState,...})`
+
+If supplied, called on every render, just before this view is rendered. However, note that a view that does not intersect the current update rect may not be rendered during that render frame, in which case the callback will not be called.
+
+
+##### `onAfterRender({gl, view, viewport, viewState,...})`
+
+If supplied, called on every render, just after this view was rendered. Note that a view that does not intersect the current update rect may not be rendered during that render frame, in which case the callback will not be called.
+
+
+##### `parameters`
+
+Enables the application to provide a full set of GL parameters, perhaps most importantly, selecting framebuffer.
+
+* `framebuffer` - makes this view render into a framebuffer
+* `parameters`: {blendMode, ...}
+
+
+##### `framebuffer` : `Framebuffer` | `null`
+
+* Rendering to offscreen framebuffers
+
+If supplied, controls which framebuffer will be the default render target for the layers rendered in this view. Enables vertain views to be rendered to offscreen framebuffers.
+
+TODO: investigate implications
+* relative viewport sizes will be resolved against the framebuffer size.
+* viewports with framebuffers will not be involved in picking.
+* ...
+
+
+### More Advanced Features
+
+We could address use cases beyond simply rendering multiple views:
+More ambitous extensions:
+* Each descriptor can provide its own layer and effects lists...
+* Multiple render passes over the same viewport - avoid clearing background
+
+A viewport descriptor could specify additional information like:
+* a named renderbuffer from a previous stage (viewport descriptor) to be used as input for effects, stencil buffering etc.
+* a `context object` with parameters that get passed to property animation functions.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,17 +1,20 @@
 <p align="center">
   These docs are for
-  <a href="https://github.com/uber/deck.gl/blob/6.0-release/docs/README.md">
-    <img src="https://img.shields.io/badge/deck.gl-v6.0-brightgreen.svg?style=flat-square" />
+  <a href="https://github.com/uber/deck.gl/blob/6.1-release/docs/README.md">
+    <img src="https://img.shields.io/badge/deck.gl-v6.1-brightgreen.svg?style=flat-square" />
   </a>
   Looking for an old version?
+  <a href="https://github.com/uber/deck.gl/blob/6.0-release/docs/README.md">
+    <img src="https://img.shields.io/badge/deck.gl-v6.0-green.svg?style=flat-square" />
+  </a>
   <a href="https://github.com/uber/deck.gl/blob/5.3-release/docs/README.md">
-    <img src="https://img.shields.io/badge/v-5.3-brightgreen.svg?style=flat-square" />
+    <img src="https://img.shields.io/badge/v-5.3-green.svg?style=flat-square" />
   </a>
   <a href="https://github.com/uber/deck.gl/blob/5.2-release/docs/README.md">
-    <img src="https://img.shields.io/badge/v-5.2-brightgreen.svg?style=flat-square" />
+    <img src="https://img.shields.io/badge/v-5.2-green.svg?style=flat-square" />
   </a>
   <a href="https://github.com/uber/deck.gl/blob/5.1-release/docs/README.md">
-    <img src="https://img.shields.io/badge/v-5.1-brightgreen.svg?style=flat-square" />
+    <img src="https://img.shields.io/badge/v-5.1-green.svg?style=flat-square" />
   </a>
   <a href="https://github.com/uber/deck.gl/blob/5.0-release/docs/README.md">
     <img src="https://img.shields.io/badge/v-5.0-green.svg?style=flat-square" />

--- a/docs/api-reference/view.md
+++ b/docs/api-reference/view.md
@@ -33,6 +33,7 @@ const view = View({id, x, y, width, height, ...});
 ```
 
 Parameters:
+
 * `props` : Object - See documentation of props below.
 
 

--- a/docs/api-reference/view.md
+++ b/docs/api-reference/view.md
@@ -25,33 +25,46 @@ const {x, y, width, height} = view.getDimensions({width: 1024, height: 768});
 ```
 
 
-## Constructor
+## Constructor(props : Object)
 
 ```js
+const view = View(props);
 const view = View({id, x, y, width, height, ...});
 ```
 
 Parameters:
+* `props` : Object - See documentation of props below.
 
-* `id` (String)
-* `x` (String|Number) - A relative or absolute position. Default `0`.
+
+Note that like layers, Views are immutable once constructed.
+
+
+## Properties
+
+
+##### `id : String`
+
+
+##### `x : String|Number`
+
+A relative (e.g. `'10%'`) or absolute (e.g. `200`) position. Default `0`.
+
+
+##### `y : String|Number`
+
 * `y` (String|Number) - A relative or absolute position. Default `0`.
-* `width` (String|Number) - A relative or absolute extent. Default `'100%'`.
-* `height` (String|Number) - A relative or absolute extent. Default `'100%'`.
 
-Projection Matrix Parameters
 
-* `projectionMatrix`= (`Array[16]`, optional) - Projection matrix.
+A relative (e.g. `'10%'`) or absolute (e.g. `200`) position. Default `0`.
 
-If `projectionMatrix` is not supplied, `Viewport` will build a matrix from the following parameters:
+##### `width` (String|Number)
 
-* `fovyDegrees`=`75` (`Number`) - Field of view covered by camera, in the perspective case.
-* `aspect`= (`Number`) - Aspect ratio. Defaults to the Viewport's `width/height` ratio.
-* `near`=`0.1` (`Number`) - Distance of near clipping plane.
-* `far`=`1000` (`Number`) - Distance of far clipping plane.
-* `orthographic`=`false` (`Boolean`) - whether to create an orthographic or perspective projection matrix. Default is perspective projection.
-* `focalDistance`=`1` (`Number`) - (orthographic projections only) The distance at which the field-of-view frustum is sampled to extract the extents of the view box. Note: lso used for pixel scale identity distance above.
-* `orthographicFocalDistance` (`Number`) - (orthographic projections only) Can be used to specify different values for pixel scale focal distance and orthographic focal distance.
+A relative or absolute extent. Default `'100%'`.
+
+
+##### `height` (String|Number)
+
+A relative or absolute extent. Default `'100%'`.
 
 * `controller` (`Function` | `Boolean` | `Object`) - options for viewport interactivity.
   - `null` or `false`: this view is not interactive.
@@ -63,7 +76,88 @@ If `projectionMatrix` is not supplied, `Viewport` will build a matrix from the f
 
 Default `null`.
 
+
+##### `viewState` : String | Object | `null`
+
+The optional `viewState` property enables a `View` to specify, select or select-and-modify its view state.
+
+`viewState` is an overloaded property that can take either just a view state id string, or an object specifying view state parameters and optionally a view state id string:
+
+* `null` (default): Will select a view state based on `view.id`, falling back to using the first view state.
+* `String`: Will attempt to match the indicated 	view state.
+* `Object` (with `id` field): if the object contains an `id` field which matches a dynamic view state, the remaining fields will override fields in that view state.
+* `Object` (with no `id` field): If no `id` is provided, the `View.viewState` object will be used directly as the view state, essentially representing a fixed or constant view state.
+
+Note that specifying `viewState` as an object with an `id` field effectively allows the View to modify a dynamic view state by overriding some of its fields. This is useful in multiview situations where it enables having one view that fixes some parameters (eg. zoom, pitch and bearing to show an overview map).
+
+The `viewState` property is intended to support a number of use cases:
+
+* Sharing view states between multiple views - If a `View` id is different from the designed view state's id.
+* specify a complete, constant (fixed) view state directly in the view
+* Overriding a partial set of view state properties from a selected view state.
+
+
+##### `clear`: Boolean | Object
+
+Clears the contents (pixels) of the viewport. The value of the `clear` prop is passed as argument to luma.gl's `clear` function. If `true` clears color and depth buffers. If an object, behaviour is controller by the following fields:
+
+* `color` (Boolean or Array) - if not `false`, clears all active color buffers with either the provided color or the currently set clear color.
+* `depth` (Boolean)  - if `true`, clears the depth buffer.
+* `stencil` (Boolean) - if `true` clears the stencil buffer.
+
+Note that deck.gl always clears the screen before each render, and clearing, while cheap, is not totally free. This means that viewports should only specify the `clear` property if they need additional clearing, e.g. because they are rendering on top of another viewport, or want to have a different background color etc.
+
+
+##### `projectionMatrix`= (`Array[16]`, optional)
+
+Projection matrix.
+
+
+## Projection Matrix Props
+
+If `projectionMatrix` is not supplied, the `View` class will build a projection matrix from the following parameters:
+
+
+##### `fovyDegrees`=`75` (`Number`)
+
+Field of view covered by camera, in the perspective case.
+
+
+##### `aspect`= (`Number`)
+
+Aspect ratio. Defaults to the Viewport's `width/height` ratio.
+
+
+##### `near`=`0.1` (`Number`)
+
+Distance of near clipping plane.
+
+
+##### `far`=`1000` (`Number`)
+
+Distance of far clipping plane.
+
+
+##### `orthographic`=`false` (`Boolean`)
+
+Whether to create an orthographic or perspective projection matrix. Default is perspective projection.
+
+
+##### `focalDistance`=`1` (`Number`)
+
+Note: Used by orthographic projections only. The distance at which the field-of-view frustum is sampled to extract the extents of the view box. Note: lso used for pixel scale identity distance above.
+
+
+##### `orthographicFocalDistance` (`Number`)
+
+Noe: (orthographic projections only) Can be used to specify different values for pixel scale focal distance and orthographic focal distance.
+
+
+
 ## Methods
+
+Note: most applications just create Views with the appropriate props and do not need to call the following View methods directly.
+
 
 ##### `equals`
 
@@ -80,7 +174,7 @@ Returns:
 Note: For speed, deck.gl uses shallow equality. This means that a value of `false` does not guarantee that the views are not equivalent.
 
 
-##### `makeViewport`
+##### `makeViewport({width : Number, height : Number, viewState : Object}) : Viewport`
 
 ```js
 View.makeViewport({width, height, viewState})
@@ -89,7 +183,7 @@ View.makeViewport({width, height, viewState})
 Builds a viewport using the viewport type and props in the `View`and provided `width`, `height` and `viewState`. The contents of `viewState` needs to be compatible with the particular `View` sublass in use.
 
 
-##### `getDimensions`
+##### `getDimensions({width : Number, height : Number}) : Object`
 
 Returns the actual pixel position and size that this `View` will occupy in a given "canvas" size.
 
@@ -110,7 +204,7 @@ Returns:
 * `height` (`Number`) - height in CSS pixels
 
 
-##### `getMatrix`
+##### `getMatrix({width : Number, height : Number}) : Array`
 
 ```js
 View.getMatrix({width, height})

--- a/docs/api-reference/view.md
+++ b/docs/api-reference/view.md
@@ -71,7 +71,7 @@ A relative or absolute extent. Default `'100%'`.
   - `null` or `false`: this view is not interactive.
   - `true`: initiates the default controller with default options.
   - `Controller` class (not instance): initiates the provided controller with default options.
-  - `Object`: controller options. This will be merged with the default controller options. 
+  - `Object`: controller options. This will be merged with the default controller options.
     + `controller.type`: the controller class
     + For other options, consult the documentation of [Controller](/docs/api-reference/controller.md).
 
@@ -86,7 +86,7 @@ The optional `viewState` property enables a `View` to specify, select or select-
 
 * `null` (default): Will select a view state based on `view.id`, falling back to using the first view state.
 * `String`: Will attempt to match the indicated 	view state.
-* `Object` (with `id` field): if the object contains an `id` field which matches a dynamic view state, the remaining fields will override fields in that view state.
+* `Object` (with `id` field): if the object contains an `id` field which matches a dynamic view state, the remaining fields in `View.viewState` will extend (be merged into a copy of) the selected dynamic view state.
 * `Object` (with no `id` field): If no `id` is provided, the `View.viewState` object will be used directly as the view state, essentially representing a fixed or constant view state.
 
 Note that specifying `viewState` as an object with an `id` field effectively allows the View to modify a dynamic view state by overriding some of its fields. This is useful in multiview situations where it enables having one view that fixes some parameters (eg. zoom, pitch and bearing to show an overview map).

--- a/docs/developer-guide/json/README.md
+++ b/docs/developer-guide/json/README.md
@@ -1,0 +1,11 @@
+# @deck.gl/json
+
+The deck.gl JSON module provides support for specifying deck.gl visualizations using JSON formatted text files and strings.
+
+<div align="center">
+  <div>
+    <img src="https://raw.github.com/uber-common/deck.gl-data/master/images/docs/json-layers.gif" />
+    <p><i>deck.gl's JSON layer browser allows end users to explore the deck.gl API through interactive editing of JSON, processed by the `@deck.gl/json` module.</i></p>
+  </div>
+</div>
+

--- a/docs/developer-guide/json/using-json-api.md
+++ b/docs/developer-guide/json/using-json-api.md
@@ -9,7 +9,7 @@ References:
 
 ## Schema
 
-The valid combinations are essentially defined by the documented deck.gl API
+The valid combinations are essentially defined by the documented deck.gl API.
 
 
 ## Error Handling

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -10,8 +10,14 @@ Release date: TBD, Target late Aug, 2018
   <tbody>
     <tr>
       <td>
-        <img height=200 src="https://raw.github.com/uber-common/deck.gl-data/master/images/attribute-transition.gif" />
+        <img height=150 src="https://raw.github.com/uber-common/deck.gl-data/master/images/json-layers-thumb.gif" />
         <p><i>JSON API</i></p>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <img height=150 src="https://raw.github.com/uber-common/deck.gl-data/master/images/whats-new/minimap-thumb.gif" />
+        <p><i>Enhanced Multi-View API</i></p>
       </td>
     </tr>
   </tbody>
@@ -21,6 +27,11 @@ Release date: TBD, Target late Aug, 2018
 ### JSON API (Experimental)
 
 A new experimental module `@deck.gl/json` provides a set of classes that allows deck.gl layers and views to be specified using JSON-formatted text files.
+
+
+### Enhanced Multiview Support
+
+deck.gl's multiview support has been significantly enhanced. New `View` properties give applications more control over rendering, making it possible to implement e.g. overlapping views, partially synchronized views (share some but not all view state props), views with different background colors etc.
 
 
 ## deck.gl v6.0

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -18,8 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import LayerManager from '../lib/layer-manager';
-import ViewManager from '../views/view-manager';
+import LayerManager from './layer-manager';
+import ViewManager from './view-manager';
 import MapView from '../views/map-view';
 import EffectManager from '../experimental/lib/effect-manager';
 import Effect from '../experimental/lib/effect';
@@ -521,7 +521,8 @@ export default class Deck {
 
     this.layerManager.drawLayers({
       pass: 'screen',
-      viewports: this.getViewports(),
+      viewports: this.viewManager.getViewports(),
+      views: this.viewManager.getViews(),
       redrawReason,
       drawPickingColors: this.props.drawPickingColors // Debug picking, helps in framebuffered layers
     });

--- a/modules/core/src/lib/draw-layers.js
+++ b/modules/core/src/lib/draw-layers.js
@@ -20,7 +20,7 @@
 
 /* global window */
 import GL from 'luma.gl/constants';
-import {withParameters, setParameters} from 'luma.gl';
+import {withParameters, setParameters, clear} from 'luma.gl';
 import log from '../utils/log';
 import assert from '../utils/assert';
 
@@ -66,6 +66,7 @@ export function drawLayers(
   {
     layers,
     viewports,
+    views,
     onViewportActive,
     useDevicePixels,
     drawPickingColors = false,
@@ -83,6 +84,7 @@ export function drawLayers(
 
   viewports.forEach((viewportOrDescriptor, i) => {
     const viewport = getViewportFromDescriptor(viewportOrDescriptor);
+    const view = views && views[viewport.id];
 
     // Update context to point to this viewport
     onViewportActive(viewport);
@@ -91,6 +93,7 @@ export function drawLayers(
     drawLayersInViewport(gl, {
       layers,
       viewport,
+      view,
       useDevicePixels,
       drawPickingColors,
       deviceRect,
@@ -162,6 +165,7 @@ function drawLayersInViewport(
   {
     layers,
     viewport,
+    view,
     useDevicePixels,
     drawPickingColors = false,
     deviceRect = null,
@@ -174,6 +178,17 @@ function drawLayersInViewport(
 ) {
   const pixelRatio = getPixelRatio({useDevicePixels});
   const glViewport = getGLViewport(gl, {viewport, pixelRatio});
+
+  if (view && view.props.clear) {
+    withParameters(
+      gl,
+      {
+        scissorTest: true,
+        scissor: glViewport
+      },
+      () => clear(view.props.clear)
+    );
+  }
 
   // render layers in normal colors
   const renderStats = {

--- a/modules/core/src/lib/layer-manager.js
+++ b/modules/core/src/lib/layer-manager.js
@@ -237,7 +237,7 @@ export default class LayerManager {
   //
 
   // Draw all layers in all views
-  drawLayers({pass = 'render to screen', viewports, redrawReason = 'unknown reason'}) {
+  drawLayers({pass = 'render to screen', viewports, views, redrawReason = 'unknown reason'}) {
     const {drawPickingColors} = this;
     const {gl, useDevicePixels} = this.context;
 
@@ -245,6 +245,7 @@ export default class LayerManager {
     drawLayers(gl, {
       layers: this.layers,
       viewports,
+      views,
       onViewportActive: this._activateViewport,
       useDevicePixels,
       drawPickingColors,

--- a/modules/core/src/views/view.js
+++ b/modules/core/src/views/view.js
@@ -76,10 +76,49 @@ export default class View {
       return this.viewportInstance;
     }
 
+    viewState = this.filterViewState(viewState);
+
     // Resolve relative viewport dimensions
     const viewportDimensions = this.getDimensions({width, height});
     const props = Object.assign({viewState}, viewState, this.props, viewportDimensions);
     return this._getViewport(props);
+  }
+
+  getViewStateId() {
+    switch (typeof this.props.viewState) {
+    case 'string':
+      // if View.viewState is a string, return it
+      return this.props.viewState;
+
+    case 'object':
+      // If it is an object, return its id component
+      return this.props.viewState && this.props.viewState.id;
+
+    default:
+      return this.id;
+    }
+  }
+
+  // Allows view to override (or completely define) viewState
+  filterViewState(viewState) {
+    if (this.props.viewState && typeof this.props.viewState === 'object') {
+      // If we have specified an id, then intent is to override,
+      // If not, completely specify the view state
+      if (!this.props.viewState.id) {
+        return this.props.viewState;
+      }
+
+      // Merge in all props from View's viewState, except id
+      const newViewState = Object.assign({}, viewState);
+      for (const key in this.props.viewState) {
+        if (key !== 'id') {
+          newViewState[key] = this.props.viewState[key];
+        }
+      }
+      return newViewState;
+    }
+
+    return viewState;
   }
 
   // Resolve relative viewport dimensions into actual dimensions (y='50%', width=800 => y=400)

--- a/modules/core/src/views/view.js
+++ b/modules/core/src/views/view.js
@@ -86,16 +86,16 @@ export default class View {
 
   getViewStateId() {
     switch (typeof this.props.viewState) {
-    case 'string':
-      // if View.viewState is a string, return it
-      return this.props.viewState;
+      case 'string':
+        // if View.viewState is a string, return it
+        return this.props.viewState;
 
-    case 'object':
-      // If it is an object, return its id component
-      return this.props.viewState && this.props.viewState.id;
+      case 'object':
+        // If it is an object, return its id component
+        return this.props.viewState && this.props.viewState.id;
 
-    default:
-      return this.id;
+      default:
+        return this.id;
     }
   }
 

--- a/modules/json/README.md
+++ b/modules/json/README.md
@@ -4,3 +4,10 @@ JSON support for deck.gl. Provides deck.gl classes that support specifying deck.
 
 See [deck.gl](http://deck.gl) for documentation.
 
+<div align="center">
+  <div>
+    <img src="https://raw.github.com/uber-common/deck.gl-data/master/images/docs/json-layers.gif" />
+    <p><i>PoC: JSON layer browser built on new @deck.gl/json module.</i></p>
+  </div>
+</div>
+

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "test-render": "webpack-dev-server --config test/webpack.config.js --env.render --progress --hot --open",
     "bench": "scripts/test.sh bench",
     "bench-browser": "webpack-dev-server --config test/webpack.config.js --env.bench --progress --hot --open",
-    "collect-metrics": "./scripts/collect-metrics.sh"
+    "collect-metrics": "./scripts/collect-metrics.sh",
+    "link-luma": "yarn && (cd node_modules && mv luma.gl luma.orig && ln -s ../../luma.gl/modules/core)",
+    "unlink-luma": "(cd node_modules && mv luma.gl luma.ln && mv luma.orig luma.gl)"
   },
   "devDependencies": {
     "@babel/cli": "7.0.0-rc.1",

--- a/test/modules/core/views/view-manager.spec.js
+++ b/test/modules/core/views/view-manager.spec.js
@@ -1,5 +1,5 @@
 import test from 'tape-catch';
-import ViewManager from '@deck.gl/core/views/view-manager';
+import ViewManager from '@deck.gl/core/lib/view-manager';
 import {MapView, Viewport} from 'deck.gl';
 
 const INITIAL_VIEW_STATE = {latitude: 0, longitude: 0, zoom: 1};

--- a/website/package.json
+++ b/website/package.json
@@ -8,6 +8,7 @@
   "main": "index.js",
   "scripts": {
     "start": "webpack-dev-server --env.local --progress --content-base ./src/static --open",
+    "start-local": "yarn start",
     "build-clean": "rm -rf ./dist && mkdir dist",
     "build-static": "cp -r ./src/static/* dist && babel ./src/static/workers --out-dir dist/workers",
     "build-script": "webpack -p --env.prod",

--- a/website/webpack.config.js
+++ b/website/webpack.config.js
@@ -89,7 +89,10 @@ const addDevConfig = config => {
 
     plugins: config.plugins.concat([
       // new webpack.HotModuleReplacementPlugin(),
-      new webpack.NoEmitOnErrorsPlugin()
+      new webpack.NoEmitOnErrorsPlugin(),
+      new webpack.DefinePlugin({
+        USE_LOCAL_PAGES: true // eslint-disable-line
+      })
     ])
 
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -578,8 +578,8 @@
     glob-to-regexp "^0.3.0"
 
 "@nodelib/fs.stat@^1.0.1":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.0.tgz#50c1e2260ac0ed9439a181de3725a0168d59c48a"
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.1.tgz#53f349bb986ab273d601175aa1b25a655ab90ee3"
 
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
@@ -811,13 +811,13 @@ ajv@^5.2.3, ajv@^5.3.0:
     json-schema-traverse "^0.3.0"
 
 ajv@^6.1.0:
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.5.2.tgz#678495f9b82f7cca6be248dd92f59bff5e1f4360"
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.5.3.tgz#71a569d189ecf4f4f321224fecb166f071dd90f9"
   dependencies:
     fast-deep-equal "^2.0.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
-    uri-js "^4.2.1"
+    uri-js "^4.2.2"
 
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
@@ -1067,8 +1067,8 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
 atob@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.1.tgz#ae2d5a729477f289d60dd7f96a6314a22dd6c22a"
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
 
 aws-sign2@~0.6.0:
   version "0.6.0"
@@ -2343,9 +2343,9 @@ chrome-trace-event@^1.0.0:
   dependencies:
     tslib "^1.9.0"
 
-ci-info@^1.0.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.3.0.tgz#ea8219b0355a58692b762baf1cdd76ceb4503283"
+ci-info@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.4.0.tgz#4841d53cad49f11b827b648ebde27a6e189b412f"
 
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
@@ -2367,11 +2367,11 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-clean-css@4.1.x:
-  version "4.1.11"
-  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.1.11.tgz#2ecdf145aba38f54740f26cefd0ff3e03e125d6a"
+clean-css@4.2.x:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.1.tgz#2d411ef76b8569b6d0c84068dabe85b0aa5e5c17"
   dependencies:
-    source-map "0.5.x"
+    source-map "~0.6.0"
 
 cli-cursor@^1.0.2:
   version "1.0.2"
@@ -2521,17 +2521,17 @@ command-join@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/command-join/-/command-join-2.0.0.tgz#52e8b984f4872d952ff1bdc8b98397d27c7144cf"
 
-commander@2, commander@^2.13.0, commander@^2.8.1, commander@^2.9.0:
+commander@2, commander@2.17.x, commander@^2.13.0, commander@^2.8.1, commander@^2.9.0:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
-
-commander@2.16.x, commander@~2.16.0:
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.16.0.tgz#f16390593996ceb4f3eeb020b31d78528f7f8a50"
 
 commander@~2.13.0:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
+
+commander@~2.16.0:
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.16.0.tgz#f16390593996ceb4f3eeb020b31d78528f7f8a50"
 
 commander@~2.9.0:
   version "2.9.0"
@@ -3056,11 +3056,10 @@ defaults@^1.0.3:
     clone "^1.0.2"
 
 define-properties@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
   dependencies:
-    foreach "^2.0.5"
-    object-keys "^1.0.8"
+    object-keys "^1.0.12"
 
 define-property@^0.2.5:
   version "0.2.5"
@@ -3994,8 +3993,8 @@ flat-colors@3.0.0:
   resolved "https://registry.yarnpkg.com/flat-colors/-/flat-colors-3.0.0.tgz#253ab1a23989c321f13b0acd4bf73fff4072ecb7"
 
 flow-parser@^0.*:
-  version "0.78.0"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.78.0.tgz#4ec829a97fa68cff6e97691dfff7b6ddebbc187c"
+  version "0.79.1"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.79.1.tgz#bd556bf1b0416e6a3ada6398df360c3747cecf3f"
 
 flush-write-stream@^1.0.0:
   version "1.0.3"
@@ -4713,12 +4712,12 @@ html-entities@^1.2.0:
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.1.tgz#0df29351f0721163515dfb9e5543e5f6eed5162f"
 
 html-minifier@^3.2.3:
-  version "3.5.19"
-  resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-3.5.19.tgz#ed53c4b7326fe507bc3a1adbcc3bbb56660a2ebd"
+  version "3.5.20"
+  resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-3.5.20.tgz#7b19fd3caa0cb79f7cde5ee5c3abdf8ecaa6bb14"
   dependencies:
     camel-case "3.0.x"
-    clean-css "4.1.x"
-    commander "2.16.x"
+    clean-css "4.2.x"
+    commander "2.17.x"
     he "1.1.x"
     param-case "2.1.x"
     relateurl "0.2.x"
@@ -5008,10 +5007,10 @@ is-callable@^1.1.1, is-callable@^1.1.3:
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
 
 is-ci@^1.0.10:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.1.0.tgz#247e4162e7860cebbdaf30b774d6b0ac7dcfe7a5"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.2.0.tgz#3f4a08d6303a09882cef3f0fb97439c5f5ce2d53"
   dependencies:
-    ci-info "^1.0.0"
+    ci-info "^1.3.0"
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -5713,14 +5712,14 @@ listr@^0.14.1:
     strip-ansi "^3.0.1"
 
 load-bmfont@^1.2.3:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/load-bmfont/-/load-bmfont-1.3.0.tgz#bb7e7c710de6bcafcb13cb3b8c81e0c0131ecbc9"
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/load-bmfont/-/load-bmfont-1.3.1.tgz#0e7933f66543409882127b0d0fbad7a66d5a7869"
   dependencies:
     buffer-equal "0.0.1"
     mime "^1.3.4"
     parse-bmfont-ascii "^1.0.3"
     parse-bmfont-binary "^1.0.5"
-    parse-bmfont-xml "^1.1.0"
+    parse-bmfont-xml "^1.1.4"
     xhr "^2.0.1"
     xtend "^4.0.0"
 
@@ -6192,7 +6191,11 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-"mime-db@>= 1.34.0 < 2", mime-db@~1.35.0:
+"mime-db@>= 1.34.0 < 2":
+  version "1.36.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.36.0.tgz#5020478db3c7fe93aad7bbcc4dcf869c43363397"
+
+mime-db@~1.35.0:
   version "1.35.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.35.0.tgz#0569d657466491283709663ad379a99b90d9ab47"
 
@@ -6649,7 +6652,7 @@ object-inspect@~1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.6.0.tgz#c70b6cbf72f274aab4c34c0c82f5167bf82cf15b"
 
-object-keys@^1.0.11, object-keys@^1.0.6, object-keys@^1.0.8:
+object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.0.6:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
 
@@ -6913,9 +6916,9 @@ parse-bmfont-binary@^1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/parse-bmfont-binary/-/parse-bmfont-binary-1.0.6.tgz#d038b476d3e9dd9db1e11a0b0e53a22792b69006"
 
-parse-bmfont-xml@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/parse-bmfont-xml/-/parse-bmfont-xml-1.1.3.tgz#d6b66a371afd39c5007d9f0eeb262a4f2cce7b7c"
+parse-bmfont-xml@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/parse-bmfont-xml/-/parse-bmfont-xml-1.1.4.tgz#015319797e3e12f9e739c4d513872cd2fa35f389"
   dependencies:
     xml-parse-from-string "^1.0.0"
     xml2js "^0.4.5"
@@ -7101,8 +7104,8 @@ pngjs@^3.0.0:
   resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-3.3.3.tgz#85173703bde3edac8998757b96e5821d0966a21b"
 
 portfinder@^1.0.9:
-  version "1.0.16"
-  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.16.tgz#a6a68be9c352bc66c1a4c17a261f661f3facaf52"
+  version "1.0.17"
+  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.17.tgz#a8a1691143e46c4735edefcf4fbcccedad26456a"
   dependencies:
     async "^1.5.2"
     debug "^2.2.0"
@@ -7715,8 +7718,8 @@ renderkid@^2.0.1:
     utila "~0.3"
 
 repeat-element@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.2.tgz#ef089a178d1483baae4d93eb98b4f9e4e11d990a"
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
 
 repeat-string@^1.5.2, repeat-string@^1.6.1:
   version "1.6.1"
@@ -7995,8 +7998,8 @@ selfsigned@^1.9.1:
     node-forge "0.7.5"
 
 "semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
 
 semver@~5.3.0:
   version "5.3.0"
@@ -8274,17 +8277,17 @@ source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
 
-source-map@0.5.x, source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1:
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
-
 source-map@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.6.1, source-map@~0.6.1:
+source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+
+source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
@@ -8611,8 +8614,8 @@ supports-color@^3.1.2:
     has-flag "^1.0.0"
 
 supports-color@^5.1.0, supports-color@^5.3.0, supports-color@^5.4.0:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   dependencies:
     has-flag "^3.0.0"
 
@@ -9064,7 +9067,7 @@ upper-case@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
 
-uri-js@^4.2.1:
+uri-js@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
   dependencies:


### PR DESCRIPTION
# For #2072

#### Background
- Implements [View Class Extensions RFC](https://github.com/uber/deck.gl/blob/master/dev-docs/RFCs/v6.1/view-class-extension-rfc.md)
- Adds a version of trips example with minimap support

![minimap](https://user-images.githubusercontent.com/7025232/43679050-1e386cec-97d3-11e8-8c0f-37e7b75cb503.gif)

#### Change List
- Add some `View` capabilities, `viewStateId`, `filterViewState`, `clear`.
- Clone trips example and add minimap.
- Move `ViewManager` to `lib`, it handles more than Views and feels more natural there.

