### PR TITLE
add type for defaultProps in path outline layer

### DIFF
--- a/modules/experimental-layers/src/path-outline-layer/path-outline-layer.js
+++ b/modules/experimental-layers/src/path-outline-layer/path-outline-layer.js
@@ -2,7 +2,6 @@ import {PathLayer} from '@deck.gl/layers';
 import GL from '@luma.gl/constants';
 import {Framebuffer, Texture2D} from 'luma.gl';
 import outline from '../shaderlib/outline/outline';
-import assert from '../../../core/src/utils/assert';
 
 // TODO - this should be built into assembleShaders
 function injectShaderCode({source, declarations = '', code = ''}) {
@@ -137,11 +136,7 @@ export default class PathOutlineLayer extends PathLayer {
     attribute.value = pathTesselator._updateAttribute({
       target: attribute.value,
       size: 1,
-      getValue: (object, index) => {
-        const zLevel = getZLevel(object, index);
-        assert(!isNaN(zLevel), '`getZLevel` does not return a number!');
-        return [zLevel];
-      }
+      getValue: (object, index) => [getZLevel(object, index) || 0]
     });
   }
 }

--- a/modules/experimental-layers/src/path-outline-layer/path-outline-layer.js
+++ b/modules/experimental-layers/src/path-outline-layer/path-outline-layer.js
@@ -62,6 +62,7 @@ export default class PathOutlineLayer extends PathLayer {
       instanceZLevel: {
         size: 1,
         type: GL.UNSIGNED_BYTE,
+        update: this.calculateZLevels,
         accessor: 'getZLevel',
         defaultValue: 0
       }

--- a/modules/experimental-layers/src/path-outline-layer/path-outline-layer.js
+++ b/modules/experimental-layers/src/path-outline-layer/path-outline-layer.js
@@ -33,7 +33,7 @@ const FS_CODE = `\
 `;
 
 const defaultProps = {
-  getZLevel: object => object.zLevel | 0
+  getZLevel: {type: 'accessor', value: 0}
 };
 
 export default class PathOutlineLayer extends PathLayer {
@@ -62,8 +62,8 @@ export default class PathOutlineLayer extends PathLayer {
       instanceZLevel: {
         size: 1,
         type: GL.UNSIGNED_BYTE,
-        update: this.calculateZLevels,
-        accessor: 'getZLevel'
+        accessor: 'getZLevel',
+        defaultValue: 0
       }
     });
   }

--- a/modules/experimental-layers/src/path-outline-layer/path-outline-layer.js
+++ b/modules/experimental-layers/src/path-outline-layer/path-outline-layer.js
@@ -2,6 +2,7 @@ import {PathLayer} from '@deck.gl/layers';
 import GL from '@luma.gl/constants';
 import {Framebuffer, Texture2D} from 'luma.gl';
 import outline from '../shaderlib/outline/outline';
+import assert from '../../../core/src/utils/assert';
 
 // TODO - this should be built into assembleShaders
 function injectShaderCode({source, declarations = '', code = ''}) {
@@ -138,7 +139,8 @@ export default class PathOutlineLayer extends PathLayer {
       size: 1,
       getValue: (object, index) => {
         const zLevel = getZLevel(object, index);
-        return isNaN(zLevel) ? 0 : [zLevel];
+        assert(!isNaN(zLevel), '`getZLevel` does not return a number!');
+        return [zLevel];
       }
     });
   }

--- a/modules/experimental-layers/src/path-outline-layer/path-outline-layer.js
+++ b/modules/experimental-layers/src/path-outline-layer/path-outline-layer.js
@@ -63,8 +63,7 @@ export default class PathOutlineLayer extends PathLayer {
         size: 1,
         type: GL.UNSIGNED_BYTE,
         update: this.calculateZLevels,
-        accessor: 'getZLevel',
-        defaultValue: 0
+        accessor: 'getZLevel'
       }
     });
   }

--- a/modules/experimental-layers/src/path-outline-layer/path-outline-layer.js
+++ b/modules/experimental-layers/src/path-outline-layer/path-outline-layer.js
@@ -136,7 +136,10 @@ export default class PathOutlineLayer extends PathLayer {
     attribute.value = pathTesselator._updateAttribute({
       target: attribute.value,
       size: 1,
-      getValue: (object, index) => getZLevel(object, index) || 0
+      getValue: (object, index) => {
+        const zLevel = getZLevel(object, index);
+        return isNaN(zLevel) ? 0 : [zLevel];
+      }
     });
   }
 }


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #2477 
<!-- For other PRs without open issue -->
#### Background
In path outline layer, the defaultProps don't have types specified. We need to specify type for those props.
<!-- For all the PRs -->
#### Change List
- Add type to the defaultProps in path outline layer

note: tested with render test and layer-browser. compared the rendering result with that in 6.3-release