### PR TITLE
GPUGridAggregator: Add support for MEAN operations

### DIFF
--- a/modules/core/src/experimental/utils/gpu-grid-aggregation/transform-mean-vs.glsl.js
+++ b/modules/core/src/experimental/utils/gpu-grid-aggregation/transform-mean-vs.glsl.js
@@ -1,0 +1,34 @@
+// Copyright (c) 2015 - 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+export default `\
+#define SHADER_NAME gpu-aggregation-transform-mean-vs
+attribute vec4 aggregationValues;
+varying vec4 meanValues;
+
+void main()
+{
+  // TODO: Use 64-bit division ?? not needed given this is aggregation ??
+  bool isCellValid = bool(aggregationValues.w);
+  // aggregationValues:  XYZ contain aggregated values, W contains count
+  meanValues.xyz = isCellValid ? aggregationValues.xyz/aggregationValues.w : vec3(0, 0, 0);
+  meanValues.w = aggregationValues.w;
+}
+`;

--- a/test/modules/core/experimental/utils/gpu-grid-aggregator.spec.js
+++ b/test/modules/core/experimental/utils/gpu-grid-aggregator.spec.js
@@ -23,7 +23,11 @@ function verifyResults({t, cpuResults, gpuResults, testName}) {
     if (equals(cpuResults[name], gpuResults[name])) {
       t.pass(`${testName}: ${name} CPU and GPU results matched`);
     } else {
-      t.fail(`${testName}: ${name}: results didn't match cpu: ${cpuResults[name]} gpu: ${gpuResults[name]}`);
+      t.fail(
+        `${testName}: ${name}: results didn't match cpu: ${cpuResults[name]} gpu: ${
+          gpuResults[name]
+        }`
+      );
     }
   }
 }
@@ -130,7 +134,6 @@ function testAggregationOperations(opts) {
   verifyResults({t, cpuResults, gpuResults, testName});
   config.EPSILON = oldEpsilon;
 }
-
 
 test('GPUGridAggregator#CompareCPUandGPU', t => {
   const pointsData = generateRandomGridPoints(5000);

--- a/test/modules/core/experimental/utils/gpu-grid-aggregator.spec.js
+++ b/test/modules/core/experimental/utils/gpu-grid-aggregator.spec.js
@@ -1,7 +1,8 @@
 import test from 'tape-catch';
-import {_GPUGridAggregator as GPUGridAggregator} from '@deck.gl/core';
+import {_GPUGridAggregator as GPUGridAggregator, AGGREGATION_OPERATION} from '@deck.gl/core';
 import {gl} from '@deck.gl/test-utils';
 import {GridAggregationData} from 'deck.gl/test/data';
+import {equals, config} from 'math.gl';
 
 const {fixture, fixtureUpdated, fixtureWorldSpace} = GridAggregationData;
 
@@ -15,6 +16,16 @@ function getGPUResults({aggregationBuffer, minBuffer, maxBuffer}) {
     minData: minBuffer.getData(),
     maxData: maxBuffer.getData()
   };
+}
+
+function verifyResults({t, cpuResults, gpuResults, testName}) {
+  for (const name in cpuResults) {
+    if (equals(cpuResults[name], gpuResults[name])) {
+      t.pass(`${testName}: ${name} CPU and GPU results matched`);
+    } else {
+      t.fail(`${testName}: ${name}: results didn't match cpu: ${cpuResults[name]} gpu: ${gpuResults[name]}`);
+    }
+  }
 }
 
 /* eslint-disable max-statements */
@@ -76,14 +87,22 @@ test('GPUGridAggregator#CPU', t => {
   t.end();
 });
 
-test('GPUGridAggregator#CompareCPUandGPU', t => {
+function testAggregationOperations(opts) {
+  const {t, op, testName, pointsData} = opts;
+  const oldEpsilon = config.EPSILON;
+  if (op === AGGREGATION_OPERATION.MEAN) {
+    // cpu: 4.692307472229004 VS gpu: 4.692307949066162
+    // cpu: 4.21212100982666 VS gpu: 4.212121486663818
+    config.EPSILON = 1e-6;
+  }
+
   const aggregator = new GPUGridAggregator(gl);
 
-  const pointsData = generateRandomGridPoints(5000);
-  const maxMinweight = Object.assign({}, pointsData.weights.weight1, {combineMaxMin: true});
-  let results = aggregator.run(Object.assign({}, fixture, {useGPU: false}, pointsData));
-  // console.log('CPU:');
-  // GPUGridAggregator.logData(results.weight1);
+  const weight = Object.assign({}, pointsData.weights.weight1, {operation: op});
+  const maxMinweight = Object.assign({}, weight, {combineMaxMin: true});
+  let results = aggregator.run(
+    Object.assign({}, fixture, {useGPU: false}, pointsData, {weights: {weight1: weight}})
+  );
   const cpuResults = {
     aggregationData: results.weight1.aggregationBuffer.getData(),
     minData: results.weight1.minBuffer.getData(),
@@ -94,9 +113,9 @@ test('GPUGridAggregator#CompareCPUandGPU', t => {
   );
   cpuResults.maxMinData = results.weight1.maxMinBuffer.getData();
 
-  results = aggregator.run(Object.assign({}, fixture, {useGPU: true}, pointsData));
-  // console.log('GPU:');
-  // GPUGridAggregator.logData(results.weight1);
+  results = aggregator.run(
+    Object.assign({}, fixture, {useGPU: true}, pointsData, {weights: {weight1: weight}})
+  );
   const gpuResults = {
     aggregationData: results.weight1.aggregationBuffer.getData(),
     minData: results.weight1.minBuffer.getData(),
@@ -108,7 +127,16 @@ test('GPUGridAggregator#CompareCPUandGPU', t => {
   gpuResults.maxMinData = results.weight1.maxMinBuffer.getData();
 
   // Compare aggregation details for each grid-cell, total count and max count.
-  t.deepEqual(gpuResults, cpuResults, 'cpu and gpu results should match');
+  verifyResults({t, cpuResults, gpuResults, testName});
+  config.EPSILON = oldEpsilon;
+}
+
+
+test('GPUGridAggregator#CompareCPUandGPU', t => {
+  const pointsData = generateRandomGridPoints(5000);
+  for (const opName in AGGREGATION_OPERATION) {
+    testAggregationOperations({t, testName: opName, op: AGGREGATION_OPERATION[opName], pointsData});
+  }
   t.end();
 });
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #2291
<!-- For other PRs without open issue -->
#### Background
Adding Mean operation support.
CPU: After initial aggregation, calculate mean weights (RGB) based on count (Alpha).
GPU: Use `Transform`'s texture API to calculate Mean.
<!-- For all the PRs -->
#### Change List
- CPU: Add Mean operation support, and unit tests.
- GPU: Add Mean operation support
