### PR TITLE
fix pickMultipleObjects in pathLayer(6.3-release)

### DIFF
--- a/modules/layers/src/path-layer/path-layer.js
+++ b/modules/layers/src/path-layer/path-layer.js
@@ -434,6 +434,24 @@ export default class PathLayer extends Layer {
       }
     });
   }
+
+  clearPickingColor(color) {
+    const pickedPathIndex = this.decodePickingColor(color);
+    const {bufferLayout} = this.state;
+    const numVertices = bufferLayout[pickedPathIndex];
+
+    let startInstanceIndex = 0;
+    for (let pathIndex = 0; pathIndex < pickedPathIndex; pathIndex++) {
+      startInstanceIndex += bufferLayout[pathIndex];
+    }
+
+    const {instancePickingColors} = this.getAttributeManager().attributes;
+
+    const {value} = instancePickingColors;
+    const endInstanceIndex = startInstanceIndex + numVertices;
+    value.fill(0, startInstanceIndex * 3, endInstanceIndex * 3);
+    instancePickingColors.update({value});
+  }
 }
 
 PathLayer.layerName = 'PathLayer';


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #2478 
<!-- For other PRs without open issue -->
#### Background
In pathLayer, pickMultipleObjects is expected to return an array of different objects at the picking point. But it returns an array of same objects.
<!-- For all the PRs -->
#### Change List
- add clearPickingColor in pathLayer which overrides its parent class(layer.js)

Note: tested with layer browser and render-test
