### PR TITLE
Fix broken link to documentation on some examples

### DIFF
--- a/examples/experimental/bezier/README.md
+++ b/examples/experimental/bezier/README.md
@@ -8,4 +8,4 @@ npm start
 ```
 
 ### Data format
-To use your own data, checkout the [documentation of BezierCurveLayer](../../docs/layers/bezier-curve-layer.md).
+To use your own data, checkout the [documentation of BezierCurveLayer](../../../docs/layers/bezier-curve-layer.md).

--- a/examples/experimental/bezier/README.md
+++ b/examples/experimental/bezier/README.md
@@ -8,4 +8,4 @@ npm start
 ```
 
 ### Data format
-To use your own data, checkout the [documentation of BezierCurveLayer](../../../docs/layers/bezier-curve-layer.md).
+To use your own data, checkout the [documentation of BezierCurveLayer](../../docs/layers/bezier-curve-layer.md).

--- a/examples/website/3d-heatmap/README.md
+++ b/examples/website/3d-heatmap/README.md
@@ -33,4 +33,4 @@ npm start
 
 ### Data format
 Sample data is stored in [deck.gl Example Data](https://github.com/uber-common/deck.gl-data/tree/master/examples/3d-heatmap). To use your own data, checkout
-the [documentation of HexagonLayer](../../docs/layers/hexagon-layer.md)
+the [documentation of HexagonLayer](../../../docs/layers/hexagon-layer.md)

--- a/examples/website/arc/README.md
+++ b/examples/website/arc/README.md
@@ -10,4 +10,4 @@ npm start
 
 ### Data format
 Sample data is stored in [deck.gl Example Data](https://github.com/uber-common/deck.gl-data/tree/master/examples/arc). To use your own data, checkout
-the [documentation of ArcLayer](../../docs/layers/arc-layer.md).
+the [documentation of ArcLayer](../../../docs/layers/arc-layer.md).

--- a/examples/website/brushing/README.md
+++ b/examples/website/brushing/README.md
@@ -33,4 +33,4 @@ npm start
 
 ### Data format
 Sample data is stored in [deck.gl Example Data](https://github.com/uber-common/deck.gl-data/tree/master/examples/arc). To use your own data, checkout
-the [documentation of ArcLayer](../../docs/layers/arc-layer.md).
+the [documentation of ArcLayer](../../../docs/layers/arc-layer.md).

--- a/examples/website/geojson/README.md
+++ b/examples/website/geojson/README.md
@@ -10,4 +10,4 @@ npm start
 
 ### Data format
 Sample data is stored in [deck.gl Example Data](https://github.com/uber-common/deck.gl-data/tree/master/examples/geojson). To use your own data, checkout
-the [documentation of GeoJsonLayer](../../docs/layers/geojson-layer.md).
+the [documentation of GeoJsonLayer](../../../docs/layers/geojson-layer.md).

--- a/examples/website/highway/README.md
+++ b/examples/website/highway/README.md
@@ -10,4 +10,4 @@ npm start
 
 ### Data format
 Sample data is stored in [deck.gl Example Data](https://github.com/uber-common/deck.gl-data/tree/master/examples/geojson). To use your own data, checkout
-the [documentation of GeoJsonLayer](../../docs/layers/geojson-layer.md).
+the [documentation of GeoJsonLayer](../../../docs/layers/geojson-layer.md).

--- a/examples/website/icon/README.md
+++ b/examples/website/icon/README.md
@@ -10,4 +10,4 @@ npm start
 
 ### Data format
 Sample data is stored in [deck.gl Example Data](https://github.com/uber-common/deck.gl-data/tree/master/examples/icon). To use your own data, checkout
-the [documentation of IconLayer](../../docs/layers/icon-layer.md).
+the [documentation of IconLayer](../../../docs/layers/icon-layer.md).

--- a/examples/website/line/README.md
+++ b/examples/website/line/README.md
@@ -10,4 +10,4 @@ npm start
 
 ### Data format
 Sample data is stored in [deck.gl Example Data](https://github.com/uber-common/deck.gl-data/tree/master/examples/line). To use your own data, checkout
-the [documentation of LineLayer](../../docs/layers/line-layer.md).
+the [documentation of LineLayer](../../../docs/layers/line-layer.md).

--- a/examples/website/scatterplot/README.md
+++ b/examples/website/scatterplot/README.md
@@ -10,4 +10,4 @@ npm start
 
 ### Data format
 Sample data is stored in [deck.gl Example Data](https://github.com/uber-common/deck.gl-data/tree/master/examples/scatterplot). To use your own data, checkout
-the [documentation of ScatterplotLayer](../../docs/layers/scatterplot-layer.md).
+the [documentation of ScatterplotLayer](../../../docs/layers/scatterplot-layer.md).

--- a/examples/website/screen-grid/README.md
+++ b/examples/website/screen-grid/README.md
@@ -10,4 +10,4 @@ npm start
 
 ### Data format
 Sample data is stored in [deck.gl Example Data](https://github.com/uber-common/deck.gl-data/tree/master/examples/screen-grid). To use your own data, checkout
-the [documentation of ScreenGridLayer](../../docs/layers/screen-grid-layer.md).
+the [documentation of ScreenGridLayer](../../../docs/layers/screen-grid-layer.md).


### PR DESCRIPTION

#### Background
The links to the documentation on some of the examples is broken, it links to a 404 page.

#### Change List
Change link to documentation
