### PR TITLE
PathLayer: fix various precision issues

### DIFF
--- a/examples/layer-browser/src/data-samples.js
+++ b/examples/layer-browser/src/data-samples.js
@@ -75,6 +75,7 @@ export const worldGrid = pointsToWorldGrid(points, 500);
 
 export const zigzag = [
   {
+    // Big zigzag
     path: new Array(12)
       .fill(0)
       .map((d, i) => [
@@ -83,11 +84,21 @@ export const zigzag = [
       ])
   },
   {
-    path: new Array(6)
+    // Tiny zigzag
+    path: new Array(12)
       .fill(0)
       .map((d, i) => [
-        positionOrigin[0] + (Math.cos(i * Math.PI) * 0.05) / (i + 4),
-        positionOrigin[1] - i * i * 0.0003
+        positionOrigin[0] - 0.001 - i * i * 1e-5,
+        positionOrigin[1] + (Math.cos(i * Math.PI) * 2e-3) / (i + 4)
+      ])
+  },
+  {
+    // Tiny circle
+    path: new Array(25)
+      .fill(0)
+      .map((d, i) => [
+        positionOrigin[0] + Math.cos((i / 12) * Math.PI) * 2e-5,
+        positionOrigin[1] + Math.sin((i / 12) * Math.PI) * 2e-5
       ])
   },
   {

--- a/modules/layers/src/path-layer/path-layer-vertex-64.glsl.js
+++ b/modules/layers/src/path-layer/path-layer-vertex-64.glsl.js
@@ -50,7 +50,6 @@ varying float vPathPosition;
 varying float vPathLength;
 
 const float EPSILON = 0.001;
-const float PIXEL_EPSILON = 0.1;
 
 float flipIfTrue(bool flag) {
   return -(float(flag) * 2. - 1.);
@@ -82,8 +81,8 @@ vec3 lineJoin(vec2 prevPoint64[2], vec2 currPoint64[2], vec2 nextPoint64[2]) {
 
   // when two points are closer than PIXEL_EPSILON in pixels,
   // assume they are the same point to avoid precision issue
-  lenA = lenA > PIXEL_EPSILON ? lenA : 0.0;
-  lenB = lenB > PIXEL_EPSILON ? lenB : 0.0;
+  lenA = lenA / width > EPSILON ? lenA : 0.0;
+  lenB = lenB / width > EPSILON ? lenB : 0.0;
   vec2 dirA = lenA > 0. ? deltaA / lenA : vec2(0.0, 0.0);
   vec2 dirB = lenB > 0. ? deltaB / lenB : vec2(0.0, 0.0);
 

--- a/modules/layers/src/path-layer/path-layer-vertex.glsl.js
+++ b/modules/layers/src/path-layer/path-layer-vertex.glsl.js
@@ -203,6 +203,7 @@ void main() {
   vec3 prevPosition = instanceStartPositions;
   vec2 prevPosition64xyLow = instanceStartEndPositions64xyLow.xy;
   if (project_uCoordinateSystem == COORDINATE_SYSTEM_LNGLAT_AUTO_OFFSET) {
+    // In auto offset mode, add delta to low part of the positions for better precision
     prevPosition64xyLow += mix(-instanceLeftDeltas, vec3(0.0), isEnd).xy;
   } else {
     prevPosition += mix(-instanceLeftDeltas, vec3(0.0), isEnd);
@@ -216,6 +217,7 @@ void main() {
   vec3 nextPosition = instanceEndPositions;
   vec2 nextPosition64xyLow = instanceStartEndPositions64xyLow.zw;
   if (project_uCoordinateSystem == COORDINATE_SYSTEM_LNGLAT_AUTO_OFFSET) {
+    // In auto offset mode, add delta to low part of the positions for better precision
     nextPosition64xyLow += mix(vec3(0.0), instanceRightDeltas, isEnd).xy;
   } else {
     nextPosition += mix(vec3(0.0), instanceRightDeltas, isEnd);

--- a/modules/layers/src/path-layer/path-layer-vertex.glsl.js
+++ b/modules/layers/src/path-layer/path-layer-vertex.glsl.js
@@ -49,7 +49,6 @@ varying float vPathPosition;
 varying float vPathLength;
 
 const float EPSILON = 0.001;
-const float PIXEL_EPSILON = 0.001;
 
 float flipIfTrue(bool flag) {
   return -(float(flag) * 2. - 1.);
@@ -69,8 +68,8 @@ vec3 lineJoin(
 
   // when two points are closer than PIXEL_EPSILON in pixels,
   // assume they are the same point to avoid precision issue
-  lenA = lenA / width > PIXEL_EPSILON ? lenA : 0.0;
-  lenB = lenB / width > PIXEL_EPSILON ? lenB : 0.0;
+  lenA = lenA / width > EPSILON ? lenA : 0.0;
+  lenB = lenB / width > EPSILON ? lenB : 0.0;
 
   vec2 dirA = lenA > 0. ? normalize(deltaA) : vec2(0.0, 0.0);
   vec2 dirB = lenB > 0. ? normalize(deltaB) : vec2(0.0, 0.0);


### PR DESCRIPTION
For
https://github.com/uber/deck.gl/issues/2384
https://github.com/uber/deck.gl/issues/2301

#### Change List
- Point filter should use relative distance instead of absolute (tiny line segment use case)
- Precision fix: apply delta to position64xyLow in auto-offset mode

Before: 
![path-layer-precision-0](https://user-images.githubusercontent.com/2059298/49683536-b2a6d700-fa7b-11e8-9714-bfa46762feab.gif)

After:
![path-layer-precision-1](https://user-images.githubusercontent.com/2059298/49683539-b6d2f480-fa7b-11e8-9e86-c5fd1a0ad049.gif)
