### PR TITLE
Handle TileLayer Caching Better

### DIFF
--- a/modules/experimental-layers/src/tile-layer/tile-layer.js
+++ b/modules/experimental-layers/src/tile-layer/tile-layer.js
@@ -5,7 +5,8 @@ const defaultProps = {
   renderSubLayers: props => new GeoJsonLayer(props),
   getTileData: ({x, y, z}) => Promise.resolve(null),
   maxZoom: null,
-  minZoom: null
+  minZoom: null,
+  maxCacheSize: null
 };
 
 export default class TileLayer extends CompositeLayer {
@@ -13,7 +14,8 @@ export default class TileLayer extends CompositeLayer {
     const {maxZoom, minZoom, getTileData} = this.props;
     this.state = {
       tiles: [],
-      tileCache: new TileCache({getTileData, maxZoom, minZoom})
+      tileCache: new TileCache({getTileData, maxZoom, minZoom}),
+      isLoaded: false
     };
   }
 
@@ -26,16 +28,26 @@ export default class TileLayer extends CompositeLayer {
       changeFlags.updateTriggersChanged &&
       (changeFlags.updateTriggersChanged.all || changeFlags.updateTriggersChanged.getTileData)
     ) {
-      const {getTileData, maxZoom, minZoom} = props;
+      const {getTileData, maxZoom, minZoom, maxCacheSize} = props;
       this.state.tileCache.finalize();
       this.setState({
-        tileCache: new TileCache({getTileData, maxZoom, minZoom})
+        tileCache: new TileCache({getTileData, maxSize: maxCacheSize, maxZoom, minZoom})
       });
     }
     if (changeFlags.viewportChanged) {
       const {viewport} = context;
+      const z = this.getLayerZoomLevel();
       if (viewport.id !== 'DEFAULT-INITIAL-VIEWPORT') {
-        this.state.tileCache.update(viewport, tiles => this.setState({tiles}));
+        this.state.tileCache.update(viewport, tiles => {
+          const currTiles = tiles.filter(tile => tile.z === z);
+          const allCurrTilesLoaded = currTiles.every(tile => tile.isLoaded);
+          this.setState({tiles, isLoaded: allCurrTilesLoaded});
+          if (!allCurrTilesLoaded) {
+            Promise.all(currTiles.map(tile => tile.data)).then(() =>
+              this.setState({isLoaded: true})
+            );
+          }
+        });
       }
     }
   }
@@ -44,14 +56,27 @@ export default class TileLayer extends CompositeLayer {
     return info;
   }
 
+  getLayerZoomLevel() {
+    const z = Math.floor(this.context.viewport.zoom);
+    const {maxZoom, minZoom} = this.props;
+    if (maxZoom && parseInt(maxZoom, 10) === maxZoom && z > maxZoom) {
+      return maxZoom;
+    } else if (minZoom && parseInt(minZoom, 10) === minZoom && z < minZoom) {
+      return minZoom;
+    }
+    return z;
+  }
+
   renderLayers() {
     // eslint-disable-next-line no-unused-vars
     const {getTileData, renderSubLayers, ...geoProps} = this.props;
+    const z = this.getLayerZoomLevel();
     return this.state.tiles.map(tile => {
       return renderSubLayers({
         ...geoProps,
         id: `${this.id}-${tile.x}-${tile.y}-${tile.z}`,
-        data: tile.data
+        data: tile.data,
+        visible: !this.state.isLoaded || tile.z === z
       });
     });
   }

--- a/modules/experimental-layers/src/tile-layer/tile-layer.js
+++ b/modules/experimental-layers/src/tile-layer/tile-layer.js
@@ -8,9 +8,10 @@ const defaultProps = {
 
 export default class TileLayer extends CompositeLayer {
   initializeState() {
+    const {maxZoom, minZoom, getTileData} = this.props;
     this.state = {
       tiles: [],
-      tileCache: new TileCache({getTileData: this.props.getTileData})
+      tileCache: new TileCache({getTileData, maxZoom, minZoom})
     };
   }
 
@@ -23,13 +24,17 @@ export default class TileLayer extends CompositeLayer {
       changeFlags.updateTriggersChanged &&
       (changeFlags.updateTriggersChanged.all || changeFlags.updateTriggersChanged.getTileData)
     ) {
+      const {getTileData, maxZoom, minZoom} = props;
       this.state.tileCache.finalize();
       this.setState({
-        tileCache: new TileCache({getTileData: this.props.getTileData})
+        tileCache: new TileCache({getTileData, maxZoom, minZoom})
       });
     }
     if (changeFlags.viewportChanged) {
-      this.state.tileCache.update(context.viewport, tiles => this.setState({tiles}));
+      const {viewport} = context;
+      if (viewport.id !== 'DEFAULT-INITIAL-VIEWPORT') {
+        this.state.tileCache.update(viewport, tiles => this.setState({tiles}));
+      }
     }
   }
 

--- a/modules/experimental-layers/src/tile-layer/tile-layer.js
+++ b/modules/experimental-layers/src/tile-layer/tile-layer.js
@@ -3,7 +3,9 @@ import TileCache from './utils/tile-cache';
 
 const defaultProps = {
   renderSubLayers: props => new GeoJsonLayer(props),
-  getTileData: ({x, y, z}) => Promise.resolve(null)
+  getTileData: ({x, y, z}) => Promise.resolve(null),
+  maxZoom: null,
+  minZoom: null
 };
 
 export default class TileLayer extends CompositeLayer {

--- a/modules/experimental-layers/src/tile-layer/tile-layer.md
+++ b/modules/experimental-layers/src/tile-layer/tile-layer.md
@@ -41,8 +41,19 @@ export const App = ({viewport}) => {
 
 ## Properties
 
-Inherits from all [Base Layer](/docs/api-reference/layer.md) properties, along with `renderSubLayer`
-and `getTileData`
+Inherits from all [Base Layer](/docs/api-reference/layer.md) properties, along with `renderSubLayer`, `getTileData`, `maxZoom` and `minZoom`.
+
+##### `maxZoom` (Number)
+
+The maximum zoom level of the tiles from consumers' data. If provided, and the current map zoom level is greater than `maxZoom`, we will fetch data at `maxZoom` instead of the current zoom level.
+
+- Default: `null`
+
+##### `minZoom` (Number)
+
+The minimum zoom level of the tiles from consumers' data. If provided, and the current map zoom level is smaller than `minZoom`, we will fetch data at `minZoom` instead of the current zoom level.
+
+- Default: `null`
 
 ### Render Options
 

--- a/modules/experimental-layers/src/tile-layer/tile-layer.md
+++ b/modules/experimental-layers/src/tile-layer/tile-layer.md
@@ -41,7 +41,7 @@ export const App = ({viewport}) => {
 
 ## Properties
 
-Inherits from all [Base Layer](/docs/api-reference/layer.md) properties, along with `renderSubLayer`, `getTileData`, `maxZoom` and `minZoom`.
+Inherits from all [Base Layer](/docs/api-reference/layer.md) properties, along with `renderSubLayer`, `getTileData`, `maxZoom`, `minZoom` and `maxCacheSize`.
 
 ##### `maxZoom` (Number)
 
@@ -52,6 +52,12 @@ The maximum zoom level of the tiles from consumers' data. If provided, and the c
 ##### `minZoom` (Number)
 
 The minimum zoom level of the tiles from consumers' data. If provided, and the current map zoom level is smaller than `minZoom`, we will fetch data at `minZoom` instead of the current zoom level.
+
+- Default: `null`
+
+##### `maxCacheSize` (Number)
+
+The maximum cache size for a tile layer. If not defined, it is calculated using the number of tiles in the current viewport times constant 5 (5 is picked because it's a common zoom range).
 
 - Default: `null`
 

--- a/modules/experimental-layers/src/tile-layer/utils/tile-cache.js
+++ b/modules/experimental-layers/src/tile-layer/utils/tile-cache.js
@@ -13,21 +13,21 @@ export default class TileCache {
    */
   constructor({getTileData, maxSize, maxZoom, minZoom}) {
     // TODO: Instead of hardcode size, we should calculate how much memory left
-    this.getTileData = getTileData;
-    this.maxSize = maxSize;
+    this._getTileData = getTileData;
+    this._maxSize = maxSize;
 
     // Maps tile id in string {z}-{x}-{y} to a Tile object
-    this.cache = new Map();
+    this._cache = new Map();
 
-    this.maxZoom = maxZoom;
-    this.minZoom = minZoom;
+    this._maxZoom = maxZoom;
+    this._minZoom = minZoom;
   }
 
   /**
    * Clear the current cache
    */
   finalize() {
-    this.cache.clear();
+    this._cache.clear();
   }
 
   /**
@@ -36,13 +36,13 @@ export default class TileCache {
    * @param {*} onUpdate
    */
   update(viewport, onUpdate) {
-    const {cache, getTileData, maxSize} = this;
-    cache.forEach(cachedTile => {
+    const {_cache, _getTileData, _maxSize} = this;
+    _cache.forEach(cachedTile => {
       cachedTile.isVisible = false;
     });
     const tileIndices = getTileIndices(viewport);
     const viewportTiles = new Set();
-    cache.forEach(cachedTile => {
+    _cache.forEach(cachedTile => {
       if (tileIndices.some(tile => cachedTile.isOverlapped(tile))) {
         cachedTile.isVisible = true;
         viewportTiles.add(cachedTile);
@@ -54,27 +54,27 @@ export default class TileCache {
       const y = Math.max(tileIndices[i].y, 0);
 
       let z = tileIndices[i].z;
-      if (this.maxZoom && z > this.maxZoom) {
-        z = this.maxZoom;
-      } else if (this.minZoom && z < this.minZoom) {
-        z = this.minZoom;
+      if (this._maxZoom && z > this._maxZoom) {
+        z = this._maxZoom;
+      } else if (this._minZoom && z < this._minZoom) {
+        z = this._minZoom;
       }
       let tile = this._getTile(x, y, z);
       if (!tile) {
         tile = new Tile({
-          getTileData,
+          getTileData: _getTileData,
           x,
           y,
           z
         });
       }
       const tileId = this._getTileId(x, y, z);
-      cache.set(tileId, tile);
+      _cache.set(tileId, tile);
       viewportTiles.add(tile);
     }
     // cache size is either the user defined maxSize or 5 * number of current tiles in the viewport.
     const commonZoomRange = 5;
-    this._resizeCache(maxSize || commonZoomRange * tileIndices.length);
+    this._resizeCache(_maxSize || commonZoomRange * tileIndices.length);
     // sort by zoom level so parents tiles don't show up when children tiles are rendered
     const viewportTilesArray = Array.from(viewportTiles).sort((t1, t2) => t1.z - t2.z);
     onUpdate(viewportTilesArray);
@@ -84,16 +84,17 @@ export default class TileCache {
    * Clear tiles that are not visible when the cache is full
    */
   _resizeCache(maxSize) {
-    const {cache} = this;
-    if (cache.size > maxSize) {
-      for (const cachedTile of cache[Symbol.iterator]) {
-        if (cache.size <= maxSize) {
+    const {_cache} = this;
+    if (_cache.size > maxSize) {
+      const iterator = _cache[Symbol.iterator]();
+      for (const cachedTile of iterator) {
+        if (_cache.size <= maxSize) {
           break;
         }
         const tileId = cachedTile[0];
         const tile = cachedTile[1];
         if (!tile.isVisible) {
-          cache.delete(tileId);
+          _cache.delete(tileId);
         }
       }
     }
@@ -101,7 +102,7 @@ export default class TileCache {
 
   _getTile(x, y, z) {
     const tileId = this._getTileId(x, y, z);
-    return this.cache.get(tileId);
+    return this._cache.get(tileId);
   }
 
   _getTileId(x, y, z) {

--- a/modules/experimental-layers/src/tile-layer/utils/tile-cache.js
+++ b/modules/experimental-layers/src/tile-layer/utils/tile-cache.js
@@ -1,5 +1,5 @@
 import Tile from './tile';
-import {getTileIndices} from './viewport-util';
+import {getTileIndices, getAdjustedTileIndex} from './viewport-util';
 
 /**
  * Manages loading and purging of tiles data. This class caches recently visited tiles
@@ -50,15 +50,13 @@ export default class TileCache {
     });
 
     for (let i = 0; i < tileIndices.length; i++) {
-      const x = Math.max(tileIndices[i].x, 0);
-      const y = Math.max(tileIndices[i].y, 0);
-
-      let z = tileIndices[i].z;
-      if (this._maxZoom && z > this._maxZoom) {
-        z = this._maxZoom;
-      } else if (this._minZoom && z < this._minZoom) {
-        z = this._minZoom;
+      let tileIndex = tileIndices[i];
+      if (this._maxZoom && tileIndex.z > this._maxZoom) {
+        tileIndex = getAdjustedTileIndex(tileIndices[i], this._maxZoom);
+      } else if (this._minZoom && tileIndex.z < this._minZoom) {
+        tileIndex = getAdjustedTileIndex(tileIndices[i], this._minZoom);
       }
+      const {x, y, z} = tileIndex;
       let tile = this._getTile(x, y, z);
       if (!tile) {
         tile = new Tile({

--- a/modules/experimental-layers/src/tile-layer/utils/tile-cache.js
+++ b/modules/experimental-layers/src/tile-layer/utils/tile-cache.js
@@ -8,13 +8,13 @@ import {getTileIndices} from './viewport-util';
 
 export default class TileCache {
   /**
-   * Takes in a function that returns tile data, a cache size (default to 10),
-   * and a max and a min zoom level
+   * Takes in a function that returns tile data, a cache size, and a max and a min zoom level.
+   * Cache size defaults to 5 * number of tiles in the current viewport
    */
-  constructor({getTileData, size = 20, maxZoom, minZoom}) {
+  constructor({getTileData, maxSize, maxZoom, minZoom}) {
     // TODO: Instead of hardcode size, we should calculate how much memory left
     this.getTileData = getTileData;
-    this.size = size;
+    this.maxSize = maxSize;
 
     // Maps tile id in string {z}-{x}-{y} to a Tile object
     this.cache = new Map();
@@ -36,28 +36,29 @@ export default class TileCache {
    * @param {*} onUpdate
    */
   update(viewport, onUpdate) {
-    const {cache, getTileData} = this;
+    const {cache, getTileData, maxSize} = this;
     cache.forEach(cachedTile => {
       cachedTile.isVisible = false;
     });
     const tileIndices = getTileIndices(viewport);
     const viewportTiles = new Set();
     cache.forEach(cachedTile => {
-      if (tileIndices.some(tile => cachedTile.overlaps(tile))) {
+      if (tileIndices.some(tile => cachedTile.isOverlapped(tile))) {
         cachedTile.isVisible = true;
         viewportTiles.add(cachedTile);
       }
     });
 
     for (let i = 0; i < tileIndices.length; i++) {
-      const {x, y} = tileIndices[i];
-      let {z} = tileIndices[i];
+      const x = Math.max(tileIndices[i].x, 0);
+      const y = Math.max(tileIndices[i].y, 0);
+
+      let z = tileIndices[i].z;
       if (this.maxZoom && z > this.maxZoom) {
         z = this.maxZoom;
       } else if (this.minZoom && z < this.minZoom) {
         z = this.minZoom;
       }
-
       let tile = this._getTile(x, y, z);
       if (!tile) {
         tile = new Tile({
@@ -71,7 +72,9 @@ export default class TileCache {
       cache.set(tileId, tile);
       viewportTiles.add(tile);
     }
-    this._resizeCache();
+    // cache size is either the user defined maxSize or 5 * number of current tiles in the viewport.
+    const commonZoomRange = 5;
+    this._resizeCache(maxSize || commonZoomRange * tileIndices.length);
     // sort by zoom level so parents tiles don't show up when children tiles are rendered
     const viewportTilesArray = Array.from(viewportTiles).sort((t1, t2) => t1.z - t2.z);
     onUpdate(viewportTilesArray);
@@ -80,11 +83,11 @@ export default class TileCache {
   /**
    * Clear tiles that are not visible when the cache is full
    */
-  _resizeCache() {
-    const {cache, size} = this;
-    if (cache.size > size) {
+  _resizeCache(maxSize) {
+    const {cache} = this;
+    if (cache.size > maxSize) {
       for (const cachedTile of cache[Symbol.iterator]) {
-        if (cache.size <= size) {
+        if (cache.size <= maxSize) {
           break;
         }
         const tileId = cachedTile[0];

--- a/modules/experimental-layers/src/tile-layer/utils/tile.js
+++ b/modules/experimental-layers/src/tile-layer/utils/tile.js
@@ -3,13 +3,11 @@ export default class Tile {
     this.x = x;
     this.y = y;
     this.z = z;
+    this.isVisible = true;
+    this.getTileData = getTileData;
 
     this._data = null;
     this._loader = null;
-    this.isVisible = false;
-
-    this.getTileData = getTileData;
-
     this._loader = this._loadData();
   }
 
@@ -20,30 +18,22 @@ export default class Tile {
     return this._loader;
   }
 
-  get isLoaded() {
-    return this._data !== null;
-  }
-
-  overlaps(tile) {
-    const {x, y, z} = this;
-    const m = Math.pow(2, tile.z - z);
-    return Math.floor(tile.x / m) === x && Math.floor(tile.y / m) === y;
-  }
-
   _loadData() {
     const {x, y, z} = this;
     if (!this.getTileData) {
       return null;
     }
-    return this.getTileData({x, y, z})
-      .then(buffers => {
-        this._data = buffers;
-        return buffers;
-      })
-      .catch(error => {
-        // TODO: error handling: consider the case when we don't have tiles above MAX_ZOOM,
-        // we should fallback to using data from an available zoom level.
-        throw new Error(`Could not load tile data with tile ${z}-${x}-${y}: ${error}`);
-      });
+    const getTileDataPromise = this.getTileData({x, y, z});
+    getTileDataPromise.then(buffers => {
+      this._data = buffers;
+      return buffers;
+    });
+    return getTileDataPromise;
+  }
+
+  isOverlapped(tile) {
+    const {x, y, z} = this;
+    const m = Math.pow(2, tile.z - z);
+    return Math.floor(tile.x / m) === x && Math.floor(tile.y / m) === y;
   }
 }

--- a/modules/experimental-layers/src/tile-layer/utils/tile.js
+++ b/modules/experimental-layers/src/tile-layer/utils/tile.js
@@ -18,6 +18,10 @@ export default class Tile {
     return this._loader;
   }
 
+  get isLoaded() {
+    return Boolean(this._data);
+  }
+
   _loadData() {
     const {x, y, z} = this;
     if (!this.getTileData) {

--- a/modules/experimental-layers/src/tile-layer/utils/viewport-util.js
+++ b/modules/experimental-layers/src/tile-layer/utils/viewport-util.js
@@ -22,8 +22,17 @@ function pixelsToTileIndex(a) {
   return Math.floor(a / TILE_SIZE);
 }
 
-export function getTileIndices(viewport) {
+/**
+ * Returns all tile indices in the current viewport. If the current zoom level is smaller
+ * than minZoom, return an empty array. If the current zoom level is greater than maxZoom,
+ * return tiles that are on maxZoom.
+ */
+export function getTileIndices(viewport, maxZoom, minZoom) {
   const z = Math.floor(viewport.zoom);
+  if (minZoom && z < minZoom) {
+    return [];
+  }
+
   viewport = new viewport.constructor({
     ...viewport,
     zoom: z
@@ -38,14 +47,20 @@ export function getTileIndices(viewport) {
 
   for (let x = minX; x <= maxX; x++) {
     for (let y = minY; y <= maxY; y++) {
-      indices.push({x, y, z});
+      if (maxZoom && z > maxZoom) {
+        indices.push(getAdjustedTileIndex({x, y, z}, maxZoom));
+      } else {
+        indices.push({x, y, z});
+      }
     }
   }
-
   return indices;
 }
 
-export function getAdjustedTileIndex({x, y, z}, adjustedZ) {
+/**
+ * Calculates and returns a new tile index {x, y, z}, with z being the given adjustedZ.
+ */
+function getAdjustedTileIndex({x, y, z}, adjustedZ) {
   const m = Math.pow(2, z - adjustedZ);
   return {
     x: Math.floor(x / m),

--- a/modules/experimental-layers/src/tile-layer/utils/viewport-util.js
+++ b/modules/experimental-layers/src/tile-layer/utils/viewport-util.js
@@ -44,3 +44,12 @@ export function getTileIndices(viewport) {
 
   return indices;
 }
+
+export function getAdjustedTileIndex({x, y, z}, adjustedZ) {
+  const m = Math.pow(2, z - adjustedZ);
+  return {
+    x: Math.floor(x / m),
+    y: Math.floor(y / m),
+    z: adjustedZ
+  };
+}

--- a/test/apps/mapbox-tile/app.js
+++ b/test/apps/mapbox-tile/app.js
@@ -5,12 +5,14 @@ import {render} from 'react-dom';
 import DeckGL from 'deck.gl';
 import TileLayer from '@deck.gl/experimental-layers/tile-layer/tile-layer';
 
-import {decodeTiles} from './utils/decode';
+import {decodeTile} from './utils/decode';
 
 // Set your mapbox token here
 const MAPBOX_TOKEN = process.env.MapboxAccessToken; // eslint-disable-line
 
 const INITIAL_VIEW_STATE = {
+  bearing: 0,
+  pitch: 0,
   longitude: -122.45,
   latitude: 37.78,
   zoom: 12,
@@ -59,13 +61,12 @@ const MAP_LAYER_STYLES = {
 class Root extends Component {
   getTileData({x, y, z}) {
     const mapSource = `https://a.tiles.mapbox.com/v4/mapbox.mapbox-streets-v7/${z}/${x}/${y}.vector.pbf?access_token=${MAPBOX_TOKEN}`;
-    const eventPromise = fetch(mapSource);
-    return eventPromise
+    return fetch(mapSource)
       .then(response => {
         return response.arrayBuffer();
       })
       .then(buffer => {
-        return decodeTiles(x, y, z, buffer);
+        return decodeTile(x, y, z, buffer);
       });
   }
 

--- a/test/modules/experimental-layers/index.js
+++ b/test/modules/experimental-layers/index.js
@@ -40,3 +40,4 @@ test('Top-level imports', t => {
 });
 
 import './contour-layer/marching-squares.spec';
+import './tile-layer/tile-cache.spec';

--- a/test/modules/experimental-layers/tile-layer/tile-cache.spec.js
+++ b/test/modules/experimental-layers/tile-layer/tile-cache.spec.js
@@ -1,0 +1,125 @@
+import test from 'tape-catch';
+import TileCache from '@deck.gl/experimental-layers/tile-layer/utils/tile-cache';
+import Tile from '@deck.gl/experimental-layers/tile-layer/utils/tile';
+import {WebMercatorViewport} from 'deck.gl';
+
+const testViewState = {
+  bearing: 0,
+  pitch: 0,
+  longitude: -77.06753216318891,
+  latitude: 38.94628276371387,
+  zoom: 12,
+  minZoom: 2,
+  maxZoom: 14,
+  height: 1,
+  width: 1
+};
+
+// testViewState should load tile 12-1171-1566
+const testTile = new Tile({x: 1171, y: 1566, z: 12});
+
+const testViewport = new WebMercatorViewport(testViewState);
+
+const cacheMaxSize = 1;
+const maxZoom = 13;
+const minZoom = 11;
+
+const getTileData = () => Promise.resolve(null);
+const testTileCache = new TileCache({
+  getTileData,
+  maxSize: cacheMaxSize,
+  minZoom,
+  maxZoom
+});
+
+test('should clear the cache when finalize is called', t => {
+  testTileCache.update(testViewport, () => null);
+  t.equal(testTileCache._cache.size, 1);
+  testTileCache.finalize();
+  t.equal(testTileCache._cache.size, 0);
+});
+
+test('should call onUpdate with the expected tiles', t => {
+  testTileCache.update(testViewport, tiles => {
+    t.equal(tiles.length, 1);
+    t.equal(tiles[0].x, testTile.x);
+    t.equal(tiles[0].y, testTile.y);
+    t.equal(tiles[0].z, testTile.z);
+    t.end();
+  });
+  testTileCache.finalize();
+});
+
+test('should clear not visible tiles when cache is full', t => {
+  // load a viewport to fill the cache
+
+  testTileCache.update(testViewport, () => null);
+  // load another viewport. The previous cached tiles shouldn't be visible
+  testTileCache.update(
+    new WebMercatorViewport({
+      ...testViewState,
+      longitude: -100,
+      latitude: 80
+      // tile is 12-910-2958
+    }),
+    tiles => {
+      t.equal(testTileCache._cache.size, 1);
+      const x = 910;
+      const y = 459;
+      const z = 12;
+      const expectedTile = new Tile({x, y, z, getTileData});
+      const actualTile = testTileCache._cache.get(`${z}-${x}-${y}`);
+      t.equal(actualTile.x, expectedTile.x);
+      t.equal(actualTile.y, expectedTile.y);
+      t.equal(actualTile.z, expectedTile.z);
+      t.end();
+    }
+  );
+  testTileCache.finalize();
+});
+
+test('should load the cached parent tiles while we are loading the current tiles', t => {
+  testTileCache.update(testViewport, tiles => null);
+
+  const zoomedInViewport = new WebMercatorViewport({
+    ...testViewState,
+    zoom: maxZoom
+  });
+  testTileCache.update(zoomedInViewport, tiles => {
+    t.true(
+      tiles.some(tile => tile.x === testTile.x && tile.y === testTile.y && tile.z === testTile.z)
+    );
+    t.end();
+  });
+  testTileCache.finalize();
+});
+
+test('should try to load the existing zoom levels if we zoom in too far', t => {
+  const zoomedInViewport = new WebMercatorViewport({
+    ...testViewState,
+    zoom: 20
+  });
+
+  testTileCache.update(zoomedInViewport, tiles => {
+    tiles.forEach(tile => {
+      t.equal(tile.z, maxZoom);
+    });
+    t.end();
+  });
+  testTileCache.finalize();
+});
+
+test('should try to load the existing zoom levels if we zoom out too far', t => {
+  const zoomedOutViewport = new WebMercatorViewport({
+    ...testViewState,
+    zoom: 1
+  });
+
+  testTileCache.update(zoomedOutViewport, tiles => {
+    tiles.forEach(tile => {
+      t.equal(tile.z, minZoom);
+    });
+    t.end();
+  });
+  testTileCache.finalize();
+});

--- a/test/modules/experimental-layers/tile-layer/tile-cache.spec.js
+++ b/test/modules/experimental-layers/tile-layer/tile-cache.spec.js
@@ -110,16 +110,14 @@ test('should try to load the existing zoom levels if we zoom in too far', t => {
   testTileCache.finalize();
 });
 
-test('should try to load the existing zoom levels if we zoom out too far', t => {
+test('should not display anything if we zoom out too far', t => {
   const zoomedOutViewport = new WebMercatorViewport({
     ...testViewState,
     zoom: 1
   });
 
   testTileCache.update(zoomedOutViewport, tiles => {
-    tiles.forEach(tile => {
-      t.equal(tile.z, minZoom);
-    });
+    t.equal(tiles.length, 0);
     t.end();
   });
   testTileCache.finalize();

--- a/test/modules/experimental-layers/tile-layer/tile-cache.spec.js
+++ b/test/modules/experimental-layers/tile-layer/tile-cache.spec.js
@@ -37,6 +37,7 @@ test('should clear the cache when finalize is called', t => {
   t.equal(testTileCache._cache.size, 1);
   testTileCache.finalize();
   t.equal(testTileCache._cache.size, 0);
+  t.end();
 });
 
 test('should call onUpdate with the expected tiles', t => {


### PR DESCRIPTION
**Tile Cache**
- Set default caching size based on the size of the viewport
- When cache is full, only remove tiles that are not visible
- Use cached parents tiles when we are waiting for a new tile to be loaded

**Tile Layer**
- Only Render tiles that are between minZoom and maxZoom level
