### PR TITLE
Handle GeoJSON GeometryCollection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist-demo/
 node_modules/
 coverage/
 .nyc_output/
+.vscode/
 
 dist-bundle.js
 examples/winds/data/*.html

--- a/examples/layer-browser/data/sample.geo.json
+++ b/examples/layer-browser/data/sample.geo.json
@@ -171,5 +171,38 @@
         ]
       ]
     }
+  }, {
+    "type": "Feature",
+    "properties": {},
+    "geometry": {
+      "type": "GeometryCollection",
+      "geometries": [
+        {
+          "type": "LineString",
+          "coordinates": [
+            [-122.493, 37.78],
+            [-122.493, 37.79]
+          ]
+        },
+        {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [-122.49, 37.79],
+              [-122.49, 37.78],
+              [-122.48, 37.785],
+              [-122.49, 37.79]
+            ]
+          ]
+        }
+      ]
+    }
+  }, {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "GeometryCollection",
+        "geometries": []
+      }
   }]
 }

--- a/modules/layers/src/geojson-layer/geojson.js
+++ b/modules/layers/src/geojson-layer/geojson.js
@@ -48,9 +48,6 @@ export function getGeojsonFeatures(geojson) {
   assert(geojson.type, 'GeoJSON does not have type');
 
   switch (geojson.type) {
-    case 'GeometryCollection':
-      assert(Array.isArray(geojson.geometries), 'GeoJSON does not have geometries array');
-      return geojson.geometries.map(geometry => ({geometry}));
     case 'Feature':
       // Wrap the feature in a 'Features' array
       return [geojson];
@@ -87,7 +84,8 @@ export function separateGeojsonFeatures(features) {
     };
 
     if (geometry.type === 'GeometryCollection') {
-      const {geometries} = feature.geometry;
+      assert(Array.isArray(geometry.geometries), 'GeoJSON does not have geometries array');
+      const {geometries} = geometry;
       for (let i = 0; i < geometries.length; i++) {
         const subGeometry = geometries[i];
         separateGeometry(subGeometry, separated, sourceFeature);

--- a/test/modules/layers/geojson.spec.js
+++ b/test/modules/layers/geojson.spec.js
@@ -135,12 +135,12 @@ const TEST_CASES = [
       lineFeaturesLength: 1,
       polygonFeaturesLength: 0,
       polygonOutlineFeaturesLength: 0,
-      pointSourceFeatures: [TEST_DATA.GEOMETRY_COLLECTION.geometries[0]],
-      lineSourceFeatures: [TEST_DATA.GEOMETRY_COLLECTION.geometries[1]],
+      pointSourceFeatures: [TEST_DATA.GEOMETRY_COLLECTION],
+      lineSourceFeatures: [TEST_DATA.GEOMETRY_COLLECTION],
       polygonSourceFeatures: [],
       polygonOutlineSourceFeatures: [],
       pointFeatureIndexes: [0],
-      lineFeatureIndexes: [1],
+      lineFeatureIndexes: [0],
       polygonFeatureIndexes: [],
       polygonOutlineFeatureIndexes: []
     }


### PR DESCRIPTION
Handle geometry with `type='GeometryCollection'`.

`GeometryCollection` is described in [section 3.1.8 of the GeoJSON spec](https://tools.ietf.org/html/rfc7946#section-3.1.8).

TODO
[X] Tests