### PR TITLE
【Feature】Scatterplot-layer add some new properties, it will both has …

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -22,6 +22,9 @@ Release date: TBD, Target late Aug, 2018
 
 A new experimental module `@deck.gl/json` provides a set of classes that allows deck.gl layers and views to be rendered using JSON specifications.
 
+## stroke, strokeColor
+Scatterplot-layer add some new properties, it will both has fill and border with `stroke` property. `strokeColor` property can change border color.
+
 
 ## deck.gl v6.0
 

--- a/examples/layer-browser/src/examples/core-layers.js
+++ b/examples/layer-browser/src/examples/core-layers.js
@@ -219,7 +219,10 @@ const ScatterplotLayerExample = {
     pickable: true,
     radiusScale: 30,
     radiusMinPixels: 1,
-    radiusMaxPixels: 30
+    radiusMaxPixels: 30,
+    stroke: false,
+    outline: false,
+    getStrokeColor: [0, 0, 255]
   }
 };
 

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer.js
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer.js
@@ -27,6 +27,7 @@ import vs from './scatterplot-layer-vertex.glsl';
 import fs from './scatterplot-layer-fragment.glsl';
 
 const DEFAULT_COLOR = [0, 0, 0, 255];
+const DEFAULT_STROKE_COLOR = [255, 255, 255, 255];
 
 const defaultProps = {
   radiusScale: 1,
@@ -35,10 +36,12 @@ const defaultProps = {
   strokeWidth: 1,
   outline: false,
   fp64: false,
+  stroke: false,
 
   getPosition: x => x.position,
   getRadius: 1,
-  getColor: DEFAULT_COLOR
+  getColor: DEFAULT_COLOR,
+  getStrokeColor: DEFAULT_STROKE_COLOR
 };
 
 export default class ScatterplotLayer extends Layer {
@@ -71,6 +74,13 @@ export default class ScatterplotLayer extends Layer {
         type: GL.UNSIGNED_BYTE,
         accessor: 'getColor',
         defaultValue: [0, 0, 0, 255]
+      },
+      instanceStrokeColors: {
+        size: 4,
+        transition: true,
+        type: GL.UNSIGNED_BYTE,
+        accessor: 'getStrokeColor',
+        defaultValue: [255, 255, 255, 255]
       }
     });
   }
@@ -88,10 +98,18 @@ export default class ScatterplotLayer extends Layer {
   }
 
   draw({uniforms}) {
-    const {radiusScale, radiusMinPixels, radiusMaxPixels, outline, strokeWidth} = this.props;
+    const {radiusScale, radiusMinPixels, radiusMaxPixels, outline, strokeWidth, stroke} = this.props;
+
+    if(!strokeWidth && stroke) {
+      stroke = false;
+      //fix when strokeWidth = 0, the graphic elements will disppear 
+      if(outline) outline = false;
+    }
+
     this.state.model.render(
       Object.assign({}, uniforms, {
-        outline: outline ? 1 : 0,
+        stroke: stroke ? 1 : 0,
+        outline: outline || stroke ? 1 : 0,
         strokeWidth,
         radiusScale,
         radiusMinPixels,


### PR DESCRIPTION

### background
It's a need for me to create layer both has border and fill. In the same time the point geomtry need use pixel as unit.

#### Change List
-Scatterplot-layer add new property "stroke", "strokeColor", the layer can both has border and fill color

### test



![tim 20180807151559](https://user-images.githubusercontent.com/42170635/43774207-fa45d4a0-9a7a-11e8-9a0a-2e075760945c.png)
