### PR TITLE
GPUGridAggregator: Project to clip space to handle offset project modes.

### DIFF
--- a/modules/core/src/experimental/utils/gpu-grid-aggregation/aggregate-to-grid-vs.glsl.js
+++ b/modules/core/src/experimental/utils/gpu-grid-aggregation/aggregate-to-grid-vs.glsl.js
@@ -22,7 +22,6 @@ export default `\
 #define SHADER_NAME gpu-aggregation-to-grid-vs
 
 attribute vec2 positions;
-attribute vec2 positions64xyLow;
 attribute float weights;
 uniform vec2 windowSize;
 uniform vec2 cellSize;
@@ -32,9 +31,8 @@ uniform bool projectPoints;
 
 varying float vWeights;
 
-vec2 project_to_pixel(vec2 pos) {
-  vec4 position = vec4(pos, 0., 1.);
-  vec4 result =  uProjectionMatrix * position;
+vec2 project_to_pixel(vec4 pos) {
+  vec4 result =  uProjectionMatrix * pos;
   return result.xy/result.w;
 }
 
@@ -42,16 +40,15 @@ void main(void) {
 
   vWeights = weights;
 
-  vec2 windowPos = positions;
-  vec2 windowPos64xyLow = positions64xyLow;
+  vec4 windowPos = vec4(positions, 0, 1.);
   if (projectPoints) {
-    windowPos = project_position(windowPos);
+    windowPos = project_position_to_clipspace(vec3(positions, 0), vec2(0, 0), vec3(0, 0, 0));
   }
 
-  windowPos = project_to_pixel(windowPos);
+  vec2 pos = project_to_pixel(windowPos);
 
   // Transform (0,0):windowSize -> (0, 0): gridSize
-  vec2 pos = floor(windowPos / cellSize);
+  pos = floor(pos / cellSize);
 
   // Transform (0,0):gridSize -> (-1, -1):(1,1)
   pos = (pos * (2., 2.) / (gridSize)) - (1., 1.);

--- a/modules/core/src/viewports/viewport.js
+++ b/modules/core/src/viewports/viewport.js
@@ -445,11 +445,13 @@ export default class Viewport {
      */
 
     // matrix for conversion from world location to screen (pixel) coordinates
-    const m = createMat4();
-    mat4_scale(m, m, [this.width / 2, -this.height / 2, 1]);
-    mat4_translate(m, m, [1, -1, 0]);
-    mat4_multiply(m, m, this.viewProjectionMatrix);
-    this.pixelProjectionMatrix = m;
+    const viewportMatrix = createMat4(); // matrix from NDC to viewport.
+    const pixelProjectionMatrix = createMat4(); // matrix from world space to viewport.
+    mat4_scale(viewportMatrix, viewportMatrix, [this.width / 2, -this.height / 2, 1]);
+    mat4_translate(viewportMatrix, viewportMatrix, [1, -1, 0]);
+    mat4_multiply(pixelProjectionMatrix, viewportMatrix, this.viewProjectionMatrix);
+    this.pixelProjectionMatrix = pixelProjectionMatrix;
+    this.viewportMatrix = viewportMatrix;
 
     this.pixelUnprojectionMatrix = mat4_invert(createMat4(), this.pixelProjectionMatrix);
     if (!this.pixelUnprojectionMatrix) {

--- a/modules/layers/src/screen-grid-layer/screen-grid-layer.js
+++ b/modules/layers/src/screen-grid-layer/screen-grid-layer.js
@@ -296,18 +296,30 @@ export default class ScreenGridLayer extends Layer {
     const {cellSizePixels, gpuAggregation} = this.props;
 
     const {positions, weights, maxCountBuffer, countsBuffer} = this.state;
+    const {viewport} = this.context;
 
-    const projectPoints = this.context.viewport instanceof WebMercatorViewport;
+    let projectPoints = false;
+    let gridTransformMatrix = null;
+
+    if (this.context.viewport instanceof WebMercatorViewport) {
+      // project points from world space (lng/lat) to viewport (screen) space.
+      projectPoints = true;
+    } else {
+      projectPoints = false;
+      // Use pixelProjectionMatrix to transform points to viewport (screen) space.
+      gridTransformMatrix = viewport.pixelProjectionMatrix;
+    }
     const results = this.state.gpuGridAggregator.run({
       positions,
       weights,
       cellSize: [cellSizePixels, cellSizePixels],
-      viewport: this.context.viewport,
+      viewport,
       countsBuffer,
       maxCountBuffer,
       changeFlags,
       useGPU: gpuAggregation,
-      projectPoints
+      projectPoints,
+      gridTransformMatrix
     });
 
     const {maxWeight = 0} = results;


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #2350 
<!-- For other PRs without open issue -->
#### Background
ScreenGridLayer uses GPUAggregator to to perform aggregation in screen (viewport) space. It first uses `project_position` to perform mercator projection then trnasforms the result into viewport (screen) sapce to perform aggregation.
With the introduction of new LNGLAT_OFFSET (now LNGLAT) projection mode, when zoom level is more than a certain level (12), `project_position` only returns projected offsets instead of actual points. And required offset is added back during `project_to_clipspace`.

The fix is, replaced `project_position` with `project_position_to_clipspace` and instead of using `pixelProjectionMatrix` use `viewportMatrix` to convert projected points from NDC to viewport (screen) space.

<!-- For all the PRs -->
#### Change List
- GPUGridAggregator: Project to clip space to handle offset project modes
