### PR TITLE
apply proptypes in layers

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -1,5 +1,12 @@
 # Upgrade Guide
 
+## Upgrading from deck.gl v6.2 to v6.3
+
+#### GridLayer and HexagonLayer
+
+Shallow changes in `getColorValue` and `getElevationValue` props are now ignored by default. To trigger an update, use the `updateTriggers` prop. This new behavior is aligned with other core layers and improves runtime performance.
+
+
 ## Upgrading from deck.gl v6.1 to v6.2
 
 #### fp64

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -2,6 +2,13 @@
 
 This page contains highlights of each deck.gl release. Also check our [vis.gl blog](https://medium.com/vis-gl) for news about new releases and features in deck.gl.
 
+## deck.gl v6.3
+
+### Prop Types System
+
+Layers can now supply rich definitions to their default props. This enables prop validation in debug mode and performance improvements for all core layers.
+
+
 ## deck.gl v6.2
 
 <table style="border: 0;" align="center">

--- a/modules/layers/src/arc-layer/arc-layer.js
+++ b/modules/layers/src/arc-layer/arc-layer.js
@@ -33,11 +33,11 @@ const DEFAULT_COLOR = [0, 0, 0, 255];
 const defaultProps = {
   fp64: false,
 
-  getSourcePosition: x => x.sourcePosition,
-  getTargetPosition: x => x.targetPosition,
-  getSourceColor: DEFAULT_COLOR,
-  getTargetColor: DEFAULT_COLOR,
-  getStrokeWidth: 1
+  getSourcePosition: {type: 'accessor', value: x => x.sourcePosition},
+  getTargetPosition: {type: 'accessor', value: x => x.targetPosition},
+  getSourceColor: {type: 'accessor', value: DEFAULT_COLOR},
+  getTargetColor: {type: 'accessor', value: DEFAULT_COLOR},
+  getStrokeWidth: {type: 'accessor', value: 1}
 };
 
 export default class ArcLayer extends Layer {

--- a/modules/layers/src/contour-layer/contour-layer.js
+++ b/modules/layers/src/contour-layer/contour-layer.js
@@ -34,7 +34,7 @@ const DEFAULT_THRESHOLD = 1;
 const defaultProps = {
   // grid aggregation
   cellSize: {type: 'number', min: 1, max: 1000, value: 1000},
-  getPosition: x => x.position,
+  getPosition: {type: 'accessor', value: x => x.position},
 
   // contour lines
   contours: [{threshold: DEFAULT_THRESHOLD}],

--- a/modules/layers/src/geojson-layer/geojson-layer.js
+++ b/modules/layers/src/geojson-layer/geojson-layer.js
@@ -56,17 +56,17 @@ const defaultProps = {
   fp64: false,
 
   // Line and polygon outline color
-  getLineColor: defaultLineColor,
+  getLineColor: {type: 'accessor', value: defaultLineColor},
   // Point and polygon fill color
-  getFillColor: defaultFillColor,
+  getFillColor: {type: 'accessor', value: defaultFillColor},
   // Point radius
-  getRadius: 1,
+  getRadius: {type: 'accessor', value: 1},
   // Line and polygon outline accessors
-  getLineWidth: 1,
+  getLineWidth: {type: 'accessor', value: 1},
   // Line dash array accessor
-  getLineDashArray: null,
+  getLineDashArray: {type: 'accessor', value: [0, 0]},
   // Polygon extrusion accessor
-  getElevation: 1000,
+  getElevation: {type: 'accessor', value: 1000},
 
   subLayers: {
     PointLayer: ScatterplotLayer,

--- a/modules/layers/src/grid-cell-layer/grid-cell-layer.js
+++ b/modules/layers/src/grid-cell-layer/grid-cell-layer.js
@@ -35,9 +35,9 @@ const defaultProps = {
   extruded: true,
   fp64: false,
 
-  getPosition: x => x.position,
-  getElevation: 1000,
-  getColor: DEFAULT_COLOR,
+  getPosition: {type: 'accessor', value: x => x.position},
+  getElevation: {type: 'accessor', value: 1000},
+  getColor: {type: 'accessor', value: DEFAULT_COLOR},
 
   lightSettings: {}
 };

--- a/modules/layers/src/grid-layer/grid-layer.js
+++ b/modules/layers/src/grid-layer/grid-layer.js
@@ -31,7 +31,7 @@ const defaultProps = {
   // color
   colorDomain: null,
   colorRange: defaultColorRange,
-  getColorValue: points => points.length,
+  getColorValue: {type: 'accessor', value: points => points.length},
   lowerPercentile: {type: 'number', min: 0, max: 100, value: 0},
   upperPercentile: {type: 'number', min: 0, max: 100, value: 100},
   onSetColorDomain: nop,
@@ -39,7 +39,7 @@ const defaultProps = {
   // elevation
   elevationDomain: null,
   elevationRange: [0, 1000],
-  getElevationValue: points => points.length,
+  getElevationValue: {type: 'accessor', value: points => points.length},
   elevationLowerPercentile: {type: 'number', min: 0, max: 100, value: 0},
   elevationUpperPercentile: {type: 'number', min: 0, max: 100, value: 100},
   elevationScale: 1,
@@ -48,7 +48,7 @@ const defaultProps = {
   // grid
   cellSize: {type: 'number', min: 0, max: 1000, value: 1000},
   coverage: {type: 'number', min: 0, max: 1, value: 1},
-  getPosition: x => x.position,
+  getPosition: {type: 'accessor', value: x => x.position},
   extruded: false,
   fp64: false,
 

--- a/modules/layers/src/hexagon-cell-layer/hexagon-cell-layer.js
+++ b/modules/layers/src/hexagon-cell-layer/hexagon-cell-layer.js
@@ -37,9 +37,9 @@ const defaultProps = {
   extruded: true,
   fp64: false,
 
-  getCentroid: x => x.centroid,
-  getColor: DEFAULT_COLOR,
-  getElevation: 1000,
+  getCentroid: {type: 'accessor', value: x => x.centroid},
+  getColor: {type: 'accessor', value: DEFAULT_COLOR},
+  getElevation: {type: 'accessor', value: 1000},
 
   lightSettings: {}
 };

--- a/modules/layers/src/hexagon-layer/hexagon-layer.js
+++ b/modules/layers/src/hexagon-layer/hexagon-layer.js
@@ -31,25 +31,25 @@ const defaultProps = {
   // color
   colorDomain: null,
   colorRange: defaultColorRange,
-  getColorValue: points => points.length,
-  lowerPercentile: 0,
-  upperPercentile: 100,
+  getColorValue: {type: 'accessor', value: points => points.length},
+  lowerPercentile: {type: 'number', value: 0, min: 0, max: 100},
+  upperPercentile: {type: 'number', value: 100, min: 0, max: 100},
   onSetColorDomain: nop,
 
   // elevation
   elevationDomain: null,
   elevationRange: [0, 1000],
-  getElevationValue: points => points.length,
-  elevationLowerPercentile: 0,
-  elevationUpperPercentile: 100,
+  getElevationValue: {type: 'accessor', value: points => points.length},
+  elevationLowerPercentile: {type: 'number', value: 0, min: 0, max: 100},
+  elevationUpperPercentile: {type: 'number', value: 100, min: 0, max: 100},
   elevationScale: {type: 'number', min: 0, value: 1},
   onSetElevationDomain: nop,
 
-  radius: 1000,
+  radius: {type: 'number', value: 1000, min: 1},
   coverage: {type: 'number', min: 0, max: 1, value: 1},
   extruded: false,
   hexagonAggregator: pointToHexbin,
-  getPosition: x => x.position,
+  getPosition: {type: 'accessor', value: x => x.position},
   fp64: false,
   // Optional settings for 'lighting' shader module
   lightSettings: {}
@@ -64,7 +64,7 @@ export default class HexagonLayer extends CompositeLayer {
           'Now using 1000 meter as default'
       )();
 
-      props.radius = defaultProps.radius;
+      props.radius = defaultProps.radius.value;
     }
 
     if (
@@ -76,7 +76,7 @@ export default class HexagonLayer extends CompositeLayer {
         'HexagonLayer: upperPercentile should be between 0 and 100. ' + 'Assign to 100 by default'
       )();
 
-      props.upperPercentile = defaultProps.upperPercentile;
+      props.upperPercentile = defaultProps.upperPercentile.value;
     }
 
     if (
@@ -88,7 +88,7 @@ export default class HexagonLayer extends CompositeLayer {
         'HexagonLayer: lowerPercentile should be between 0 and 100. ' + 'Assign to 0 by default'
       )();
 
-      props.lowerPercentile = defaultProps.upperPercentile;
+      props.lowerPercentile = defaultProps.upperPercentile.value;
     }
 
     if (props.lowerPercentile >= props.upperPercentile) {
@@ -98,7 +98,7 @@ export default class HexagonLayer extends CompositeLayer {
           'upperPercentile. Assign to 0 by default'
       )();
 
-      props.lowerPercentile = defaultProps.lowerPercentile;
+      props.lowerPercentile = defaultProps.lowerPercentile.value;
     }
 
     super(props);

--- a/modules/layers/src/icon-layer/icon-layer.js
+++ b/modules/layers/src/icon-layer/icon-layer.js
@@ -56,14 +56,14 @@ const DEFAULT_TEXTURE_MAG_FILTER = GL.LINEAR;
 const defaultProps = {
   iconAtlas: null,
   iconMapping: {type: 'object', value: {}, async: true},
-  sizeScale: 1,
+  sizeScale: {type: 'number', value: 1, min: 0},
   fp64: false,
 
-  getPosition: x => x.position,
-  getIcon: x => x.icon,
-  getColor: DEFAULT_COLOR,
-  getSize: 1,
-  getAngle: 0
+  getPosition: {type: 'accessor', value: x => x.position},
+  getIcon: {type: 'accessor', value: x => x.icon},
+  getColor: {type: 'accessor', value: DEFAULT_COLOR},
+  getSize: {type: 'accessor', value: 1},
+  getAngle: {type: 'accessor', value: 0}
 };
 
 export default class IconLayer extends Layer {

--- a/modules/layers/src/line-layer/line-layer.js
+++ b/modules/layers/src/line-layer/line-layer.js
@@ -31,10 +31,10 @@ const DEFAULT_COLOR = [0, 0, 0, 255];
 const defaultProps = {
   fp64: false,
 
-  getSourcePosition: x => x.sourcePosition,
-  getTargetPosition: x => x.targetPosition,
-  getColor: DEFAULT_COLOR,
-  getStrokeWidth: 1
+  getSourcePosition: {type: 'accessor', value: x => x.sourcePosition},
+  getTargetPosition: {type: 'accessor', value: x => x.targetPosition},
+  getColor: {type: 'accessor', value: DEFAULT_COLOR},
+  getStrokeWidth: {type: 'accessor', value: 1}
 };
 
 export default class LineLayer extends Layer {

--- a/modules/layers/src/path-layer/path-layer.js
+++ b/modules/layers/src/path-layer/path-layer.js
@@ -30,18 +30,18 @@ import fs from './path-layer-fragment.glsl';
 const DEFAULT_COLOR = [0, 0, 0, 255];
 
 const defaultProps = {
-  widthScale: 1, // stroke width in meters
-  widthMinPixels: 0, //  min stroke width in pixels
-  widthMaxPixels: Number.MAX_SAFE_INTEGER, // max stroke width in pixels
+  widthScale: {type: 'number', min: 0, value: 1}, // stroke width in meters
+  widthMinPixels: {type: 'number', min: 0, value: 0}, //  min stroke width in pixels
+  widthMaxPixels: {type: 'number', min: 0, value: Number.MAX_SAFE_INTEGER}, // max stroke width in pixels
   rounded: false,
-  miterLimit: 4,
+  miterLimit: {type: 'number', min: 0, value: 4},
   fp64: false,
   dashJustified: false,
 
-  getPath: object => object.path,
-  getColor: DEFAULT_COLOR,
-  getWidth: 1,
-  getDashArray: null
+  getPath: {type: 'accessor', value: object => object.path},
+  getColor: {type: 'accessor', value: DEFAULT_COLOR},
+  getWidth: {type: 'accessor', value: 1},
+  getDashArray: {type: 'accessor', value: [0, 0]}
 };
 
 const isClosed = path => {

--- a/modules/layers/src/point-cloud-layer/point-cloud-layer.js
+++ b/modules/layers/src/point-cloud-layer/point-cloud-layer.js
@@ -30,12 +30,12 @@ const DEFAULT_COLOR = [0, 0, 0, 255];
 const DEFAULT_NORMAL = [0, 0, 1];
 
 const defaultProps = {
-  radiusPixels: 10, //  point radius in pixels
+  radiusPixels: {type: 'number', min: 0, value: 10}, //  point radius in pixels
   fp64: false,
 
-  getPosition: x => x.position,
-  getNormal: DEFAULT_NORMAL,
-  getColor: DEFAULT_COLOR,
+  getPosition: {type: 'accessor', value: x => x.position},
+  getNormal: {type: 'accessor', value: DEFAULT_NORMAL},
+  getColor: {type: 'accessor', value: DEFAULT_COLOR},
 
   lightSettings: {}
 };

--- a/modules/layers/src/polygon-layer/polygon-layer.js
+++ b/modules/layers/src/polygon-layer/polygon-layer.js
@@ -41,17 +41,17 @@ const defaultProps = {
   lineDashJustified: false,
   fp64: false,
 
-  getPolygon: f => f.polygon,
+  getPolygon: {type: 'accessor', value: f => f.polygon},
   // Polygon fill color
-  getFillColor: defaultFillColor,
+  getFillColor: {type: 'accessor', value: defaultFillColor},
   // Point, line and polygon outline color
-  getLineColor: defaultLineColor,
+  getLineColor: {type: 'accessor', value: defaultLineColor},
   // Line and polygon outline accessors
-  getLineWidth: 1,
+  getLineWidth: {type: 'accessor', value: 1},
   // Line dash array accessor
-  getLineDashArray: null,
+  getLineDashArray: {type: 'accessor', value: [0, 0]},
   // Polygon extrusion accessor
-  getElevation: 1000,
+  getElevation: {type: 'accessor', value: 1000},
 
   // Optional settings for 'lighting' shader module
   lightSettings: {}

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer.js
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer.js
@@ -29,16 +29,16 @@ import fs from './scatterplot-layer-fragment.glsl';
 const DEFAULT_COLOR = [0, 0, 0, 255];
 
 const defaultProps = {
-  radiusScale: 1,
-  radiusMinPixels: 0, //  min point radius in pixels
-  radiusMaxPixels: Number.MAX_SAFE_INTEGER, // max point radius in pixels
-  strokeWidth: 1,
+  radiusScale: {type: 'number', min: 0, value: 1},
+  radiusMinPixels: {type: 'number', min: 0, value: 0}, //  min point radius in pixels
+  radiusMaxPixels: {type: 'number', min: 0, value: Number.MAX_SAFE_INTEGER}, // max point radius in pixels
+  strokeWidth: {type: 'number', min: 0, value: 1},
   outline: false,
   fp64: false,
 
-  getPosition: x => x.position,
-  getRadius: 1,
-  getColor: DEFAULT_COLOR
+  getPosition: {type: 'accessor', value: x => x.position},
+  getRadius: {type: 'accessor', value: 1},
+  getColor: {type: 'accessor', value: DEFAULT_COLOR}
 };
 
 export default class ScatterplotLayer extends Layer {

--- a/modules/layers/src/screen-grid-layer/screen-grid-layer.js
+++ b/modules/layers/src/screen-grid-layer/screen-grid-layer.js
@@ -49,8 +49,8 @@ const defaultProps = {
   colorDomain: null,
   colorRange: defaultColorRange,
 
-  getPosition: d => d.position,
-  getWeight: d => 1,
+  getPosition: {type: 'accessor', value: d => d.position},
+  getWeight: {type: 'accessor', value: d => 1},
 
   gpuAggregation: true
 };

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -39,15 +39,15 @@ const defaultProps = {
   fp64: false,
 
   // elevation multiplier
-  elevationScale: 1,
+  elevationScale: {type: 'number', min: 0, value: 1},
 
   // Accessor for polygon geometry
-  getPolygon: f => f.polygon,
+  getPolygon: {type: 'accessor', value: f => f.polygon},
   // Accessor for extrusion height
-  getElevation: 1000,
+  getElevation: {type: 'accessor', value: 1000},
   // Accessor for colors
-  getFillColor: DEFAULT_COLOR,
-  getLineColor: DEFAULT_COLOR,
+  getFillColor: {type: 'accessor', value: DEFAULT_COLOR},
+  getLineColor: {type: 'accessor', value: DEFAULT_COLOR},
 
   // Optional settings for 'lighting' shader module
   lightSettings: {}

--- a/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer.js
+++ b/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer.js
@@ -23,13 +23,13 @@ import IconLayer from '../../icon-layer/icon-layer';
 import vs from './multi-icon-layer-vertex.glsl';
 
 const defaultProps = {
-  getShiftInQueue: x => x.shift || 0,
-  getLengthOfQueue: x => x.len || 1,
+  getShiftInQueue: {type: 'accessor', value: x => x.shift || 0},
+  getLengthOfQueue: {type: 'accessor', value: x => x.len || 1},
   // 1: left, 0: middle, -1: right
-  getAnchorX: x => x.anchorX || 0,
+  getAnchorX: {type: 'accessor', value: x => x.anchorX || 0},
   // 1: top, 0: center, -1: bottom
-  getAnchorY: x => x.anchorY || 0,
-  getPixelOffset: [0, 0]
+  getAnchorY: {type: 'accessor', value: x => x.anchorY || 0},
+  getPixelOffset: {type: 'accessor', value: [0, 0]}
 };
 
 export default class MultiIconLayer extends IconLayer {

--- a/modules/layers/src/text-layer/text-layer.js
+++ b/modules/layers/src/text-layer/text-layer.js
@@ -45,14 +45,14 @@ const defaultProps = {
   fontFamily: DEFAULT_FONT_FAMILY,
   characterSet: DEFAULT_CHAR_SET,
 
-  getText: x => x.text,
-  getPosition: x => x.position,
-  getColor: DEFAULT_COLOR,
-  getSize: 32,
-  getAngle: 0,
-  getTextAnchor: 'middle',
-  getAlignmentBaseline: 'center',
-  getPixelOffset: [0, 0]
+  getText: {type: 'accessor', value: x => x.text},
+  getPosition: {type: 'accessor', value: x => x.position},
+  getColor: {type: 'accessor', value: DEFAULT_COLOR},
+  getSize: {type: 'accessor', value: 32},
+  getAngle: {type: 'accessor', value: 0},
+  getTextAnchor: {type: 'accessor', value: 'middle'},
+  getAlignmentBaseline: {type: 'accessor', value: 'center'},
+  getPixelOffset: {type: 'accessor', value: [0, 0]}
 };
 
 export default class TextLayer extends CompositeLayer {

--- a/test/modules/layers/grid-layer.spec.js
+++ b/test/modules/layers/grid-layer.spec.js
@@ -170,7 +170,10 @@ test('GridLayer#updates', t => {
       },
       {
         updateProps: {
-          getPosition: d => d.COORDINATES
+          getPosition: d => d.COORDINATES,
+          updateTriggers: {
+            getPosition: 1
+          }
         },
         assert({layer, oldState}) {
           t.ok(
@@ -211,19 +214,22 @@ test('GridLayer#updates', t => {
       },
       {
         updateProps: {
-          getColorValue
+          getColorValue,
+          updateTriggers: {
+            getColorValue: 1
+          }
         },
         assert({layer, oldState}) {
           t.ok(oldState.layerData === layer.state.layerData, 'should not update layer data');
 
           t.ok(
             oldState.sortedColorBins !== layer.state.sortedColorBins,
-            'should not update sortedColorBins'
+            'should update sortedColorBins'
           );
 
           t.ok(
             oldState.sortedElevationBins === layer.state.sortedElevationBins,
-            'should update sortedElevationBins'
+            'should not update sortedElevationBins'
           );
 
           t.ok(
@@ -325,7 +331,10 @@ test('GridLayer#updates', t => {
       },
       {
         updateProps: {
-          getElevationValue
+          getElevationValue,
+          updateTriggers: {
+            getElevationValue: 1
+          }
         },
         assert({layer, oldState}) {
           t.ok(oldState.layerData === layer.state.layerData, 'should not update layer data');
@@ -487,7 +496,10 @@ test('GridLayer#updateTriggers', t => {
       },
       {
         updateProps: {
-          getColorValue
+          getColorValue,
+          updateTriggers: {
+            getColorValue: 1
+          }
         },
         assert({subLayer, spies}) {
           t.ok(
@@ -517,7 +529,10 @@ test('GridLayer#updateTriggers', t => {
       },
       {
         updateProps: {
-          getElevationValue
+          getElevationValue,
+          updateTriggers: {
+            getElevationValue: 1
+          }
         },
         assert({subLayer, spies}) {
           t.ok(

--- a/test/modules/layers/hexagon-layer.spec.js
+++ b/test/modules/layers/hexagon-layer.spec.js
@@ -88,7 +88,10 @@ test('HexagonLayer#updateLayer', t => {
       {
         title: 'Update getColorValue accessor',
         updateProps: {
-          getColorValue
+          getColorValue,
+          updateTriggers: {
+            getColorValue: 1
+          }
         },
         assert({layer, oldState, userData}) {
           t.ok(oldState.hexagons === layer.state.hexagons, 'should not update layer data');
@@ -205,7 +208,10 @@ test('HexagonLayer#updateLayer', t => {
       {
         title: 'Update getElevationValue accessor',
         updateProps: {
-          getElevationValue
+          getElevationValue,
+          updateTriggers: {
+            getElevationValue: 1
+          }
         },
         assert({layer, oldState, userData}) {
           t.ok(oldState.hexagons === layer.state.hexagons, 'should not update layer data');
@@ -373,7 +379,10 @@ test('HexagonLayer#updateTriggers', t => {
       {
         title: 'Update getColorValue prop',
         updateProps: {
-          getColorValue
+          getColorValue,
+          updateTriggers: {
+            getColorValue: 1
+          }
         },
         assert({subLayer, spies, userData}) {
           t.ok(
@@ -405,7 +414,10 @@ test('HexagonLayer#updateTriggers', t => {
       {
         title: 'Update getElevationValue prop',
         updateProps: {
-          getElevationValue
+          getElevationValue,
+          updateTriggers: {
+            getElevationValue: 1
+          }
         },
         assert({subLayer, spies, userData}) {
           t.ok(


### PR DESCRIPTION
For #1371 

GeoJsonLayer shows 2x FPS during constant React rerender (hover and viewport manipulation)

#### Change List
- Use prop types in all core layers
- BREAKING: HexagonLayer and GridLayer no longer updates when `getColorValue` and `getElevationValue` change shallowly - use updateTriggers instead

#### TODO
- [x] update what's new / upgrade guide