### PR TITLE
Generate layer attributes on a worker (PR 1/3)

### DIFF
--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -35,7 +35,7 @@
     "gl-matrix": "^3.0.0-0",
     "luma.gl": "^7.0.0-alpha.6",
     "math.gl": "^2.2.0",
-    "mjolnir.js": "^2.0.0",
+    "mjolnir.js": "^2.0.2",
     "probe.gl": "^2.0.1",
     "seer": "^0.2.4",
     "viewport-mercator-project": "^6.0.0"

--- a/modules/core/src/lib/attribute-transition-manager.js
+++ b/modules/core/src/lib/attribute-transition-manager.js
@@ -27,7 +27,8 @@ export default class AttributeTransitionManager {
 
     if (Transform.isSupported(gl)) {
       this.isSupported = true;
-    } else {
+    } else if (gl) {
+      // This class may be instantiated without a WebGL context (e.g. web worker)
       log.warn('WebGL2 not supported by this browser. Transition animation is disabled.')();
     }
   }

--- a/modules/core/src/lib/attribute.js
+++ b/modules/core/src/lib/attribute.js
@@ -3,6 +3,8 @@ import assert from '../utils/assert';
 import GL from '@luma.gl/constants';
 import {Buffer, _Attribute as Attribute} from 'luma.gl';
 
+import log from '../utils/log';
+
 const DEFAULT_STATE = {
   isExternalBuffer: false,
   needsUpdate: true,
@@ -206,18 +208,25 @@ export default class LayerAttribute extends Attribute {
           this.update({constant: false, buffer});
           state.needsRedraw = true;
         }
-      } else {
-        const ArrayType = glArrayFromType(this.type || GL.FLOAT);
-        if (!(buffer instanceof ArrayType)) {
-          throw new Error(`Attribute ${this.id} must be of type ${ArrayType.name}`);
+      } else if (this.value !== buffer) {
+        if (!ArrayBuffer.isView(buffer)) {
+          throw new Error('Attribute prop must be typed array');
         }
         if (state.auto && buffer.length <= numInstances * this.size) {
           throw new Error('Attribute prop array must match length and size');
         }
-        if (this.value !== buffer) {
+
+        const ArrayType = glArrayFromType(this.type || GL.FLOAT);
+        if (buffer instanceof ArrayType) {
           this.update({constant: false, value: buffer});
-          state.needsRedraw = true;
+        } else {
+          log.warn(`Attribute prop ${this.id} is casted to ${ArrayType.name}`)();
+          // Cast to proper type
+          this.update({constant: false, value: new ArrayType(buffer)});
         }
+        // Save original typed array
+        this.value = buffer;
+        state.needsRedraw = true;
       }
       return true;
     }

--- a/modules/core/src/lib/layer-manager.js
+++ b/modules/core/src/lib/layer-manager.js
@@ -88,7 +88,7 @@ export default class LayerManager {
 
       gl,
       // Enabling luma.gl Program caching using private API (_cachePrograms)
-      shaderCache: new ShaderCache({gl, _cachePrograms: true}),
+      shaderCache: gl && new ShaderCache({gl, _cachePrograms: true}),
       stats: stats || new Stats({id: 'deck.gl'}),
       lastPickedInfo: {
         // For callback tracking and autohighlight

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -474,14 +474,14 @@ export default class Layer extends Component {
   getNumInstances(props) {
     props = props || this.props;
 
-    // First check if the layer has set its own value
-    if (this.state && this.state.numInstances !== undefined) {
-      return this.state.numInstances;
-    }
-
-    // Check if app has provided an explicit value
+    // First Check if app has provided an explicit value
     if (props.numInstances !== undefined) {
       return props.numInstances;
+    }
+
+    // Second check if the layer has set its own value
+    if (this.state && this.state.numInstances !== undefined) {
+      return this.state.numInstances;
     }
 
     // Use container library to get a count for any ES6 container or object
@@ -495,8 +495,6 @@ export default class Layer extends Component {
   // Called by layer manager when a new layer is found
   /* eslint-disable max-statements */
   _initialize() {
-    assert(this.context.gl);
-
     this._initState();
 
     // Call subclass lifecycle methods

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -535,8 +535,16 @@ export default class Layer extends Component {
   _updateState() {
     const updateParams = this._getUpdateParams();
 
-    // Call subclass lifecycle methods
-    this.updateState(updateParams);
+    // Safely call subclass lifecycle methods
+    if (this.context.gl) {
+      this.updateState(updateParams);
+    } else {
+      try {
+        this.updateState(updateParams);
+      } catch (error) {
+        // ignore error if gl context is missing
+      }
+    }
     // End subclass lifecycle methods
 
     if (this.isComposite) {

--- a/modules/core/src/utils/tesselator.js
+++ b/modules/core/src/utils/tesselator.js
@@ -43,6 +43,9 @@ class TypedArrayManager {
   }
 
   _allocate(Type = Float32Array, size) {
+    if (Type === Uint16Array && size > 65535) {
+      throw new Error('Vertex count exceeds browser index limit');
+    }
     // TODO - check if available in pool
     return new Type(size);
   }

--- a/modules/core/src/utils/tesselator.js
+++ b/modules/core/src/utils/tesselator.js
@@ -43,9 +43,6 @@ class TypedArrayManager {
   }
 
   _allocate(Type = Float32Array, size) {
-    if (Type === Uint16Array && size > 65535) {
-      throw new Error('Vertex count exceeds browser index limit');
-    }
     // TODO - check if available in pool
     return new Type(size);
   }

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -20,7 +20,7 @@
 
 import {Layer} from '@deck.gl/core';
 import GL from '@luma.gl/constants';
-import {Model, Geometry, hasFeature, FEATURES} from 'luma.gl';
+import {Model, Geometry} from 'luma.gl';
 
 // Polygon geometry generation is managed by the polygon tesselator
 import PolygonTesselator from './polygon-tesselator';
@@ -66,14 +66,6 @@ export default class SolidPolygonLayer extends Layer {
   }
 
   initializeState() {
-    const {gl} = this.context;
-    this.setState({
-      numInstances: 0,
-      polygonTesselator: new PolygonTesselator({
-        IndexType: hasFeature(gl, FEATURES.ELEMENT_INDEX_UINT32) ? Uint32Array : Uint16Array
-      })
-    });
-
     const attributeManager = this.getAttributeManager();
     const noAlloc = true;
 
@@ -123,6 +115,16 @@ export default class SolidPolygonLayer extends Layer {
       pickingColors: {size: 3, type: GL.UNSIGNED_BYTE, update: this.calculatePickingColors}
     });
     /* eslint-enable max-len */
+
+    this.setState({
+      numInstances: 0,
+      polygonTesselator: new PolygonTesselator({
+        IndexType:
+          attributeManager.getAttributes().indices.type === GL.UNSIGNED_SHORT
+            ? Uint16Array
+            : Uint32Array
+      })
+    });
   }
 
   draw({uniforms}) {

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -20,7 +20,7 @@
 
 import {Layer} from '@deck.gl/core';
 import GL from '@luma.gl/constants';
-import {Model, Geometry} from 'luma.gl';
+import {Model, Geometry, hasFeature, FEATURES} from 'luma.gl';
 
 // Polygon geometry generation is managed by the polygon tesselator
 import PolygonTesselator from './polygon-tesselator';
@@ -66,6 +66,14 @@ export default class SolidPolygonLayer extends Layer {
   }
 
   initializeState() {
+    const {gl} = this.context;
+    this.setState({
+      numInstances: 0,
+      polygonTesselator: new PolygonTesselator({
+        IndexType: !gl || hasFeature(gl, FEATURES.ELEMENT_INDEX_UINT32) ? Uint32Array : Uint16Array
+      })
+    });
+
     const attributeManager = this.getAttributeManager();
     const noAlloc = true;
 
@@ -115,16 +123,6 @@ export default class SolidPolygonLayer extends Layer {
       pickingColors: {size: 3, type: GL.UNSIGNED_BYTE, update: this.calculatePickingColors}
     });
     /* eslint-enable max-len */
-
-    this.setState({
-      numInstances: 0,
-      polygonTesselator: new PolygonTesselator({
-        IndexType:
-          attributeManager.getAttributes().indices.type === GL.UNSIGNED_SHORT
-            ? Uint16Array
-            : Uint32Array
-      })
-    });
   }
 
   draw({uniforms}) {

--- a/test/modules/core/lib/attribute-manager.spec.js
+++ b/test/modules/core/lib/attribute-manager.spec.js
@@ -164,18 +164,15 @@ test('AttributeManager.update - external buffers', t => {
   attribute = attributeManager.getAttributes()['colors'];
   t.ok(ArrayBuffer.isView(attribute.value), 'colors attribute has typed array');
 
-  t.throws(
-    () =>
-      attributeManager.update({
-        numInstances: 1,
-        buffers: {
-          positions: new Float32Array([0, 0]),
-          colors: new Float32Array([0, 0, 0])
-        }
-      }),
-    /Uint8ClampedArray/,
-    'should throw error for incorrect buffer type'
-  );
+  attributeManager.update({
+    numInstances: 1,
+    buffers: {
+      positions: new Float32Array([0, 0]),
+      colors: new Float32Array([0, 0, 0])
+    }
+  });
+
+  t.is(attribute.buffer.accessor.type, gl.UNSIGNED_BYTE, 'colors casted to incorrect type');
 
   t.end();
 });

--- a/test/modules/core/lib/attribute-manager.spec.js
+++ b/test/modules/core/lib/attribute-manager.spec.js
@@ -172,7 +172,7 @@ test('AttributeManager.update - external buffers', t => {
     }
   });
 
-  t.is(attribute.buffer.accessor.type, gl.UNSIGNED_BYTE, 'colors casted to incorrect type');
+  t.is(attribute.buffer.accessor.type, gl.UNSIGNED_BYTE, 'colors casted to correct type');
 
   t.end();
 });

--- a/test/modules/core/lib/attribute-transition-manager.spec.js
+++ b/test/modules/core/lib/attribute-transition-manager.spec.js
@@ -32,13 +32,20 @@ const TEST_ATTRIBUTES = {
 };
 
 test('AttributeTransitionManager#constructor', t => {
-  const manager = new AttributeTransitionManager(gl, {id: 'attribute-transition'});
+  let manager = new AttributeTransitionManager(gl, {id: 'attribute-transition'});
   t.ok(manager, 'AttributeTransitionManager is constructed');
   t.is(
     Boolean(manager.isSupported),
     isWebGL2(gl),
     'AttributeTransitionManager checks WebGL support'
   );
+
+  manager.finalize();
+  t.pass('AttributeTransitionManager is finalized');
+
+  manager = new AttributeTransitionManager(null, {id: 'attribute-transition'});
+  t.ok(manager, 'AttributeTransitionManager is constructed without GL context');
+  t.notOk(manager.isSupported, 'AttributeTransitionManager checks WebGL support');
 
   manager.finalize();
   t.pass('AttributeTransitionManager is finalized');

--- a/test/modules/core/lib/layer-manager.spec.js
+++ b/test/modules/core/lib/layer-manager.spec.js
@@ -46,8 +46,17 @@ const LAYERS = [
 
 test('LayerManager#constructor', t => {
   t.ok(LayerManager, 'LayerManager imported');
-  const layerManager = new LayerManager(gl);
+
+  let layerManager = new LayerManager(gl);
   t.ok(layerManager, 'LayerManager created');
+  layerManager.finalize();
+  t.pass('LayerManager finalized');
+
+  layerManager = new LayerManager(null);
+  t.ok(layerManager, 'LayerManager created without GL context');
+  layerManager.finalize();
+  t.pass('LayerManager finalized');
+
   t.end();
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7378,10 +7378,10 @@ mjolnir.js@^1.2.1:
   dependencies:
     hammerjs "^2.0.8"
 
-mjolnir.js@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/mjolnir.js/-/mjolnir.js-2.0.0.tgz#8475d2fb3b09780dbff122f245c6b3ddc46fc41e"
-  integrity sha512-2OfO77sNbPBlPl3ptU/EdDA/f482C/WunbDPkQyUmqkxGi88qQyvSEyxWGWV3Zw5RAHrWzLx1rH6htTFkzaOKg==
+mjolnir.js@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/mjolnir.js/-/mjolnir.js-2.0.2.tgz#bd8f4ee36ce8a05d9643e3b4738436c1df2e3a04"
+  integrity sha512-xNWPIHATqMAgxv3KO1R/c6XfxRJ0eNNlEHXuUKEgN2S3NjuSxQ1Evvqu5DkNdJ7SWwGDpmenUUpi5/Vak+f3+Q==
   dependencies:
     "@babel/runtime" "^7.0.0"
     hammerjs "^2.0.8"


### PR DESCRIPTION
For #2489 

This PR contains necessary changes to the core classes.

### Change List
- Use the latest mjolnir.js (can be safely imported in a worker)
- Use the latest luma.gl (`Attribute` ignores missing WebGLContext, and properly infers index type)
- Make the following constructors ignore missing WebGLContext: `AttributeManager`, `AttributeTransitionManager`, `LayerManager`.
- `numInstances` and `vertexCount` defined in layer `props` override those in `state`.
- When using external buffers for attribute values, relax type check from throwing an error to a warning.
