### PR TITLE
fixed invalid accessor comparisons in contour layer and grid layer

### DIFF
--- a/modules/layers/src/contour-layer/contour-layer.js
+++ b/modules/layers/src/contour-layer/contour-layer.js
@@ -155,8 +155,9 @@ export default class ContourLayer extends CompositeLayer {
     let aggregationFlags = null;
     if (
       changeFlags.dataChanged ||
-      oldProps.getPosition !== props.getPosition ||
-      oldProps.gpuAggregation !== props.gpuAggregation
+      oldProps.gpuAggregation !== props.gpuAggregation ||
+      (changeFlags.updateTriggersChanged &&
+        (changeFlags.updateTriggersChanged.all || changeFlags.updateTriggersChanged.getPosition))
     ) {
       aggregationFlags = Object.assign({}, aggregationFlags, {dataChanged: true});
     }

--- a/modules/layers/src/grid-layer/grid-layer.js
+++ b/modules/layers/src/grid-layer/grid-layer.js
@@ -71,7 +71,7 @@ export default class GridLayer extends CompositeLayer {
   }
 
   updateState({oldProps, props, changeFlags}) {
-    const reprojectNeeded = this.needsReProjectPoints(oldProps, props);
+    const reprojectNeeded = this.needsReProjectPoints(oldProps, props, changeFlags);
 
     if (changeFlags.dataChanged || reprojectNeeded) {
       // project data into hexagons, and get sortedBins
@@ -82,8 +82,12 @@ export default class GridLayer extends CompositeLayer {
     }
   }
 
-  needsReProjectPoints(oldProps, props) {
-    return oldProps.cellSize !== props.cellSize || oldProps.getPosition !== props.getPosition;
+  needsReProjectPoints(oldProps, props, changeFlags) {
+    return (
+      oldProps.cellSize !== props.cellSize ||
+      (changeFlags.updateTriggersChanged &&
+        (changeFlags.updateTriggersChanged.all || changeFlags.updateTriggersChanged.getPosition))
+    );
   }
 
   getDimensionUpdaters() {


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #2399 
<!-- For other PRs without open issue -->
#### Background
All layers should make use of changeFlags.updateTriggersChanged instead of comparing function type accessors.
<!-- For all the PRs -->
#### Change List
- modified the incorrect comparison in contour layer and grid layer
