### PR TITLE
Fix offset projection under offset modes

### DIFF
--- a/modules/core/src/shaderlib/project/project-functions.js
+++ b/modules/core/src/shaderlib/project/project-functions.js
@@ -85,7 +85,6 @@ export function projectPosition(
     case COORDINATE_SYSTEM.METER_OFFSETS:
       const originWorld = lngLatZToWorldPosition(coordinateOrigin, viewport);
       vec3_sub(worldPosition, worldPosition, originWorld);
-      worldPosition[1] = -worldPosition[1];
       break;
 
     default:

--- a/modules/core/src/shaderlib/project/project.glsl.js
+++ b/modules/core/src/shaderlib/project/project.glsl.js
@@ -86,7 +86,6 @@ vec3 project_normal(vec3 vector) {
 
 vec4 project_offset_(vec4 offset) {
   vec3 pixelsPerUnit = project_uPixelsPerUnit + project_uPixelsPerUnit2 * offset.y;
-  pixelsPerUnit.y = -pixelsPerUnit.y;
   return vec4(offset.xyz * pixelsPerUnit, offset.w);
 }
 

--- a/modules/core/src/shaderlib/project/project.glsl.js
+++ b/modules/core/src/shaderlib/project/project.glsl.js
@@ -86,6 +86,7 @@ vec3 project_normal(vec3 vector) {
 
 vec4 project_offset_(vec4 offset) {
   vec3 pixelsPerUnit = project_uPixelsPerUnit + project_uPixelsPerUnit2 * offset.y;
+  pixelsPerUnit.y = -pixelsPerUnit.y;
   return vec4(offset.xyz * pixelsPerUnit, offset.w);
 }
 

--- a/modules/core/src/shaderlib/project/viewport-uniforms.js
+++ b/modules/core/src/shaderlib/project/viewport-uniforms.js
@@ -259,7 +259,9 @@ function calculateViewportUniforms({
   switch (shaderCoordinateSystem) {
     case PROJECT_COORDINATE_SYSTEM.METER_OFFSETS:
       uniforms.project_uPixelsPerUnit = distanceScalesAtOrigin.pixelsPerMeter;
+      uniforms.project_uPixelsPerUnit[1] *= -1;
       uniforms.project_uPixelsPerUnit2 = distanceScalesAtOrigin.pixelsPerMeter2;
+      uniforms.project_uPixelsPerUnit2[1] *= -1;
       break;
 
     case PROJECT_COORDINATE_SYSTEM.LNGLAT_AUTO_OFFSET:
@@ -267,7 +269,9 @@ function calculateViewportUniforms({
     // eslint-disable-line no-fallthrough
     case PROJECT_COORDINATE_SYSTEM.LNGLAT_OFFSETS:
       uniforms.project_uPixelsPerUnit = distanceScalesAtOrigin.pixelsPerDegree;
+      uniforms.project_uPixelsPerUnit[1] *= -1;
       uniforms.project_uPixelsPerUnit2 = distanceScalesAtOrigin.pixelsPerDegree2;
+      uniforms.project_uPixelsPerUnit2[1] *= -1;
       break;
 
     default:

--- a/modules/core/src/viewports/viewport.js
+++ b/modules/core/src/viewports/viewport.js
@@ -340,9 +340,6 @@ export default class Viewport {
       this.viewMatrix = new Matrix4()
         // Apply the uncentered view matrix
         .multiplyRight(this.viewMatrixUncentered)
-        // The Mercator world coordinate system is upper left,
-        // but GL expects lower left, so we flip it around the center after all transforms are done
-        .scale([1, -1, 1])
         // And center it
         .translate(new Vector3(this.center || ZERO_VECTOR).negate());
     } else {

--- a/modules/core/src/viewports/web-mercator-viewport.js
+++ b/modules/core/src/viewports/web-mercator-viewport.js
@@ -83,7 +83,8 @@ export default class WebMercatorViewport extends Viewport {
       height,
       pitch,
       bearing,
-      altitude
+      altitude,
+      flipY: true
     });
 
     // TODO / hack - prevent vertical offsets if not FirstPersonViewport

--- a/modules/experimental-layers/src/mesh-layer/mesh-layer-vertex.glsl.js
+++ b/modules/experimental-layers/src/mesh-layer/mesh-layer-vertex.glsl.js
@@ -51,13 +51,6 @@ void main(void) {
   pos = project_scale(pos * sizeScale);
   pos = rotationMatrix * pos;
 
-  if (project_uCoordinateSystem != COORDINATE_SYSTEM_LNG_LAT) {
-    // Mercator projection reverses Y but this gets compensated
-    // only for COORDINATE_SYSTEM_LNG_LAT inside the projection logic
-    // TODO - handle this inside the projection module logic
-    pos.y = -pos.y;
-  }
-
   vec4 worldPosition;
   gl_Position = project_position_to_clipspace(instancePositions, instancePositions64xy, pos, worldPosition);
 

--- a/test/modules/core/shaderlib/project/project-functions.spec.js
+++ b/test/modules/core/shaderlib/project/project-functions.spec.js
@@ -81,7 +81,7 @@ const TEST_CASES = [
       coordinateOrigin: TEST_COORDINATE_ORIGIN,
       fromCoordinateSystem: COORDINATE_SYSTEM.LNGLAT
     },
-    result: [-233.01688888831995, 589.7206230699085, 265.13951782419525]
+    result: [-233.01688888831995, -589.7206230699085, 265.13951782419525]
   },
   {
     title: 'LNGLAT to LNGLAT_OFFSETS',
@@ -92,7 +92,7 @@ const TEST_CASES = [
       coordinateOrigin: TEST_COORDINATE_ORIGIN,
       fromCoordinateSystem: COORDINATE_SYSTEM.LNGLAT
     },
-    result: [-233.01688888831995, 589.7206230699085, 265.13951782419525]
+    result: [-233.01688888831995, -589.7206230699085, 265.13951782419525]
   }
 ];
 
@@ -105,7 +105,7 @@ vec4 project_offset_(vec4 offset) {
 function projectOffset(offset, pixelsPerUnit, pixelsPerUnit2) {
   return [
     offset[0] * (pixelsPerUnit[0] + pixelsPerUnit2[0] * offset[1]),
-    offset[1] * (pixelsPerUnit[1] + pixelsPerUnit2[1] * offset[1]),
+    -offset[1] * (pixelsPerUnit[1] + pixelsPerUnit2[1] * offset[1]),
     offset[2] * (pixelsPerUnit[2] + pixelsPerUnit2[2] * offset[1])
   ];
 }


### PR DESCRIPTION
### Background

Instance Y is flipped when using offset modes. The switch from LNGLAT to LNGLAT_AUTO_OFFSETS can illustrate this issue:
![projection-bug](https://user-images.githubusercontent.com/2059298/44557701-b729c880-a6f4-11e8-8853-f6786ccd87b8.gif)

Related PR:
https://github.com/uber/deck.gl/pull/2167

### Cause
- Y is reversed in Web Mercator projection (`worldPosition.y` goes down as `lnglat.y` goes up) during projection.
- CPU projection function (`webMercatorViewport.projectFlat`) produces flipped Y. This is used in calculating the projection center.
- Shader function `project_mercator_` produces flipped Y. This is used in the old LNGLAT projection mode.
- Shader function `project_offset_` produces non-flipped Y. This is used in offset modes (`LNGLAT_OFFSETS`, `METER_OFFSETS`, `LNGLAT_AUTO_OFFSET`).
- Shader function `project_scale` produces non-flipped Y. This is used in all modes.

A `Viewport` instance has two properties: `viewMatrixUncentered` and `viewMatrix`. Only `viewMatrix` contains a Y flip.

In LNGLAT mode, the projection to clipspace roughly goes like this:

```glsl
project_uViewProjectionMatrix * (project_mercator_(position) + project_scale(offset))
```

a.k.a.

`(flipped) * (flipped + non-flipped)`

In offset modes, `viewport.viewMatrixUncentered` is used instead of `viewMatrix`, see [here](https://github.com/uber/deck.gl/blob/projection-fix/modules/core/src/shaderlib/project/viewport-uniforms.js#L131). As a result, `viewProjectionMatrix` does not include the Y flip.

```glsl
project_uCenter + project_uViewProjectionMatrix * (project_offset_(position) + project_scale(offset))
```

a.k.a.

`(flipped) + (non-flipped) * (non-flipped + non-flipped)`

This PR makes the offset modes behave consistently with the LNGLAT mode.

### The question remains

Whether we should flip Y in `project_scale` to conform with the east-north coordinate system (likely by changing viewport-mercator-project to produce reversed y values in `pixelsPer*` in `getDistanceScale`). Since it will be a breaking change, I do not think we should do it in a patch/minor release.

### Change List
- Move y flip to `viewMatrixUncentered`
- Flip y in `project_offset_`
