### PR TITLE
Fallback to canvas.width/height when clientWidth/clientHeight are not available

### DIFF
--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -355,9 +355,15 @@ export default class Deck {
   // If canvas size has changed, reads out the new size and returns true
   _checkForCanvasSizeChange() {
     const {canvas} = this;
-    if (canvas && (this.width !== canvas.clientWidth || this.height !== canvas.clientHeight)) {
-      this.width = canvas.clientWidth;
-      this.height = canvas.clientHeight;
+    if (!canvas) {
+      return false;
+    }
+    // Fallback to width/height when clientWidth/clientHeight are 0 or undefined.
+    const newWidth = canvas.clientWidth || canvas.width;
+    const newHeight = canvas.clientHeight || canvas.height;
+    if (newWidth !== this.width || newHeight !== this.height) {
+      this.width = newWidth;
+      this.height = newHeight;
       return true;
     }
     return false;


### PR DESCRIPTION


<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #2296 
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
- Fallback to canvas.width/height when clientWidth/clientHeight are not available.
