### PR TITLE
PathLayer shader: 2-dimensional vPathPosition

### DIFF
--- a/modules/layers/src/path-layer/path-layer-fragment.glsl.js
+++ b/modules/layers/src/path-layer/path-layer-fragment.glsl.js
@@ -31,6 +31,11 @@ varying vec4 vColor;
 varying vec2 vCornerOffset;
 varying float vMiterLength;
 varying vec2 vDashArray;
+/*
+ * vPathPosition represents the relative coordinates of the current fragment on the path segment.
+ * vPathPosition.x - position along the width of the path, between [-1, 1]. 0 is the center line.
+ * vPathPosition.y - position along the length of the path, between [0, L / width].
+ */
 varying vec2 vPathPosition;
 varying float vPathLength;
 

--- a/modules/layers/src/path-layer/path-layer-fragment.glsl.js
+++ b/modules/layers/src/path-layer/path-layer-fragment.glsl.js
@@ -31,7 +31,7 @@ varying vec4 vColor;
 varying vec2 vCornerOffset;
 varying float vMiterLength;
 varying vec2 vDashArray;
-varying float vPathPosition;
+varying vec2 vPathPosition;
 varying float vPathLength;
 
 // mod doesn't work correctly for negative numbers
@@ -70,9 +70,9 @@ bool dash_isFragInGap() {
   float offset = alignMode * solidLength / 2.0;
 
   return gapLength > 0.0 &&
-    vPathPosition >= 0.0 &&
-    vPathPosition <= vPathLength &&
-    mod2(vPathPosition + offset, unitLength) > solidLength;
+    vPathPosition.y >= 0.0 &&
+    vPathPosition.y <= vPathLength &&
+    mod2(vPathPosition.y + offset, unitLength) > solidLength;
 }
 
 void main(void) {

--- a/modules/layers/src/path-layer/path-layer-vertex-64.glsl.js
+++ b/modules/layers/src/path-layer/path-layer-vertex-64.glsl.js
@@ -46,7 +46,7 @@ varying vec4 vColor;
 varying vec2 vCornerOffset;
 varying float vMiterLength;
 varying vec2 vDashArray;
-varying float vPathPosition;
+varying vec2 vPathPosition;
 varying float vPathLength;
 
 const float EPSILON = 0.001;
@@ -177,7 +177,10 @@ vec3 lineJoin(vec2 prevPoint64[2], vec2 currPoint64[2], vec2 nextPoint64[2]) {
   float isEnd = positions.x;
   vec2 offsetFromStartOfPath = mix(vCornerOffset, vCornerOffset + deltaA / width, isEnd);
   vec2 dir = mix(dirB, dirA, isEnd);
-  vPathPosition = dot(offsetFromStartOfPath, dir);
+  vPathPosition = vec2(
+    positions.y + positions.z * offsetDirection,
+    dot(offsetFromStartOfPath, dir)
+  );
 
   return vec3(vCornerOffset * width, 0.0);
 }

--- a/modules/layers/src/path-layer/path-layer-vertex.glsl.js
+++ b/modules/layers/src/path-layer/path-layer-vertex.glsl.js
@@ -45,7 +45,7 @@ varying vec4 vColor;
 varying vec2 vCornerOffset;
 varying float vMiterLength;
 varying vec2 vDashArray;
-varying float vPathPosition;
+varying vec2 vPathPosition;
 varying float vPathLength;
 
 const float EPSILON = 0.001;
@@ -164,7 +164,10 @@ vec3 lineJoin(
     offsetFromStartOfPath += deltaA / width;
   }
   vec2 dir = isEnd ? dirA : dirB;
-  vPathPosition = dot(offsetFromStartOfPath, dir);
+  vPathPosition = vec2(
+    positions.y + positions.z * offsetDirection,
+    dot(offsetFromStartOfPath, dir)
+  );
 
   return currPoint + vec3(vCornerOffset * width, 0.0);
 }


### PR DESCRIPTION
#### Background
The old varying `float vPathPosition` is set to the position of a fragment along the length of the path, normalized by width. This PR makes the varying a `vec2`, adding the position along the width of the path as the `x` component.

As an attempt to make the PathLayer more customizable, this change addresses an internal use case where we need to subclass the PathLayer to add custom fill logic in the fragment shader, including double line, path offset, and custom marking patterns.

Example to draw double line:

```js
class MyPathLayer extends PathLayer {
  getShaders() {
    return {
      ...super.getShaders(),
      inject: {
        'fs:#main-start': `if (abs(vPathPosition.x) < 0.1) discard;`
      }
    }
  }
}
```

#### Change List
- Change `vPathPosition` varying from `float` to `vec2`
