### PR TITLE
Implement Mapbox custom layer API RFC

### DIFF
--- a/modules/mapbox/src/mapbox-layer.js
+++ b/modules/mapbox/src/mapbox-layer.js
@@ -1,6 +1,7 @@
 import {getDeckInstance, addLayer, removeLayer, updateLayer, drawLayer} from './deck-utils';
 
-export default class DeckLayer {
+export default class MapboxLayer {
+  /* eslint-disable no-this-before-super */
   constructor(props) {
     if (!props.id) {
       throw new Error('Layer must have an unique id');
@@ -9,13 +10,16 @@ export default class DeckLayer {
     this.id = props.id;
     this.type = 'custom';
     this.renderingMode = '3d';
+    this.map = null;
     this.deck = null;
     this.props = props;
   }
 
+  /* Mapbox custom layer methods */
+
   onAdd(map, gl) {
     this.map = map;
-    this.deck = getDeckInstance({map, gl});
+    this.deck = getDeckInstance({map, gl, deck: this.props.deck});
     addLayer(this.deck, this);
   }
 
@@ -27,7 +31,6 @@ export default class DeckLayer {
     // id cannot be changed
     Object.assign(this.props, props, {id: this.id});
     updateLayer(this.deck, this);
-    this.map.triggerRepaint();
   }
 
   render(gl, matrix) {

--- a/test/apps/mapbox-layers/index.html
+++ b/test/apps/mapbox-layers/index.html
@@ -4,28 +4,18 @@
     <meta charset='UTF-8' />
     <title>deck.gl example</title>
     <style>
-    #container {
-      position: fixed;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-    }
-    #container > * {
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-    }
+      #map {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+      }
     </style>
     <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.44.2/mapbox-gl.css' rel='stylesheet' />
   </head>
   <body>
-    <div id="container">
-      <div id="map"></div>
-      <canvas id="deck-canvas" style="pointer-events: none"></canvas>
-    </div>
-    <script src='app.js'></script>
+    <div id="map"></div>
   </body>
+  <script src='app.js'></script>
 </html>


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/2132

#### Background

API proposal to provide a path for deck.gl pure-js and React users to use Mapbox custom layers. This change allows user to leverage deck.gl top-level API such as `pickingRadius`, `onLayerHover` etc.

Example:

```js
import Deck, {ScatterplotLayer} from '@deck.gl/core';
import {MapboxLayer} from '@deck.gl/mapbox';

const map = new mapboxgl.Map({...});

const deck = new Deck({
  width: '100%',
  height: '100%',
  longitude: -122.4,
  latitude: 37.8
  layers: [
    new ScatterplotLayer({
	  id: 'my-scatterplot',
	  ...
	})
  ]
});

map.on('load', () => {
  map.addLayer(new MapboxLayer({id: 'my-scatterplot', deck}), getFirstTextLayerId(map.getStyle()));
});
```

#### Change List
- Support composite layers in Mapbox integration
- Support Deck top-level props in Mapbox integration

