### PR TITLE
Fix async prop comparison bug

### DIFF
--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -835,9 +835,6 @@ ${flags.viewportChanged ? 'viewport' : ''}\
       model.userData.layer = this;
     }
 
-    // Ensure any async props are updated
-    this.internalState.setAsyncProps(this.props);
-
     this.diffProps(this.props, this.internalState.getOldProps());
   }
 

--- a/modules/core/src/lifecycle/create-props.js
+++ b/modules/core/src/lifecycle/create-props.js
@@ -183,13 +183,16 @@ function getDescriptorForAsyncProp(name) {
           return value;
         }
 
-        // It's an async prop value: look into component state
-        const state = this._component && this._component.internalState;
-        if (state && state.hasAsyncProp(name)) {
-          return state.getAsyncProp(name);
+        if (name in this._asyncPropOriginalValues) {
+          // It's an async prop value: look into component state
+          const state = this._component && this._component.internalState;
+          if (state && state.hasAsyncProp(name)) {
+            return state.getAsyncProp(name);
+          }
         }
       }
 
+      // the prop is not supplied, or
       // component not yet initialized/matched, return the component's default value for the prop
       return this._asyncPropDefaultValues[name];
     }


### PR DESCRIPTION
These new test cases capture a bug: if an async prop (e.g. `data`) is not specified by the user, instead of resolving to default (`[]`), it is assumed to be "loading". As a result, when later a value is supplied to this prop via layer update, `changeFlags.dataChanged` is set to `false`.

This issue does not block any applications (can be worked around by setting `data: null`), but it causes unexpected behavior in some of our core layer tests.

#### Change List
- Resolve undefined async props correctly
- Remove a duplicate setAsyncProps call
