### PR TITLE
update layer.project to use actual coordinate system

### DIFF
--- a/docs/api-reference/layer.md
+++ b/docs/api-reference/layer.md
@@ -446,13 +446,11 @@ While most projection is handled "automatically" in the layers vertex shader, it
 
 ##### `project`
 
-Projects a map coordinate using the current viewport settings.
+Projects a map coordinate to screen coordinate, using the current viewport settings and the current coordinate system.
 
 Parameters:
 
-* `coordinates` (Array) - `[lng, lat, altitude]` Passing an altitude is optional.
-* `opts` (Object)
-  - `topLeft` (Boolean, optional) - Whether projected coords are top left. Default to `true`.
+* `coordinates` (Array) - `[x, y, z]` in this layer's coordinate system.
 
 Returns:
 
@@ -460,43 +458,28 @@ Returns:
 
 ##### `unproject`
 
-Unprojects a pixel coordinate using the current viewport settings.
+Unprojects a screen coordinate using the current viewport settings.
 
 Parameters:
 
 * `pixels` (Array) - `[x, y, z]` Passing a `z` is optional.
-* `opts` (Object)
-  - `topLeft` (Boolean, optional) - Whether projected coords are top left. Default to `true`.
 
 Returns:
 
 * A map coordinates array `[lng, lat]` or `[lng, lat, altitude]` if a `z` was given.
 
-##### `projectFlat`
+##### `projectPosition`
 
-Projects a map coordinate using the current viewport settings, ignoring any perspective tilt. Can be useful to calculate screen space distances.
-
-Parameters:
-
-* `coordinates` (Array) - `[longitude, latitude]` coordinates.
-* `scale` (Number) - Map zoom scale calculated from `Math.pow(2, zoom)`.
-
-Returns:
-
-* Screen coordinates in `[x, y]`.
-
-##### `unprojectFlat`
-
-Unrojects a pixel coordinate using the current viewport settings, ignoring any perspective tilt (meaning that the pixel was projected).
+Projects a map coordinate to world coordinate using the current viewport settings and the current coordinate system. Can be useful to calculate world space angle and distances.
 
 Parameters:
 
-* `pixels` (Array) - `[x, y]`
-* `scale` (Number) - Map zoom scale calculated from `Math.pow(2, zoom)`.
+* `coordinates` (Array) - `[x, y, z]` in this layer's coordinate system.
 
 Returns:
 
-* Map or world coordinates in `[longitude, latitude]`.
+* World coordinates in `[x, y]`.
+
 
 ##### `screenToDevicePixels`
 

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -30,7 +30,7 @@ import log from '../utils/log';
 import GL from 'luma.gl/constants';
 import {withParameters} from 'luma.gl';
 import assert from '../utils/assert';
-import {projectPosition} from '../shaderlib/project/project-functions';
+import {projectPosition, getWorldPosition} from '../shaderlib/project/project-functions';
 
 import Component from '../lifecycle/component';
 import LayerState from './layer-state';
@@ -161,9 +161,16 @@ export default class Layer extends Component {
   // From the current layer's coordinate system to screen
   project(xyz) {
     const {viewport} = this.context;
-    const worldPosition = this.projectPosition(xyz);
-    const coord = worldToPixels(worldPosition, viewport.pixelProjectionMatrix);
-    return xyz.length === 2 ? [coord[0], coord[1]] : coord;
+    const worldPosition = getWorldPosition(xyz, {
+      viewport,
+      modelMatrix: this.props.modelMatrix,
+      coordinateOrigin: this.props.coordinateOrigin,
+      coordinateSystem: this.props.coordinateSystem
+    });
+    const coords = worldToPixels(worldPosition, viewport.viewProjectionMatrix);
+    const x = ((coords[0] + 1) * viewport.width) / 2;
+    const y = ((1 - coords[1]) * viewport.height) / 2;
+    return xyz.length === 2 ? [x, y] : [x, y, coords[2]];
   }
 
   // Note: this does not reverse `project`.

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -167,10 +167,8 @@ export default class Layer extends Component {
       coordinateOrigin: this.props.coordinateOrigin,
       coordinateSystem: this.props.coordinateSystem
     });
-    const coords = worldToPixels(worldPosition, viewport.viewProjectionMatrix);
-    const x = ((coords[0] + 1) * viewport.width) / 2;
-    const y = ((1 - coords[1]) * viewport.height) / 2;
-    return xyz.length === 2 ? [x, y] : [x, y, coords[2]];
+    const [x, y, z] = worldToPixels(worldPosition, viewport.pixelProjectionMatrix);
+    return xyz.length === 2 ? [x, y] : [x, y, z];
   }
 
   // Note: this does not reverse `project`.

--- a/modules/core/src/shaderlib/project/project-functions.js
+++ b/modules/core/src/shaderlib/project/project-functions.js
@@ -54,7 +54,7 @@ function normalizeParameters(opts) {
   return normalizedParams;
 }
 
-function getWorldPosition(
+export function getWorldPosition(
   position,
   {viewport, modelMatrix, coordinateSystem, coordinateOrigin, offsetMode}
 ) {


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/2272

#### Background

`Layer.project` does not respect the coordinate system of the position

#### Change List
- Use the current coordinate system for projection
- **Proposed** deprecate `Layer.projectFlat` and replace with `Layer.projectPosition`
- **Proposed** deprecate `Layer.unprojectFlat`. There is no easy way to unproject back to the original coordinate system.
