### PR TITLE
fixed broken link to documentation of TripsLayer

### DIFF
--- a/examples/website/trips/README.md
+++ b/examples/website/trips/README.md
@@ -1,4 +1,4 @@
-This is a minimal standalone version of the TripsLayer example
+This is a minimal standalone version of the [TripsLayer example](https://deck.gl/#/examples/custom-layers/trip-routes)
 on [deck.gl](http://deck.gl) website.
 
 ### Usage
@@ -10,4 +10,4 @@ npm start
 
 ### Data format
 Sample data is stored in [deck.gl Example Data](https://github.com/uber-common/deck.gl-data/tree/master/examples/trips). To use your own data, checkout
-the [documentation of TripsLayer](./trips-layer/README.md).
+the [documentation of TripsLayer](https://github.com/uber/deck.gl/tree/master/modules/experimental-layers/src/trips-layer).


### PR DESCRIPTION
Added link to TripsLayer example on deck.gl website.
