### PR TITLE
specify types for defaultProps in mesh layer

### DIFF
--- a/modules/experimental-layers/src/mesh-layer/mesh-layer.js
+++ b/modules/experimental-layers/src/mesh-layer/mesh-layer.js
@@ -106,13 +106,13 @@ const defaultProps = {
   lightSettings: {},
 
   getPosition: {type: 'accessor', value: x => x.position},
-  getColor: {type: 'accessor', DEFAULT_COLOR},
+  getColor: {type: 'accessor', value: DEFAULT_COLOR},
 
   // yaw, pitch and roll are in degrees
   // https://en.wikipedia.org/wiki/Euler_angles
-  getYaw: {type: 'accessor', value: 0},
-  getPitch: {type: 'accessor', value: 0},
-  getRoll: {type: 'accessor', value: 0}
+  getYaw: {type: 'accessor', value: x => x.yaw || x.angle || 0},
+  getPitch: {type: 'accessor', value: x => x.pitch || 0},
+  getRoll: {type: 'accessor', value: x => x.roll || 0}
 };
 
 export default class MeshLayer extends Layer {
@@ -136,7 +136,7 @@ export default class MeshLayer extends Layer {
       instanceRotations: {
         size: 3,
         accessor: ['getYaw', 'getPitch', 'getRoll'],
-        defaultValue: [0, 0, 0]
+        update: this.calculateInstanceRotations
       },
       instanceColors: {
         size: 4,
@@ -240,6 +240,18 @@ export default class MeshLayer extends Layer {
       const position = getPosition(point);
       value[i++] = fp64LowPart(position[0]);
       value[i++] = fp64LowPart(position[1]);
+    }
+  }
+
+  // yaw(z), pitch(y) and roll(x) in radians
+  calculateInstanceRotations(attribute) {
+    const {data, getYaw, getPitch, getRoll} = this.props;
+    const {value, size} = attribute;
+    let i = 0;
+    for (const point of data) {
+      value[i++] = getRoll(point) * RADIAN_PER_DEGREE;
+      value[i++] = getPitch(point) * RADIAN_PER_DEGREE;
+      value[i++] = getYaw(point) * RADIAN_PER_DEGREE;
     }
   }
 }

--- a/modules/experimental-layers/src/mesh-layer/mesh-layer.js
+++ b/modules/experimental-layers/src/mesh-layer/mesh-layer.js
@@ -94,7 +94,7 @@ const DEFAULT_COLOR = [0, 0, 0, 255];
 const defaultProps = {
   mesh: null,
   texture: null,
-  sizeScale: 1,
+  sizeScale: {type: 'number', value: 1, min: 0},
 
   // TODO - parameters should be merged, not completely overridden
   parameters: {
@@ -105,14 +105,14 @@ const defaultProps = {
   // Optional settings for 'lighting' shader module
   lightSettings: {},
 
-  getPosition: x => x.position,
-  getColor: x => x.color || DEFAULT_COLOR,
+  getPosition: {type: 'accessor', value: x => x.position},
+  getColor: {type: 'accessor', DEFAULT_COLOR},
 
   // yaw, pitch and roll are in degrees
   // https://en.wikipedia.org/wiki/Euler_angles
-  getYaw: x => x.yaw || x.angle || 0,
-  getPitch: x => x.pitch || 0,
-  getRoll: x => x.roll || 0
+  getYaw: {type: 'accessor', value: 0},
+  getPitch: {type: 'accessor', value: 0},
+  getRoll: {type: 'accessor', value: 0}
 };
 
 export default class MeshLayer extends Layer {
@@ -126,8 +126,7 @@ export default class MeshLayer extends Layer {
     attributeManager.addInstanced({
       instancePositions: {
         size: 3,
-        accessor: 'getPosition',
-        update: this.calculateInstancePositions
+        accessor: 'getPosition'
       },
       instancePositions64xy: {
         size: 2,
@@ -137,9 +136,13 @@ export default class MeshLayer extends Layer {
       instanceRotations: {
         size: 3,
         accessor: ['getYaw', 'getPitch', 'getRoll'],
-        update: this.calculateInstanceRotations
+        defaultValue: [0, 0, 0]
       },
-      instanceColors: {size: 4, accessor: 'getColor', update: this.calculateInstanceColors}
+      instanceColors: {
+        size: 4,
+        accessor: 'getColor',
+        defaultValue: [0, 0, 0, 255]
+      }
     });
 
     this.setState({
@@ -221,19 +224,6 @@ export default class MeshLayer extends Layer {
     }
   }
 
-  calculateInstancePositions(attribute) {
-    const {data, getPosition} = this.props;
-    const {value, size} = attribute;
-    let i = 0;
-    for (const point of data) {
-      const position = getPosition(point);
-      value[i] = position[0];
-      value[i + 1] = position[1];
-      value[i + 2] = position[2] || 0;
-      i += size;
-    }
-  }
-
   calculateInstancePositions64xyLow(attribute) {
     const isFP64 = this.use64bitPositions();
     attribute.constant = !isFP64;
@@ -250,31 +240,6 @@ export default class MeshLayer extends Layer {
       const position = getPosition(point);
       value[i++] = fp64LowPart(position[0]);
       value[i++] = fp64LowPart(position[1]);
-    }
-  }
-
-  // yaw(z), pitch(y) and roll(x) in radians
-  calculateInstanceRotations(attribute) {
-    const {data, getYaw, getPitch, getRoll} = this.props;
-    const {value, size} = attribute;
-    let i = 0;
-    for (const point of data) {
-      value[i++] = getRoll(point) * RADIAN_PER_DEGREE;
-      value[i++] = getPitch(point) * RADIAN_PER_DEGREE;
-      value[i++] = getYaw(point) * RADIAN_PER_DEGREE;
-    }
-  }
-
-  calculateInstanceColors(attribute) {
-    const {data, getColor} = this.props;
-    const {value} = attribute;
-    let i = 0;
-    for (const point of data) {
-      const color = getColor(point) || DEFAULT_COLOR;
-      value[i++] = color[0];
-      value[i++] = color[1];
-      value[i++] = color[2];
-      value[i++] = isNaN(color[3]) ? 255 : color[3];
     }
   }
 }

--- a/modules/experimental-layers/src/mesh-layer/mesh-layer.md
+++ b/modules/experimental-layers/src/mesh-layer/mesh-layer.md
@@ -97,9 +97,9 @@ The roll (bank) in degrees of each object.
 See [Euler angles](https://en.wikipedia.org/wiki/Euler_angles).
 
 
-##### `getColor` (Function, optional)
+##### `getColor` (Function|Array, optional)
 
-- Default: `object => [0, 0, 0, 255]`
+- Default: `[0, 0, 0, 255]`
 
 The color of each object. Only used if `texture` is empty.
 

--- a/modules/experimental-layers/src/mesh-layer/mesh-layer.md
+++ b/modules/experimental-layers/src/mesh-layer/mesh-layer.md
@@ -99,7 +99,7 @@ See [Euler angles](https://en.wikipedia.org/wiki/Euler_angles).
 
 ##### `getColor` (Function, optional)
 
-- Default: `object => object.color || [0, 0, 0, 255]`
+- Default: `object => [0, 0, 0, 255]`
 
 The color of each object. Only used if `texture` is empty.
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #2477 
<!-- For other PRs without open issue -->
#### Background
In mesh layer, the defaultProps don't have types specified. We need to specify type for those props.
<!-- For all the PRs -->
#### Change List
- Add type to the defaultProps in the mesh layer

note: tested with render test and layer browser