### PR TITLE
Apply TinySDF to TextLayer

### DIFF
--- a/docs/layers/text-layer.md
+++ b/docs/layers/text-layer.md
@@ -49,8 +49,10 @@ const App = ({data, viewport}) => {
 
 ## Example: rendering with sdf (Signed Distance Fields)
 
-This approach is slower but can provide a better this font is slower to generate but can provide a sharper look
-when used with very large or small font sizes.
+You may consider using [`sdf` (Signed Distance Fields)](http://cs.brown.edu/people/pfelzens/papers/dt-final.pdf)
+option when rendering with very large or small font sizes, which will provide a sharper look. `TextLayer` integrates 
+with [`TinySDF`](https://github.com/mapbox/tiny-sdf) which implements the `sdf` algorithm. You can enable `sdf` by 
+setting `sdf` to true or pass customized options, which will be used in `TinySDF`.
 
 ```js
 import DeckGL from 'deck.gl';
@@ -69,14 +71,14 @@ const App = ({data, viewport}) => {
     id: 'text-layer',
     data,
    
-   // sdf will be used to construct `TinySDF` instance
+   // sdf object will be used to construct `TinySDF` instance
    // https://github.com/mapbox/tiny-sdf
     sdf: {
       fontSize: 64,
-      buffer: 0,
+      buffer: 1,
       radius: 3,
       cutoff: 0.25,
-      fontWeight: 'normal',
+      fontWeight: 'normal'
     },
 
     pickable: true,

--- a/docs/layers/text-layer.md
+++ b/docs/layers/text-layer.md
@@ -8,6 +8,10 @@
 
 The text layer renders text labels on the map using texture mapping. This Layer is extended based on [Icon Layer](/docs/layers/icon-layer.md) and wrapped using [Composite Layer](/docs/api-reference/composite-layer.md).
 
+Auto pack required `characterSet` into a shared texture `fontAtlas`.
+
+## Example
+
 ```js
 import DeckGL from 'deck.gl';
 import TextLayer from './text-layer';
@@ -43,7 +47,104 @@ const App = ({data, viewport}) => {
 };
 ```
 
+## Example: rendering with sdf (Signed Distance Fields)
+
+This approach is slower but can provide a better this font is slower to generate but can provide a sharper look
+when used with very large or small font sizes.
+
+```js
+import DeckGL from 'deck.gl';
+import TextLayer from './text-layer';
+
+const App = ({data, viewport}) => {
+  /**
+   * Data format:
+   * [
+   *   {name: 'Colma (COLM)', address: '365 D Street, Colma CA 94014', coordinates: [-122.466233, 37.684638]},
+   *   ...
+   * ]
+   */
+
+  const layer = new TextLayer({
+    id: 'text-layer',
+    data,
+   
+   // sdf will be used to construct `TinySDF` instance
+   // https://github.com/mapbox/tiny-sdf
+    sdf: {
+      fontSize: 64,
+      buffer: 0,
+      radius: 3,
+      cutoff: 0.25,
+      fontWeight: 'normal',
+    },
+
+    pickable: true,
+    getPosition: d => d.coordinates,
+    getText: d => d.name,
+    getSize: 32,
+    getAngle: 0,
+    getTextAnchor: 'middle',
+    getAlignmentBaseline: 'center',
+    onHover: ({object, x, y}) => {
+      const tooltip = `${object.name}\n${object.address}`;
+      /* Update tooltip
+         http://deck.gl/#/documentation/developer-guide/adding-interactivity?section=example-display-a-tooltip-for-hovered-object
+      */
+    }
+  });
+
+  return <DeckGL {...viewport} layers={[layer]} />;
+};
+```
+
 ## Properties
+
+### Rendering Options
+
+##### `sizeScale` (Number, optional)
+
+* Default: 1
+
+Text size multiplier.
+
+##### `fp64` (Boolean, optional)
+
+* Default: `false`
+
+Whether the layer should be rendered in high-precision 64-bit mode. Note that since deck.gl v6.1, the default 32-bit projection uses a hybrid mode that matches 64-bit precision with significantly better performance.
+
+##### `fontFamily` (String, optional)
+
+* Default: `'Monaco, monospace'`
+
+Specifies a prioritized list of one or more font family names and/or generic family names. Follow the specs for CSS [font-family](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family).
+
+##### `characterSet` (Array | String, optional)
+
+Specifies a list of characters to include in the font. By default, only characters in the Ascii code range 32-128 are included. Use this prop if you need to display special characters.
+
+##### `sdf` (Boolean | Object, optional)
+
+* Default: `false`
+
+To use [`sdf` (Signed Distance Fields)](http://cs.brown.edu/people/pfelzens/papers/dt-final.pdf) to 
+generate font, set `sdf` to be true or use customized parameters. The parameters will be used in constructing
+[`TinySDF`](https://github.com/mapbox/tiny-sdf) instance.  
+
+Default `sdf` preset is
+
+```js
+{
+ fontSize: 64,
+ buffer: 2,
+ radius: 3,
+ cutoff: 0.25,
+ 
+ fontFamily: props.fontFamily, // from layer property 
+ fontWeight: 'normal'
+}
+```
 
 ### Data Accessors
 
@@ -89,31 +190,6 @@ The rotating angle of each text label, in degrees.
 * If a number is provided, it is used as the angle for all objects.
 * If a function is provided, it is called on each object to retrieve its angle.
 
-
-### Rendering Options
-
-##### `sizeScale` (Number, optional)
-
-* Default: 1
-
-Text size multiplier.
-
-##### `fp64` (Boolean, optional)
-
-* Default: `false`
-
-Whether the layer should be rendered in high-precision 64-bit mode. Note that since deck.gl v6.1, the default 32-bit projection uses a hybrid mode that matches 64-bit precision with significantly better performance.
-
-##### `fontFamily` (String, optional)
-
-* Default: `'Monaco, monospace'`
-
-Specifies a prioritized list of one or more font family names and/or generic family names. Follow the specs for CSS [font-family](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family).
-
-##### `characterSet` (Array | String, optional)
-
-Specifies a list of characters to include in the font. By default, only characters in the Ascii code range 32-128 are included. Use this prop if you need to display special characters.
-
 ### Text Alignment Options
 
 ##### `getTextAnchor` (Function|String, optional)
@@ -149,5 +225,3 @@ Screen space offset relative to the `coordinates` in pixel unit.
 ## Source
 
 [modules/layers/src/text-layer](https://github.com/uber/deck.gl/tree/master/modules/layers/src/text-layer)
-
-

--- a/examples/layer-browser/src/examples/core-layers.js
+++ b/examples/layer-browser/src/examples/core-layers.js
@@ -363,7 +363,7 @@ const TextLayerExample = {
     }
   },
   props: {
-    id: 'text-layer',
+    id: 'textgetAnchorX-layer',
     sizeScale: 1,
     fontFamily: 'Monaco',
     getText: x => x.LOCATION_NAME,

--- a/modules/layers/package.json
+++ b/modules/layers/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@deck.gl/core": "^7.0.0-alpha.2",
+    "@mapbox/tiny-sdf": "^1.1.0",
     "d3-hexbin": "^0.2.1",
     "earcut": "^2.0.6"
   }

--- a/modules/layers/src/text-layer/font-atlas.js
+++ b/modules/layers/src/text-layer/font-atlas.js
@@ -45,8 +45,8 @@ function buildMapping({ctx, fontHeight, buffer, characterSet, maxCanvasWidth}) {
       row++;
     }
     mapping[char] = {
-      x,
-      y: row * (fontHeight + buffer * 2),
+      x: x + buffer,
+      y: row * (fontHeight + buffer * 2) + buffer,
       width,
       height: fontHeight,
       mask: true
@@ -109,12 +109,16 @@ export function makeFontAtlas(
     // used to store distance values from tinySDF
     const imageData = ctx.createImageData(tinySDF.size, tinySDF.size);
 
-    for (const char in mapping) {
+    for (const char of characterSet) {
       populateAlphaChannel(tinySDF.draw(char), imageData);
-      ctx.putImageData(imageData, mapping[char].x, mapping[char].y);
+      ctx.putImageData(
+        imageData,
+        mapping[char].x - fontSettings.buffer,
+        mapping[char].y - fontSettings.buffer
+      );
     }
   } else {
-    for (const char in mapping) {
+    for (const char of characterSet) {
       ctx.fillText(char, mapping[char].x, mapping[char].y + fontSettings.fontSize * BASELINE_SCALE);
     }
   }

--- a/modules/layers/src/text-layer/font-atlas.js
+++ b/modules/layers/src/text-layer/font-atlas.js
@@ -1,19 +1,28 @@
 /* global document */
 import {Texture2D} from 'luma.gl';
+import TinySDF from '@mapbox/tiny-sdf';
 
 const GL_TEXTURE_WRAP_S = 0x2802;
 const GL_TEXTURE_WRAP_T = 0x2803;
 const GL_CLAMP_TO_EDGE = 0x812f;
 const MAX_CANVAS_WIDTH = 1024;
-const DEFAULT_FONT_SIZE = 64;
-const DEFAULT_PADDING = 4;
 
 const BASELINE_SCALE = 0.9;
 const HEIGHT_SCALE = 1.2;
 
+export const DEFAULT_PADDING = 2;
+export const DEFAULT_FONT_SIZE = 64;
+
 export const DEFAULT_CHAR_SET = [];
 for (let i = 32; i < 128; i++) {
   DEFAULT_CHAR_SET.push(String.fromCharCode(i));
+}
+
+function populateAlphaChannel(alphaChannel, imageData) {
+  // populate distance value from tinySDF to image alpha channel
+  for (let i = 0; i < alphaChannel.length; i++) {
+    imageData.data[4 * i + 3] = alphaChannel[i];
+  }
 }
 
 function setTextStyle(ctx, fontFamily, fontSize) {
@@ -23,50 +32,77 @@ function setTextStyle(ctx, fontFamily, fontSize) {
   ctx.textAlign = 'left';
 }
 
+function buildMapping({ctx, fontHeight, buffer, characterSet, maxCanvasWidth}) {
+  const mapping = {};
+  let row = 0;
+  let x = 0;
+  Array.from(characterSet).forEach(char => {
+    // measure texts
+    const {width} = ctx.measureText(char);
+
+    if (x + width > maxCanvasWidth) {
+      x = 0;
+      row++;
+    }
+    mapping[char] = {
+      x,
+      y: row * (fontHeight + buffer * 2),
+      width,
+      height: fontHeight,
+      mask: true
+    };
+    x += width + buffer * 2;
+  });
+
+  const canvasHeight = (row + 1) * (fontHeight + buffer * 2);
+
+  return {mapping, canvasHeight};
+}
+
 export function makeFontAtlas(
   gl,
   {
+    sdf,
     fontFamily,
-    characterSet = DEFAULT_CHAR_SET,
     fontSize = DEFAULT_FONT_SIZE,
+    characterSet = DEFAULT_CHAR_SET,
     padding = DEFAULT_PADDING
   }
 ) {
   const canvas = document.createElement('canvas');
   const ctx = canvas.getContext('2d');
 
-  // measure texts
-  let row = 0;
-  let x = 0;
+  // build mapping
   // TODO - use Advanced text metrics when they are adopted:
   // https://developer.mozilla.org/en-US/docs/Web/API/TextMetrics
-  const fontHeight = fontSize * HEIGHT_SCALE;
   setTextStyle(ctx, fontFamily, fontSize);
-  const mapping = {};
-
-  Array.from(characterSet).forEach(char => {
-    const {width} = ctx.measureText(char);
-
-    if (x + width > MAX_CANVAS_WIDTH) {
-      x = 0;
-      row++;
-    }
-    mapping[char] = {
-      x,
-      y: row * (fontHeight + padding),
-      width,
-      height: fontHeight,
-      mask: true
-    };
-    x += width + padding;
+  const {canvasHeight, mapping} = buildMapping({
+    ctx,
+    fontHeight: (sdf ? sdf.fontSize : fontSize) * HEIGHT_SCALE,
+    buffer: sdf ? sdf.buffer : padding,
+    characterSet,
+    maxCanvasWidth: MAX_CANVAS_WIDTH
   });
 
   canvas.width = MAX_CANVAS_WIDTH;
-  canvas.height = (row + 1) * (fontHeight + padding);
-
+  canvas.height = canvasHeight;
   setTextStyle(ctx, fontFamily, fontSize);
-  for (const char in mapping) {
-    ctx.fillText(char, mapping[char].x, mapping[char].y + fontSize * BASELINE_SCALE);
+
+  // layout characters
+  if (sdf) {
+    const {buffer, radius, cutoff, fontWeight} = sdf;
+    const tinySDF = new TinySDF(fontSize, buffer, radius, cutoff, fontFamily, fontWeight);
+    // used to store distance values from tinySDF
+    const imageData = ctx.createImageData(tinySDF.size, tinySDF.size);
+
+    for (const char in mapping) {
+      populateAlphaChannel(tinySDF.draw(char), imageData);
+      ctx.putImageData(imageData, mapping[char].x, mapping[char].y);
+    }
+  } else {
+    for (const char in mapping) {
+      ctx.fillText(char, mapping[char].x, mapping[char].y + fontSize * BASELINE_SCALE);
+    }
   }
 
   return {

--- a/modules/layers/src/text-layer/font-atlas.js
+++ b/modules/layers/src/text-layer/font-atlas.js
@@ -75,23 +75,37 @@ export function makeFontAtlas(
   // build mapping
   // TODO - use Advanced text metrics when they are adopted:
   // https://developer.mozilla.org/en-US/docs/Web/API/TextMetrics
-  setTextStyle(ctx, fontFamily, fontSize);
+  const fontSettings = {
+    fontSize: sdf ? sdf.fontSize : fontSize,
+    fontFamily: sdf ? sdf.fontFamily : fontFamily,
+    fontHeight: (sdf ? sdf.fontSize : fontSize) * HEIGHT_SCALE,
+    buffer: sdf ? sdf.buffer : padding
+  };
+
+  setTextStyle(ctx, fontSettings.fontFamily, fontSettings.fontSize);
   const {canvasHeight, mapping} = buildMapping({
     ctx,
-    fontHeight: (sdf ? sdf.fontSize : fontSize) * HEIGHT_SCALE,
-    buffer: sdf ? sdf.buffer : padding,
+    fontHeight: fontSettings.fontHeight,
+    buffer: fontSettings.buffer,
     characterSet,
     maxCanvasWidth: MAX_CANVAS_WIDTH
   });
 
   canvas.width = MAX_CANVAS_WIDTH;
   canvas.height = canvasHeight;
-  setTextStyle(ctx, fontFamily, fontSize);
+  setTextStyle(ctx, fontSettings.fontFamily, fontSettings.fontSize);
 
   // layout characters
   if (sdf) {
-    const {buffer, radius, cutoff, fontWeight} = sdf;
-    const tinySDF = new TinySDF(fontSize, buffer, radius, cutoff, fontFamily, fontWeight);
+    const tinySDF = new TinySDF(
+      fontSettings.fontSize,
+      fontSettings.buffer,
+      sdf.radius,
+      sdf.cutoff,
+      fontSettings.fontFamily,
+      sdf.fontWeight
+    );
+    setTextStyle(tinySDF.ctx, fontFamily, fontSize);
     // used to store distance values from tinySDF
     const imageData = ctx.createImageData(tinySDF.size, tinySDF.size);
 
@@ -101,7 +115,7 @@ export function makeFontAtlas(
     }
   } else {
     for (const char in mapping) {
-      ctx.fillText(char, mapping[char].x, mapping[char].y + fontSize * BASELINE_SCALE);
+      ctx.fillText(char, mapping[char].x, mapping[char].y + fontSettings.fontSize * BASELINE_SCALE);
     }
   }
 

--- a/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer-fragment.glsl.js
+++ b/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer-fragment.glsl.js
@@ -23,10 +23,9 @@ export default `\
 
 precision highp float;
 
-uniform float opacity;
 uniform sampler2D iconsTexture;
 uniform float buffer;
-uniform float sdf;
+uniform bool sdf;
 
 varying vec4 vColor;
 varying vec2 vTextureCoords;
@@ -39,13 +38,13 @@ void main(void) {
   
   float alpha = texColor.a;
   // if enable sdf (signed distance fields)
-  if (sdf > 0.5) {
+  if (sdf) {
     float distance = texture2D(iconsTexture, vTextureCoords).a;
     alpha = smoothstep(buffer - vGamma, buffer + vGamma, distance);
   }
 
   // Take the global opacity and the alpha from vColor into account for the alpha component
-  float a = alpha * opacity * vColor.a;
+  float a = alpha * vColor.a;
 
   if (a < MIN_ALPHA) {
     discard;

--- a/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer-fragment.glsl.js
+++ b/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer-fragment.glsl.js
@@ -1,0 +1,62 @@
+// Copyright (c) 2015 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+export default `\
+#define SHADER_NAME multi-icon-layer-fragment-shader
+
+precision highp float;
+
+uniform float opacity;
+uniform sampler2D iconsTexture;
+uniform float buffer;
+uniform float sdf;
+
+varying vec4 vColor;
+varying vec2 vTextureCoords;
+varying float vGamma;
+
+const float MIN_ALPHA = 0.05;
+
+void main(void) {
+  vec4 texColor = texture2D(iconsTexture, vTextureCoords);
+  
+  float alpha = texColor.a;
+  // if enable sdf (signed distance fields)
+  if (sdf > 0.5) {
+    float distance = texture2D(iconsTexture, vTextureCoords).a;
+    alpha = smoothstep(buffer - vGamma, buffer + vGamma, distance);
+  }
+
+  // Take the global opacity and the alpha from vColor into account for the alpha component
+  float a = alpha * opacity * vColor.a;
+
+  if (a < MIN_ALPHA) {
+    discard;
+  }
+
+  gl_FragColor = vec4(vColor.rgb, a);
+
+  // use highlight color if this fragment belongs to the selected object.
+  gl_FragColor = picking_filterHighlightColor(gl_FragColor);
+
+  // use picking color if rendering to picking FBO.
+  gl_FragColor = picking_filterPickingColor(gl_FragColor);
+}
+`;

--- a/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer-vertex.glsl.js
+++ b/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer-vertex.glsl.js
@@ -38,10 +38,12 @@ attribute vec2 instancePixelOffset;
 
 uniform float sizeScale;
 uniform vec2 iconsTextureDim;
+uniform float gamma;
 
 varying float vColorMode;
 varying vec4 vColor;
 varying vec2 vTextureCoords;
+varying float vGamma;
 
 vec2 rotate_by_angle(vec2 vertex, float angle) {
   float angle_radian = angle * PI / 180.0;
@@ -77,6 +79,6 @@ void main(void) {
   vColor = instanceColors / 255.;
   picking_setPickingColor(instancePickingColors);
 
-  vColorMode = instanceColorModes;
+  vGamma = gamma / (sizeScale * iconSize.y);
 }
 `;

--- a/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer-vertex.glsl.js
+++ b/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer-vertex.glsl.js
@@ -39,6 +39,7 @@ attribute vec2 instancePixelOffset;
 uniform float sizeScale;
 uniform vec2 iconsTextureDim;
 uniform float gamma;
+uniform float opacity;
 
 varying float vColorMode;
 varying vec4 vColor;
@@ -76,7 +77,7 @@ void main(void) {
 
   vTextureCoords.y = 1.0 - vTextureCoords.y;
 
-  vColor = instanceColors / 255.;
+  vColor = vec4(instanceColors.rgb, instanceColors.a * opacity) / 255.;
   picking_setPickingColor(instancePickingColors);
 
   vGamma = gamma / (sizeScale * iconSize.y);

--- a/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer.js
+++ b/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer.js
@@ -21,6 +21,11 @@
 import IconLayer from '../../icon-layer/icon-layer';
 
 import vs from './multi-icon-layer-vertex.glsl';
+import fs from './multi-icon-layer-fragment.glsl';
+
+// TODO expose as layer properties
+const DEFAULT_GAMMA = 0.2;
+const DEFAULT_BUFFER = 192.0 / 256;
 
 const defaultProps = {
   getShiftInQueue: {type: 'accessor', value: x => x.shift || 0},
@@ -35,7 +40,8 @@ const defaultProps = {
 export default class MultiIconLayer extends IconLayer {
   getShaders() {
     return Object.assign({}, super.getShaders(), {
-      vs
+      vs,
+      fs
     });
   }
 
@@ -62,6 +68,19 @@ export default class MultiIconLayer extends IconLayer {
     ) {
       this.getAttributeManager().invalidate('instanceOffsets');
     }
+  }
+
+  draw({uniforms}) {
+    const {sdf} = this.props;
+    super.draw({
+      uniforms: Object.assign({}, uniforms, {
+        // Refer the following doc about gamma and buffer
+        // https://blog.mapbox.com/drawing-text-with-signed-distance-fields-in-mapbox-gl-b0933af6f817
+        buffer: DEFAULT_BUFFER,
+        gamma: DEFAULT_GAMMA,
+        sdf: Boolean(sdf)
+      })
+    });
   }
 
   calculateInstanceOffsets(attribute) {

--- a/modules/layers/src/text-layer/text-layer.js
+++ b/modules/layers/src/text-layer/text-layer.js
@@ -40,9 +40,9 @@ const DEFAULT_COLOR = [0, 0, 0, 255];
 const MISSING_CHAR_WIDTH = 32;
 
 // used in TinySDF
-const SDFPreset = {
+const SDF_PRESET = {
   fontSize: DEFAULT_FONT_SIZE,
-  radius: 3,
+  radius: 2,
   buffer: 2,
   cutoff: 0.25,
   fontWeight: 'normal'
@@ -92,8 +92,18 @@ export default class TextLayer extends CompositeLayer {
     const {gl} = this.context;
     const {sdf, fontFamily, characterSet} = this.props;
 
+    let sdfSettings = null;
+    if (sdf) {
+      sdfSettings = Object.assign({}, SDF_PRESET, {fontFamily});
+      // merge with user settings
+      // override fontFamily with layer prop's fontFamily
+      if (typeof sdf === 'object') {
+        Object.assign(sdfSettings, sdf, {fontFamily});
+      }
+    }
+
     const {scale, mapping, texture} = makeFontAtlas(gl, {
-      sdf: sdf ? SDFPreset : null,
+      sdf: sdfSettings,
       fontFamily,
       characterSet
     });

--- a/modules/layers/src/text-layer/text-layer.js
+++ b/modules/layers/src/text-layer/text-layer.js
@@ -20,7 +20,7 @@
 
 import {CompositeLayer, log} from '@deck.gl/core';
 import MultiIconLayer from './multi-icon-layer/multi-icon-layer';
-import {makeFontAtlas, DEFAULT_CHAR_SET} from './font-atlas';
+import {makeFontAtlas, DEFAULT_CHAR_SET, DEFAULT_FONT_SIZE} from './font-atlas';
 
 const TEXT_ANCHOR = {
   start: 1,
@@ -39,11 +39,21 @@ const DEFAULT_COLOR = [0, 0, 0, 255];
 
 const MISSING_CHAR_WIDTH = 32;
 
+// used in TinySDF
+const SDFPreset = {
+  fontSize: DEFAULT_FONT_SIZE,
+  radius: 3,
+  buffer: 2,
+  cutoff: 0.25,
+  fontWeight: 'normal'
+};
+
 const defaultProps = {
   fp64: false,
   sizeScale: 1,
-  fontFamily: DEFAULT_FONT_FAMILY,
+  sdf: false,
   characterSet: DEFAULT_CHAR_SET,
+  fontFamily: DEFAULT_FONT_FAMILY,
 
   getText: {type: 'accessor', value: x => x.text},
   getPosition: {type: 'accessor', value: x => x.position},
@@ -58,10 +68,12 @@ const defaultProps = {
 export default class TextLayer extends CompositeLayer {
   updateState({props, oldProps, changeFlags}) {
     const fontChanged =
-      oldProps.fontFamily !== props.fontFamily || oldProps.characterSet !== props.characterSet;
+      oldProps.fontFamily !== props.fontFamily ||
+      oldProps.characterSet !== props.characterSet ||
+      oldProps.sdf !== props.sdf;
 
     if (fontChanged) {
-      this.updateFontAtlas(props.fontFamily, props.characterSet);
+      this.updateFontAtlas();
     }
 
     if (
@@ -74,9 +86,20 @@ export default class TextLayer extends CompositeLayer {
     }
   }
 
-  updateFontAtlas(fontFamily, characterSet) {
+  updateFontAtlas() {
+    const startTime = Date.now();
+
     const {gl} = this.context;
-    const {scale, mapping, texture} = makeFontAtlas(gl, {fontFamily, characterSet});
+    const {sdf, fontFamily, characterSet} = this.props;
+
+    const {scale, mapping, texture} = makeFontAtlas(gl, {
+      sdf: sdf ? SDFPreset : null,
+      fontFamily,
+      characterSet
+    });
+
+    log.log(`Make font atlas in ${Date.now() - startTime} milliseconds.`)();
+
     this.setState({
       scale,
       iconAtlas: texture,
@@ -172,6 +195,7 @@ export default class TextLayer extends CompositeLayer {
       getAlignmentBaseline,
       getPixelOffset,
       fp64,
+      sdf,
       sizeScale,
       transitions,
       updateTriggers
@@ -182,6 +206,7 @@ export default class TextLayer extends CompositeLayer {
         this.getSubLayerProps({
           id: 'text-multi-icon-layer',
           data,
+          sdf,
           iconAtlas,
           iconMapping,
           getIcon: d => d.text,
@@ -196,6 +221,7 @@ export default class TextLayer extends CompositeLayer {
           getPixelOffset: this._getAccessor(getPixelOffset),
           fp64,
           sizeScale: sizeScale * scale,
+
           transitions: transitions && {
             getPosition: transitions.getPosition,
             getAngle: transitions.getAngle,


### PR DESCRIPTION
#### Background
[issue](https://github.com/uber/deck.gl/issues/2546)

This PR focuses on the first and second items

- Use SDF in font atlas generation
- fontSmoothing: Number

<!-- For all the PRs -->
#### Change List
- Applied `TinySDF` library to encode the distance (distance between a data point and nearest character edge) into texture alpha channel


Rendering comparison:

1. looking:
```
sizeScale: 48
getSize: 100
```

Left is the original code, right is with `sdf` applied. 

![tiny-sdf](https://user-images.githubusercontent.com/2927808/51114220-f0c6b180-1804-11e9-984b-915eb2e39d4d.png)

2. performance:

```
fontSize: 64 // used in generating `fontAtlas`
```
Time used for generating fontAtlas:
```
original: <5 milliseconds 
sdf:      ~50 - 100 milliseconds 
```






