### PR TITLE
add picking test

### DIFF
--- a/modules/experimental-layers/src/advanced-text-layer/advanced-text-layer.js
+++ b/modules/experimental-layers/src/advanced-text-layer/advanced-text-layer.js
@@ -37,14 +37,14 @@ const DEFAULT_COLOR = [0, 0, 0, 255];
 // };
 
 const defaultProps = {
-  getText: x => x.text,
-  getPosition: x => x.coordinates,
-  getColor: x => x.color || DEFAULT_COLOR,
-  getSize: x => x.size || 32,
-  getAngle: x => x.angle || 0,
-  getTextAnchor: x => x.textAnchor || 'middle',
-  getAlignmentBaseline: x => x.alignmentBaseline || 'center',
-  getPixelOffset: x => x.pixelOffset || [0, 0],
+  getText: {type: 'accessor', value: x => x.text},
+  getPosition: {type: 'accessor', value: x => x.coordinates},
+  getColor: {type: 'accessor', value: x => x.color || DEFAULT_COLOR},
+  getSize: {type: 'accessor', value: x => x.size || 32},
+  getAngle: {type: 'accessor', value: x => x.angle || 0},
+  getTextAnchor: {type: 'accessor', value: x => x.textAnchor || 'middle'},
+  getAlignmentBaseline: {type: 'accessor', value: x => x.alignmentBaseline || 'center'},
+  getPixelOffset: {type: 'accessor', value: x => x.pixelOffset || [0, 0]},
   fp64: false,
   fontTexture: null,
   fontInfo: null,

--- a/modules/experimental-layers/src/bezier-curve-layer/bezier-curve-layer.js
+++ b/modules/experimental-layers/src/bezier-curve-layer/bezier-curve-layer.js
@@ -32,10 +32,10 @@ const DEFAULT_COLOR = [0, 0, 0, 255];
 const defaultProps = {
   strokeWidth: 1,
   fp64: false,
-  getSourcePosition: x => x.sourcePosition,
-  getTargetPosition: x => x.targetPosition,
-  getControlPoint: x => x.controlPoint,
-  getColor: x => x.color || DEFAULT_COLOR
+  getSourcePosition: {type: 'accessor', value: x => x.sourcePosition},
+  getTargetPosition: {type: 'accessor', value: x => x.targetPosition},
+  getControlPoint: {type: 'accessor', value: x => x.controlPoint},
+  getColor: {type: 'accessor', value: x => x.color || DEFAULT_COLOR}
 };
 
 export default class BezierCurveLayer extends Layer {

--- a/modules/experimental-layers/src/bitmap-layer/bitmap-layer.js
+++ b/modules/experimental-layers/src/bitmap-layer/bitmap-layer.js
@@ -39,8 +39,8 @@ const defaultProps = {
   transparentColor: [0, 0, 0, 0],
   tintColor: [255, 255, 255],
   // accessors
-  getCenter: x => x.center,
-  getRotation: x => x.rotation
+  getCenter: {type: 'accessor', value: x => x.center},
+  getRotation: {type: 'accessor', value: x => x.rotation}
 };
 
 /*

--- a/modules/experimental-layers/src/gpu-grid-layer/gpu-grid-layer.js
+++ b/modules/experimental-layers/src/gpu-grid-layer/gpu-grid-layer.js
@@ -37,7 +37,7 @@ const defaultProps = {
   // grid
   cellSize: {type: 'number', min: 0, max: 1000, value: 1000},
   coverage: {type: 'number', min: 0, max: 1, value: 1},
-  getPosition: x => x.position,
+  getPosition: {type: 'accessor', value: x => x.position},
   extruded: false,
   fp64: false,
   pickable: false, // TODO: Enable picking with GPU Aggregation

--- a/modules/experimental-layers/src/mesh-layer/mesh-layer.js
+++ b/modules/experimental-layers/src/mesh-layer/mesh-layer.js
@@ -105,14 +105,14 @@ const defaultProps = {
   // Optional settings for 'lighting' shader module
   lightSettings: {},
 
-  getPosition: x => x.position,
-  getColor: x => x.color || DEFAULT_COLOR,
+  getPosition: {type: 'accessor', value: x => x.position},
+  getColor: {type: 'accessor', value: x => x.color || DEFAULT_COLOR},
 
   // yaw, pitch and roll are in degrees
   // https://en.wikipedia.org/wiki/Euler_angles
-  getYaw: x => x.yaw || x.angle || 0,
-  getPitch: x => x.pitch || 0,
-  getRoll: x => x.roll || 0
+  getYaw: {type: 'accessor', value: x => x.yaw || x.angle || 0},
+  getPitch: {type: 'accessor', value: x => x.pitch || 0},
+  getRoll: {type: 'accessor', value: x => x.roll || 0}
 };
 
 export default class MeshLayer extends Layer {

--- a/modules/experimental-layers/src/path-marker-layer/path-marker-layer.js
+++ b/modules/experimental-layers/src/path-marker-layer/path-marker-layer.js
@@ -28,12 +28,15 @@ const defaultProps = Object.assign({}, PathOutlineLayer.defaultProps, {
   hightlightIndex: -1,
   highlightPoint: null,
 
-  getPath: x => x.path,
-  getColor: x => x.color,
-  getMarkerColor: x => [0, 0, 0, 255],
-  getDirection: x => x.direction,
-  getMarkerPercentages: (object, {lineLength}) =>
-    lineLength > DISTANCE_FOR_MULTI_ARROWS ? [0.25, 0.5, 0.75] : [0.5]
+  getPath: {type: 'accessor', value: x => x.path},
+  getColor: {type: 'accessor', value: x => x.color},
+  getMarkerColor: {type: 'accessor', value: x => [0, 0, 0, 255]},
+  getDirection: {type: 'accessor', value: x => x.direction},
+  getMarkerPercentages: {
+    type: 'accessor',
+    value: (object, {lineLength}) =>
+      lineLength > DISTANCE_FOR_MULTI_ARROWS ? [0.25, 0.5, 0.75] : [0.5]
+  }
 });
 
 export default class PathMarkerLayer extends CompositeLayer {

--- a/modules/experimental-layers/src/path-outline-layer/path-outline-layer.js
+++ b/modules/experimental-layers/src/path-outline-layer/path-outline-layer.js
@@ -33,7 +33,7 @@ const FS_CODE = `\
 `;
 
 const defaultProps = {
-  getZLevel: object => object.zLevel | 0
+  getZLevel: {type: 'accessor', value: object => object.zLevel | 0}
 };
 
 export default class PathOutlineLayer extends PathLayer {

--- a/modules/experimental-layers/src/tile-layer/tile-layer.js
+++ b/modules/experimental-layers/src/tile-layer/tile-layer.js
@@ -2,11 +2,11 @@ import {GeoJsonLayer, CompositeLayer} from 'deck.gl';
 import TileCache from './utils/tile-cache';
 
 const defaultProps = {
-  renderSubLayers: props => new GeoJsonLayer(props),
-  getTileData: ({x, y, z}) => Promise.resolve(null),
-  onDataLoaded: () => {},
+  renderSubLayers: {type: 'function', value: props => new GeoJsonLayer(props)},
+  getTileData: {type: 'accessor', value: ({x, y, z}) => Promise.resolve(null)},
+  onDataLoaded: {type: 'function', value: () => {}},
   // eslint-disable-next-line
-  onGetTileDataError: err => console.error(err),
+  onGetTileDataError: {type: 'function', value: err => console.error(err)},
   maxZoom: null,
   minZoom: null,
   maxCacheSize: null

--- a/modules/experimental-layers/src/trips-layer/trips-layer.js
+++ b/modules/experimental-layers/src/trips-layer/trips-layer.js
@@ -8,8 +8,8 @@ import tripsFragment from './trips-layer-fragment.glsl';
 const defaultProps = {
   trailLength: 120,
   currentTime: 0,
-  getPath: d => d.path,
-  getColor: d => d.color
+  getPath: {type: 'accessor', value: d => d.path},
+  getColor: {type: 'accessor', value: d => d.color}
 };
 
 export default class TripsLayer extends Layer {

--- a/test/modules/core/lib/pick-layers.spec.js
+++ b/test/modules/core/lib/pick-layers.spec.js
@@ -1,0 +1,424 @@
+// Copyright (c) 2015 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+/* eslint-disable dot-notation, max-statements, no-unused-vars */
+
+import test from 'tape-catch';
+import {MapView, ScatterplotLayer, Deck, PolygonLayer, PathLayer} from 'deck.gl';
+import * as DATA from '../../../../examples/layer-browser/src/data-samples';
+
+const VIEW_STATE = {
+  latitude: 37.751537058389985,
+  longitude: -122.42694203247012,
+  zoom: 11.5,
+  pitch: 0,
+  bearing: 0
+};
+
+const TEST_CASES = [
+  {
+    id: 'scatterplotLayer',
+    props: {
+      width: 500,
+      height: 550,
+      layers: [
+        new ScatterplotLayer({
+          data: DATA.points,
+          getPosition: d => d.COORDINATES,
+          getColor: [255, 128, 0],
+          getRadius: d => d.SPACES,
+          opacity: 0.3,
+          pickable: true,
+          radiusScale: 30,
+          radiusMinPixels: 1,
+          radiusMaxPixels: 30
+        })
+      ],
+      views: [new MapView()],
+      viewState: VIEW_STATE,
+      useDevicePixels: false
+    },
+    pickingMethods: {
+      singlePixel: [
+        {
+          funcName: 'pickObject',
+          positions: {
+            x: 60,
+            y: 160
+          },
+          count: 1
+        },
+        {
+          funcName: 'pickObject',
+          positions: {
+            x: 90,
+            y: 350
+          },
+          count: 0
+        }
+      ],
+      rectangle: [
+        {
+          funcName: 'pickObjects',
+          positions: {
+            x: 300,
+            y: 300,
+            width: 100,
+            height: 100
+          },
+          count: 33
+        },
+        {
+          funcName: 'pickObjects',
+          positions: {
+            x: 50,
+            y: 50,
+            width: 10,
+            height: 10
+          },
+          count: 0
+        }
+      ],
+      multiDepth: [
+        {
+          funcName: 'pickMultipleObjects',
+          positions: {
+            x: 250,
+            y: 273
+          },
+          count: 2
+        },
+        {
+          funcName: 'pickMultipleObjects',
+          positions: {
+            x: 300,
+            y: 300
+          },
+          count: 0
+        }
+      ]
+    }
+  },
+  {
+    id: 'polygonLayer',
+    props: {
+      width: 500,
+      height: 550,
+      layers: [
+        new PolygonLayer({
+          data: DATA.polygons,
+          getPolygon: f => f,
+          getFillColor: () => [255 * Math.random(), 0, 0],
+          getLineColor: [0, 0, 0, 255],
+          getLineDashArray: [20, 0],
+          getWidth: 20,
+          getElevation: () => Math.random() * 1000,
+          opacity: 0.3,
+          pickable: true,
+          lineDashJustified: true,
+          elevationScale: 0.6
+        })
+      ],
+      views: [new MapView()],
+      viewState: VIEW_STATE,
+      useDevicePixels: false
+    },
+    pickingMethods: {
+      singlePixel: [
+        {
+          funcName: 'pickObject',
+          positions: {
+            x: 60,
+            y: 160
+          },
+          count: 1
+        },
+        {
+          funcName: 'pickObject',
+          positions: {
+            x: 10,
+            y: 10
+          },
+          count: 0
+        }
+      ],
+      rectangle: [
+        {
+          funcName: 'pickObjects',
+          positions: {
+            x: 300,
+            y: 300,
+            width: 100,
+            height: 100
+          },
+          count: 3
+        },
+        {
+          funcName: 'pickObjects',
+          positions: {
+            x: 10,
+            y: 10,
+            width: 10,
+            height: 10
+          },
+          count: 0
+        }
+      ],
+      multiDepth: [
+        {
+          funcName: 'pickMultipleObjects',
+          positions: {
+            x: 250,
+            y: 273
+          },
+          count: 1
+        },
+        {
+          funcName: 'pickMultipleObjects',
+          positions: {
+            x: 10,
+            y: 10
+          },
+          count: 0
+        }
+      ]
+    }
+  },
+  {
+    id: 'pathLayer',
+    props: {
+      width: 500,
+      height: 550,
+      layers: [
+        new PathLayer({
+          data: DATA.zigzag,
+          opacity: 0.6,
+          getPath: f => f.path,
+          getColor: [128, 0, 0],
+          getWidth: 10,
+          getDashArray: [20, 0],
+          widthMinPixels: 1,
+          pickable: true
+        })
+      ],
+      views: [new MapView()],
+      viewState: VIEW_STATE,
+      useDevicePixels: false
+    },
+    pickingMethods: {
+      singlePixel: [
+        {
+          funcName: 'pickObject',
+          positions: {
+            x: 260,
+            y: 300
+          },
+          count: 1
+        },
+        {
+          funcName: 'pickObject',
+          positions: {
+            x: 10,
+            y: 10
+          },
+          count: 0
+        }
+      ],
+      rectangle: [
+        {
+          funcName: 'pickObjects',
+          positions: {
+            x: 0,
+            y: 0,
+            width: 400,
+            height: 400
+          },
+          count: 3
+        },
+        {
+          funcName: 'pickObjects',
+          positions: {
+            x: 10,
+            y: 10,
+            width: 10,
+            height: 10
+          },
+          count: 0
+        }
+      ],
+      multiDepth: [
+        // {
+        //   funcName: 'pickMultipleObjects',
+        //   positions: {
+        //     x: 260,
+        //     y: 300
+        //   },
+        //   count: 1
+        // },
+        {
+          funcName: 'pickMultipleObjects',
+          positions: {
+            x: 10,
+            y: 10
+          },
+          count: 0
+        }
+      ]
+    }
+  },
+  {
+    id: 'multiLayers',
+    props: {
+      width: 500,
+      height: 550,
+      layers: [
+        new ScatterplotLayer({
+          data: DATA.points,
+          getPosition: d => d.COORDINATES,
+          getColor: [255, 128, 0],
+          getRadius: d => d.SPACES,
+          opacity: 0.1,
+          pickable: true,
+          radiusScale: 30,
+          radiusMinPixels: 1,
+          radiusMaxPixels: 30
+        }),
+        new PolygonLayer({
+          data: DATA.polygons,
+          getPolygon: f => f,
+          getFillColor: () => [255 * Math.random(), 0, 0],
+          getLineColor: [0, 0, 0, 255],
+          getLineDashArray: [20, 0],
+          getWidth: 20,
+          getElevation: () => Math.random() * 1000,
+          opacity: 0.1,
+          pickable: true,
+          lineDashJustified: true,
+          elevationScale: 0.6
+        }),
+        new PathLayer({
+          data: DATA.zigzag,
+          opacity: 0.6,
+          getPath: f => f.path,
+          getColor: [128, 0, 0],
+          getWidth: 10,
+          getDashArray: [20, 0],
+          widthMinPixels: 1,
+          pickable: true
+        })
+      ],
+      views: [new MapView()],
+      viewState: VIEW_STATE,
+      useDevicePixels: false
+    },
+    pickingMethods: {
+      singlePixel: [
+        {
+          funcName: 'pickObject',
+          positions: {
+            x: 260,
+            y: 300
+          },
+          count: 1
+        },
+        {
+          funcName: 'pickObject',
+          positions: {
+            x: 10,
+            y: 10
+          },
+          count: 0
+        }
+      ],
+      rectangle: [
+        {
+          funcName: 'pickObjects',
+          positions: {
+            x: 0,
+            y: 0,
+            width: 400,
+            height: 400
+          },
+          count: 32
+        },
+        {
+          funcName: 'pickObjects',
+          positions: {
+            x: 10,
+            y: 10,
+            width: 10,
+            height: 10
+          },
+          count: 0
+        }
+      ],
+      multiDepth: [
+        // {
+        //   funcName: 'pickMultipleObjects',
+        //   positions: {
+        //     x: 260,
+        //     y: 300
+        //   },
+        //   count: 1
+        // },
+        {
+          funcName: 'pickMultipleObjects',
+          positions: {
+            x: 10,
+            y: 10
+          },
+          count: 0
+        }
+      ]
+    }
+  }
+];
+
+for (const testCase of TEST_CASES) {
+  // eslint-disable-next-line no-loop-func
+  test(`picking#${testCase.id}`, t => {
+    const deck = new Deck();
+
+    t.ok(deck, 'Deck should be constructed');
+
+    deck.setProps(Object.assign({}, testCase.props, {onAfterRender: runTests}));
+
+    function runTests() {
+      const pickingMethods = testCase.pickingMethods;
+
+      let pickInfos;
+      for (const i in pickingMethods) {
+        for (const j in pickingMethods[i]) {
+          const pickingMethod = pickingMethods[i][j];
+          const pickingFunc = pickingMethod.funcName;
+          const pickingPos = pickingMethod.positions;
+          pickInfos = deck[pickingFunc](pickingPos);
+          t.equal(
+            !pickInfos ? 0 : !Array.isArray(pickInfos) ? 1 : pickInfos.length,
+            pickingMethod.count,
+            `${pickingFunc} should find expected number of objects`
+          );
+        }
+      }
+      deck.animationLoop.stop();
+      t.end();
+    }
+  });
+}

--- a/test/modules/index.js
+++ b/test/modules/index.js
@@ -30,4 +30,5 @@ if (typeof document !== 'undefined') {
   require('./lite');
   require('./core/experimental/utils/gpu-grid-aggregator.spec');
   require('./core/experimental/utils/grid-aggregation-utils.spec');
+  require('./core/lib/pick-layers.spec');
 }


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #1756 
<!-- For other PRs without open issue -->
#### Background
We need to enhance deck.gl test utils to test different approaches of picking objects, such as single-pixel picking, rectangular picking and multi-depth picking.
<!-- For all the PRs -->
#### Change List
- add test cases for picking test
- test scatterplotLayer, polygonLayer, pathLayer and multiple layers overlapping
- test single-pixel picking, rectangular picking and multi-depth picking
