### PR TITLE
Revert hack in SolidPolygonLayer

### DIFF
--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -269,9 +269,9 @@ export default class SolidPolygonLayer extends Layer {
           geometry: new Geometry({
             drawMode: GL.TRIANGLES,
             attributes: {
-              vertexPositions: {size: 2, isInstanced: true, value: new Float32Array([0, 1])},
-              nextPositions: {size: 3, isInstanced: true, value: new Float32Array(3)},
-              nextPositions64xyLow: {size: 2, isInstanced: true, value: new Float32Array(2)}
+              vertexPositions: {size: 2, constant: true, value: new Float32Array([0, 1])},
+              nextPositions: {size: 3, constant: true, value: new Float32Array(3)},
+              nextPositions64xyLow: {size: 2, constant: true, value: new Float32Array(2)}
             }
           }),
           uniforms: {


### PR DESCRIPTION
#### Background

The hack was put in before 6.0 release due to the WebGL1 constant attribute bug.
This fix depends on the latest VertexArray fix on luma.gl.

#### Change List
- Revert hack.
