### PR TITLE
Match `viewport.project` behavior with shader projection

### DIFF
--- a/docs/api-reference/viewport.md
+++ b/docs/api-reference/viewport.md
@@ -115,6 +115,33 @@ Note:
 
 * By default, takes top-left coordinates from JavaScript mouse events.
 
+
+##### `projectPosition`
+
+Projects latitude, longitude (and altitude) to coordinates in the WebMercator world.
+
+Parameters:
+
+* `coordinates` (Array) - `[lng, lat, altitude]` Passing an altitude is optional.
+
+Returns:
+
+* `[x, y, z]` in WebMercator coordinates.
+
+
+##### `unprojectPosition`
+
+Projects a coordinate from the WebMercator world to latitude, longitude and altitude.
+
+Parameters:
+
+* `coordinates` (Array) - `[x, y, z]` in the WebMercator world. `z` is optional.
+
+Returns:
+
+* `[longitude, latitude, altitude]`
+
+
 ## Remarks
 
 * The `Viewport` class and its subclasses are perhaps best thought of as geospatially enabled counterparts of the typical `Camera` classes found in most 3D libraries.

--- a/modules/core/src/viewports/viewport.js
+++ b/modules/core/src/viewports/viewport.js
@@ -151,7 +151,10 @@ export default class Viewport {
     const coord = pixelsToWorld([x, y2, z], this.pixelUnprojectionMatrix, targetZWorld);
     const [X, Y, Z] = this.unprojectPosition(coord);
 
-    return xyz.length >= 3 || Number.isFinite(targetZ) ? [X, Y, Z] : [X, Y];
+    if (Number.isFinite(z)) {
+      return [X, Y, Z];
+    }
+    return Number.isFinite(targetZ) ? [X, Y, targetZ] : [X, Y];
   }
 
   // NON_LINEAR PROJECTION HOOKS

--- a/modules/core/src/viewports/viewport.js
+++ b/modules/core/src/viewports/viewport.js
@@ -126,7 +126,8 @@ export default class Viewport {
     const [x0, y0, z0 = 0] = xyz;
 
     const [X, Y] = this.projectFlat([x0, y0]);
-    const coord = worldToPixels([X, Y, z0], this.pixelProjectionMatrix);
+    const Z = z0 * this.distanceScales.pixelsPerMeter[2];
+    const coord = worldToPixels([X, Y, Z], this.pixelProjectionMatrix);
 
     const [x, y] = coord;
     const y2 = topLeft ? y : this.height - y;
@@ -147,12 +148,14 @@ export default class Viewport {
     const [x, y, z] = xyz;
 
     const y2 = topLeft ? y : this.height - y;
-    const coord = pixelsToWorld([x, y2, z], this.pixelUnprojectionMatrix, targetZ);
+    const targetZWorld = targetZ && targetZ * this.distanceScales.pixelsPerMeter[2];
+    const coord = pixelsToWorld([x, y2, z], this.pixelUnprojectionMatrix, targetZWorld);
     const [X, Y] = this.unprojectFlat(coord);
 
     if (Number.isFinite(z)) {
       // Has depth component
-      return [X, Y, coord[2]];
+      const Z = coord[2] * this.distanceScales.metersPerPixel[2];
+      return [X, Y, Z];
     }
 
     return Number.isFinite(targetZ) ? [X, Y, targetZ] : [X, Y];

--- a/modules/core/src/viewports/viewport.js
+++ b/modules/core/src/viewports/viewport.js
@@ -89,6 +89,8 @@ export default class Viewport {
     this.equals = this.equals.bind(this);
     this.project = this.project.bind(this);
     this.unproject = this.unproject.bind(this);
+    this.projectPosition = this.projectPosition.bind(this);
+    this.unprojectPosition = this.unprojectPosition.bind(this);
     this.projectFlat = this.projectFlat.bind(this);
     this.unprojectFlat = this.unprojectFlat.bind(this);
     this.getMatrices = this.getMatrices.bind(this);
@@ -123,11 +125,8 @@ export default class Viewport {
    * @return {Array} - [x, y] or [x, y, z] in top left coords
    */
   project(xyz, {topLeft = true} = {}) {
-    const [x0, y0, z0 = 0] = xyz;
-
-    const [X, Y] = this.projectFlat([x0, y0]);
-    const Z = z0 * this.distanceScales.pixelsPerMeter[2];
-    const coord = worldToPixels([X, Y, Z], this.pixelProjectionMatrix);
+    const worldPosition = this.projectPosition(xyz);
+    const coord = worldToPixels(worldPosition, this.pixelProjectionMatrix);
 
     const [x, y] = coord;
     const y2 = topLeft ? y : this.height - y;
@@ -150,19 +149,25 @@ export default class Viewport {
     const y2 = topLeft ? y : this.height - y;
     const targetZWorld = targetZ && targetZ * this.distanceScales.pixelsPerMeter[2];
     const coord = pixelsToWorld([x, y2, z], this.pixelUnprojectionMatrix, targetZWorld);
-    const [X, Y] = this.unprojectFlat(coord);
+    const [X, Y, Z] = this.unprojectPosition(coord);
 
-    if (Number.isFinite(z)) {
-      // Has depth component
-      const Z = coord[2] * this.distanceScales.metersPerPixel[2];
-      return [X, Y, Z];
-    }
-
-    return Number.isFinite(targetZ) ? [X, Y, targetZ] : [X, Y];
+    return xyz.length >= 3 || Number.isFinite(targetZ) ? [X, Y, Z] : [X, Y];
   }
 
   // NON_LINEAR PROJECTION HOOKS
   // Used for web meractor projection
+
+  projectPosition(xyz) {
+    const [X, Y] = this.projectFlat(xyz);
+    const Z = (xyz[2] || 0) * this.distanceScales.pixelsPerMeter[2];
+    return [X, Y, Z];
+  }
+
+  unprojectPosition(xyz) {
+    const [X, Y] = this.unprojectFlat(xyz);
+    const Z = (xyz[2] || 0) * this.distanceScales.metersPerPixel[2];
+    return [X, Y, Z];
+  }
 
   /**
    * Project [lng,lat] on sphere onto [x,y] on 512*512 Mercator Zoom 0 tile.

--- a/test/modules/core/shaderlib/project/project-functions.spec.js
+++ b/test/modules/core/shaderlib/project/project-functions.spec.js
@@ -22,7 +22,7 @@ import test from 'tape-catch';
 
 import {COORDINATE_SYSTEM, WebMercatorViewport} from 'deck.gl';
 import {projectPosition} from '@deck.gl/core/shaderlib/project/project-functions';
-import {equals} from 'math.gl';
+import {equals, config} from 'math.gl';
 
 const TEST_VIEWPORT = new WebMercatorViewport({
   longitude: -122.45,
@@ -111,6 +111,8 @@ function projectOffset(offset, pixelsPerUnit, pixelsPerUnit2) {
 }
 
 test('project#projectPosition', t => {
+  config.EPSILON = 1e-7;
+
   TEST_CASES.forEach(testCase => {
     const result = projectPosition(testCase.position, testCase.params);
     t.comment(result);

--- a/test/modules/core/shaderlib/project/project-glsl.spec.js
+++ b/test/modules/core/shaderlib/project/project-glsl.spec.js
@@ -98,6 +98,15 @@ const TEST_CASES = [
         },
         output: TEST_VIEWPORT.project([-122.45, 37.78, 0]),
         precision: PIXEL_TOLERANCE
+      },
+      {
+        name: 'project_to_clipspace',
+        func: ({project_position, project_to_clipspace}) => {
+          const coords = project_to_clipspace(project_position([-122.45, 37.78, 100, 1], [0, 0]));
+          return clipspaceToScreen(TEST_VIEWPORT, coords);
+        },
+        output: TEST_VIEWPORT.project([-122.45, 37.78, 100]),
+        precision: PIXEL_TOLERANCE
       }
     ]
   },
@@ -125,6 +134,15 @@ const TEST_CASES = [
         },
         output: TEST_VIEWPORT_HIGH_ZOOM.project([-122.05, 37.92, 0]),
         precision: PIXEL_TOLERANCE
+      },
+      {
+        name: 'project_to_clipspace',
+        func: ({project_position, project_to_clipspace}) => {
+          const coords = project_to_clipspace(project_position([-122.05, 37.92, 100, 1], [0, 0]));
+          return clipspaceToScreen(TEST_VIEWPORT_HIGH_ZOOM, coords);
+        },
+        output: TEST_VIEWPORT_HIGH_ZOOM.project([-122.05, 37.92, 100]),
+        precision: PIXEL_TOLERANCE
       }
     ]
   },
@@ -133,7 +151,8 @@ const TEST_CASES = [
     params: {
       viewport: TEST_VIEWPORT,
       coordinateSystem: COORDINATE_SYSTEM.METER_OFFSETS,
-      coordinateOrigin: [-122.05, 37.92]
+      coordinateOrigin: [-122.05, 37.92],
+      modelMatrix: new Matrix4().translate([0, 0, 100])
     },
     tests: [
       {
@@ -143,7 +162,8 @@ const TEST_CASES = [
         // destination([-122.05, 37.92], 1 * Math.sqrt(2), 45) -> [ -122.0385984916185, 37.92899265369385 ]
         output: getPixelOffset(
           TEST_VIEWPORT.projectFlat([-122.0385984916185, 37.92899265369385]),
-          TEST_VIEWPORT.projectFlat([-122.05, 37.92])
+          TEST_VIEWPORT.projectFlat([-122.05, 37.92]),
+          100 * TEST_VIEWPORT.distanceScales.pixelsPerMeter[2]
         ),
         precision: PIXEL_TOLERANCE
       },
@@ -153,7 +173,7 @@ const TEST_CASES = [
           const coords = project_to_clipspace(project_position([1000, 1000, 0, 1], [0, 0]));
           return clipspaceToScreen(TEST_VIEWPORT, coords);
         },
-        output: TEST_VIEWPORT.project([-122.0385984916185, 37.92899265369385, 0]),
+        output: TEST_VIEWPORT.project([-122.0385984916185, 37.92899265369385, 100]),
         precision: PIXEL_TOLERANCE
       }
     ]

--- a/test/modules/core/viewports/web-mercator-viewport.spec.js
+++ b/test/modules/core/viewports/web-mercator-viewport.spec.js
@@ -23,7 +23,8 @@ import {equals, config} from 'math.gl';
 import {WebMercatorViewport} from 'deck.gl';
 
 // Adjust sensitivity of math.gl's equals
-config.EPSILON = 0.000001;
+const LNGLAT_TOLERANCE = 1e-6;
+const ALT_TOLERANCE = 1e-5;
 
 /* eslint-disable */
 const TEST_VIEWPORTS = [
@@ -86,6 +87,8 @@ test('WebMercatorViewport#constructor - 0 width/height', t => {
 });
 
 test('WebMercatorViewport.projectFlat', t => {
+  config.EPSILON = LNGLAT_TOLERANCE;
+
   for (const vc of TEST_VIEWPORTS) {
     const viewport = new WebMercatorViewport(vc.mapState);
     for (const tc of TEST_VIEWPORTS) {
@@ -103,21 +106,21 @@ test('WebMercatorViewport.project#3D', t => {
   for (const vc of TEST_VIEWPORTS) {
     const viewport = new WebMercatorViewport(vc.mapState);
     for (const offset of [0, 0.5, 1.0, 5.0]) {
-      const lnglatIn = [vc.mapState.longitude + offset, vc.mapState.latitude + offset];
-      const xyz = viewport.project(lnglatIn);
-      const lnglat = viewport.unproject(xyz);
-      t.ok(equals(lnglatIn, lnglat), `Project/unproject ${lnglatIn} to ${lnglat}`);
-
       const lnglatIn3 = [vc.mapState.longitude + offset, vc.mapState.latitude + offset, 0];
       const xyz3 = viewport.project(lnglatIn3);
       const lnglat3 = viewport.unproject(xyz3);
-      t.ok(equals(lnglatIn3, lnglat3), `Project/unproject ${lnglatIn3}=>${xyz3}=>${lnglat3}`);
+      t.comment(`Project/unproject ${lnglatIn3} => ${xyz3} => ${lnglat3}`);
+      config.EPSILON = LNGLAT_TOLERANCE;
+      t.ok(equals(lnglatIn3.slice(0, 2), lnglat3.slice(0, 2)), 'LngLat input/output match');
+      config.EPSILON = ALT_TOLERANCE;
+      t.ok(equals(lnglatIn3[2], lnglat3[2]), 'Altitude input/output match');
     }
   }
   t.end();
 });
 
 test('WebMercatorViewport.project#2D', t => {
+  config.EPSILON = LNGLAT_TOLERANCE;
   // Cross check positions
   for (const vc of TEST_VIEWPORTS) {
     const viewport = new WebMercatorViewport(vc.mapState);
@@ -145,6 +148,8 @@ test('WebMercatorViewport.getScales', t => {
 });
 
 test('WebMercatorViewport.meterDeltas', t => {
+  config.EPSILON = LNGLAT_TOLERANCE;
+
   for (const vc of TEST_VIEWPORTS) {
     const viewport = new WebMercatorViewport(vc.mapState);
     for (const tc of TEST_VIEWPORTS) {


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/2272

#### Background

The GPU project functions convert LngLatZ to world space (pixels) before projecting to clipspace.
The CPU project function convert LngLat to world space (pixels) but leaves Z in meters before projecting to clipspace.

#### Change List
- New: `viewport.projectPosition` and `viewport.unprojectPosition`
- Fix: `viewport.project` and `viewport.unproject`
- Test: add 3d projection test cases to compare project modules's vertex shader output agains that of `viewport.project`
- Test: set math.gl's equality tolerance by test case 
