### PR TITLE
Remove account check in publish script

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -6,14 +6,6 @@ set -e
 # beta or prod
 MODE=$1
 
-# Check permission
-ACCOUNT=`npm whoami`
-
-if [[ $ACCOUNT != 'deck.gl' ]]; then
-  echo "Must sign in to deck.gl account to publish"
-  exit 1
-fi
-
 case $MODE in
   "beta")
     # npm-tag argument: npm publish --tag <beta>


### PR DESCRIPTION
We will be able to publish from personal accounts from now on

#### Change List
- Remove account check in publish script
