### PR TITLE
Support multiple arguments in CompositeLayer constructor

### DIFF
--- a/modules/core/src/lib/composite-layer.js
+++ b/modules/core/src/lib/composite-layer.js
@@ -22,10 +22,6 @@ import log from '../utils/log';
 import {flatten} from '../utils/flatten';
 
 export default class CompositeLayer extends Layer {
-  constructor(props) {
-    super(props);
-  }
-
   get isComposite() {
     return true;
   }


### PR DESCRIPTION
#### Background
Base `Layer` class constructor supports multiple arguments, e.g.:
`new ScatterplotLayer(props1, props2)`.

#### Change List
- Allow multiple arguments in CompositeLayer constructor
