### PR TITLE
Fix handling for event callback function return values

### DIFF
--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -246,14 +246,16 @@ export default class Layer extends Component {
   // Event handling
   onHover(info) {
     if (this.props.onHover) {
-      this.props.onHover(info, this.context.pickingEvent);
+      return this.props.onHover(info, this.context.pickingEvent);
     }
+    return false;
   }
 
   onClick(info) {
     if (this.props.onClick) {
-      this.props.onClick(info, this.context.pickingEvent);
+      return this.props.onClick(info, this.context.pickingEvent);
     }
+    return false;
   }
 
   // Returns the picking color that doesn't match any subfeature


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/2533

#### Background

We are using the return value of `layer.onClick` and `layer.onHover` here:
https://github.com/uber/deck.gl/blob/master/modules/core/src/lib/pick-layers.js#L398
But the default implementations do not return anything.

This was broken by
https://github.com/uber/deck.gl/commit/940f1b023c1b53be6dadcf4edcb0083331ddf136#diff-53a662c6a53ead1797297b72797107d9

#### Change List
- Use the return values of user supplied `onClick` and `onHover`
