### PR TITLE
Flat path data proposal

### DIFF
--- a/dev-docs/RFCs/v7.x/binary-data-rfc.md
+++ b/dev-docs/RFCs/v7.x/binary-data-rfc.md
@@ -99,19 +99,19 @@ A binary data buffer may be sliced into messages with variable sizes:
 
 ```js
 // lon1, lat1, alt1, lon2, lat2, alt2, ...
-const vertices = new Float32Array([-122.426942, 37.801537, 0, -122.425942, 37.711537, 0, ...]);
+const positions = new Float32Array([-122.426942, 37.801537, 0, -122.425942, 37.711537, 0, ...]);
 // path1_start_index, path2_start_index, ...
-const indices = new Uint16Array([0, 36, 72, 147]);
+const pathStartIndices = new Uint16Array([0, 36, 72, 147]);
 
-const data = {vertices, indices, length: 4};
+const data = {positions, pathStartIndices, length: 4};
 
 new PathLayer({
   data,
   getPath: (object, {index, data}) => {
-    const {vertices, indices} = data;
-    const startIndex = indices[index];
-    const endIndex = indices[index + 1] || vertices.length / 3;
-    return vertices.subarray(startIndex * 3, endIndex * 3);
+    const {positions, pathStartIndices} = data;
+    const startIndex = pathStartIndices[index];
+    const endIndex = pathStartIndices[index + 1] || positions.length / 3;
+    return positions.subarray(startIndex * 3, endIndex * 3);
   },
   getWidth: 10,
   getColor: [255, 0, 0]

--- a/dev-docs/RFCs/v7.x/binary-data-rfc.md
+++ b/dev-docs/RFCs/v7.x/binary-data-rfc.md
@@ -1,7 +1,7 @@
 # RFC: Using Binary Data
 
-* Authors: Ib Green, ...
-* Date: June 13, 2018
+* Authors: Ib Green, Xiaoji Chen
+* Date: December 19, 2018
 * Status: **Draft**
 
 
@@ -27,7 +27,27 @@ In some cases the application may receive all or parts of a layer's geometry in 
 
 One of the biggest differences that makes it hard to use binary arrays directly is that they are flat, whereas JavaScript arrays tend to have a sub-array for each vertex or color.
 
-TBA...
+```js
+new Scatterplot({
+  data: new Float32Array([-122.4, 37.78, 1000, 255, 200, 0, -122.41, 37.775, 500, 200, 0, 0, -122.39, 37.8, 500, 0, 40, 200]),
+  datumSize: 6,
+  getPosition: d => d.slice(0, 2),
+  getRadius: d => d[2],
+  getColor: d => d.slice(3)
+})
+```
+
+The binary data object may be sliced into messages with variable size:
+
+```js
+new PathLayer({
+  data: new Float32Array([-122.426942, 37.801537, 0, -122.425942, 37.711537, 0, ...]),
+  datumSize: [36, 36, 75, 6],
+  getPath: d => d,
+  getWidth: 10,
+  getColor: [255, 0, 0]
+})
+```
 
 deck.gl layers carefully formats data in memory so that it can be accessed efficiently by the GPU...
 

--- a/dev-docs/RFCs/v7.x/binary-data-rfc.md
+++ b/dev-docs/RFCs/v7.x/binary-data-rfc.md
@@ -21,7 +21,7 @@ This article focused on the following use cases:
 * **Using typed arrays as layer input data** - Using The input data is in binary form, perhaps it is delivered this way from the back-end, and it would be preferable to not have to unpack it.
 * **Using typed arrays or GPU buffers directly as layer attributes** - The input data is already formatted in the memory format expected by the GPU and deck.gl's shaders.
 
-## Using Flattend Data (Typed Arrays as layer input data)
+## Using Flattened Data (Typed Arrays) as layer input data
 
 In some cases the application may receive all or parts of a layer's geometry in the form of binary typed arrays instead of Javascript arrays. When communicating with a server or web workers, typed arrays can be transported more efficiently in binary form than classic arrays that tend to be JSON stringified and then parsed. For example, a ScatterplotLayer may receive input data like this:
 
@@ -30,7 +30,7 @@ In some cases the application may receive all or parts of a layer's geometry in 
 const binaryData = new Float32Array([-122.4, 37.78, 1000, 255, 200, 0, -122.41, 37.775, 500, 200, 0, 0, -122.39, 37.8, 500, 0, 40, 200]);
 ```
 
-Upon receiving the typed arrays, we can of course re-construct a classic JavaScript array:
+Upon receiving the typed arrays, the application can of course re-construct a classic JavaScript array:
 
 ```js
 const data = [];
@@ -50,14 +50,14 @@ new ScatterplotLayer({
 });
 ```
 
-However, this array will take valuable CPU time to create and significantly more memory to store than its binary form. In performance-sensitive applications that constantly push a large volumn of data (e.g. animations), this method will not be efficient enough.
+However, in addition to requiring custom repacking code, this array will take valuable CPU time to create, and significantly more memory to store than its binary form. In performance-sensitive applications that constantly push a large volumn of data (e.g. animations), this method will not be efficient enough.
 
 Alternatively, one may supply a non-iterable object (not Array or TypedArray) to the `data` object. In this case, it must contain a `length` field that specifies the total number of objects. Since `data` is not iterable, each accessor will not receive a valid `object` argument, and therefore responsible of interpreting the input data's buffer layout:
 
 ```js
 const data = {src: binaryData, length: 3}
 
-new Scatterplot({
+new ScatterplotLayer({
   data,
   getPosition: (object, {index, data, target}) => {
     target[0] = data.src[index * 6];
@@ -81,9 +81,8 @@ new Scatterplot({
 When non-iterable data is used, to populate the picking event with a valid `object` value, one may optionally specify a `getPickingInfo` callback:
 
 ```js
-const data = {
-  src: binaryData,
-  length: 3,
+new ScatterplotLayer({
+  ...
   getPickingInfo: ({info, data}) => {
     const i = info.index * 6;
     info.object = {
@@ -93,7 +92,7 @@ const data = {
     };
     return info;
   }
-}
+})
 ```
 
 A binary data buffer may be sliced into messages with variable sizes:

--- a/docs/layers/path-layer.md
+++ b/docs/layers/path-layer.md
@@ -88,12 +88,6 @@ Only works if `rounded` is `false`.
 
 Whether the layer should be rendered in high-precision 64-bit mode. Note that since deck.gl v6.1, the default 32-bit projection uses a hybrid mode that matches 64-bit precision with significantly better performance.
 
-##### `is3D` (Boolean, optional)
-
-* Default: `true`
-
-Whether the vertex positions along the path are 3-dimensional (contain `z`). See `getPath` for more information.
-
 ##### `dashJustified` (Boolean, optional)
 
 * Default: `false`
@@ -110,14 +104,14 @@ Returns the specified path for the object.
 
 A path can be one of the following formats:
 
-* An array of coordinates following the GeoJSON [LineString](https://tools.ietf.org/html/rfc7946#section-3.1.4) specification.
-* A flat array or [TypedArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) of numbers, in the shape of `[x0, y0, z0, x1, y1, z1, ...]`. By default, each coordinate is assumed to contain 3 numbers. Set the `is3D` prop to `false` if it should be sliced differently:
+* An array of points (`[x, y, z]`). Compatible with the GeoJSON [LineString](https://tools.ietf.org/html/rfc7946#section-3.1.4) specification.
+* A flat array or [TypedArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) of numbers, in the shape of `[x0, y0, z0, x1, y1, z1, ...]`. By default, each coordinate is assumed to contain 3 consecutive numbers. If each coordinate contains only two numbers (x, y), set the `positionFormat` prop to `XY`:
 
 ```js
 new PathLayer({
   ...
   getPath: object => object.vertices, // [x0, y0, x1, y1, x2, y2, ...]
-  is3D: false
+  positionFormat: `XY`
 })
 ```
 

--- a/docs/layers/path-layer.md
+++ b/docs/layers/path-layer.md
@@ -103,8 +103,9 @@ Only effective if `getDashArray` is specified. If `true`, adjust gaps for the da
 Returns the specified path for the object.
 
 A path can be one of the following formats:
-- An array of coordinates following the GeoJSON [LineString](https://tools.ietf.org/html/rfc7946#section-3.1.4) specification.
-- A flat array or [TypedArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) of numbers, in the shape of `[x0, y0, z0, x1, y1, z1, ...]`. By default, each coordinate is assumed to contain 3 numbers. Attach a `stride` field to the array if it should be sliced differently:
+
+* An array of coordinates following the GeoJSON [LineString](https://tools.ietf.org/html/rfc7946#section-3.1.4) specification.
+* A flat array or [TypedArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) of numbers, in the shape of `[x0, y0, z0, x1, y1, z1, ...]`. By default, each coordinate is assumed to contain 3 numbers. Attach a `stride` field to the array if it should be sliced differently:
 
 ```js
 getPath: object => {

--- a/docs/layers/path-layer.md
+++ b/docs/layers/path-layer.md
@@ -102,7 +102,17 @@ Only effective if `getDashArray` is specified. If `true`, adjust gaps for the da
 
 Returns the specified path for the object.
 
-A path is an array of coordinates.
+A path can be one of the following formats:
+- An array of coordinates following the GeoJSON [LineString](https://tools.ietf.org/html/rfc7946#section-3.1.4) specification.
+- A flat array or [TypedArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) of numbers, in the shape of `[x0, y0, z0, x1, y1, z1, ...]`. By default, each coordinate is assumed to contain 3 numbers. Attach a `stride` field to the array if it should be sliced differently:
+
+```js
+getPath: object => {
+  const points = object.vertices; // [x0, y0, x1, y1, x2, y2, ...]
+  points.stride = 2;
+  return points;
+}
+```
 
 ##### `getColor` (Function|Array, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 

--- a/docs/layers/path-layer.md
+++ b/docs/layers/path-layer.md
@@ -88,6 +88,12 @@ Only works if `rounded` is `false`.
 
 Whether the layer should be rendered in high-precision 64-bit mode. Note that since deck.gl v6.1, the default 32-bit projection uses a hybrid mode that matches 64-bit precision with significantly better performance.
 
+##### `is3D` (Boolean, optional)
+
+* Default: `true`
+
+Whether the vertex positions along the path are 3-dimensional (contain `z`). See `getPath` for more information.
+
 ##### `dashJustified` (Boolean, optional)
 
 * Default: `false`
@@ -105,14 +111,14 @@ Returns the specified path for the object.
 A path can be one of the following formats:
 
 * An array of coordinates following the GeoJSON [LineString](https://tools.ietf.org/html/rfc7946#section-3.1.4) specification.
-* A flat array or [TypedArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) of numbers, in the shape of `[x0, y0, z0, x1, y1, z1, ...]`. By default, each coordinate is assumed to contain 3 numbers. Attach a `stride` field to the array if it should be sliced differently:
+* A flat array or [TypedArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) of numbers, in the shape of `[x0, y0, z0, x1, y1, z1, ...]`. By default, each coordinate is assumed to contain 3 numbers. Set the `is3D` prop to `false` if it should be sliced differently:
 
 ```js
-getPath: object => {
-  const points = object.vertices; // [x0, y0, x1, y1, x2, y2, ...]
-  points.stride = 2;
-  return points;
-}
+new PathLayer({
+  ...
+  getPath: object => object.vertices, // [x0, y0, x1, y1, x2, y2, ...]
+  is3D: false
+})
 ```
 
 ##### `getColor` (Function|Array, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")

--- a/examples/layer-browser/src/examples/core-layers.js
+++ b/examples/layer-browser/src/examples/core-layers.js
@@ -187,10 +187,8 @@ const PathLayerBinaryExample = {
   },
   props: {
     ...PathLayerExample.props,
-    getPath: d => {
-      d.stride = 2;
-      return d;
-    }
+    getPath: d => d,
+    is3D: false
   }
 };
 

--- a/examples/layer-browser/src/examples/core-layers.js
+++ b/examples/layer-browser/src/examples/core-layers.js
@@ -188,7 +188,7 @@ const PathLayerBinaryExample = {
   props: {
     ...PathLayerExample.props,
     getPath: d => d,
-    is3D: false
+    positionFormat: 'XY'
   }
 };
 

--- a/examples/layer-browser/src/examples/core-layers.js
+++ b/examples/layer-browser/src/examples/core-layers.js
@@ -13,9 +13,11 @@ import {
   GeoJsonLayer,
   PolygonLayer,
   PathLayer,
-  TextLayer
+  TextLayer,
+  experimental
   //  ContourLayer
 } from 'deck.gl';
+const {flattenVertices} = experimental;
 
 import ContourLayer from '@deck.gl/layers/contour-layer/contour-layer';
 
@@ -169,6 +171,26 @@ const PathLayerExample = {
     getDashArray: f => [20, 0],
     widthMinPixels: 1,
     pickable: true
+  }
+};
+
+const PathLayerBinaryExample = {
+  ...PathLayerExample,
+  getData: () => {
+    const data = [];
+    dataSamples.zigzag.forEach(({path}) => {
+      // Convert each path from an array of points to an array of numbers
+      // TODO: flatten the entire data array
+      data.push(flattenVertices(path, {dimensions: 2}));
+    });
+    return data;
+  },
+  props: {
+    ...PathLayerExample.props,
+    getPath: d => {
+      d.stride = 2;
+      return d;
+    }
   }
 };
 
@@ -383,6 +405,7 @@ export default {
     'GeoJsonLayer (Extruded)': GeoJsonLayerExtrudedExample,
     PolygonLayer: PolygonLayerExample,
     PathLayer: PathLayerExample,
+    'PathLayer (Flat)': PathLayerBinaryExample,
     ScatterplotLayer: ScatterplotLayerExample,
     ArcLayer: ArcLayerExample,
     LineLayer: LineLayerExample,

--- a/modules/core/src/utils/tesselator.js
+++ b/modules/core/src/utils/tesselator.js
@@ -78,11 +78,11 @@ export default class Tesselator {
   }
 
   /* Public methods */
-  updateGeometry({data, getGeometry, stride, fp64}) {
+  updateGeometry({data, getGeometry, positionFormat, fp64}) {
     this.data = data;
     this.getGeometry = getGeometry;
     this.fp64 = fp64;
-    this.stride = stride === 2 ? 2 : 3;
+    this.positionSize = positionFormat === 'XY' ? 2 : 3;
     this._rebuildGeometry();
   }
 

--- a/modules/core/src/utils/tesselator.js
+++ b/modules/core/src/utils/tesselator.js
@@ -78,10 +78,11 @@ export default class Tesselator {
   }
 
   /* Public methods */
-  updateGeometry({data, getGeometry, fp64}) {
+  updateGeometry({data, getGeometry, stride, fp64}) {
     this.data = data;
     this.getGeometry = getGeometry;
     this.fp64 = fp64;
+    this.stride = stride === 2 ? 2 : 3;
     this._rebuildGeometry();
   }
 

--- a/modules/layers/src/path-layer/path-layer.js
+++ b/modules/layers/src/path-layer/path-layer.js
@@ -38,7 +38,6 @@ const defaultProps = {
   miterLimit: {type: 'number', min: 0, value: 4},
   fp64: false,
   dashJustified: false,
-  is3D: true,
 
   getPath: {type: 'accessor', value: object => object.path},
   getColor: {type: 'accessor', value: DEFAULT_COLOR},
@@ -126,7 +125,6 @@ export default class PathLayer extends Layer {
     const geometryChanged =
       changeFlags.dataChanged ||
       props.fp64 !== oldProps.fp64 ||
-      props.is3D !== oldProps.is3D ||
       (changeFlags.updateTriggersChanged &&
         (changeFlags.updateTriggersChanged.all || changeFlags.updateTriggersChanged.getPath));
 
@@ -134,7 +132,7 @@ export default class PathLayer extends Layer {
       this.state.pathTesselator.updateGeometry({
         data: props.data,
         getGeometry: props.getPath,
-        stride: props.is3D ? 3 : 2,
+        positionFormat: props.positionFormat,
         fp64: this.use64bitPositions()
       });
       this.setState({

--- a/modules/layers/src/path-layer/path-layer.js
+++ b/modules/layers/src/path-layer/path-layer.js
@@ -38,6 +38,7 @@ const defaultProps = {
   miterLimit: {type: 'number', min: 0, value: 4},
   fp64: false,
   dashJustified: false,
+  is3D: true,
 
   getPath: {type: 'accessor', value: object => object.path},
   getColor: {type: 'accessor', value: DEFAULT_COLOR},
@@ -125,6 +126,7 @@ export default class PathLayer extends Layer {
     const geometryChanged =
       changeFlags.dataChanged ||
       props.fp64 !== oldProps.fp64 ||
+      props.is3D !== oldProps.is3D ||
       (changeFlags.updateTriggersChanged &&
         (changeFlags.updateTriggersChanged.all || changeFlags.updateTriggersChanged.getPath));
 
@@ -132,6 +134,7 @@ export default class PathLayer extends Layer {
       this.state.pathTesselator.updateGeometry({
         data: props.data,
         getGeometry: props.getPath,
+        stride: props.is3D ? 3 : 2,
         fp64: this.use64bitPositions()
       });
       this.setState({

--- a/modules/layers/src/path-layer/path-tesselator.js
+++ b/modules/layers/src/path-layer/path-tesselator.js
@@ -144,10 +144,25 @@ export default class PathTesselator extends Tesselator {
 
   /* Utilities */
   getPathLength(path) {
+    if (Number.isFinite(path[0]) || path.stride) {
+      // flat format
+      const stride = path.stride || 3;
+      return path.length / stride;
+    }
     return path.length;
   }
 
   getPointOnPath(path, index) {
+    if (Number.isFinite(path[0]) || path.stride) {
+      // flat format
+      const stride = path.stride || 3;
+      // TODO - avoid creating new arrays when using binary
+      return [
+        path[index * stride],
+        path[index * stride + 1],
+        stride > 2 ? path[index * stride + 2] : 0
+      ];
+    }
     return path[index];
   }
 

--- a/modules/layers/src/path-layer/path-tesselator.js
+++ b/modules/layers/src/path-layer/path-tesselator.js
@@ -25,11 +25,12 @@ const {fp64LowPart} = fp64Module;
 // This class is set up to allow querying one attribute at a time
 // the way the AttributeManager expects it
 export default class PathTesselator extends Tesselator {
-  constructor({data, getGeometry, fp64}) {
+  constructor({data, getGeometry, stride, fp64}) {
     super({
       data,
       getGeometry,
       fp64,
+      stride,
       attributes: {
         startPositions: {size: 3},
         endPositions: {size: 3},
@@ -144,23 +145,22 @@ export default class PathTesselator extends Tesselator {
 
   /* Utilities */
   getPathLength(path) {
-    if (Number.isFinite(path[0]) || path.stride) {
+    if (Number.isFinite(path[0])) {
       // flat format
-      const stride = path.stride || 3;
-      return path.length / stride;
+      return path.length / this.stride;
     }
     return path.length;
   }
 
   getPointOnPath(path, index) {
-    if (Number.isFinite(path[0]) || path.stride) {
+    if (Number.isFinite(path[0])) {
       // flat format
-      const stride = path.stride || 3;
+      const {stride} = this;
       // TODO - avoid creating new arrays when using binary
       return [
         path[index * stride],
         path[index * stride + 1],
-        stride > 2 ? path[index * stride + 2] : 0
+        stride === 3 ? path[index * stride + 2] : 0
       ];
     }
     return path[index];

--- a/modules/layers/src/path-layer/path-tesselator.js
+++ b/modules/layers/src/path-layer/path-tesselator.js
@@ -25,12 +25,12 @@ const {fp64LowPart} = fp64Module;
 // This class is set up to allow querying one attribute at a time
 // the way the AttributeManager expects it
 export default class PathTesselator extends Tesselator {
-  constructor({data, getGeometry, stride, fp64}) {
+  constructor({data, getGeometry, positionFormat, fp64}) {
     super({
       data,
       getGeometry,
       fp64,
-      stride,
+      positionFormat,
       attributes: {
         startPositions: {size: 3},
         endPositions: {size: 3},
@@ -147,7 +147,7 @@ export default class PathTesselator extends Tesselator {
   getPathLength(path) {
     if (Number.isFinite(path[0])) {
       // flat format
-      return path.length / this.stride;
+      return path.length / this.positionSize;
     }
     return path.length;
   }
@@ -155,12 +155,12 @@ export default class PathTesselator extends Tesselator {
   getPointOnPath(path, index) {
     if (Number.isFinite(path[0])) {
       // flat format
-      const {stride} = this;
+      const {positionSize} = this;
       // TODO - avoid creating new arrays when using binary
       return [
-        path[index * stride],
-        path[index * stride + 1],
-        stride === 3 ? path[index * stride + 2] : 0
+        path[index * positionSize],
+        path[index * positionSize + 1],
+        positionSize === 3 ? path[index * positionSize + 2] : 0
       ];
     }
     return path[index];


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/2492

#### Background

There are several components to supporting generic binary input:

- Users need to be able to specify per-object size when the `data` prop is a flat array (see discussion on https://github.com/uber/deck.gl/pull/2436)
- PathLayer and PolygonLayer need to support flattened coordinates
- Users need to be able to supply additional information along with the flattened coordinates (e.g. dimensions of the points; hole indices, if drawing complex polygon)

#### Change List
- Binary data RFC
- Add flat path data example to layer browser
- Support flat coordinates in PathLayer (proof of concept)
- PathLayer documentation
