### PR TITLE
LayerManager: fix initial viewport

### DIFF
--- a/docs/developer-guide/prop-types.md
+++ b/docs/developer-guide/prop-types.md
@@ -82,8 +82,8 @@ MyLayerClass.defaultProps = {
 A numeric value.
 
 - Options:
-    + `min` (number, optional) - the minimum allowed value
-    + `max` (number, optional) - the maximum allowed value
+  + `min` (number, optional) - the minimum allowed value
+  + `max` (number, optional) - the maximum allowed value
 - Default `validate`: value is finite and within bounds (if specified)
 - Default `equal`: strict equal
 
@@ -115,7 +115,7 @@ MyLayerClass.defaultProps = {
 An array of objects.
 
 - Options:
-    + `compare` (boolean, optional) - compare deeply during prop comparison. Default `false`.
+  + `compare` (boolean, optional) - compare deeply during prop comparison. Default `false`.
 - Default `validate`: value is an array of 3 or 4 elements
 - Default `equal`: shallow equal if `compare: false`, otherwise deep equal
 
@@ -147,7 +147,7 @@ MyLayerClass.defaultProps = {
 A function.
 
 - Options:
-    + `compare` (boolean, optional) - compare strictly during prop comparison. Default `true`.
+  + `compare` (boolean, optional) - compare strictly during prop comparison. Default `true`.
 - Default `validate`: value is a function
 - Default `equal`: `true` if `compare: false`, otherwise strict equal
 
@@ -217,4 +217,3 @@ const defaultProps = {
 ```
 
 The default comparator of the `access` prop type ignores shallow changes in functions. As a result, deck.gl decides that no props have changed between the two renders, and the GeoJsonLayer does not need to be updated.
-

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -477,8 +477,7 @@ export default class Deck {
     // viewManager must be initialized before layerManager
     // layerManager depends on viewport created by viewManager.
     assert(this.viewManager);
-    const viewports = this.viewManager.getViewports();
-    const viewport = viewports.length > 0 ? viewports[0] : null;
+    const viewport = this.viewManager.getViewports()[0];
     // Note: avoid React setState due GL animation loop / setState timing issue
     this.layerManager = new LayerManager(gl, {
       stats: this.stats,

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -396,6 +396,20 @@ export default class Deck {
     return views;
   }
 
+  // Returns default viewport based on initialViewState/viewState.
+  _getDefaultViewport(props) {
+    const viewState = this._getViewState(props);
+    const views = this._getViews(props);
+    const viewport =
+      views[0] &&
+      views[0].makeViewport({
+        width: this.width,
+        height: this.height,
+        viewState
+      });
+    return viewport;
+  }
+
   _pickAndCallback(options) {
     const pos = options.event.offsetCenter;
     // Do not trigger callbacks when click/hover position is invalid. Doing so will cause a
@@ -471,7 +485,11 @@ export default class Deck {
     });
 
     // Note: avoid React setState due GL animation loop / setState timing issue
-    this.layerManager = new LayerManager(gl, {stats: this.stats});
+    this.layerManager = new LayerManager(gl, {
+      stats: this.stats,
+      // Valid viewport must be set, so layers can use viewport.project* methods
+      viewport: this._getDefaultViewport(this.props)
+    });
 
     this.effectManager = new EffectManager({gl, layerManager: this.layerManager});
 

--- a/modules/core/src/lib/layer-manager.js
+++ b/modules/core/src/lib/layer-manager.js
@@ -53,9 +53,6 @@ const INITIAL_CONTEXT = Object.seal({
   // General resources
   stats: null, // for tracking lifecycle performance
 
-  // Make sure context.viewport is not empty on the first layer initialization
-  viewport: new Viewport(), // Current viewport, exposed to layers for project* function
-
   // GL Resources
   shaderCache: null,
   pickingFBO: null, // Screen-size framebuffer that layers can reuse
@@ -72,7 +69,7 @@ const layerName = layer => (layer instanceof Layer ? `${layer}` : !layer ? 'null
 
 export default class LayerManager {
   // eslint-disable-next-line
-  constructor(gl, {stats} = {}) {
+  constructor(gl, {stats, viewport} = {}) {
     // Currently deck.gl expects the DeckGL.layers array to be different
     // whenever React rerenders. If the same layers array is used, the
     // LayerManager's diffing algorithm will generate a fatal error and
@@ -96,7 +93,9 @@ export default class LayerManager {
         // For callback tracking and autohighlight
         index: -1,
         layerId: null
-      }
+      },
+      // Make sure context.viewport is not empty on the first layer initialization
+      viewport: viewport || new Viewport() // Current viewport, exposed to layers for project* function
     });
 
     this.layerFilter = null;

--- a/modules/core/src/lib/layer-manager.js
+++ b/modules/core/src/lib/layer-manager.js
@@ -69,7 +69,7 @@ const layerName = layer => (layer instanceof Layer ? `${layer}` : !layer ? 'null
 
 export default class LayerManager {
   // eslint-disable-next-line
-  constructor(gl, {stats, viewport} = {}) {
+  constructor(gl, {stats, viewport = null} = {}) {
     // Currently deck.gl expects the DeckGL.layers array to be different
     // whenever React rerenders. If the same layers array is used, the
     // LayerManager's diffing algorithm will generate a fatal error and

--- a/modules/core/src/lib/layer-manager.js
+++ b/modules/core/src/lib/layer-manager.js
@@ -95,7 +95,7 @@ export default class LayerManager {
         layerId: null
       },
       // Make sure context.viewport is not empty on the first layer initialization
-      viewport: viewport || new Viewport() // Current viewport, exposed to layers for project* function
+      viewport: viewport || new Viewport({id: 'DEFAULT-INITIAL-VIEWPORT'}) // Current viewport, exposed to layers for project* function
     });
 
     this.layerFilter = null;

--- a/modules/core/src/lib/layer-manager.js
+++ b/modules/core/src/lib/layer-manager.js
@@ -54,7 +54,7 @@ const INITIAL_CONTEXT = Object.seal({
   stats: null, // for tracking lifecycle performance
 
   // Make sure context.viewport is not empty on the first layer initialization
-  viewport: new Viewport({id: 'DEFAULT-INITIAL-VIEWPORT'}), // Current viewport, exposed to layers for project* function
+  viewport: new Viewport(), // Current viewport, exposed to layers for project* function
 
   // GL Resources
   shaderCache: null,

--- a/modules/layers/src/hexagon-layer/hexagon-layer.js
+++ b/modules/layers/src/hexagon-layer/hexagon-layer.js
@@ -118,18 +118,10 @@ export default class HexagonLayer extends CompositeLayer {
     };
   }
 
-  shouldUpdateState({changeFlags}) {
-    return (
-      changeFlags.propsOrDataChanged ||
-      // if viewport is changed and aggregation to hexbins has not happened yet.
-      (changeFlags.viewportChanged && this.state.hexagons.length === 0)
-    );
-  }
-
   updateState({oldProps, props, changeFlags}) {
     const dimensionChanges = this.getDimensionChanges(oldProps, props);
 
-    if (this.needsReProjectPoints(oldProps, props, changeFlags)) {
+    if (changeFlags.dataChanged || this.needsReProjectPoints(oldProps, props)) {
       // project data into hexagons, and get sortedColorBins
       this.getHexagons();
     } else if (dimensionChanges) {
@@ -137,12 +129,9 @@ export default class HexagonLayer extends CompositeLayer {
     }
   }
 
-  needsReProjectPoints(oldProps, props, changeFlags) {
+  needsReProjectPoints(oldProps, props) {
     return (
-      changeFlags.dataChanged ||
-      this.state.hexagons.length === 0 ||
-      oldProps.radius !== props.radius ||
-      oldProps.hexagonAggregator !== props.hexagonAggregator
+      oldProps.radius !== props.radius || oldProps.hexagonAggregator !== props.hexagonAggregator
     );
   }
 
@@ -209,14 +198,11 @@ export default class HexagonLayer extends CompositeLayer {
   }
 
   getHexagons() {
+    const {hexagonAggregator} = this.props;
     const {viewport} = this.context;
-    // layer is first initialzed with defautl viewport which could be non geospatial
-    if (viewport.isGeospatial) {
-      const {hexagonAggregator} = this.props;
-      const {hexagons, hexagonVertices} = hexagonAggregator(this.props, viewport);
-      this.setState({hexagons, hexagonVertices});
-      this.getSortedBins();
-    }
+    const {hexagons, hexagonVertices} = hexagonAggregator(this.props, viewport);
+    this.setState({hexagons, hexagonVertices});
+    this.getSortedBins();
   }
 
   getPickingInfo({info}) {

--- a/modules/test-utils/src/lifecycle-test-deprecated.js
+++ b/modules/test-utils/src/lifecycle-test-deprecated.js
@@ -23,9 +23,6 @@ import gl from './utils/setup-gl';
 
 export function testInitializeLayer({layer, viewport}) {
   const layerManager = new LayerManager(gl);
-  if (viewport) {
-    layerManager.context.viewport = viewport;
-  }
 
   try {
     layerManager.setLayers([layer]);

--- a/test/modules/layers/hexagon-layer.spec.js
+++ b/test/modules/layers/hexagon-layer.spec.js
@@ -24,7 +24,7 @@ import {makeSpy} from 'probe.gl/test-utils';
 import * as data from 'deck.gl/test/data';
 import {testLayer, testInitializeLayer} from '@deck.gl/test-utils';
 
-import {HexagonLayer, HexagonCellLayer, WebMercatorViewport} from 'deck.gl';
+import {HexagonLayer, HexagonCellLayer} from 'deck.gl';
 
 const getColorValue = points => points.length;
 const getElevationValue = points => points.length;
@@ -517,7 +517,7 @@ test('HexagonLayer#renderSubLayer', t => {
     pickable: true
   });
 
-  testInitializeLayer({layer, viewport: new WebMercatorViewport()});
+  testInitializeLayer({layer});
 
   // render sublayer
   const subLayer = layer.renderLayers();


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #2111 and #2215 
<!-- For other PRs without open issue -->
#### Background
Before version 6, it was guaranteed that layers are always initialized with a viewport built with user provided parameters, during multi-viewport support this code was re-structured and now layers are initialized with a default viewport (not built with user provided `viewState` or `initialViewState`) causing issues. For example, layers that use `context.viewport` to perform projection on `data`.  Actual viewport is only set during draw time.

To fix this, build `viewport` from user provided `view`/`viewState` or default when not available, and use it to initialize the `LayerManager`, this will match the old behavior.

This change also reverts previously added WA for HexagonLayer : #2239
<!-- For all the PRs -->
#### Change List
- Revert "Hexagon aggregation with valid viewport (#2239)"
- LayerManager: Initialize with correct viewport.
