### PR TITLE
Fix lighting in LNGLAT_AUTO_OFFSET mode

### DIFF
--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -208,7 +208,7 @@ export default class Layer extends Component {
 
   use64bitProjection() {
     if (this.props.fp64) {
-      if (this.props.coordinateSystem === COORDINATE_SYSTEM.LNGLAT) {
+      if (this.props.coordinateSystem === COORDINATE_SYSTEM.LNGLAT_DEPRECATED) {
         return true;
       }
       log.once(

--- a/modules/core/src/shaderlib/lighting/lighting.js
+++ b/modules/core/src/shaderlib/lighting/lighting.js
@@ -20,7 +20,6 @@
 
 import lightingShader from './lighting.glsl';
 import project from '../project/project';
-import {COORDINATE_SYSTEM} from '../../lib/constants';
 import {projectPosition} from '../project/project-functions';
 import memoize from '../../utils/memoize';
 
@@ -42,7 +41,6 @@ const DEFAULT_LIGHTS_STRENGTH = [2.0, 0.0];
 const DEFAULT_AMBIENT_RATIO = 0.4;
 const DEFAULT_DIFFUSE_RATIO = 0.6;
 const DEFAULT_SPECULAR_RATIO = 0.8;
-const DEFAULT_COORDINATE_ORIGIN = [0, 0, 0];
 
 const getMemoizedLightPositions = memoize(preprojectLightPositions);
 
@@ -54,20 +52,22 @@ function getUniforms(opts = INITIAL_MODULE_OPTIONS) {
   }
 
   const {
-    numberOfLights = 1,
-
-    lightsPosition = DEFAULT_LIGHTS_POSITION,
-    lightsStrength = DEFAULT_LIGHTS_STRENGTH,
     coordinateSystem,
     coordinateOrigin,
-    coordinateSystem: fromCoordinateSystem = COORDINATE_SYSTEM.LNGLAT,
-    coordinateOrigin: fromCoordinateOrigin = DEFAULT_COORDINATE_ORIGIN,
-    modelMatrix = null,
+    lightSettings: {
+      numberOfLights = 1,
 
-    ambientRatio = DEFAULT_AMBIENT_RATIO,
-    diffuseRatio = DEFAULT_DIFFUSE_RATIO,
-    specularRatio = DEFAULT_SPECULAR_RATIO
-  } = opts.lightSettings;
+      lightsPosition = DEFAULT_LIGHTS_POSITION,
+      lightsStrength = DEFAULT_LIGHTS_STRENGTH,
+      coordinateSystem: fromCoordinateSystem,
+      coordinateOrigin: fromCoordinateOrigin,
+      modelMatrix = null,
+
+      ambientRatio = DEFAULT_AMBIENT_RATIO,
+      diffuseRatio = DEFAULT_DIFFUSE_RATIO,
+      specularRatio = DEFAULT_SPECULAR_RATIO
+    }
+  } = opts;
 
   // Pre-project light positions
   const lightsPositionWorld = getMemoizedLightPositions({

--- a/modules/core/src/shaderlib/project/viewport-uniforms.js
+++ b/modules/core/src/shaderlib/project/viewport-uniforms.js
@@ -42,12 +42,7 @@ export const LNGLAT_AUTO_OFFSET_ZOOM_THRESHOLD = 12;
 
 const getMemoizedViewportUniforms = memoize(calculateViewportUniforms);
 
-function getShaderCoordinateSystem(coordinateSystem, fp64) {
-  if (fp64) {
-    // This is the only mode that works with fp64
-    return PROJECT_COORDINATE_SYSTEM.LNG_LAT;
-  }
-
+function getShaderCoordinateSystem(coordinateSystem) {
   switch (coordinateSystem) {
     case COORDINATE_SYSTEM.LNGLAT:
     case COORDINATE_SYSTEM.LNGLAT_EXPERIMENTAL:
@@ -78,8 +73,7 @@ function calculateMatrixAndOffset({
   // NEW PARAMS
   coordinateSystem,
   coordinateOrigin,
-  coordinateZoom,
-  fp64
+  coordinateZoom
 }) {
   const {viewMatrixUncentered} = viewport;
   let {viewMatrix} = viewport;
@@ -87,7 +81,7 @@ function calculateMatrixAndOffset({
   let {viewProjectionMatrix} = viewport;
 
   let projectionCenter;
-  let shaderCoordinateSystem = getShaderCoordinateSystem(coordinateSystem, fp64);
+  let shaderCoordinateSystem = getShaderCoordinateSystem(coordinateSystem);
   let shaderCoordinateOrigin = coordinateOrigin;
 
   if (shaderCoordinateSystem === PROJECT_COORDINATE_SYSTEM.LNGLAT_AUTO_OFFSET) {
@@ -168,7 +162,6 @@ export function getUniformsFromViewport({
   coordinateSystem = COORDINATE_SYSTEM.LNGLAT,
   coordinateOrigin = DEFAULT_COORDINATE_ORIGIN,
   wrapLongitude = false,
-  fp64 = false,
   // Deprecated
   projectionMode,
   positionOrigin
@@ -191,8 +184,7 @@ export function getUniformsFromViewport({
       devicePixelRatio,
       coordinateSystem,
       coordinateOrigin,
-      wrapLongitude,
-      fp64
+      wrapLongitude
     })
   );
 }
@@ -202,8 +194,7 @@ function calculateViewportUniforms({
   devicePixelRatio,
   coordinateSystem,
   coordinateOrigin,
-  wrapLongitude,
-  fp64
+  wrapLongitude
 }) {
   const coordinateZoom = viewport.zoom;
   assert(coordinateZoom >= 0);
@@ -218,8 +209,7 @@ function calculateViewportUniforms({
     coordinateSystem,
     coordinateOrigin,
     coordinateZoom,
-    viewport,
-    fp64
+    viewport
   });
 
   assert(viewProjectionMatrix, 'Viewport missing modelViewProjectionMatrix');

--- a/test/modules/core/lib/layer.spec.js
+++ b/test/modules/core/lib/layer.spec.js
@@ -173,10 +173,13 @@ test('Layer#use64bitProjection', t => {
   t.false(layer.use64bitProjection(), 'returns false for fp64: false');
 
   layer = new SubLayer({fp64: true});
-  t.true(layer.use64bitProjection(), 'returns true for fp64: true');
+  t.false(layer.use64bitProjection(), 'returns false for default mode');
 
   layer = new SubLayer({coordinateSystem: COORDINATE_SYSTEM.METER_OFFSETS, fp64: true});
-  t.false(layer.use64bitProjection(), 'returns false for non-lnglat mode');
+  t.false(layer.use64bitProjection(), 'returns false for default mode');
+
+  layer = new SubLayer({coordinateSystem: COORDINATE_SYSTEM.LNGLAT_DEPRECATED, fp64: true});
+  t.true(layer.use64bitProjection(), 'returns true for legacy lnglat mode');
 
   t.end();
 });

--- a/test/render/test-cases.js
+++ b/test/render/test-cases.js
@@ -265,6 +265,7 @@ export const TEST_CASES = [
       new PolygonLayer({
         id: 'polygon-lnglat-64',
         data: dataSamples.polygons,
+        coordinateSystem: COORDINATE_SYSTEM.LNGLAT_DEPRECATED,
         fp64: true,
         getPolygon: f => f,
         getFillColor: f => [200, 0, 0],
@@ -318,6 +319,7 @@ export const TEST_CASES = [
       new PathLayer({
         id: 'path-lnglat-64',
         data: dataSamples.zigzag,
+        coordinateSystem: COORDINATE_SYSTEM.LNGLAT_DEPRECATED,
         fp64: true,
         opacity: 0.6,
         getPath: f => f.path,
@@ -368,6 +370,7 @@ export const TEST_CASES = [
       new ScatterplotLayer({
         id: 'scatterplot-lnglat-64',
         data: dataSamples.points,
+        coordinateSystem: COORDINATE_SYSTEM.LNGLAT_DEPRECATED,
         fp64: true,
         getPosition: d => d.COORDINATES,
         getColor: d => [255, 128, 0],
@@ -419,6 +422,7 @@ export const TEST_CASES = [
         id: 'arc-lnglat-64',
         data: dataSamples.routes,
         strokeWidth: 0.5,
+        coordinateSystem: COORDINATE_SYSTEM.LNGLAT_DEPRECATED,
         fp64: true,
         getSourcePosition: d => d.START,
         getTargetPosition: d => d.END,
@@ -467,6 +471,7 @@ export const TEST_CASES = [
         id: 'line-lnglat-64',
         data: dataSamples.routes,
         strokeWidth: 0.5,
+        coordinateSystem: COORDINATE_SYSTEM.LNGLAT_DEPRECATED,
         fp64: true,
         getSourcePosition: d => d.START,
         getTargetPosition: d => d.END,
@@ -524,6 +529,7 @@ export const TEST_CASES = [
         iconAtlas: ICON_ATLAS,
         iconMapping: dataSamples.iconAtlas,
         sizeScale: 12,
+        coordinateSystem: COORDINATE_SYSTEM.LNGLAT_DEPRECATED,
         fp64: true,
         getPosition: d => d.COORDINATES,
         getColor: d => [64, 64, 72],
@@ -565,6 +571,7 @@ export const TEST_CASES = [
         lineWidthScale: 10,
         lineWidthMinPixels: 1,
         pickable: true,
+        coordinateSystem: COORDINATE_SYSTEM.LNGLAT_DEPRECATED,
         fp64: true,
         lightSettings: LIGHT_SETTINGS
       })
@@ -637,6 +644,7 @@ export const TEST_CASES = [
         data: dataSamples.worldGrid.data,
         cellSize: dataSamples.worldGrid.cellSize,
         extruded: true,
+        coordinateSystem: COORDINATE_SYSTEM.LNGLAT_DEPRECATED,
         fp64: true,
         pickable: true,
         opacity: 1,
@@ -756,6 +764,7 @@ export const TEST_CASES = [
       new HexagonCellLayer({
         id: 'hexagoncell-lnglat-64',
         data: dataSamples.hexagons,
+        coordinateSystem: COORDINATE_SYSTEM.LNGLAT_DEPRECATED,
         fp64: true,
         hexagonVertices: dataSamples.hexagons[0].vertices,
         coverage: 1,
@@ -837,7 +846,7 @@ export const TEST_CASES = [
       new PointCloudLayer({
         id: 'pointcloud-lnglat-64',
         data: dataSamples.getPointCloud(),
-        coordinateSystem: COORDINATE_SYSTEM.LNGLAT,
+        coordinateSystem: COORDINATE_SYSTEM.LNGLAT_DEPRECATED,
         coordinateOrigin: dataSamples.positionOrigin,
         fp64: true,
         getPosition: d => [
@@ -946,6 +955,7 @@ export const TEST_CASES = [
       new MeshLayer({
         id: 'mesh-lnglat-64',
         data: arrowDataLngLat,
+        coordinateSystem: COORDINATE_SYSTEM.LNGLAT_DEPRECATED,
         fp64: true,
         mesh: new Arrow2DGeometry(),
         sizeScale: 10000
@@ -998,6 +1008,7 @@ export const TEST_CASES = [
       new PathOutlineLayer({
         id: 'path-outline-64',
         data: dataSamples.routes,
+        coordinateSystem: COORDINATE_SYSTEM.LNGLAT_DEPRECATED,
         fp64: true,
         opacity: 0.6,
         getPath: f => [f.START, f.END],
@@ -1090,6 +1101,7 @@ export const TEST_CASES = [
       new TextLayer({
         id: 'text-layer-64',
         data: dataSamples.points.slice(0, 50),
+        coordinateSystem: COORDINATE_SYSTEM.LNGLAT_DEPRECATED,
         fp64: true,
         getText: x => `${x.PLACEMENT}-${x.YR_INSTALLED}`,
         getPosition: x => x.COORDINATES,


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/2334
and https://github.com/uber/deck.gl/issues/2345

#### Change List
- Fix `Layer.use64bitProjection`
- Fix lighting module opts
- Remove inconsistent fp64 handling from `getShaderCoordinateSystem`
- Update fp64 render tests to use correct coordinate system