### PR TITLE
Fix FirstPersonView flip bug

### DIFF
--- a/modules/core/src/viewports/viewport.js
+++ b/modules/core/src/viewports/viewport.js
@@ -341,11 +341,12 @@ export default class Viewport {
       this.meterOffset = modelMatrix ? modelMatrix.transformVector(position) : position;
     }
 
-    this.viewMatrixUncentered = viewMatrix;
-
     if (this.isGeospatial) {
       // Determine camera center
       this.center = this._getCenterInWorld({longitude, latitude});
+
+      // Flip Y to match the orientation of the Mercator plane
+      this.viewMatrixUncentered = mat4_scale([], viewMatrix, [1, -1, 1]);
 
       // Make a centered version of the matrix for projection modes without an offset
       this.viewMatrix = new Matrix4()
@@ -355,6 +356,7 @@ export default class Viewport {
         .translate(new Vector3(this.center || ZERO_VECTOR).negate());
     } else {
       this.center = position;
+      this.viewMatrixUncentered = viewMatrix;
       this.viewMatrix = viewMatrix;
     }
   }

--- a/modules/core/src/viewports/web-mercator-viewport.js
+++ b/modules/core/src/viewports/web-mercator-viewport.js
@@ -86,8 +86,7 @@ export default class WebMercatorViewport extends Viewport {
       height,
       pitch,
       bearing,
-      altitude,
-      flipY: true
+      altitude
     });
 
     // TODO / hack - prevent vertical offsets if not FirstPersonViewport


### PR DESCRIPTION
For #2379 

#### Background
This was broken by https://github.com/uber/deck.gl/pull/2230/files#diff-893b87494b0cae962ca726e100f10fa7L345

The original PR was correct that the Y flip should be applied to both `viewMatrixUncentered` and `viewMatrix`. However, it only flipped the `viewMatrixUncentered` of `WebMercatorViewport`, and left the geospatial version of `FirstPersonView` and `ThirdPersonView` broken.

#### Change List
- Move Y-flipping from `WebMercatorViewport` back into `Viewport`.

#### TODO
- Add a render test case for `FirstPersonView`
