### PR TITLE
Add a width scale to arc layer so it maintains projected size

### DIFF
--- a/docs/layers/arc-layer.md
+++ b/docs/layers/arc-layer.md
@@ -36,6 +36,7 @@ const App = ({data, viewport}) => {
     data,
     pickable: true,
     getStrokeWidth: 12,
+    widthScale: Math.pow(viewport.zoom, 2) / 4096,
     getSourcePosition: d => d.from.coordinates,
     getTargetPosition: d => d.to.coordinates,
     getSourceColor: d => [Math.sqrt(d.inbound), 140, 0],
@@ -58,6 +59,12 @@ Inherits from all [Base Layer](/docs/api-reference/layer.md) properties.
 * Default: `false`
 
 Whether the layer should be rendered in high-precision 64-bit mode. Note that since deck.gl v6.1, the default 32-bit projection uses a hybrid mode that matches 64-bit precision with significantly better performance.
+
+##### `widthScale` (number, optional)
+
+* Default: 1
+
+The scaling factor for the width of each arc. Usually `Math.pow(viewport.zoom, 2) / Math.pow(2, 12)`, corresponding to the current zoom level and the width of 1 pixel at zoom level 12. You can limit the minimum size of the arc with this property.
 
 ### Data Accessors
 

--- a/docs/layers/arc-layer.md
+++ b/docs/layers/arc-layer.md
@@ -36,7 +36,6 @@ const App = ({data, viewport}) => {
     data,
     pickable: true,
     getStrokeWidth: 12,
-    widthScale: Math.pow(viewport.zoom, 2) / 4096,
     getSourcePosition: d => d.from.coordinates,
     getTargetPosition: d => d.to.coordinates,
     getSourceColor: d => [Math.sqrt(d.inbound), 140, 0],
@@ -64,7 +63,7 @@ Whether the layer should be rendered in high-precision 64-bit mode. Note that si
 
 * Default: 1
 
-The scaling factor for the width of each arc. Usually `Math.pow(viewport.zoom, 2) / Math.pow(2, 12)`, corresponding to the current zoom level and the width of 1 pixel at zoom level 12. You can limit the minimum size of the arc with this property.
+The scaling factor for the width of each arc. If you set the property to `Math.pow(2, viewport.zoom - 12)` it will keep the width constant, corresponding to the current zoom level and the width of 1 pixel at zoom level 12. You can also limit the minimum size of the arc with this property.
 
 ### Data Accessors
 

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -35,7 +35,7 @@
     "luma.gl": "^6.2.0",
     "math.gl": "^2.1.0",
     "mjolnir.js": "^1.0.0",
-    "probe.gl": "^2.0.0",
+    "probe.gl": "^2.0.1",
     "seer": "^0.2.4",
     "viewport-mercator-project": "^6.0.0"
   }

--- a/modules/layers/src/arc-layer/arc-layer-vertex-64.glsl.js
+++ b/modules/layers/src/arc-layer/arc-layer-vertex-64.glsl.js
@@ -33,6 +33,7 @@ attribute float instanceWidths;
 
 uniform float numSegments;
 uniform float opacity;
+uniform float widthScale;
 
 varying vec4 vColor;
 
@@ -56,7 +57,7 @@ vec2 getExtrusionOffset(vec2 line_clipspace, float offset_direction) {
   // rotate by 90 degrees
   dir_screenspace = vec2(-dir_screenspace.y, dir_screenspace.x);
 
-  vec2 offset_screenspace = dir_screenspace * offset_direction * instanceWidths / 2.0;
+  vec2 offset_screenspace = dir_screenspace * offset_direction * instanceWidths * widthScale / 2.0;
   vec2 offset_clipspace = project_pixel_to_clipspace(offset_screenspace).xy;
 
   return offset_clipspace;

--- a/modules/layers/src/arc-layer/arc-layer-vertex.glsl.js
+++ b/modules/layers/src/arc-layer/arc-layer-vertex.glsl.js
@@ -31,6 +31,7 @@ attribute float instanceWidths;
 
 uniform float numSegments;
 uniform float opacity;
+uniform float widthScale;
 
 varying vec4 vColor;
 
@@ -52,7 +53,7 @@ vec2 getExtrusionOffset(vec2 line_clipspace, float offset_direction) {
   // rotate by 90 degrees
   dir_screenspace = vec2(-dir_screenspace.y, dir_screenspace.x);
 
-  vec2 offset_screenspace = dir_screenspace * offset_direction * instanceWidths / 2.0;
+  vec2 offset_screenspace = dir_screenspace * offset_direction * instanceWidths * widthScale / 2.0;
   vec2 offset_clipspace = project_pixel_to_clipspace(offset_screenspace).xy;
 
   return offset_clipspace;

--- a/modules/layers/src/arc-layer/arc-layer.js
+++ b/modules/layers/src/arc-layer/arc-layer.js
@@ -37,7 +37,8 @@ const defaultProps = {
   getTargetPosition: {type: 'accessor', value: x => x.targetPosition},
   getSourceColor: {type: 'accessor', value: DEFAULT_COLOR},
   getTargetColor: {type: 'accessor', value: DEFAULT_COLOR},
-  getStrokeWidth: {type: 'accessor', value: 1}
+  getStrokeWidth: {type: 'accessor', value: 1},
+  widthScale: {type: 'number', value: 1, min: 0}
 };
 
 export default class ArcLayer extends Layer {
@@ -109,6 +110,10 @@ export default class ArcLayer extends Layer {
       this.setState({model: this._getModel(gl)});
       this.getAttributeManager().invalidateAll();
     }
+
+    this.state.model.setUniforms({
+      widthScale: props.widthScale
+    });
   }
 
   _getModel(gl) {


### PR DESCRIPTION
#### Background
![example](https://i.imgur.com/Du6ACxJ.gif)
As you zoom out, the ArcLayer's line widths appear to grow instead of staying consistent with the projection of the viewport. 

#### Change List
-This adds a `widthScale` uniform float prop meant to be used to determine the scaling factor based on the zoom level:

```
new ArcLayer({
  // ...
  widthScale: Math.pow(2, viewport.zoom) / scaleFactor,
})
```

Alternatively, the layer could unproject the viewport's zoom by default, and call worldToPixels on the scaleFactor. Open to suggestions.