### PR TITLE
UnitTests: for path layer shaders

### DIFF
--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "gl-matrix": "^3.0.0-0",
-    "luma.gl": "^6.3.0",
+    "luma.gl": "^7.0.0-alpha.2",
     "math.gl": "^2.2.0",
     "mjolnir.js": "^2.0.0",
     "probe.gl": "^2.0.1",

--- a/test/modules/layers/index.js
+++ b/test/modules/layers/index.js
@@ -31,3 +31,4 @@ import './hexagon-layer.spec';
 import './hexagon-aggregator.spec';
 import './contour-layer/marching-squares.spec';
 import './contour-layer/contour-layer.spec';
+import './path-layer/path-layer-vertex.spec';

--- a/test/modules/layers/path-layer/path-layer-vertex.spec.js
+++ b/test/modules/layers/path-layer/path-layer-vertex.spec.js
@@ -1,0 +1,41 @@
+import test from 'tape-catch';
+
+// import {COORDINATE_SYSTEM, Viewport, WebMercatorViewport} from 'deck.gl';
+import {gl} from '@deck.gl/test-utils';
+import {Transform, Buffer} from 'luma.gl';
+import VS from '../../../../modules/layers/src/path-layer/path-layer-vertex.glsl';
+
+test('path-layer-vertex#flipIfTrue', t => {
+  if (!Transform.isSupported(gl)) {
+    t.comment('Transform not supported skipping the test');
+    t.end();
+    return;
+  }
+
+  const inject = {
+    'vs:#decl': `
+attribute float inFlag;
+varying float result;
+`,
+    'vs:#main-start': '  if (true) { result = flipIfTrue(bool(inFlag)); } else {\n',
+    'vs:#main-end': '  }\n'
+  };
+  const inFlag = new Buffer(gl, new Float32Array([0, 1]));
+  const expectedResult = [1, -1];
+  const transform = new Transform(gl, {
+    sourceBuffers: {
+      inFlag
+    },
+    vs: VS,
+    modules: ['picking'],
+    inject,
+    feedbackMap: {
+      inFlag: 'result'
+    },
+    elementCount: 2
+  });
+  transform.run();
+  const result = transform.getData({varyingName: 'result'});
+  t.deepEqual(result, expectedResult, 'flipIfTrue: should return correct value');
+  t.end();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -6883,10 +6883,10 @@ lru-cache@^4.0.1, lru-cache@^4.1.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
-luma.gl@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/luma.gl/-/luma.gl-6.3.0.tgz#05a253ea6912a8c075e85445275581b5369cde65"
-  integrity sha512-d27IdSOQxeozLVTpt53e2PkUHeuvd5yAP5pSxSPgd5PwjzbRTIc1qqL1mFk1uSN9XJ5SrFqufRWr/sZfmRsPbw==
+luma.gl@^7.0.0-alpha.2:
+  version "7.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/luma.gl/-/luma.gl-7.0.0-alpha.2.tgz#d83ebc095418557c6252a803f8f735de8b59a009"
+  integrity sha512-S000cJax7EsoYMTgX2SUQ2cWkN94bf6rnrF8eFR5J47AKofS9TBCJikIyk0n7LipvGZuCDTp28rXtmeVAtgAJA==
   dependencies:
     "@babel/runtime" "^7.0.0"
     math.gl "^2.2.0"


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
**NOTE** requires : https://github.com/uber/luma.gl/pull/812

As discussed in https://github.com/uber/deck.gl/pull/2495

<!-- For other PRs without open issue -->
#### Background
Reference implementation to add unit tests for a layer shader. Shader should be divded into multiple glsl functions and these functions can be tested individually.
More robust unit tests can be added using this as reference, for which we need the correct values for intermediate shader variables.
<!-- For all the PRs -->
#### Change List
- UnitTests: for path layer shaders
