### PR TITLE
Implement Event handling RFC

### DIFF
--- a/docs/api-reference/deck.md
+++ b/docs/api-reference/deck.md
@@ -187,13 +187,44 @@ Callback Arguments:
 
 ##### `onLayerClick` (Function, optional)
 
-Callback - called when clicking on the layer.
+Callback - called when clicking on the canvas.
 
 Callback Arguments:
 
 * `info` - the [`info`](/docs/get-started/interactivity.md#the-picking-info-object) object for the topmost picked layer at the coordinate, null when no object is picked.
 * `pickedInfos` - an array of info objects for all pickable layers that are affected.
 * `event` - the original [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) object
+
+##### `onDragStart` (Function, optional)
+
+Callback - called when the user starts dragging on the canvas.
+
+Callback Arguments:
+
+* `info` - the [`info`](/docs/get-started/interactivity.md#the-picking-info-object) object for the topmost picked layer at the coordinate, null when no object is picked.
+* `pickedInfos` - an array of info objects for all pickable layers that are affected.
+* `event` - the original gesture event
+
+##### `onDrag` (Function, optional)
+
+Callback - called when dragging the canvas.
+
+Callback Arguments:
+
+* `info` - the [`info`](/docs/get-started/interactivity.md#the-picking-info-object) object for the topmost picked layer at the coordinate, null when no object is picked.
+* `pickedInfos` - an array of info objects for all pickable layers that are affected.
+* `event` - the original gesture event
+
+##### `onDragEnd` (Function, optional)
+
+Callback - called when the user releases from dragging the canvas.
+
+Callback Arguments:
+
+* `info` - the [`info`](/docs/get-started/interactivity.md#the-picking-info-object) object for the topmost picked layer at the coordinate, null when no object is picked.
+* `pickedInfos` - an array of info objects for all pickable layers that are affected.
+* `event` - the original gesture event
+
 
 ##### `onLoad` (Function, optional)
 

--- a/docs/api-reference/deck.md
+++ b/docs/api-reference/deck.md
@@ -201,8 +201,7 @@ Callback - called when the user starts dragging on the canvas.
 
 Callback Arguments:
 
-* `info` - the [`info`](/docs/get-started/interactivity.md#the-picking-info-object) object for the topmost picked layer at the coordinate, null when no object is picked.
-* `pickedInfos` - an array of info objects for all pickable layers that are affected.
+* `info` - the [picking info](/docs/get-started/interactivity.md#the-picking-info-object) describing the object being dragged.
 * `event` - the original gesture event
 
 ##### `onDrag` (Function, optional)
@@ -211,8 +210,7 @@ Callback - called when dragging the canvas.
 
 Callback Arguments:
 
-* `info` - the [`info`](/docs/get-started/interactivity.md#the-picking-info-object) object for the topmost picked layer at the coordinate, null when no object is picked.
-* `pickedInfos` - an array of info objects for all pickable layers that are affected.
+* `info` - the [picking info](/docs/get-started/interactivity.md#the-picking-info-object) describing the object being dragged.
 * `event` - the original gesture event
 
 ##### `onDragEnd` (Function, optional)
@@ -221,8 +219,7 @@ Callback - called when the user releases from dragging the canvas.
 
 Callback Arguments:
 
-* `info` - the [`info`](/docs/get-started/interactivity.md#the-picking-info-object) object for the topmost picked layer at the coordinate, null when no object is picked.
-* `pickedInfos` - an array of info objects for all pickable layers that are affected.
+* `info` - the [picking info](/docs/get-started/interactivity.md#the-picking-info-object) describing the object being dragged.
 * `event` - the original gesture event
 
 

--- a/docs/api-reference/layer.md
+++ b/docs/api-reference/layer.md
@@ -118,7 +118,40 @@ Requires `pickable` to be true.
 
 This callback will be called when the mouse clicks over an object of this deck.gl layer with a single parameter [`info`](/docs/get-started/interactivity.md#the-picking-info-object).
 
-If this callback returns a truthy value, the `hover` event is marked as handled and will not bubble up to the [`onLayerClick`](/docs/api-reference/react/deckgl.md#-onlayerclick-function-optional-) callback of the `DeckGL` canvas.
+If this callback returns a truthy value, the `click` event is marked as handled and will not bubble up to the [`onLayerClick`](/docs/api-reference/react/deckgl.md#-onlayerclick-function-optional-) callback of the `DeckGL` canvas.
+
+Requires `pickable` to be true.
+
+##### `onDragStart` (Function, optional)
+
+This callback will be called when the mouse starts dragging an object of this deck.gl layer with the following parameters:
+
+* [`info`](/docs/get-started/interactivity.md#the-picking-info-object)
+* `event` - the source event
+
+If this callback returns a truthy value, the `dragstart` event is marked as handled and will not bubble up to the [`onDragStart`](/docs/api-reference/react/deckgl.md#-ondragstart-function-optional-) callback of the `DeckGL` canvas.
+
+Requires `pickable` to be true.
+
+##### `onDrag` (Function, optional)
+
+This callback will be called when the mouse drags an object of this deck.gl layer with the following parameters:
+
+* [`info`](/docs/get-started/interactivity.md#the-picking-info-object)
+* `event` - the source event
+
+If this callback returns a truthy value, the `drag` event is marked as handled and will not bubble up to the [`onDrag`](/docs/api-reference/react/deckgl.md#-ondrag-function-optional-) callback of the `DeckGL` canvas.
+
+Requires `pickable` to be true.
+
+##### `onDragEnd` (Function, optional)
+
+This callback will be called when the mouse releases an object of this deck.gl layer with the following parameters:
+
+* [`info`](/docs/get-started/interactivity.md#the-picking-info-object)
+* `event` - the source event
+
+If this callback returns a truthy value, the `dragend` event is marked as handled and will not bubble up to the [`onDragEnd`](/docs/api-reference/react/deckgl.md#-ondragend-function-optional-) callback of the `DeckGL` canvas.
 
 Requires `pickable` to be true.
 

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "luma.gl": "^6.3.0-alpha",
     "math.gl": "^2.1.0",
-    "mjolnir.js": "^1.0.0",
+    "mjolnir.js": "^2.0.0-alpha",
     "probe.gl": "^2.0.1",
     "seer": "^0.2.4",
     "viewport-mercator-project": "^6.0.0"

--- a/modules/core/src/lib/constants.js
+++ b/modules/core/src/lib/constants.js
@@ -43,3 +43,9 @@ export const COORDINATE_SYSTEM = {
   // Positions and distances are not transformed: [x, y, z] in unit coordinates
   IDENTITY: 0
 };
+
+export const EVENTS = {
+  panstart: {handler: 'onDragStart'},
+  panmove: {handler: 'onDrag'},
+  panend: {handler: 'onDragEnd'}
+};

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -593,21 +593,28 @@ export default class Deck {
 
   _onEvent(event) {
     const eventOptions = EVENTS[event.type];
-    const rootHandler = this.props[eventOptions.handler];
+    const pos = event.offsetCenter;
+
+    if (!eventOptions || !pos) {
+      return;
+    }
 
     // Reuse last picked object
-    const {info} = this.layerManager.context.lastPickedInfo;
-    const layer = info ? this.layerManager.layers.find(l => l.id === info.layer.id) : null;
+    const info = this.layerManager.getLastPickedObject({
+      x: pos.x,
+      y: pos.y,
+      viewports: this.getViewports(pos)
+    });
+
+    const {layer} = info;
+    const rootHandler = this.props[eventOptions.handler];
     let handled = false;
 
-    if (layer) {
-      info.layer = layer;
-    }
     if (layer && layer.props[eventOptions.handler]) {
       handled = layer.props[eventOptions.handler](info, event);
     }
     if (!handled && rootHandler) {
-      rootHandler(info, info ? [info] : [], event);
+      rootHandler(info, event);
     }
   }
 

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -457,15 +457,16 @@ export default class Deck {
     this.props.onWebGLInitialized(gl);
 
     if (!this.props._customRender) {
-      const events = {
-        click: this._onClick,
-        pointermove: this._onPointerMove,
-        pointerleave: this._onPointerLeave
-      };
+      this.eventManager = new EventManager(gl.canvas, {
+        events: {
+          click: this._onClick,
+          pointermove: this._onPointerMove,
+          pointerleave: this._onPointerLeave
+        }
+      });
       for (const eventType in EVENTS) {
-        events[eventType] = this._onEvent;
+        this.eventManager.on(eventType, this._onEvent);
       }
-      this.eventManager = new EventManager(gl.canvas, {events});
     }
 
     this.viewManager = new ViewManager({
@@ -592,9 +593,6 @@ export default class Deck {
 
   _onEvent(event) {
     const eventOptions = EVENTS[event.type];
-    if (!eventOptions) {
-      return;
-    }
     const rootHandler = this.props[eventOptions.handler];
 
     // Reuse last picked object

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -607,11 +607,12 @@ export default class Deck {
     });
 
     const {layer} = info;
+    const layerHandler = layer && layer.props[eventOptions.handler];
     const rootHandler = this.props[eventOptions.handler];
     let handled = false;
 
-    if (layer && layer.props[eventOptions.handler]) {
-      handled = layer.props[eventOptions.handler](info, event);
+    if (layerHandler) {
+      handled = layerHandler(info, event);
     }
     if (!handled && rootHandler) {
       rootHandler(info, event);

--- a/modules/core/src/lib/layer-manager.js
+++ b/modules/core/src/lib/layer-manager.js
@@ -268,6 +268,25 @@ export default class LayerManager {
     });
   }
 
+  // Returns a new picking info object by assuming the last picked object is still picked
+  getLastPickedObject({x, y, viewports}) {
+    const lastPickedInfo = this.context.lastPickedInfo.info;
+    const lastPickedLayerId = lastPickedInfo && lastPickedInfo.layer && lastPickedInfo.layer.id;
+    const layer = lastPickedLayerId ? this.layers.find(l => l.id === lastPickedLayerId) : null;
+
+    const info = {
+      x,
+      y,
+      lngLat: viewports[0] && viewports[0].unproject([x, y]),
+      layer
+    };
+
+    if (layer) {
+      return Object.assign({}, lastPickedInfo, info);
+    }
+    return Object.assign(info, {color: null, object: null, index: -1});
+  }
+
   // Pick the closest info at given coordinate
   pickObject({x, y, mode, radius = 0, layerIds, viewports, depth = 1}) {
     const {gl, useDevicePixels} = this.context;

--- a/modules/core/src/lib/layer-manager.js
+++ b/modules/core/src/lib/layer-manager.js
@@ -92,7 +92,8 @@ export default class LayerManager {
       lastPickedInfo: {
         // For callback tracking and autohighlight
         index: -1,
-        layerId: null
+        layerId: null,
+        info: null
       },
       // Make sure context.viewport is not empty on the first layer initialization
       viewport: viewport || new Viewport({id: 'DEFAULT-INITIAL-VIEWPORT'}) // Current viewport, exposed to layers for project* function

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -60,7 +60,7 @@ const defaultProps = {
   opacity: {type: 'number', min: 0, max: 1, value: 0.8},
 
   onHover: {type: 'function', value: noop, compare: false},
-  onClick: {type: 'function', value: null, compare: false, optional: true},
+  onClick: {type: 'function', value: noop, compare: false},
   onDragStart: {type: 'function', value: null, compare: false, optional: true},
   onDrag: {type: 'function', value: null, compare: false, optional: true},
   onDragEnd: {type: 'function', value: null, compare: false, optional: true},

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -60,7 +60,10 @@ const defaultProps = {
   opacity: {type: 'number', min: 0, max: 1, value: 0.8},
 
   onHover: {type: 'function', value: noop, compare: false},
-  onClick: {type: 'function', value: noop, compare: false},
+  onClick: {type: 'function', value: null, compare: false, optional: true},
+  onDragStart: {type: 'function', value: null, compare: false, optional: true},
+  onDrag: {type: 'function', value: null, compare: false, optional: true},
+  onDragEnd: {type: 'function', value: null, compare: false, optional: true},
 
   coordinateSystem: COORDINATE_SYSTEM.LNGLAT,
   coordinateOrigin: {type: 'array', value: [0, 0, 0], compare: true},

--- a/modules/core/src/lib/pick-layers.js
+++ b/modules/core/src/lib/pick-layers.js
@@ -318,6 +318,7 @@ function processPickInfo({
       // Update layer manager context
       lastPickedInfo.layerId = pickedLayerId;
       lastPickedInfo.index = pickedObjectIndex;
+      lastPickedInfo.info = null;
     }
   }
 
@@ -352,6 +353,10 @@ function processPickInfo({
     }
 
     info = getLayerPickingInfo({layer, info, mode});
+
+    if (layer === pickedLayer && mode === 'hover') {
+      lastPickedInfo.info = info;
+    }
 
     // This guarantees that there will be only one copy of info for
     // one composite layer

--- a/yarn.lock
+++ b/yarn.lock
@@ -614,6 +614,31 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
+"@deck.gl/core@>=6.1.0-alpha.1", "@deck.gl/core@^6.2.3":
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/@deck.gl/core/-/core-6.2.3.tgz#ee32697271a60fd252307ca685a89db138174a66"
+  dependencies:
+    luma.gl "^6.2.0"
+    math.gl "^2.1.0"
+    mjolnir.js "^1.0.0"
+    probe.gl "^2.0.1"
+    seer "^0.2.4"
+    viewport-mercator-project "^6.0.0"
+
+"@deck.gl/layers@>=6.1.0-alpha.1":
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/@deck.gl/layers/-/layers-6.2.3.tgz#e2c4142c50400a60ae045039af1c60b880c6f9f9"
+  dependencies:
+    "@deck.gl/core" "^6.2.3"
+    d3-hexbin "^0.2.1"
+    earcut "^2.0.6"
+
+"@deck.gl/mapbox@>=6.1.0-alpha.1":
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/@deck.gl/mapbox/-/mapbox-6.2.3.tgz#4a40dae21e58b38e37df8f286bb386893c0fcc4d"
+  dependencies:
+    "@deck.gl/core" "^6.2.3"
+
 "@mapbox/geojson-area@0.2.2":
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@mapbox/geojson-area/-/geojson-area-0.2.2.tgz#18d7814aa36bf23fbbcc379f8e26a22927debf10"
@@ -5971,6 +5996,16 @@ luma.gl@^6.2.0:
     seer "^0.2.4"
     webgl-debug "^2.0.0"
 
+luma.gl@^6.3.0-alpha:
+  version "6.3.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/luma.gl/-/luma.gl-6.3.0-alpha.1.tgz#2dcb92ce57c83c9e8a6ef4f8ecf32c3cdbbb41f2"
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    math.gl "^2.2.0"
+    probe.gl "^2.0.1"
+    seer "^0.2.4"
+    webgl-debug "^2.0.0"
+
 magic-string@^0.22.4:
   version "0.22.5"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.22.5.tgz#8e9cf5afddf44385c1da5bc2a6a0dbd10b03657e"
@@ -6379,6 +6414,13 @@ mjolnir.js@^1.0.0, mjolnir.js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/mjolnir.js/-/mjolnir.js-1.2.1.tgz#ab3237afc5fbbc8aa4bafc965b10735c4bf8328c"
   dependencies:
+    hammerjs "^2.0.8"
+
+mjolnir.js@^2.0.0-alpha:
+  version "2.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/mjolnir.js/-/mjolnir.js-2.0.0-alpha.3.tgz#cc9c0575b0780363894e298ff26c8ac19ebcd8e1"
+  dependencies:
+    "@babel/runtime" "^7.0.0"
     hammerjs "^2.0.8"
 
 mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:


### PR DESCRIPTION
#### Background

[RFC](https://github.com/uber/deck.gl/blob/master/dev-docs/RFCs/v6.x/event-handling-rfc.md)

#### Change List
- Support `onDragStart`, `onDrag`, `onDragEnd` callbacks in both layer and deck props.
