### PR TITLE
Fix lastPickingInfo bug

### DIFF
--- a/modules/core/src/lib/layer-manager.js
+++ b/modules/core/src/lib/layer-manager.js
@@ -61,11 +61,7 @@ const INITIAL_CONTEXT = Object.seal({
   pickingFBO: null, // Screen-size framebuffer that layers can reuse
 
   // State
-  lastPickedInfo: {
-    // For callback tracking and autohighlight
-    index: -1,
-    layerId: null
-  },
+  lastPickedInfo: null,
 
   animationProps: null,
 
@@ -95,7 +91,12 @@ export default class LayerManager {
       gl,
       // Enabling luma.gl Program caching using private API (_cachePrograms)
       shaderCache: new ShaderCache({gl, _cachePrograms: true}),
-      stats: stats || new Stats({id: 'deck.gl'})
+      stats: stats || new Stats({id: 'deck.gl'}),
+      lastPickedInfo: {
+        // For callback tracking and autohighlight
+        index: -1,
+        layerId: null
+      }
     });
 
     this.layerFilter = null;


### PR DESCRIPTION
This is needed by the Mapbox custom layer API.

#### Background
When there are multiple `Deck` instances, their layer managers share the same `lastPickedInfo` object which results in unintended side effects.

#### Change List
- Each `LayerManager` instance now has its own `lastPickedInfo` object
