### PR TITLE
Fix various deck issues that cause excessive redraw

### DIFF
--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -487,7 +487,7 @@ export default class Deck {
     this.props.onLoad();
   }
 
-  _drawLayers(redrawReason, animationProps = {}) {
+  _drawLayers(redrawReason) {
     const {gl} = this.layerManager.context;
 
     setParameters(gl, this.props.parameters);
@@ -535,13 +535,12 @@ export default class Deck {
 
     // Check if we need to redraw
     const redrawReason = this.needsRedraw({clearRedrawFlags: true});
-    if (redrawReason) {
-      this.stats.bump('render-fps');
-      this._drawLayers(redrawReason, animationProps);
-      return true;
+    if (!redrawReason) {
+      return;
     }
 
-    return false;
+    this.stats.bump('render-fps');
+    this._drawLayers(redrawReason);
   }
 
   // Callbacks

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -691,9 +691,8 @@ ${flags.viewportChanged ? 'viewport' : ''}\
     const attributeManager = this.getAttributeManager();
     const attributeManagerNeedsRedraw =
       attributeManager && attributeManager.getNeedsRedraw({clearRedrawFlags});
-    redraw = redraw || attributeManagerNeedsRedraw;
-
-    redraw = redraw || this._modelNeedsRedraw(clearRedrawFlags);
+    const modelNeedsRedraw = this._modelNeedsRedraw(clearRedrawFlags);
+    redraw = redraw || attributeManagerNeedsRedraw || modelNeedsRedraw;
 
     return redraw;
   }

--- a/modules/core/src/views/view.js
+++ b/modules/core/src/views/view.js
@@ -64,7 +64,7 @@ export default class View {
     }
 
     // TODO - implement deep equal on view descriptors
-    const viewChanged = deepEqual(this, view);
+    const viewChanged = deepEqual(this.props, view.props);
 
     return viewChanged;
   }

--- a/modules/core/src/views/view.js
+++ b/modules/core/src/views/view.js
@@ -63,7 +63,6 @@ export default class View {
       return view.viewportInstance && this.viewportInstance.equals(view.viewportInstance);
     }
 
-    // TODO - implement deep equal on view descriptors
     const viewChanged = deepEqual(this.props, view.props);
 
     return viewChanged;

--- a/test/modules/core/views/view.spec.js
+++ b/test/modules/core/views/view.spec.js
@@ -1,7 +1,44 @@
 import test from 'tape-catch';
-import {View} from 'deck.gl';
+import {View, MapView} from 'deck.gl';
 
 test('View#imports', t => {
   t.ok(View, 'View import ok');
+  t.end();
+});
+
+test('View#equals', t => {
+  const mapView1 = new MapView({
+    id: 'default-view',
+    latitude: 0,
+    longitude: 0,
+    zoom: 11,
+    position: [0, 0]
+  });
+  const mapView2 = new MapView({
+    id: 'default-view',
+    latitude: 0,
+    longitude: 0,
+    zoom: 11,
+    position: [0, 0]
+  });
+  const mapView3 = new MapView({
+    id: 'default-view',
+    latitude: 0,
+    longitude: 0,
+    zoom: 11,
+    position: [0, 1]
+  });
+  const mapView4 = new View({
+    id: 'default-view',
+    latitude: 0,
+    longitude: 0,
+    zoom: 11,
+    position: [0, 0]
+  });
+
+  t.ok(mapView1.equals(mapView2), 'Identical view props');
+  t.notOk(mapView1.equals(mapView3), 'Different view props');
+  t.notOk(mapView1.equals(mapView4), 'Different type');
+
   t.end();
 });


### PR DESCRIPTION
#### Background
This is needed by the Mapbox integration.

- `deck.needsRedraw({clearRedrawFlags})` stops executing as soon as a truthy value is found. Instead, it should recursively clear the redraw flags on all its descendants. This is causing excessive redraw in the following frames.
- `deck._redrawLayers` contains two parts of code. The first half executes on every animation frame (update canvas, async props, animation props etc.) and the second half only runs if `needsRedraw`. The `Deck` instance used in Mapbox integration calls `_redrawLayers` once per layer during redraw. To (A) ensure that updates are performed without redraw and (B) bypass the internal flag check when `_redrawLayers` is repeatedly called, the general update procedure and the actual redraw must be separated.
- `view.equals` is not properly implemented and always returns `true` for two view instances.

#### Change List
- `deck.needsRedraw` and `layer.needsRedraw` now propagate throughout the chain
- Fix `view.equals`
- Move general updates that are not bound by `needsRedraw` from `deck._redrawLayers` to `deck._onRenderFrame`
