### PR TITLE
fix pickMultipleObjects in pathLayer

### DIFF
--- a/modules/layers/src/path-layer/path-layer.js
+++ b/modules/layers/src/path-layer/path-layer.js
@@ -307,6 +307,25 @@ export default class PathLayer extends Layer {
     const {pathTesselator} = this.state;
     attribute.value = pathTesselator.get('pickingColors', attribute.value, this.encodePickingColor);
   }
+
+  clearPickingColor(color) {
+    const index = this.decodePickingColor(color);
+    const {bufferLayout} = this.state.pathTesselator;
+    const numVertices = bufferLayout[index];
+
+    let startInd = 0;
+    for (let i = 0; i < index; i++) {
+      startInd += bufferLayout[i];
+    }
+
+    const {instancePickingColors} = this.getAttributeManager().attributes;
+
+    const {value} = instancePickingColors;
+    for (let i = 0, start = startInd * 3; i < numVertices * 3; i++) {
+      value[start + i] = 0;
+    }
+    instancePickingColors.update({value});
+  }
 }
 
 PathLayer.layerName = 'PathLayer';

--- a/modules/layers/src/path-layer/path-layer.js
+++ b/modules/layers/src/path-layer/path-layer.js
@@ -322,11 +322,7 @@ export default class PathLayer extends Layer {
 
     const {value} = instancePickingColors;
     const endInstanceIndex = startInstanceIndex + numVertices;
-    for (let i = startInstanceIndex; i < endInstanceIndex; i++) {
-      value[i * 3] = 0;
-      value[i * 3 + 1] = 0;
-      value[i * 3 + 2] = 0;
-    }
+    value.fill(0, startInstanceIndex * 3, endInstanceIndex * 3);
     instancePickingColors.update({value});
   }
 }

--- a/modules/layers/src/path-layer/path-layer.js
+++ b/modules/layers/src/path-layer/path-layer.js
@@ -309,20 +309,23 @@ export default class PathLayer extends Layer {
   }
 
   clearPickingColor(color) {
-    const index = this.decodePickingColor(color);
+    const pickedPathIndex = this.decodePickingColor(color);
     const {bufferLayout} = this.state.pathTesselator;
-    const numVertices = bufferLayout[index];
+    const numVertices = bufferLayout[pickedPathIndex];
 
-    let startInd = 0;
-    for (let i = 0; i < index; i++) {
-      startInd += bufferLayout[i];
+    let startInstanceIndex = 0;
+    for (let pathIndex = 0; pathIndex < pickedPathIndex; pathIndex++) {
+      startInstanceIndex += bufferLayout[pathIndex];
     }
 
     const {instancePickingColors} = this.getAttributeManager().attributes;
 
     const {value} = instancePickingColors;
-    for (let i = 0, start = startInd * 3; i < numVertices * 3; i++) {
-      value[start + i] = 0;
+    const endInstanceIndex = startInstanceIndex + numVertices;
+    for (let i = startInstanceIndex; i < endInstanceIndex; i++) {
+      value[i * 3] = 0;
+      value[i * 3 + 1] = 0;
+      value[i * 3 + 2] = 0;
     }
     instancePickingColors.update({value});
   }

--- a/test/modules/core/lib/pick-layers.spec.js
+++ b/test/modules/core/lib/pick-layers.spec.js
@@ -267,15 +267,15 @@ const TEST_CASES = [
         }
       ],
       pickMultipleObjects: [
-        // {
-        //   parameters: {
-        //     x: 260,
-        //     y: 300
-        //   },
-        //   results: {
-        //     count: 1
-        //   }
-        // },
+        {
+          parameters: {
+            x: 260,
+            y: 300
+          },
+          results: {
+            count: 1
+          }
+        },
         {
           parameters: {
             x: 10,
@@ -366,15 +366,15 @@ const TEST_CASES = [
         }
       ],
       pickMultipleObjects: [
-        // {
-        //   parameters: {
-        //     x: 260,
-        //     y: 300
-        //   },
-        //   results: {
-        //     count: 1
-        //   }
-        // },
+        {
+          parameters: {
+            x: 260,
+            y: 300
+          },
+          results: {
+            count: 2
+          }
+        },
         {
           parameters: {
             x: 10,


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #2478 
<!-- For other PRs without open issue -->
#### Background
In pathLayer, pickMultipleObjects is expected to return an array of different objects at the picking point. But it returns an array of same objects.
<!-- For all the PRs -->
#### Change List
- add clearPickingColor in pathLayer which overrides its parent class(layer.js)
- add test cases in picking test

Note: tested with layer browser and picking test
