### PR TITLE
Fix missing mapbox style in layer-browser

### DIFF
--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -299,7 +299,7 @@ export default class App extends PureComponent {
           <View id="basemap">
             <StaticMap
               key="map"
-              mapStyle="mapbox://styles/uberdata/cive48w2e001a2imn5mcu2vrs"
+              mapStyle="mapbox://styles/mapbox/light-v9"
               mapboxApiAccessToken={MapboxAccessToken || 'no_token'}
             />
             <ViewportLabel key="label">Map View</ViewportLabel>

--- a/test/apps/attribute-transition/app.js
+++ b/test/apps/attribute-transition/app.js
@@ -92,7 +92,7 @@ class Root extends Component {
           <StaticMap
             viewId="map"
             {...viewState}
-            mapStyle="mapbox://styles/uberdata/cive48w2e001a2imn5mcu2vrs"
+            mapStyle="mapbox://styles/mapbox/light-v9"
             mapboxApiAccessToken={MAPBOX_TOKEN}
           />
         </DeckGL>


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #2480 
<!-- For other PRs without open issue -->
#### Background
The layer-browser app was referencing the Uber light Mapbox style at mapbox://styles/uberdata/cive48w2e001a2imn5mcu2vrs.  This Uber light Mapbox style used to be public, but appears to have been made private.  This Uber light Mapbox style is shared by many teams at Uber, so to prevent this issue in the future, I've switched the layer-browser example to use Mapbox's default light style mapbox://styles/mapbox/light-v9, which many of the other examples do as well.  I also replaced one other use of the Uber specific Mapbox style in a unit test.
<!-- For all the PRs -->