### PR TITLE
GPUAggregator: Return ArrayBuffer objects when aggregating on CPU

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -54,7 +54,7 @@ deck.gl's layer catalog is extended by adding new `ContourLayer`, this layer can
 
 ### GPU Aggregation Enhancements (Experimental)
 
-For auto-aggregating layers, deck.gl can now calculate all aggregation parameters based on the selected coordinate system. Layers and application can utilize new utility methods to achieve aggregation in Layer's coordinate system (either LNGLAT or IDENTITY).
+Several under the hood changes in GPU Aggregation flow to support multiple layer coordinate systems (LNGLAT and IDENTITY).
 
 
 ## deck.gl v6.0

--- a/modules/core/src/experimental/utils/gpu-grid-aggregation/gpu-grid-aggregator.js
+++ b/modules/core/src/experimental/utils/gpu-grid-aggregation/gpu-grid-aggregator.js
@@ -310,8 +310,12 @@ export default class GPUGridAggregator {
       maxCountBuffer = new Buffer(this.gl, {data: maxCountBufferData});
     }
     return {
+      // Buffer objects
       countsBuffer,
       maxCountBuffer,
+      // ArrayView objects
+      countsData: counts,
+      maxCountData: maxCountBufferData,
       // Return total aggregaton values to avoid UBO setup for WebGL1 cases
       totalCount,
       totalWeight,

--- a/modules/core/src/experimental/utils/gpu-grid-aggregation/grid-aggregation-utils.js
+++ b/modules/core/src/experimental/utils/gpu-grid-aggregation/grid-aggregation-utils.js
@@ -53,6 +53,8 @@ export function pointToDensityGridData({
   return {
     countsBuffer: aggregatedData.countsBuffer,
     maxCountBuffer: aggregatedData.maxCountBuffer,
+    countsData: aggregatedData.countsData,
+    maxCountData: aggregatedData.maxCountData,
     gridSize: opts.gridSize,
     gridOrigin: opts.gridOrigin,
     cellSize

--- a/modules/layers/src/contour-layer/contour-layer.js
+++ b/modules/layers/src/contour-layer/contour-layer.js
@@ -24,6 +24,7 @@ import {
   _pointToDensityGridData as pointToDensityGridData
 } from '@deck.gl/core';
 import {LineLayer} from '@deck.gl/layers';
+import assert from 'assert';
 
 import {generateContours} from './contour-utils';
 
@@ -105,7 +106,7 @@ export default class ContourLayer extends CompositeLayer {
       fp64,
       coordinateSystem
     } = this.props;
-    const {countsBuffer, maxCountBuffer, gridSize, gridOrigin, cellSize} = pointToDensityGridData({
+    const {countsData, gridSize, gridOrigin, cellSize} = pointToDensityGridData({
       data,
       cellSizeMeters,
       getPosition,
@@ -116,17 +117,12 @@ export default class ContourLayer extends CompositeLayer {
       viewport: this.context.viewport
     });
 
-    this.setState({countsBuffer, maxCountBuffer, gridSize, gridOrigin, cellSize});
+    this.setState({countsData, gridSize, gridOrigin, cellSize});
   }
 
   generateContours() {
-    const {gridSize, gridOrigin, cellSize} = this.state;
-    let {countsData} = this.state;
-    if (!countsData) {
-      const {countsBuffer} = this.state;
-      countsData = countsBuffer.getData();
-      this.setState({countsData});
-    }
+    const {gridSize, gridOrigin, cellSize, countsData} = this.state;
+    assert(countsData);
 
     const {cellWeights} = GPUGridAggregator.getCellData({countsData});
     const thresholds = this.props.contours.map(x => x.threshold);


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #2242 
<!-- For other PRs without open issue -->
#### Background
Under WebGL1, aggregation happens on CPU and Buffer objects are created with this data. Contour layer generates contours on CPU by reading this Buffer data, but `Buffer::getData` is WebGL2 only API. So return `ArrayView` objects and `Buffer` objects when aggregating on CPU. Applications sending this data to GPU, can use the `Buffer` objects, and applications processing this data in CPU can use `ArrayView` objects.

<!-- For all the PRs -->
#### Change List
- GPUAggregator: Return ArrayBuffer objects when aggregating on CPU
