### PR TITLE
Give TileLayer event callbacks access to source layer and tile

### DIFF
--- a/modules/experimental-layers/src/tile-layer/tile-layer.js
+++ b/modules/experimental-layers/src/tile-layer/tile-layer.js
@@ -54,6 +54,7 @@ export default class TileLayer extends CompositeLayer {
 
   getPickingInfo({info, sourceLayer}) {
     info.sourceLayer = sourceLayer;
+    info.tiles = this.state.tiles;
     return info;
   }
 
@@ -73,15 +74,13 @@ export default class TileLayer extends CompositeLayer {
     const {getTileData, renderSubLayers, ...geoProps} = this.props;
     const z = this.getLayerZoomLevel();
     return this.state.tiles.map(tile => {
-      return renderSubLayers(
-        {
-          ...geoProps,
-          id: `${this.id}-${tile.x}-${tile.y}-${tile.z}`,
-          data: tile.data,
-          visible: !this.state.isLoaded || tile.z === z
-        },
+      return renderSubLayers({
+        ...geoProps,
+        id: `${this.id}-${tile.x}-${tile.y}-${tile.z}`,
+        data: tile.data,
+        visible: !this.state.isLoaded || tile.z === z,
         tile
-      );
+      });
     });
   }
 }

--- a/modules/experimental-layers/src/tile-layer/tile-layer.js
+++ b/modules/experimental-layers/src/tile-layer/tile-layer.js
@@ -52,7 +52,8 @@ export default class TileLayer extends CompositeLayer {
     }
   }
 
-  getPickingInfo({info}) {
+  getPickingInfo({info, sourceLayer}) {
+    info.sourceLayer = sourceLayer;
     return info;
   }
 
@@ -72,12 +73,15 @@ export default class TileLayer extends CompositeLayer {
     const {getTileData, renderSubLayers, ...geoProps} = this.props;
     const z = this.getLayerZoomLevel();
     return this.state.tiles.map(tile => {
-      return renderSubLayers({
-        ...geoProps,
-        id: `${this.id}-${tile.x}-${tile.y}-${tile.z}`,
-        data: tile.data,
-        visible: !this.state.isLoaded || tile.z === z
-      });
+      return renderSubLayers(
+        {
+          ...geoProps,
+          id: `${this.id}-${tile.x}-${tile.y}-${tile.z}`,
+          data: tile.data,
+          visible: !this.state.isLoaded || tile.z === z
+        },
+        tile
+      );
     });
   }
 }


### PR DESCRIPTION
- Pass tile layer's `sourceLayer` in `getPickingInfo`, so sublayers can access
- Pass tile to `renderSubLayers`, so sublayers can access its data. 