### PR TITLE
[Discussion] Move internal dependencies to peerDependencies

### DIFF
--- a/modules/experimental-layers/package.json
+++ b/modules/experimental-layers/package.json
@@ -32,7 +32,7 @@
     "build-es5": "BABEL_ENV=es5 babel src --out-dir dist/es5 --source-maps --ignore 'node_modules/'",
     "build": "npm run clean && npm run build-es6 && npm run build-esm && npm run build-es5"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@deck.gl/core": "^7.0.0-alpha.1",
     "@deck.gl/layers": "^7.0.0-alpha.1"
   }

--- a/modules/json/package.json
+++ b/modules/json/package.json
@@ -33,7 +33,9 @@
     "build": "npm run clean && npm run build-es6 && npm run build-esm && npm run build-es5"
   },
   "dependencies": {
-    "@deck.gl/core": "^7.0.0-alpha.1",
     "d3-dsv": "^1.0.8"
+  },
+  "peerDependencies": {
+    "@deck.gl/core": "^7.0.0-alpha.1"
   }
 }

--- a/modules/layers/package.json
+++ b/modules/layers/package.json
@@ -33,8 +33,10 @@
     "build": "npm run clean && npm run build-es6 && npm run build-esm && npm run build-es5"
   },
   "dependencies": {
-    "@deck.gl/core": "^7.0.0-alpha.1",
     "d3-hexbin": "^0.2.1",
     "earcut": "^2.0.6"
+  },
+  "peerDependencies": {
+    "@deck.gl/core": "^7.0.0-alpha.1"
   }
 }

--- a/modules/mapbox/package.json
+++ b/modules/mapbox/package.json
@@ -32,7 +32,7 @@
     "build-es5": "BABEL_ENV=es5 babel src --out-dir dist/es5 --source-maps --ignore 'node_modules/'",
     "build": "npm run clean && npm run build-es6 && npm run build-esm && npm run build-es5"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@deck.gl/core": "^7.0.0-alpha.1"
   }
 }

--- a/modules/react/package.json
+++ b/modules/react/package.json
@@ -33,10 +33,10 @@
     "build": "npm run clean && npm run build-es6 && npm run build-esm && npm run build-es5"
   },
   "dependencies": {
-    "@deck.gl/core": "^7.0.0-alpha.1",
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
+    "@deck.gl/core": "^7.0.0-alpha.1",
     "react": "0.14.x - 16.x",
     "react-dom": "0.14.x - 16.x"
   }

--- a/modules/test-utils/package.json
+++ b/modules/test-utils/package.json
@@ -25,9 +25,11 @@
     "README.md"
   ],
   "dependencies": {
-    "deck.gl": "^7.0.0-alpha.1",
     "pixelmatch": "^4.0.2",
     "probe.gl": "^2.0.0"
+  },
+  "peerDependencies": {
+    "deck.gl": "^7.0.0-alpha.1"
   },
   "scripts": {
     "clean": "rm -fr dist dist-es6 && mkdir -p dist/es5 dist/esm dist/es6",


### PR DESCRIPTION
#### Background

Suppose a project has the following dependencies:
- "deck.gl": "^6.3.0"
- "@deck.gl/experimental-layers": "^6.3.0"

Then deck.gl is bumped to `^6.3.1`, and `yarn` is run.
Because of the existence of lock files, multiple copies of deck and luma end up being installed:
- "deck.gl": "6.3.1"
  + "luma.gl": "6.3.1"
- "@deck.gl/experimental-layers": "6.3.0"
  + "@deck.gl/core": "6.3.0"
  + "@deck.gl/layers": "6.3.0"
    * "luma.gl": "6.3.0"

The application no longer works because deck.gl will throw an error when multiple copies are detected.

I would argue that this is not the expected behavior. It is common practice for libraries with submodules to require something like this:

```bash
yarn add deck.gl @deck.gl/experimental-layers
```
