### PR TITLE
Match projectPosition on CPU and GPU

### DIFF
--- a/docs/api-reference/layer.md
+++ b/docs/api-reference/layer.md
@@ -446,13 +446,11 @@ While most projection is handled "automatically" in the layers vertex shader, it
 
 ##### `project`
 
-Projects a map coordinate using the current viewport settings.
+Projects a map coordinate to screen coordinate, using the current viewport settings and the current coordinate system.
 
 Parameters:
 
-* `coordinates` (Array) - `[lng, lat, altitude]` Passing an altitude is optional.
-* `opts` (Object)
-  - `topLeft` (Boolean, optional) - Whether projected coords are top left. Default to `true`.
+* `coordinates` (Array) - `[x, y, z]` in this layer's coordinate system.
 
 Returns:
 
@@ -460,43 +458,28 @@ Returns:
 
 ##### `unproject`
 
-Unprojects a pixel coordinate using the current viewport settings.
+Unprojects a screen coordinate using the current viewport settings.
 
 Parameters:
 
 * `pixels` (Array) - `[x, y, z]` Passing a `z` is optional.
-* `opts` (Object)
-  - `topLeft` (Boolean, optional) - Whether projected coords are top left. Default to `true`.
 
 Returns:
 
 * A map coordinates array `[lng, lat]` or `[lng, lat, altitude]` if a `z` was given.
 
-##### `projectFlat`
+##### `projectPosition`
 
-Projects a map coordinate using the current viewport settings, ignoring any perspective tilt. Can be useful to calculate screen space distances.
-
-Parameters:
-
-* `coordinates` (Array) - `[longitude, latitude]` coordinates.
-* `scale` (Number) - Map zoom scale calculated from `Math.pow(2, zoom)`.
-
-Returns:
-
-* Screen coordinates in `[x, y]`.
-
-##### `unprojectFlat`
-
-Unrojects a pixel coordinate using the current viewport settings, ignoring any perspective tilt (meaning that the pixel was projected).
+Projects a map coordinate to world coordinate using the current viewport settings and the current coordinate system. Can be useful to calculate world space angle and distances.
 
 Parameters:
 
-* `pixels` (Array) - `[x, y]`
-* `scale` (Number) - Map zoom scale calculated from `Math.pow(2, zoom)`.
+* `coordinates` (Array) - `[x, y, z]` in this layer's coordinate system.
 
 Returns:
 
-* Map or world coordinates in `[longitude, latitude]`.
+* World coordinates in `[x, y]`.
+
 
 ##### `screenToDevicePixels`
 

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -30,9 +30,12 @@ import log from '../utils/log';
 import GL from 'luma.gl/constants';
 import {withParameters} from 'luma.gl';
 import assert from '../utils/assert';
+import {projectPosition, getWorldPosition} from '../shaderlib/project/project-functions';
 
 import Component from '../lifecycle/component';
 import LayerState from './layer-state';
+
+import {worldToPixels} from 'viewport-mercator-project';
 
 const LOG_PRIORITY_UPDATE = 1;
 
@@ -155,27 +158,49 @@ export default class Layer extends Component {
   // PROJECTION METHODS
 
   // Projects a point with current map state (lat, lon, zoom, pitch, bearing)
-  // TODO - need to be extended to work with COORDINATE_SYSTEM.METERS,IDENTITY
-  // TODO - need to be extended to work with multiple `views`
-  project(lngLat) {
+  // From the current layer's coordinate system to screen
+  project(xyz) {
     const {viewport} = this.context;
-    assert(Array.isArray(lngLat));
-    return viewport.project(lngLat);
+    const worldPosition = getWorldPosition(xyz, {
+      viewport,
+      modelMatrix: this.props.modelMatrix,
+      coordinateOrigin: this.props.coordinateOrigin,
+      coordinateSystem: this.props.coordinateSystem
+    });
+    const [x, y, z] = worldToPixels(worldPosition, viewport.pixelProjectionMatrix);
+    return xyz.length === 2 ? [x, y] : [x, y, z];
   }
 
+  // Note: this does not reverse `project`.
+  // Always unprojects to the viewport's coordinate system
   unproject(xy) {
     const {viewport} = this.context;
     assert(Array.isArray(xy));
     return viewport.unproject(xy);
   }
 
+  projectPosition(xyz) {
+    assert(Array.isArray(xyz));
+
+    return projectPosition(xyz, {
+      viewport: this.context.viewport,
+      modelMatrix: this.props.modelMatrix,
+      coordinateOrigin: this.props.coordinateOrigin,
+      coordinateSystem: this.props.coordinateSystem
+    });
+  }
+
+  // DEPRECATE: This does not handle offset modes
   projectFlat(lngLat) {
+    log.deprecated('layer.projectFlat', 'layer.projectPosition');
     const {viewport} = this.context;
     assert(Array.isArray(lngLat));
     return viewport.projectFlat(lngLat);
   }
 
+  // DEPRECATE: This is not meaningful in offset modes
   unprojectFlat(xy) {
+    log.deprecated('layer.unprojectFlat');
     const {viewport} = this.context;
     assert(Array.isArray(xy));
     return viewport.unprojectFlat(xy);

--- a/modules/core/src/shaderlib/lighting/lighting.js
+++ b/modules/core/src/shaderlib/lighting/lighting.js
@@ -22,7 +22,6 @@ import lightingShader from './lighting.glsl';
 import project from '../project/project';
 import {COORDINATE_SYSTEM} from '../../lib/constants';
 import {projectPosition} from '../project/project-functions';
-import {PROJECT_COORDINATE_SYSTEM} from '../project/constants';
 import memoize from '../../utils/memoize';
 
 export default {
@@ -49,7 +48,7 @@ const getMemoizedLightPositions = memoize(preprojectLightPositions);
 
 // TODO: support partial update, e.g.
 // `lightedModel.setModuleParameters({diffuseRatio: 0.3});`
-function getUniforms(opts = INITIAL_MODULE_OPTIONS, context = {}) {
+function getUniforms(opts = INITIAL_MODULE_OPTIONS) {
   if (!opts.lightSettings) {
     return {};
   }
@@ -59,6 +58,8 @@ function getUniforms(opts = INITIAL_MODULE_OPTIONS, context = {}) {
 
     lightsPosition = DEFAULT_LIGHTS_POSITION,
     lightsStrength = DEFAULT_LIGHTS_STRENGTH,
+    coordinateSystem,
+    coordinateOrigin,
     coordinateSystem: fromCoordinateSystem = COORDINATE_SYSTEM.LNGLAT,
     coordinateOrigin: fromCoordinateOrigin = DEFAULT_COORDINATE_ORIGIN,
     modelMatrix = null,
@@ -67,14 +68,6 @@ function getUniforms(opts = INITIAL_MODULE_OPTIONS, context = {}) {
     diffuseRatio = DEFAULT_DIFFUSE_RATIO,
     specularRatio = DEFAULT_SPECULAR_RATIO
   } = opts.lightSettings;
-
-  let coordinateSystem = opts.coordinateSystem;
-  let coordinateOrigin = opts.coordinateOrigin;
-
-  if (context.project_uCoordinateSystem === PROJECT_COORDINATE_SYSTEM.LNGLAT_AUTO_OFFSET) {
-    coordinateSystem = COORDINATE_SYSTEM.LNGLAT_OFFSETS;
-    coordinateOrigin = context.project_coordinate_origin;
-  }
 
   // Pre-project light positions
   const lightsPositionWorld = getMemoizedLightPositions({

--- a/modules/core/src/shaderlib/project/project-functions.js
+++ b/modules/core/src/shaderlib/project/project-functions.js
@@ -3,13 +3,55 @@
  * TODO: move to Viewport class?
  */
 import {COORDINATE_SYSTEM} from '../../lib/constants';
+import {LNGLAT_AUTO_OFFSET_ZOOM_THRESHOLD} from './viewport-uniforms';
+
 import vec4_transformMat4 from 'gl-vec4/transformMat4';
 import vec3_sub from 'gl-vec3/subtract';
+import {getDistanceScales} from 'viewport-mercator-project';
 
-function lngLatZToWorldPosition(lngLatZ, viewport) {
+// In project.glsl, offset modes calculate z differently from LNG_LAT mode.
+// offset modes apply the y adjustment (pixelsPerMeter2) when projecting z
+// LNG_LAT mode only use the linear scale.
+function lngLatZToWorldPosition(lngLatZ, viewport, offsetMode = true) {
+  const [longitude, latitude, z = 0] = lngLatZ;
   const [X, Y] = viewport.projectFlat(lngLatZ);
-  const Z = (lngLatZ[2] || 0) * viewport.distanceScales.pixelsPerMeter[2];
+  const distanceScales = offsetMode
+    ? getDistanceScales({longitude, latitude, scale: viewport.scale})
+    : viewport.getDistanceScales();
+  const Z = z * distanceScales.pixelsPerMeter[2];
   return [X, Y, Z];
+}
+
+function normalizeParameters(opts) {
+  const normalizedParams = Object.assign({}, opts);
+
+  const {
+    viewport,
+    coordinateSystem,
+    coordinateOrigin,
+    fromCoordinateSystem,
+    fromCoordinateOrigin
+  } = opts;
+
+  if (fromCoordinateSystem === undefined) {
+    normalizedParams.fromCoordinateSystem = coordinateSystem;
+  }
+  if (fromCoordinateOrigin === undefined) {
+    normalizedParams.fromCoordinateOrigin = coordinateOrigin;
+  }
+
+  if (
+    coordinateSystem === COORDINATE_SYSTEM.LNGLAT &&
+    viewport.zoom >= LNGLAT_AUTO_OFFSET_ZOOM_THRESHOLD
+  ) {
+    normalizedParams.coordinateSystem = COORDINATE_SYSTEM.LNGLAT_OFFSETS;
+    normalizedParams.coordinateOrigin = [
+      Math.fround(viewport.longitude),
+      Math.fround(viewport.latitude)
+    ];
+  }
+
+  return normalizedParams;
 }
 
 /**
@@ -26,9 +68,11 @@ function lngLatZToWorldPosition(lngLatZ, viewport) {
  * @param {array} [params.fromCoordinateOrigin] - the coordinate origin that the
  *   supplied position is in. Default to the same as `coordinateOrigin`.
  */
-export function projectPosition(
-  position,
-  {
+export function projectPosition(position, params) {
+  let [x, y, z] = position;
+  let worldPosition;
+
+  const {
     // required
     viewport,
     coordinateSystem,
@@ -37,25 +81,27 @@ export function projectPosition(
     modelMatrix,
     fromCoordinateSystem,
     fromCoordinateOrigin
-  }
-) {
-  let [x, y, z] = position;
-  let worldPosition;
+  } = normalizeParameters(params);
 
   if (modelMatrix) {
     [x, y, z] = vec4_transformMat4([], [x, y, z, 1.0], modelMatrix);
   }
-  if (fromCoordinateSystem === undefined) {
-    fromCoordinateSystem = coordinateSystem;
-  }
-  if (fromCoordinateOrigin === undefined) {
-    fromCoordinateOrigin = coordinateOrigin;
+
+  let offsetMode = false;
+  switch (coordinateSystem) {
+    case COORDINATE_SYSTEM.LNGLAT_OFFSETS:
+    case COORDINATE_SYSTEM.METER_OFFSETS:
+      offsetMode = true;
+      break;
+
+    default:
   }
 
   // pre-project light coordinates
   switch (fromCoordinateSystem) {
     case COORDINATE_SYSTEM.LNGLAT:
-      worldPosition = lngLatZToWorldPosition([x, y, z], viewport);
+    case COORDINATE_SYSTEM.LNGLAT_DEPRECATED:
+      worldPosition = lngLatZToWorldPosition([x, y, z], viewport, offsetMode);
       break;
 
     case COORDINATE_SYSTEM.LNGLAT_OFFSETS:
@@ -65,14 +111,16 @@ export function projectPosition(
           y + fromCoordinateOrigin[1],
           z + (fromCoordinateOrigin[2] || 0)
         ],
-        viewport
+        viewport,
+        offsetMode
       );
       break;
 
     case COORDINATE_SYSTEM.METER_OFFSETS:
       worldPosition = lngLatZToWorldPosition(
         viewport.addMetersToLngLat(fromCoordinateOrigin, [x, y, z]),
-        viewport
+        viewport,
+        offsetMode
       );
       break;
 
@@ -80,14 +128,9 @@ export function projectPosition(
       worldPosition = [x, y, z];
   }
 
-  switch (coordinateSystem) {
-    case COORDINATE_SYSTEM.LNGLAT_OFFSETS:
-    case COORDINATE_SYSTEM.METER_OFFSETS:
-      const originWorld = lngLatZToWorldPosition(coordinateOrigin, viewport);
-      vec3_sub(worldPosition, worldPosition, originWorld);
-      break;
-
-    default:
+  if (offsetMode) {
+    const originWorld = lngLatZToWorldPosition(coordinateOrigin, viewport, offsetMode);
+    vec3_sub(worldPosition, worldPosition, originWorld);
   }
 
   return worldPosition;

--- a/modules/core/src/shaderlib/project/project-functions.js
+++ b/modules/core/src/shaderlib/project/project-functions.js
@@ -7,12 +7,12 @@ import {LNGLAT_AUTO_OFFSET_ZOOM_THRESHOLD} from './viewport-uniforms';
 
 import vec4_transformMat4 from 'gl-vec4/transformMat4';
 import vec3_sub from 'gl-vec3/subtract';
-import {getDistanceScales} from 'viewport-mercator-project';
+import {getDistanceScales, addMetersToLngLat} from 'viewport-mercator-project';
 
 // In project.glsl, offset modes calculate z differently from LNG_LAT mode.
 // offset modes apply the y adjustment (pixelsPerMeter2) when projecting z
 // LNG_LAT mode only use the linear scale.
-function lngLatZToWorldPosition(lngLatZ, viewport, offsetMode = true) {
+function lngLatZToWorldPosition(lngLatZ, viewport, offsetMode = false) {
   const [longitude, latitude, z = 0] = lngLatZ;
   const [X, Y] = viewport.projectFlat(lngLatZ);
   const distanceScales = offsetMode
@@ -54,6 +54,45 @@ function normalizeParameters(opts) {
   return normalizedParams;
 }
 
+function getWorldPosition(
+  position,
+  {viewport, modelMatrix, fromCoordinateSystem, fromCoordinateOrigin, offsetMode}
+) {
+  let [x, y, z] = position;
+
+  if (modelMatrix) {
+    [x, y, z] = vec4_transformMat4([], [x, y, z, 1.0], modelMatrix);
+  }
+
+  switch (fromCoordinateSystem) {
+    case COORDINATE_SYSTEM.LNGLAT:
+    case COORDINATE_SYSTEM.LNGLAT_DEPRECATED:
+      return lngLatZToWorldPosition([x, y, z], viewport, offsetMode);
+
+    case COORDINATE_SYSTEM.LNGLAT_OFFSETS:
+      return lngLatZToWorldPosition(
+        [
+          x + fromCoordinateOrigin[0],
+          y + fromCoordinateOrigin[1],
+          z + (fromCoordinateOrigin[2] || 0)
+        ],
+        viewport,
+        offsetMode
+      );
+
+    case COORDINATE_SYSTEM.METER_OFFSETS:
+      return lngLatZToWorldPosition(
+        addMetersToLngLat(fromCoordinateOrigin, [x, y, z]),
+        viewport,
+        offsetMode
+      );
+
+    case COORDINATE_SYSTEM.IDENTITY:
+    default:
+      return [x, y, z];
+  }
+}
+
 /**
  * Equivalent to project_position in project.glsl
  * projects a user supplied position to world position in the target coordinates system
@@ -69,69 +108,23 @@ function normalizeParameters(opts) {
  *   supplied position is in. Default to the same as `coordinateOrigin`.
  */
 export function projectPosition(position, params) {
-  let [x, y, z] = position;
-  let worldPosition;
+  params = normalizeParameters(params);
 
-  const {
-    // required
-    viewport,
-    coordinateSystem,
-    coordinateOrigin,
-    // optional
-    modelMatrix,
-    fromCoordinateSystem,
-    fromCoordinateOrigin
-  } = normalizeParameters(params);
-
-  if (modelMatrix) {
-    [x, y, z] = vec4_transformMat4([], [x, y, z, 1.0], modelMatrix);
-  }
-
-  let offsetMode = false;
-  switch (coordinateSystem) {
+  switch (params.coordinateSystem) {
     case COORDINATE_SYSTEM.LNGLAT_OFFSETS:
-    case COORDINATE_SYSTEM.METER_OFFSETS:
-      offsetMode = true;
-      break;
+    case COORDINATE_SYSTEM.METER_OFFSETS: {
+      params.offsetMode = true;
+      const worldPosition = getWorldPosition(position, params);
+      const originWorld = lngLatZToWorldPosition(params.coordinateOrigin, params.viewport, true);
+      vec3_sub(worldPosition, worldPosition, originWorld);
 
-    default:
-  }
+      return worldPosition;
+    }
 
-  // pre-project light coordinates
-  switch (fromCoordinateSystem) {
     case COORDINATE_SYSTEM.LNGLAT:
     case COORDINATE_SYSTEM.LNGLAT_DEPRECATED:
-      worldPosition = lngLatZToWorldPosition([x, y, z], viewport, offsetMode);
-      break;
-
-    case COORDINATE_SYSTEM.LNGLAT_OFFSETS:
-      worldPosition = lngLatZToWorldPosition(
-        [
-          x + fromCoordinateOrigin[0],
-          y + fromCoordinateOrigin[1],
-          z + (fromCoordinateOrigin[2] || 0)
-        ],
-        viewport,
-        offsetMode
-      );
-      break;
-
-    case COORDINATE_SYSTEM.METER_OFFSETS:
-      worldPosition = lngLatZToWorldPosition(
-        viewport.addMetersToLngLat(fromCoordinateOrigin, [x, y, z]),
-        viewport,
-        offsetMode
-      );
-      break;
-
+    case COORDINATE_SYSTEM.IDENTITY:
     default:
-      worldPosition = [x, y, z];
+      return getWorldPosition(position, params);
   }
-
-  if (offsetMode) {
-    const originWorld = lngLatZToWorldPosition(coordinateOrigin, viewport, offsetMode);
-    vec3_sub(worldPosition, worldPosition, originWorld);
-  }
-
-  return worldPosition;
 }

--- a/modules/core/src/shaderlib/project/project-functions.js
+++ b/modules/core/src/shaderlib/project/project-functions.js
@@ -54,7 +54,7 @@ function normalizeParameters(opts) {
   return normalizedParams;
 }
 
-function getWorldPosition(
+export function getWorldPosition(
   position,
   {viewport, modelMatrix, coordinateSystem, coordinateOrigin, offsetMode}
 ) {

--- a/modules/core/src/shaderlib/project/viewport-uniforms.js
+++ b/modules/core/src/shaderlib/project/viewport-uniforms.js
@@ -38,7 +38,7 @@ const DEFAULT_PIXELS_PER_UNIT2 = [0, 0, 0];
 const DEFAULT_COORDINATE_ORIGIN = [0, 0, 0];
 
 // Based on viewport-mercator-project/test/fp32-limits.js
-const LNGLAT_AUTO_OFFSET_ZOOM_THRESHOLD = 12;
+export const LNGLAT_AUTO_OFFSET_ZOOM_THRESHOLD = 12;
 
 const getMemoizedViewportUniforms = memoize(calculateViewportUniforms);
 

--- a/modules/core/src/viewports/web-mercator-viewport.js
+++ b/modules/core/src/viewports/web-mercator-viewport.js
@@ -25,6 +25,7 @@ import Viewport from './viewport';
 import {
   pixelsToWorld,
   getViewMatrix,
+  addMetersToLngLat,
   getProjectionParameters,
   fitBounds
 } from 'viewport-mercator-project';
@@ -185,11 +186,7 @@ export default class WebMercatorViewport extends Viewport {
    * @return {[Number,Number]|[Number,Number,Number]) array of [lng,lat,z] deltas
    */
   addMetersToLngLat(lngLatZ, xyz) {
-    const [lng, lat, Z = 0] = lngLatZ;
-    const [deltaLng, deltaLat, deltaZ = 0] = this.metersToLngLatDelta(xyz);
-    return lngLatZ.length === 2
-      ? [lng + deltaLng, lat + deltaLat]
-      : [lng + deltaLng, lat + deltaLat, Z + deltaZ];
+    return addMetersToLngLat(lngLatZ, xyz);
   }
 
   /**

--- a/test/modules/core/shaderlib/project/project-functions.spec.js
+++ b/test/modules/core/shaderlib/project/project-functions.spec.js
@@ -21,56 +21,71 @@
 import test from 'tape-catch';
 
 import {COORDINATE_SYSTEM, WebMercatorViewport} from 'deck.gl';
+import {project} from '@deck.gl/core/shaderlib';
 import {projectPosition} from '@deck.gl/core/shaderlib/project/project-functions';
 import {equals, config} from 'math.gl';
+
+import {compileVertexShader} from '../shaderlib-test-utils';
 
 const TEST_VIEWPORT = new WebMercatorViewport({
   longitude: -122.45,
   latitude: 37.78,
   zoom: 14
 });
+const TEST_VIEWPORT_2 = new WebMercatorViewport({
+  longitude: -70.1,
+  latitude: 40.7,
+  zoom: 8
+});
 const TEST_COORDINATE_ORIGIN = [-122.45, 37.78, 0];
-const TEST_DISTANCE_SCALES = TEST_VIEWPORT.getDistanceScales(TEST_COORDINATE_ORIGIN);
 
 const TEST_CASES = [
   {
     title: 'LNGLAT',
-    position: [-122.45, 37.78, 1000],
+    position: [-70, 41, 1000],
+    params: {
+      viewport: TEST_VIEWPORT_2,
+      coordinateSystem: COORDINATE_SYSTEM.LNGLAT
+    },
+    result: [40049.77777777778, 49142.30385463462, 4.318949934705221]
+  },
+  {
+    title: 'LNGLAT_AUTO_OFFSET',
+    position: [-122.46, 37.8, 1000],
     params: {
       viewport: TEST_VIEWPORT,
       coordinateSystem: COORDINATE_SYSTEM.LNGLAT
     },
-    result: [1341012.1955555552, 3242222.268726864, 265.13951782419525]
+    result: [-233.08799999998882, -589.7566118892282, 265.21129170127364]
+  },
+  {
+    title: 'LNGLAT_DEPRECATED',
+    position: [-122.465, 37.8, 1000],
+    params: {
+      viewport: TEST_VIEWPORT,
+      coordinateSystem: COORDINATE_SYSTEM.LNGLAT_DEPRECATED
+    },
+    result: [1340662.6702222219, 3241632.548103794, 265.13951782419525]
   },
   {
     title: 'LNGLAT_OFFSETS',
-    position: [0.01, 0.01, 0],
+    position: [-0.05, 0.06, 50],
     params: {
       viewport: TEST_VIEWPORT,
       coordinateSystem: COORDINATE_SYSTEM.LNGLAT_OFFSETS,
-      coordinateOrigin: TEST_COORDINATE_ORIGIN
+      coordinateOrigin: [-122.5, 38.8]
     },
-    result: projectOffset(
-      [0.01, 0.01, 0],
-      TEST_DISTANCE_SCALES.pixelsPerDegree,
-      TEST_DISTANCE_SCALES.pixelsPerDegree2
-    )
+    result: [-1165.0844444443937, -1794.7162351408042, 13.45595530515798]
   },
   {
-    // TODO: replace with non-trivial test case
-    // WebMercatorViewport.addMetersToLngLat is not accurate
     title: 'METER_OFFSETS',
-    position: [0, 0, 0],
+    position: [-100, 300, 50],
     params: {
       viewport: TEST_VIEWPORT,
       coordinateSystem: COORDINATE_SYSTEM.METER_OFFSETS,
-      coordinateOrigin: TEST_COORDINATE_ORIGIN
+      coordinateOrigin: [-122.5, 38.8]
     },
-    result: projectOffset(
-      [0, 0, 0],
-      TEST_DISTANCE_SCALES.pixelsPerDegree,
-      TEST_DISTANCE_SCALES.pixelsPerDegree2
-    )
+    result: [-26.890254910569638, -80.66771063674241, 13.445127479654396]
   },
   {
     title: 'LNGLAT to METER_OFFSETS',
@@ -81,7 +96,7 @@ const TEST_CASES = [
       coordinateOrigin: TEST_COORDINATE_ORIGIN,
       fromCoordinateSystem: COORDINATE_SYSTEM.LNGLAT
     },
-    result: [-233.01688888831995, -589.7206230699085, 265.13951782419525]
+    result: [-233.01688888831995, -589.7206230699085, 265.21129170127364]
   },
   {
     title: 'LNGLAT to LNGLAT_OFFSETS',
@@ -92,23 +107,9 @@ const TEST_CASES = [
       coordinateOrigin: TEST_COORDINATE_ORIGIN,
       fromCoordinateSystem: COORDINATE_SYSTEM.LNGLAT
     },
-    result: [-233.01688888831995, -589.7206230699085, 265.13951782419525]
+    result: [-233.01688888831995, -589.7206230699085, 265.21129170127364]
   }
 ];
-
-/*
-vec4 project_offset_(vec4 offset) {
-  vec3 pixelsPerUnit = project_uPixelsPerUnit + project_uPixelsPerUnit2 * offset.y;
-  return vec4(offset.xyz * pixelsPerUnit, offset.w);
-}
-*/
-function projectOffset(offset, pixelsPerUnit, pixelsPerUnit2) {
-  return [
-    offset[0] * (pixelsPerUnit[0] + pixelsPerUnit2[0] * offset[1]),
-    offset[1] * (pixelsPerUnit[1] + pixelsPerUnit2[1] * offset[1]),
-    offset[2] * (pixelsPerUnit[2] + pixelsPerUnit2[2] * offset[1])
-  ];
-}
 
 test('project#projectPosition', t => {
   config.EPSILON = 1e-7;
@@ -118,6 +119,26 @@ test('project#projectPosition', t => {
     t.comment(result);
     t.comment(testCase.result);
     t.ok(equals(result, testCase.result), testCase.title);
+  });
+
+  t.end();
+});
+
+test('project#projectPosition vs project_position', t => {
+  config.EPSILON = 1e-5;
+
+  const vsSource = project.dependencies.map(dep => dep.vs).join('') + project.vs;
+  const projectVS = compileVertexShader(vsSource);
+
+  TEST_CASES.filter(testCase => !testCase.params.fromCoordinateSystem).forEach(testCase => {
+    const uniforms = project.getUniforms(testCase.params);
+    const module = projectVS(uniforms);
+
+    const cpuResult = projectPosition(testCase.position, testCase.params);
+    const shaderResult = module.project_position_vec3(testCase.position);
+
+    t.comment(`Comparing ${cpuResult} to ${shaderResult}`);
+    t.ok(equals(cpuResult, shaderResult), testCase.title);
   });
 
   t.end();

--- a/test/modules/core/viewports/web-mercator-viewport.spec.js
+++ b/test/modules/core/viewports/web-mercator-viewport.spec.js
@@ -158,10 +158,6 @@ test('WebMercatorViewport.meterDeltas', t => {
       const deltaMeters = viewport.lngLatDeltaToMeters(deltaLngLat);
       t.comment(`Comparing [${deltaMeters}] to [${coordinate}]`);
       t.ok(equals(deltaMeters, coordinate), 'deltaLngLat to deltaMeters');
-
-      const offsetCoordinate = viewport.addMetersToLngLat([0, 0, 0], coordinate);
-      t.comment(`Comparing [${deltaLngLat}] to [${offsetCoordinate}]`);
-      t.ok(equals(offsetCoordinate, deltaLngLat), 'addMetersToLngLat');
     }
   }
   t.end();


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/2272

#### Background

`projectPosition` is the CPU utility function that projects a point from any coordinate system to the world position in another coordinate system. It is currently used by the lighting module.

In a follow up PR, I will update the `project` method on the base Layer class to use this util, so that layers can work with different coordinate systems on the CPU.

#### Change List
- Remove LNGLAT_AUTO_OFFSET hack from `lighting.getUniforms`
- Handle LNGLAT_AUTO_OFFSET mode in `projectPosition`
- Add tests that compare the returned values from `projectPosition` and compiled vertex shader function `project_position`.

