### PR TITLE
fix updateTriggers not being called issue when transitioning between 0 and null

### DIFF
--- a/modules/core/src/lifecycle/props.js
+++ b/modules/core/src/lifecycle/props.js
@@ -147,7 +147,7 @@ function diffUpdateTriggers(props, oldProps) {
 
   // If the 'all' updateTrigger fires, ignore testing others
   if ('all' in props.updateTriggers) {
-    const diffReason = diffUpdateTrigger(oldProps, props, 'all');
+    const diffReason = diffUpdateTrigger(props, oldProps, 'all');
     if (diffReason) {
       return {all: true};
     }
@@ -158,7 +158,7 @@ function diffUpdateTriggers(props, oldProps) {
   // If the 'all' updateTrigger didn't fire, need to check all others
   for (const triggerName in props.updateTriggers) {
     if (triggerName !== 'all') {
-      const diffReason = diffUpdateTrigger(oldProps, props, triggerName);
+      const diffReason = diffUpdateTrigger(props, oldProps, triggerName);
       if (diffReason) {
         triggerChanged[triggerName] = true;
         reason = triggerChanged;
@@ -170,8 +170,10 @@ function diffUpdateTriggers(props, oldProps) {
 }
 
 function diffUpdateTrigger(props, oldProps, triggerName) {
-  const newTriggers = props.updateTriggers[triggerName] || {};
-  const oldTriggers = oldProps.updateTriggers[triggerName] || {};
+  let newTriggers = props.updateTriggers[triggerName];
+  newTriggers = newTriggers === undefined || newTriggers === null ? {} : newTriggers;
+  let oldTriggers = oldProps.updateTriggers[triggerName];
+  oldTriggers = oldTriggers === undefined || oldTriggers === null ? {} : oldTriggers;
   const diffReason = compareProps({
     oldProps: oldTriggers,
     newProps: newTriggers,


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #2068 
<!-- For other PRs without open issue -->
#### Background
updateTriggers doesn't work when transitioning between 0 and null
<!-- For all the PRs -->
#### Change List
- modified diffUpdateTrigger in props.js. It should return 0 instead of {} when the trigger is 0.

Example demo(in branch `update-trigger-bug`)  
![update_trigger_bug](https://user-images.githubusercontent.com/42359372/49402304-6ddb1300-f6fe-11e8-8249-5d162bb0ad7c.gif)

