### PR TITLE
Improve mapbox module

### DIFF
--- a/modules/mapbox/src/deck-utils.js
+++ b/modules/mapbox/src/deck-utils.js
@@ -62,7 +62,7 @@ function afterRender(deck) {
 
   if (isExternal) {
     // Draw non-Mapbox layers
-    const mapboxLayerIds = Array.from(mapboxLayers).map(layer => layer.id);
+    const mapboxLayerIds = Array.from(mapboxLayers, layer => layer.id);
     deck.layerManager.layerFilter = params => {
       for (const id of mapboxLayerIds) {
         if (shouldDrawLayer(id, params.layer)) {

--- a/modules/mapbox/src/mapbox-layer.js
+++ b/modules/mapbox/src/mapbox-layer.js
@@ -9,7 +9,7 @@ export default class MapboxLayer {
 
     this.id = props.id;
     this.type = 'custom';
-    this.renderingMode = '3d';
+    this.renderingMode = props.renderingMode || '3d';
     this.map = null;
     this.deck = null;
     this.props = props;


### PR DESCRIPTION
#### Change List
- Fix a bug for React integration: `props.layerFilter` is reset every render due to default props
- Accept a new `renderingMode` prop to `MapboxLayer`. Value can be `'2d'` or `'3d'` (default)
- When using React, also draw layers that are not added to Mapbox
