### PR TITLE
specify types for defaultProps in gpu grid layer

### DIFF
--- a/modules/experimental-layers/src/gpu-grid-layer/gpu-grid-cell-layer.js
+++ b/modules/experimental-layers/src/gpu-grid-layer/gpu-grid-cell-layer.js
@@ -38,8 +38,8 @@ const defaultProps = {
   fp64: false,
   pickable: false, // TODO: add picking support (read from aggregated texture)
 
-  minColor: DEFAULT_MINCOLOR,
-  maxColor: DEFAULT_MAXCOLOR,
+  minColor: {type: 'color', value: DEFAULT_MINCOLOR},
+  maxColor: {type: 'color', value: DEFAULT_MAXCOLOR},
 
   lightSettings: {}
 };

--- a/modules/experimental-layers/src/gpu-grid-layer/gpu-grid-layer.js
+++ b/modules/experimental-layers/src/gpu-grid-layer/gpu-grid-layer.js
@@ -32,12 +32,12 @@ const MAXCOLOR = [0, 255, 0, 255];
 
 const defaultProps = {
   // elevation
-  elevationScale: 1,
+  elevationScale: {type: 'number', min: 0, value: 1},
 
   // grid
   cellSize: {type: 'number', min: 0, max: 1000, value: 1000},
   coverage: {type: 'number', min: 0, max: 1, value: 1},
-  getPosition: x => x.position,
+  getPosition: {type: 'accessor', value: x => x.position},
   extruded: false,
   fp64: false,
   pickable: false, // TODO: Enable picking with GPU Aggregation


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #2477 
<!-- For other PRs without open issue -->
#### Background
In gpu grid layer, the defaultProps don't have types specified. We need to specify type for those props.
<!-- For all the PRs -->
#### Change List
- Add type to the defaultProps in the gpu grid layers

