### PR TITLE
Add mapbox layer babelrc

### DIFF
--- a/modules/mapbox/.babelrc
+++ b/modules/mapbox/.babelrc
@@ -1,0 +1,3 @@
+{
+  "extends": "../../.babelrc"
+}


### PR DESCRIPTION
#### Background
Other modules export common-js compatible modules. Looks like the babelrc didn't get copied here which caused the mapbox layer's dist output to include es6 features like modules and makes non-es6 importers like fusion unable to parse the file.

#### Change List
- Makes dist for Mapbox layer output es5 code instead of es6