### PR TITLE
modify clearPickingColor in solid-polygon-layer

### DIFF
--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -360,6 +360,24 @@ export default class SolidPolygonLayer extends Layer {
       this.encodePickingColor
     );
   }
+
+  clearPickingColor(color) {
+    const pickedPolygonIndex = this.decodePickingColor(color);
+    const {bufferLayout} = this.state.polygonTesselator;
+    const numVertices = bufferLayout[pickedPolygonIndex];
+
+    let startInstanceIndex = 0;
+    for (let polygonIndex = 0; polygonIndex < pickedPolygonIndex; polygonIndex++) {
+      startInstanceIndex += bufferLayout[polygonIndex];
+    }
+
+    const {pickingColors} = this.getAttributeManager().attributes;
+
+    const {value} = pickingColors;
+    const endInstanceIndex = startInstanceIndex + numVertices;
+    value.fill(0, startInstanceIndex * 3, endInstanceIndex * 3);
+    pickingColors.update({value});
+  }
 }
 
 SolidPolygonLayer.layerName = 'SolidPolygonLayer';


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #2537 
<!-- For other PRs without open issue -->
#### Background
The current clearPickingColor method in solid-polygon-layer is inefficient in performance. We can improve the time complexity from linear to constant
<!-- For all the PRs -->
#### Change List
- override clearPickingColor method by finding the starting and ending offset of the data points which have the same picking color as the selected picking color and then updating values

note: tested with picking test and layer browser