### PR TITLE
More contour fixes

### DIFF
--- a/docs/layers/contour-layer.md
+++ b/docs/layers/contour-layer.md
@@ -88,4 +88,4 @@ Method called to retrieve the position of each point.
 
 ## Source
 
-[modules/experimental-layers/src/contour-layer](https://github.com/uber/deck.gl/tree/master/modules/experimental-layers/src/contour-layer)
+[/contour-layer](https://github.com/uber/deck.gl/tree/master/modules/layers/src/contour-layer)

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -32,7 +32,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "luma.gl": ">=6.1.0-beta.2",
+    "luma.gl": ">=6.1.0-beta.3",
     "math.gl": ">=2.1.0-alpha.1",
     "mjolnir.js": "^1.0.0",
     "probe.gl": "^2.0.0-beta",

--- a/modules/layers/src/contour-layer/contour-layer.js
+++ b/modules/layers/src/contour-layer/contour-layer.js
@@ -24,7 +24,6 @@ import {
   _pointToDensityGridData as pointToDensityGridData
 } from '@deck.gl/core';
 import {LineLayer} from '@deck.gl/layers';
-import assert from 'assert';
 
 import {generateContours} from './contour-utils';
 
@@ -106,7 +105,7 @@ export default class ContourLayer extends CompositeLayer {
       fp64,
       coordinateSystem
     } = this.props;
-    const {countsData, gridSize, gridOrigin, cellSize} = pointToDensityGridData({
+    const {countsData, countsBuffer, gridSize, gridOrigin, cellSize} = pointToDensityGridData({
       data,
       cellSizeMeters,
       getPosition,
@@ -117,12 +116,17 @@ export default class ContourLayer extends CompositeLayer {
       viewport: this.context.viewport
     });
 
-    this.setState({countsData, gridSize, gridOrigin, cellSize});
+    this.setState({countsData, countsBuffer, gridSize, gridOrigin, cellSize});
   }
 
   generateContours() {
-    const {gridSize, gridOrigin, cellSize, countsData} = this.state;
-    assert(countsData);
+    const {gridSize, gridOrigin, cellSize} = this.state;
+    let {countsData} = this.state;
+    if (!countsData) {
+      const {countsBuffer} = this.state;
+      countsData = countsBuffer.getData();
+      this.setState({countsData});
+    }
 
     const {cellWeights} = GPUGridAggregator.getCellData({countsData});
     const thresholds = this.props.contours.map(x => x.threshold);

--- a/website/src/components/demos/line-demo.js
+++ b/website/src/components/demos/line-demo.js
@@ -6,7 +6,6 @@ import {App, INITIAL_VIEW_STATE} from 'website-examples/line/app';
 const EMPTY_ARRAY = [];
 
 export default class LineDemo extends Component {
-
   static get data() {
     return [
       {
@@ -21,8 +20,14 @@ export default class LineDemo extends Component {
 
   static get parameters() {
     return {
-      strokeWidth: {displayName: 'Stroke Width',
-        type: 'range', value: 3, step: 0.1, min: 0, max: 10}
+      strokeWidth: {
+        displayName: 'Stroke Width',
+        type: 'range',
+        value: 3,
+        step: 0.1,
+        min: 0,
+        max: 10
+      }
     };
   }
 
@@ -40,12 +45,16 @@ export default class LineDemo extends Component {
         <h3>Flights To And From London Heathrow Airport</h3>
         <p>Flight paths in a 6-hour window</p>
         <p>From 08:32:43 GMT to 14:32:43 GMT on March 28th, 2017</p>
-        <p>Flight path data source:
-          <a href="https://opensky-network.org/"> The OpenSky Network</a><br />
+        <p>
+          Flight path data source:
+          <a href="https://opensky-network.org/"> The OpenSky Network</a>
+          <br />
           Airport location data source:
           <a href="http://www.naturalearthdata.com/"> Natural Earth</a>
         </p>
-        <div className="stat">No. of Line Segments<b>{ readableInteger(meta.count || 0) }</b></div>
+        <div className="stat">
+          No. of Line Segments<b>{readableInteger(meta.count || 0)}</b>
+        </div>
       </div>
     );
   }
@@ -56,9 +65,10 @@ export default class LineDemo extends Component {
     return (
       <App
         {...otherProps}
-        flightPaths={data && data[0] || EMPTY_ARRAY}
-        airports={data && data[1] || EMPTY_ARRAY}
-        strokeWidth={params.strokeWidth.value} />
+        flightPaths={(data && data[0]) || EMPTY_ARRAY}
+        airports={(data && data[1]) || EMPTY_ARRAY}
+        getStrokeWidth={params.strokeWidth.value}
+      />
     );
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5932,12 +5932,12 @@ lru-cache@^4.0.1, lru-cache@^4.1.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
-luma.gl@>=6.1.0-beta.2:
-  version "6.1.0-beta.2"
-  resolved "https://registry.yarnpkg.com/luma.gl/-/luma.gl-6.1.0-beta.2.tgz#d36f3a9e9be43765506a64f7f5e986b6c1a27cb9"
+luma.gl@>=6.1.0-beta.3:
+  version "6.1.0-beta.3"
+  resolved "https://registry.yarnpkg.com/luma.gl/-/luma.gl-6.1.0-beta.3.tgz#92e82038d254ff0d6abb1c7662d1dfd5cf35810c"
   dependencies:
     math.gl "^2.1.0-alpha"
-    probe.gl "^2.0.0-alpha"
+    probe.gl "^2.0.0-beta"
     seer "^0.2.4"
     webgl-debug "^2.0.0"
 
@@ -7210,7 +7210,7 @@ private@^0.1.6, private@^0.1.8, private@~0.1.5:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
 
-probe.gl@^2.0.0-alpha, probe.gl@^2.0.0-beta:
+probe.gl@^2.0.0-beta:
   version "2.0.0-beta.1"
   resolved "https://registry.yarnpkg.com/probe.gl/-/probe.gl-2.0.0-beta.1.tgz#7281d63e75d390a081c68fe201552e2e62effb6f"
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #2235
<!-- For other PRs without open issue -->
#### Background
In #2243 while fixing WebGL1 flow, I accidentally removed `Buffer.getData()` code needed for WbGL2, adding it back. Tested on Safari (WebGL1) and Chrome (WebGL2).
Also opened #2246 , since this regression should have been caught by `render-tests` script.
Fix website lineDemo issue : slider doesn't change the stroke width.
Bump luma version to 6.1.0-beta.3
<!-- For all the PRs -->
#### Change List
-  Fix ContourLayer for WebGL2
-  Bump luma version to 6.1.0-beta.3