### PR TITLE
Add tests for project vertex shader functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "eslint-config-uber-jsx": "^3.3.3",
     "eslint-plugin-react": "^7.10",
     "gl": "^4.0.3",
-    "glsl-transpiler": "1.5.9",
+    "glsl-transpiler": "^1.7.1",
     "html-webpack-plugin": "^3.2.0",
     "jsdom": "^9.11.0",
     "lerna": "^2.9.1",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "eslint-config-uber-jsx": "^3.3.3",
     "eslint-plugin-react": "^7.10",
     "gl": "^4.0.3",
+    "glsl-transpiler": "1.5.9",
     "html-webpack-plugin": "^3.2.0",
     "jsdom": "^9.11.0",
     "lerna": "^2.9.1",

--- a/test/modules/core/shaderlib/index.js
+++ b/test/modules/core/shaderlib/index.js
@@ -1,2 +1,3 @@
+import './project/project-glsl.spec';
 import './project/project-functions.spec';
 import './project/viewport-uniforms.spec';

--- a/test/modules/core/shaderlib/project/project-glsl.spec.js
+++ b/test/modules/core/shaderlib/project/project-glsl.spec.js
@@ -1,0 +1,263 @@
+// Copyright (c) 2015 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import test from 'tape-catch';
+
+import {COORDINATE_SYSTEM, Viewport, WebMercatorViewport} from 'deck.gl';
+import {project} from '@deck.gl/core/shaderlib';
+import {Matrix4, equals, config} from 'math.gl';
+
+import {compileVertexShader} from '../shaderlib-test-utils';
+
+// viewport,
+// devicePixelRatio = 1,
+// modelMatrix = null,
+// coordinateSystem = COORDINATE_SYSTEM.LNGLAT,
+// coordinateOrigin = DEFAULT_COORDINATE_ORIGIN,
+// wrapLongitude = false,
+
+const TEST_VIEWPORT = new WebMercatorViewport({
+  longitude: -122,
+  latitude: 38,
+  zoom: 10,
+  pitch: 20,
+  bearing: -35,
+  width: 800,
+  height: 600
+});
+
+const TEST_VIEWPORT_HIGH_ZOOM = new WebMercatorViewport({
+  longitude: -122,
+  latitude: 38,
+  zoom: 16,
+  pitch: 60,
+  bearing: 75,
+  width: 800,
+  height: 600
+});
+
+const TEST_VIEWPORT_ORTHO = new Viewport({
+  width: 800,
+  height: 600,
+  viewMatrix: new Matrix4().lookAt({eye: [0, 0, 1], lookAt: [0, 0, 0], up: [0, 1, 0]}),
+  projectionMatrix: new Matrix4().ortho({
+    left: -400,
+    right: 400,
+    bottom: 300,
+    top: -300,
+    near: 1,
+    far: 100
+  })
+});
+
+const TEST_CASES = [
+  {
+    title: 'LNGLAT mode',
+    params: {
+      viewport: TEST_VIEWPORT,
+      coordinateSystem: COORDINATE_SYSTEM.LNGLAT
+    },
+    tests: [
+      {
+        func: 'project_scale',
+        args: [1],
+        output: TEST_VIEWPORT.getDistanceScales().pixelsPerMeter[2]
+      },
+      {
+        func: 'project_scale_vec2',
+        args: [[1, 1]],
+        output: TEST_VIEWPORT.getDistanceScales().pixelsPerMeter.slice(0, 2)
+      },
+      {
+        func: 'project_scale_vec3',
+        args: [[1, 1, 1]],
+        output: TEST_VIEWPORT.getDistanceScales().pixelsPerMeter
+      },
+      {
+        func: 'project_position',
+        args: [[-122.45, 37.78, 0, 1], [0, 0]],
+        output: TEST_VIEWPORT.projectFlat([-122.45, 37.78]).concat([0, 1])
+      },
+      {
+        func: 'project_to_clipspace',
+        args: [TEST_VIEWPORT.projectFlat([-122.45, 37.78]).concat([0, 1])],
+        postFunc: coords => clipspaceToScreen(TEST_VIEWPORT, coords),
+        output: TEST_VIEWPORT.project([-122.45, 37.78, 0])
+      }
+    ]
+  },
+  {
+    title: 'LNGLAT_EXPERIMENTAL mode - auto offset',
+    params: {
+      viewport: TEST_VIEWPORT_HIGH_ZOOM,
+      coordinateSystem: COORDINATE_SYSTEM.LNGLAT_EXPERIMENTAL
+    },
+    tests: [
+      {
+        func: 'project_position',
+        args: [[-122.05, 37.92, 0, 1], [0, 0]],
+        output: getPixelOffset(
+          TEST_VIEWPORT_HIGH_ZOOM.projectFlat([-122.05, 37.92]),
+          TEST_VIEWPORT_HIGH_ZOOM.projectFlat([-122, 38])
+        ),
+        precision: 0.01
+      },
+      {
+        func: 'project_to_clipspace',
+        args: [
+          getPixelOffset(
+            TEST_VIEWPORT_HIGH_ZOOM.projectFlat([-122.05, 37.92]),
+            TEST_VIEWPORT_HIGH_ZOOM.projectFlat([-122, 38])
+          )
+        ],
+        postFunc: coords => clipspaceToScreen(TEST_VIEWPORT_HIGH_ZOOM, coords),
+        output: TEST_VIEWPORT_HIGH_ZOOM.project([-122.05, 37.92, 0])
+      }
+    ]
+  },
+  {
+    title: 'METER_OFFSETS mode',
+    params: {
+      viewport: TEST_VIEWPORT,
+      coordinateSystem: COORDINATE_SYSTEM.METER_OFFSETS,
+      coordinateOrigin: [-122.05, 37.92]
+    },
+    tests: [
+      {
+        func: 'project_position',
+        args: [[1000, 1000, 0, 1], [0, 0]],
+        // @turf/destination
+        // destination([-122.05, 37.92], 1 * Math.sqrt(2), 45) -> [ -122.0385984916185, 37.92899265369385 ]
+        output: getPixelOffset(
+          TEST_VIEWPORT.projectFlat([-122.0385984916185, 37.92899265369385]),
+          TEST_VIEWPORT.projectFlat([-122.05, 37.92])
+        ),
+        precision: 0.01
+      },
+      {
+        func: 'project_to_clipspace',
+        args: [
+          getPixelOffset(
+            TEST_VIEWPORT.projectFlat([-122.0385984916185, 37.92899265369385]),
+            TEST_VIEWPORT.projectFlat([-122.05, 37.92])
+          )
+        ],
+        postFunc: coords => clipspaceToScreen(TEST_VIEWPORT, coords),
+        output: TEST_VIEWPORT.project([-122.0385984916185, 37.92899265369385, 0])
+      }
+    ]
+  },
+  {
+    title: 'LNGLAT_OFFSETS mode',
+    params: {
+      viewport: TEST_VIEWPORT,
+      coordinateSystem: COORDINATE_SYSTEM.LNGLAT_OFFSETS,
+      coordinateOrigin: [-122.05, 37.92]
+    },
+    tests: [
+      {
+        func: 'project_position',
+        args: [[0.05, 0.08, 0, 1], [0, 0]],
+        output: getPixelOffset(
+          TEST_VIEWPORT.projectFlat([-122, 38]),
+          TEST_VIEWPORT.projectFlat([-122.05, 37.92])
+        ),
+        precision: 0.01
+      },
+      {
+        func: 'project_to_clipspace',
+        args: [
+          getPixelOffset(
+            TEST_VIEWPORT.projectFlat([-122, 38]),
+            TEST_VIEWPORT.projectFlat([-122.05, 37.92])
+          )
+        ],
+        postFunc: coords => clipspaceToScreen(TEST_VIEWPORT, coords),
+        output: TEST_VIEWPORT.project([-122, 38, 0])
+      }
+    ]
+  },
+  {
+    title: 'IDENTITY mode with modelMatrix',
+    params: {
+      viewport: TEST_VIEWPORT_ORTHO,
+      coordinateSystem: COORDINATE_SYSTEM.IDENTITY,
+      modelMatrix: new Matrix4().rotateZ(Math.PI / 2).translate([0, 0, 10])
+    },
+    tests: [
+      {
+        func: 'project_position',
+        args: [[200, 200, 0, 1], [0, 0]],
+        output: [-200, 200, 10, 1]
+      },
+      {
+        func: 'project_to_clipspace',
+        args: [[-200, 200, 10, 1]],
+        postFunc: coords => clipspaceToScreen(TEST_VIEWPORT_ORTHO, coords),
+        output: TEST_VIEWPORT_ORTHO.project([-200, 200, 10])
+      }
+    ]
+  }
+];
+
+function getPixelOffset(p1, p2, z = 0) {
+  return [p1[0] - p2[0], p1[1] - p2[1], z, 1];
+}
+
+function clipspaceToScreen(viewport, coords) {
+  return [
+    ((coords[0] / coords[3] + 1) / 2) * viewport.width,
+    ((1 - coords[1] / coords[3]) / 2) * viewport.height,
+    coords[2] / coords[3]
+  ];
+}
+
+test('project#vs', t => {
+  // TODO - resolve dependencies properly
+  // luma's assembleShaders require WebGL context to work
+  const vsSource = project.dependencies.map(dep => dep.vs).join('') + project.vs;
+  const projectVS = compileVertexShader(vsSource);
+  const oldEpsilon = config.EPSILON;
+
+  TEST_CASES.forEach(testCase => {
+    t.comment(testCase.title);
+
+    const uniforms = project.getUniforms(testCase.params);
+    const functions = projectVS(uniforms);
+
+    testCase.tests.forEach(c => {
+      let actual = functions[c.func].apply(null, c.args);
+      if (c.postFunc) {
+        actual = c.postFunc(actual);
+      }
+      const expected = c.output;
+      config.EPSILON = c.precision || 1e-7;
+
+      if (equals(actual, expected)) {
+        t.pass(`${c.func} returns correct result`);
+      } else {
+        t.fail(`${c.func} returns ${actual}, expecting ${expected}`);
+      }
+    });
+  });
+
+  config.EPSILON = oldEpsilon;
+  t.end();
+});

--- a/test/modules/core/shaderlib/shaderlib-test-utils.js
+++ b/test/modules/core/shaderlib/shaderlib-test-utils.js
@@ -1,9 +1,9 @@
 // TODO - move to @luma.gl/debug ?
 import Compiler from 'glsl-transpiler';
 
-const normalize = source =>
+const normalizeSource = source =>
   source
-    // prepr does not like #define without value
+    // prepr (GLSL preprocessor) does not like #define without value
     .replace(/^(#define \w+) *$/gm, ($0, $1) => `${$1} 1`);
 
 const compileVS = Compiler({
@@ -12,17 +12,11 @@ const compileVS = Compiler({
 
 // @returns JavaScript function of the transpiled shader
 export function compileVertexShader(source) {
-  source = normalize(source);
+  source = normalizeSource(source);
 
   const compiledSource = compileVS(source);
   const {compiler} = compileVS;
-
-  const stats = {
-    attributes: compiler.attributes,
-    uniforms: compiler.uniforms,
-    varyings: compiler.varyings,
-    functions: compiler.functions
-  };
+  const {functions} = compiler;
   compiler.reset();
 
   return evalScript(
@@ -31,14 +25,14 @@ export function compileVertexShader(source) {
   ${compiledSource}
 
   return {
-    ${Object.keys(stats.functions).join(',')}
+    ${Object.keys(functions).join(',')}
   };
 }`
   );
 }
 
 /* eslint-disable no-eval */
-function evalScript(value) {
-  const script = `(function() { return ${value}; })()`;
+function evalScript(source) {
+  const script = `(function() { return ${source}; })()`;
   return eval(script);
 }

--- a/test/modules/core/shaderlib/shaderlib-test-utils.js
+++ b/test/modules/core/shaderlib/shaderlib-test-utils.js
@@ -1,0 +1,44 @@
+// TODO - move to @luma.gl/debug ?
+import Compiler from 'glsl-transpiler';
+
+const normalize = source =>
+  source
+    // prepr does not like #define without value
+    .replace(/^(#define \w+) *$/gm, ($0, $1) => `${$1} 1`);
+
+const compileVS = Compiler({
+  uniform: name => `uniforms.${name}`
+});
+
+// @returns JavaScript function of the transpiled shader
+export function compileVertexShader(source) {
+  source = normalize(source);
+
+  const compiledSource = compileVS(source);
+  const {compiler} = compileVS;
+
+  const stats = {
+    attributes: compiler.attributes,
+    uniforms: compiler.uniforms,
+    varyings: compiler.varyings,
+    functions: compiler.functions
+  };
+  compiler.reset();
+
+  return evalScript(
+    `function vs(uniforms) {
+
+  ${compiledSource}
+
+  return {
+    ${Object.keys(stats.functions).join(',')}
+  };
+}`
+  );
+}
+
+/* eslint-disable no-eval */
+function evalScript(value) {
+  const script = `(function() { return ${value}; })()`;
+  return eval(script);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4486,7 +4486,7 @@ globby@^8.0.1:
     pify "^3.0.0"
     slash "^1.0.0"
 
-glsl-parser@^2.0.0:
+glsl-parser@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/glsl-parser/-/glsl-parser-2.0.1.tgz#3ffac4ee05cc4d8141fd6b1e41e82b3766ff61b9"
   dependencies:
@@ -4500,13 +4500,13 @@ glsl-tokenizer@^2.0.2, glsl-tokenizer@^2.1.4:
   dependencies:
     through2 "^0.6.3"
 
-glsl-transpiler@1.5.9:
-  version "1.5.9"
-  resolved "https://registry.yarnpkg.com/glsl-transpiler/-/glsl-transpiler-1.5.9.tgz#cdbf1e438888dd86d6d1e168e98788891a26fd50"
+glsl-transpiler@^1.7.1:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/glsl-transpiler/-/glsl-transpiler-1.7.2.tgz#c488a55edaf750ce4fbb502da1e8eb785731851e"
   dependencies:
     array-flatten "^2.0.0"
-    glsl-parser "^2.0.0"
-    glsl-tokenizer "^2.0.2"
+    glsl-parser "^2.0.1"
+    glsl-tokenizer "^2.1.4"
     inherits "^2.0.1"
     prepr "^1.1.0"
     xtend "^4.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1023,7 +1023,7 @@ array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
 
-array-flatten@^2.1.0:
+array-flatten@^2.0.0, array-flatten@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-2.1.1.tgz#426bb9da84090c1838d812c8150af20a8331e296"
 
@@ -1931,6 +1931,10 @@ babylon@^6.17.3, babylon@^6.18.0:
 babylon@^7.0.0-beta.47:
   version "7.0.0-beta.47"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.47.tgz#6d1fa44f0abec41ab7c780481e62fd9aafbdea80"
+
+balanced-match@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.3.0.tgz#a91cdd1ebef1a86659e70ff4def01625fc2d6756"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -4482,11 +4486,30 @@ globby@^8.0.1:
     pify "^3.0.0"
     slash "^1.0.0"
 
-glsl-tokenizer@^2.0.2:
+glsl-parser@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/glsl-parser/-/glsl-parser-2.0.1.tgz#3ffac4ee05cc4d8141fd6b1e41e82b3766ff61b9"
+  dependencies:
+    glsl-tokenizer "^2.1.4"
+    through "2.3.4"
+    through2 "^0.6.3"
+
+glsl-tokenizer@^2.0.2, glsl-tokenizer@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/glsl-tokenizer/-/glsl-tokenizer-2.1.4.tgz#aadec0039e68e07a6e591cd0454d97a905797225"
   dependencies:
     through2 "^0.6.3"
+
+glsl-transpiler@1.5.9:
+  version "1.5.9"
+  resolved "https://registry.yarnpkg.com/glsl-transpiler/-/glsl-transpiler-1.5.9.tgz#cdbf1e438888dd86d6d1e168e98788891a26fd50"
+  dependencies:
+    array-flatten "^2.0.0"
+    glsl-parser "^2.0.0"
+    glsl-tokenizer "^2.0.2"
+    inherits "^2.0.1"
+    prepr "^1.1.0"
+    xtend "^4.0.1"
 
 got@^6.7.1:
   version "6.7.1"
@@ -6947,6 +6970,10 @@ param-case@2.1.x:
   dependencies:
     no-case "^2.2.0"
 
+parenthesis@^3.0.0:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/parenthesis/-/parenthesis-3.1.5.tgz#077d0738bb6f65d951b9f9b7c438f2aabe965c6e"
+
 parse-asn1@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/parse-asn1/-/parse-asn1-5.1.1.tgz#f6bf293818332bd0dab54efb16087724745e6ca8"
@@ -7187,6 +7214,14 @@ prepend-http@^1.0.1:
 prepend-http@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
+
+prepr@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/prepr/-/prepr-1.1.1.tgz#9538e526cf5b3bc616b97a182e03830aac4a7351"
+  dependencies:
+    balanced-match "^0.3.0"
+    parenthesis "^3.0.0"
+    xtend "^4.0.1"
 
 preserve@^0.2.0:
   version "0.2.0"
@@ -8798,6 +8833,10 @@ through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6, through@~2.3.4,
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
+through@2.3.4:
+  version "2.3.4"
+  resolved "http://registry.npmjs.org/through/-/through-2.3.4.tgz#495e40e8d8a8eaebc7c275ea88c2b8fc14c56455"
+
 thunky@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.0.2.tgz#a862e018e3fb1ea2ec3fce5d55605cf57f247371"
@@ -9562,7 +9601,7 @@ xregexp@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-4.0.0.tgz#e698189de49dd2a18cc5687b05e17c8e43943020"
 
-"xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@~4.0.0, xtend@~4.0.1:
+"xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/2272

#### Change List
- Add tests for `project` module's vertex shader functions

#### TODO
- More tests for modelMatrix will be added in follow up PRs as I address the CPU/GPU disparity issue
- Use `Transform` instead of transpilation in browser test @1chandu 
