### PR TITLE
Upgrade viewport-mercator-project

### DIFF
--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -37,6 +37,6 @@
     "mjolnir.js": "^1.0.0",
     "probe.gl": "^2.0.0-beta",
     "seer": "^0.2.4",
-    "viewport-mercator-project": "^5.2.0"
+    "viewport-mercator-project": "^6.0.0-alpha.1"
   }
 }

--- a/modules/core/src/shaderlib/project/viewport-uniforms.js
+++ b/modules/core/src/shaderlib/project/viewport-uniforms.js
@@ -259,9 +259,7 @@ function calculateViewportUniforms({
   switch (shaderCoordinateSystem) {
     case PROJECT_COORDINATE_SYSTEM.METER_OFFSETS:
       uniforms.project_uPixelsPerUnit = distanceScalesAtOrigin.pixelsPerMeter;
-      uniforms.project_uPixelsPerUnit[1] *= -1;
       uniforms.project_uPixelsPerUnit2 = distanceScalesAtOrigin.pixelsPerMeter2;
-      uniforms.project_uPixelsPerUnit2[1] *= -1;
       break;
 
     case PROJECT_COORDINATE_SYSTEM.LNGLAT_AUTO_OFFSET:
@@ -269,9 +267,7 @@ function calculateViewportUniforms({
     // eslint-disable-line no-fallthrough
     case PROJECT_COORDINATE_SYSTEM.LNGLAT_OFFSETS:
       uniforms.project_uPixelsPerUnit = distanceScalesAtOrigin.pixelsPerDegree;
-      uniforms.project_uPixelsPerUnit[1] *= -1;
       uniforms.project_uPixelsPerUnit2 = distanceScalesAtOrigin.pixelsPerDegree2;
-      uniforms.project_uPixelsPerUnit2[1] *= -1;
       break;
 
     default:

--- a/modules/core/src/viewports/web-mercator-viewport.js
+++ b/modules/core/src/viewports/web-mercator-viewport.js
@@ -53,6 +53,7 @@ export default class WebMercatorViewport extends Viewport {
       zoom = 11,
       pitch = 0,
       bearing = 0,
+      nearZMultiplier = 0.1,
       farZMultiplier = 10,
       orthographic = false
     } = opts;
@@ -72,6 +73,7 @@ export default class WebMercatorViewport extends Viewport {
       height,
       pitch,
       altitude,
+      nearZMultiplier,
       farZMultiplier
     });
 

--- a/modules/experimental-layers/src/mesh-layer/mesh-layer-vertex.glsl.js
+++ b/modules/experimental-layers/src/mesh-layer/mesh-layer-vertex.glsl.js
@@ -50,8 +50,10 @@ void main(void) {
   vec3 pos = positions;
   pos = rotationMatrix * pos;
   pos = project_scale(pos * sizeScale);
-  // TODO - remove in next major release
-  pos.y = -pos.y;
+  // TODO - backward compatibility, remove in next major release
+  if (project_uPixelsPerMeter.y < 0.0) {
+    pos.y = -pos.y;
+  }
 
   vec4 worldPosition;
   gl_Position = project_position_to_clipspace(instancePositions, instancePositions64xy, pos, worldPosition);

--- a/modules/experimental-layers/src/mesh-layer/mesh-layer-vertex.glsl.js
+++ b/modules/experimental-layers/src/mesh-layer/mesh-layer-vertex.glsl.js
@@ -48,8 +48,10 @@ void main(void) {
   mat3 rotationMatrix = getRotationMatrix(instanceRotations);
 
   vec3 pos = positions;
-  pos = project_scale(pos * sizeScale);
   pos = rotationMatrix * pos;
+  pos = project_scale(pos * sizeScale);
+  // TODO - remove in next major release
+  pos.y = -pos.y;
 
   vec4 worldPosition;
   gl_Position = project_position_to_clipspace(instancePositions, instancePositions64xy, pos, worldPosition);

--- a/test/modules/core/shaderlib/project/project-functions.spec.js
+++ b/test/modules/core/shaderlib/project/project-functions.spec.js
@@ -105,7 +105,7 @@ vec4 project_offset_(vec4 offset) {
 function projectOffset(offset, pixelsPerUnit, pixelsPerUnit2) {
   return [
     offset[0] * (pixelsPerUnit[0] + pixelsPerUnit2[0] * offset[1]),
-    -offset[1] * (pixelsPerUnit[1] + pixelsPerUnit2[1] * offset[1]),
+    offset[1] * (pixelsPerUnit[1] + pixelsPerUnit2[1] * offset[1]),
     offset[2] * (pixelsPerUnit[2] + pixelsPerUnit2[2] * offset[1])
   ];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -547,6 +547,12 @@
     js-levenshtein "^1.1.3"
     semver "^5.3.0"
 
+"@babel/runtime@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0.tgz#adeb78fedfc855aa05bc041640f3f6f98e85424c"
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
 "@babel/template@7.0.0-rc.1":
   version "7.0.0-rc.1"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-rc.1.tgz#5f9c0a481c9f22ecdb84697b3c3a34eadeeca23c"
@@ -7663,6 +7669,10 @@ regenerator-runtime@^0.11.0, regenerator-runtime@^0.11.1:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 
+regenerator-runtime@^0.12.0:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
+
 regenerator-transform@^0.10.0:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.10.1.tgz#1e4996837231da8b7f3cf4114d71b5691a0680dd"
@@ -9216,11 +9226,18 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-viewport-mercator-project@^5.1.0, viewport-mercator-project@^5.2.0:
+viewport-mercator-project@^5.1.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/viewport-mercator-project/-/viewport-mercator-project-5.2.0.tgz#2c50bc624a085d01a3a486f22ec329c0511fe4bd"
   dependencies:
     math.gl "^2.0.0"
+
+viewport-mercator-project@^6.0.0-alpha.1:
+  version "6.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/viewport-mercator-project/-/viewport-mercator-project-6.0.0-alpha.1.tgz#1e50edd9fe79371a31e6d3c6387e5b2345ca4c79"
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    math.gl "^2.1.0"
 
 vinyl-file@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/2272

#### Change List
- Remove y-flip hack in projection uniforms
- The only layer affected by the new `project_scale` is the MeshLayer. This PR keeps  the experimental layer's output the same as v6.1. When we move it to the core layers, its behavior will change (y-flip). I will add proper render tests and documentation to ensure its correctness.
