### PR TITLE
Remove assert dependency from modules

### DIFF
--- a/modules/core/src/experimental/utils/gpu-grid-aggregation/gpu-grid-aggregator.js
+++ b/modules/core/src/experimental/utils/gpu-grid-aggregation/gpu-grid-aggregator.js
@@ -1,7 +1,7 @@
 import GL from 'luma.gl/constants';
 import {Buffer, Model, Transform, FEATURES, hasFeatures, isWebGL2} from 'luma.gl';
 import {log} from '@deck.gl/core';
-import assert from 'assert';
+import assert from '../../../utils/assert';
 import {fp64 as fp64Utils, withParameters} from 'luma.gl';
 import {worldToPixels} from 'viewport-mercator-project';
 const {fp64ifyMatrix4} = fp64Utils;

--- a/modules/core/src/experimental/utils/gpu-grid-aggregation/grid-aggregation-utils.js
+++ b/modules/core/src/experimental/utils/gpu-grid-aggregation/grid-aggregation-utils.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import assert from '../../../utils/assert';
 import {Matrix4} from 'math.gl';
 import {fp64 as fp64Utils} from 'luma.gl';
 import {COORDINATE_SYSTEM} from '../../../lib/constants';

--- a/modules/experimental-layers/src/mesh-layer/mesh-layer.js
+++ b/modules/experimental-layers/src/mesh-layer/mesh-layer.js
@@ -30,9 +30,14 @@ const {fp64LowPart} = fp64;
 import vs from './mesh-layer-vertex.glsl';
 import fs from './mesh-layer-fragment.glsl';
 
-import assert from 'assert';
-
 const RADIAN_PER_DEGREE = Math.PI / 180;
+
+// Replacement for the external assert method to reduce bundle size
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(`deck.gl: ${message}`);
+  }
+}
 
 /*
  * Load image data into luma.gl Texture2D objects

--- a/modules/layers/src/contour-layer/contour-utils.js
+++ b/modules/layers/src/contour-layer/contour-utils.js
@@ -1,5 +1,4 @@
 import * as MarchingSquares from './marching-squares';
-import assert from 'assert';
 
 // Given all the cell weights, generates contours for each threshold.
 export function generateContours({
@@ -37,7 +36,6 @@ export function generateContours({
           code
         });
         // We should always get even number of vertices
-        assert(vertices.length % 2 === 0);
         for (let i = 0; i < vertices.length; i += 2) {
           contourSegments.push({
             start: vertices[i],

--- a/modules/layers/src/contour-layer/marching-squares.js
+++ b/modules/layers/src/contour-layer/marching-squares.js
@@ -1,6 +1,5 @@
 // All utility mehtods needed to implement Marching Squres algorithm
 // Ref: https://en.wikipedia.org/wiki/Marching_squares
-import assert from 'assert';
 
 // Table to map code to the intersection offsets
 // All offsets are relative to the center of marching cell (which is top right corner of grid-cell)
@@ -39,9 +38,6 @@ export function getCode({cellWeights, thresholdValue, x, y, width, height}) {
   // When processing one cell, we process 4 cells, by extending row to top and on column to right
   // to create a 2X2 cell grid
 
-  assert(x >= -1 && x < width);
-  assert(y >= -1 && y < height);
-
   const isLeftBoundary = x < 0;
   const isRightBoundary = x >= width - 1;
   const isBottomBoundary = y < 0;
@@ -69,8 +65,6 @@ export function getCode({cellWeights, thresholdValue, x, y, width, height}) {
 
   const code = (top << 3) | (topRight << 2) | (right << 1) | current;
 
-  assert(code >= 0 && code < 16);
-
   return code;
 }
 /* eslint-enable complexity */
@@ -81,8 +75,6 @@ export function getVertices({gridOrigin, cellSize, x, y, code}) {
   const offsets = CODE_OFFSET_MAP[code];
 
   // Reference vertex is at top-right move to top-right corner
-  assert(x >= -1);
-  assert(y >= -1);
 
   const rX = (x + 1) * cellSize[0];
   const rY = (y + 1) * cellSize[1];

--- a/modules/layers/src/screen-grid-layer/screen-grid-layer.js
+++ b/modules/layers/src/screen-grid-layer/screen-grid-layer.js
@@ -35,13 +35,11 @@ import vs from './screen-grid-layer-vertex.glsl';
 import vs_WebGL1 from './screen-grid-layer-vertex-webgl1.glsl';
 import fs from './screen-grid-layer-fragment.glsl';
 import fs_WebGL1 from './screen-grid-layer-fragment-webgl1.glsl';
-import assert from 'assert';
 
 const DEFAULT_MINCOLOR = [0, 0, 0, 0];
 const DEFAULT_MAXCOLOR = [0, 255, 0, 255];
 const AGGREGATION_DATA_UBO_INDEX = 0;
 const COLOR_PROPS = [`minColor`, `maxColor`, `colorRange`, `colorDomain`];
-const COLOR_RANGE_LENGTH = 6;
 
 const defaultProps = {
   cellSizePixels: {value: 100, min: 1},
@@ -260,7 +258,6 @@ export default class ScreenGridLayer extends Layer {
       // backward compitability
       return [weight, 0, 0];
     }
-    assert(weight.length === 3);
     return weight;
   }
   // Process 'data' and build positions and weights Arrays.
@@ -362,7 +359,6 @@ export default class ScreenGridLayer extends Layer {
 
     if (oldProps.colorRange !== props.colorRange) {
       const colorRangeUniform = [];
-      assert(props.colorRange && props.colorRange.length === COLOR_RANGE_LENGTH);
       props.colorRange.forEach(color => {
         colorRangeUniform.push(color[0], color[1], color[2], color[3] || 255);
       });


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
As commented in #2429
- Use internal `assert` in core module.
- Remove assert usage in marching-squares/contour private utility methods, most of these were added for internal validation.
- Add `assert` definition for mesh layer, not sure if we need this, but added to be safe.

<!-- For all the PRs -->
#### Change List
- Remove assert dependency from modules