### PR TITLE
ScreenGridLayer: add support Min/Max/Mean aggregation

### DIFF
--- a/docs/layers/screen-grid-layer.md
+++ b/docs/layers/screen-grid-layer.md
@@ -100,6 +100,18 @@ When set to true and browser supports GPU aggregation, aggregation is performed 
 
 NOTE: GPU Aggregation requires WebGL2 support by the browser. When `gpuAggregation` is set to true and browser doesn't support WebGL2, aggregation falls back to CPU.
 
+##### `aggregation` (String, optional) **EXPERIMENTAL** **NEW in 7.0**
+
+* Default: 'SUM'
+
+Defines the type of aggregation operation, valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. When no value or an invalid value is set, 'SUM' is used as aggregation.
+
+* SUM : Grid cell contains sum of all weights that fall into it.
+* MEAN : Grid cell contains mean of all weights that fall into it.
+* MIN : Grid cell contains minimum of all weights that fall into it.
+* MAX : Grid cell contains maximum of all weights that fall into it.
+
+
 ### Data Accessors
 
 ##### `getPosition` (Function, optional)

--- a/examples/website/screen-grid/app.js
+++ b/examples/website/screen-grid/app.js
@@ -31,7 +31,7 @@ const colorRange = [
 
 export class App extends Component {
   _renderLayers() {
-    const {data = DATA_URL, cellSize = 20, gpuAggregation = true} = this.props;
+    const {data = DATA_URL, cellSize = 20, gpuAggregation = true, aggregation = 'Sum'} = this.props;
 
     return [
       new ScreenGridLayer({
@@ -41,7 +41,8 @@ export class App extends Component {
         getWeight: d => d[2],
         cellSizePixels: cellSize,
         colorRange,
-        gpuAggregation
+        gpuAggregation,
+        aggregation
       })
     ];
   }

--- a/modules/layers/src/screen-grid-layer/screen-grid-layer-fragment-webgl1.glsl.js
+++ b/modules/layers/src/screen-grid-layer/screen-grid-layer-fragment-webgl1.glsl.js
@@ -25,8 +25,12 @@ export default `\
 precision highp float;
 
 varying vec4 vColor;
+varying float vSampleCount;
 
 void main(void) {
+  if (vSampleCount <= 0.0) {
+    discard;
+  }
   gl_FragColor = vColor;
 
   gl_FragColor = picking_filterColor(gl_FragColor);

--- a/modules/layers/src/screen-grid-layer/screen-grid-layer-fragment.glsl.js
+++ b/modules/layers/src/screen-grid-layer/screen-grid-layer-fragment.glsl.js
@@ -26,9 +26,13 @@ export default `\
 precision highp float;
 
 in vec4 vColor;
+in float vSampleCount;
 out vec4 fragColor;
 
 void main(void) {
+  if (vSampleCount <= 0.0) {
+    discard;
+  }
   fragColor = vColor;
 
   fragColor = picking_filterColor(fragColor);

--- a/modules/layers/src/screen-grid-layer/screen-grid-layer-vertex-webgl1.glsl.js
+++ b/modules/layers/src/screen-grid-layer/screen-grid-layer-vertex-webgl1.glsl.js
@@ -37,6 +37,7 @@ uniform vec2 colorDomain;
 uniform bool shouldUseMinMax;
 
 varying vec4 vColor;
+varying float vSampleCount;
 
 vec4 quantizeScale(vec2 domain, vec4 range[RANGE_COUNT], float value) {
   vec4 outColor = vec4(0., 0., 0., 0.);
@@ -58,6 +59,8 @@ vec4 quantizeScale(vec2 domain, vec4 range[RANGE_COUNT], float value) {
 }
 
 void main(void) {
+  vSampleCount = instanceCounts.a;
+
   float weight = instanceCounts.r;
   float step = weight / maxWeight;
   vec4 minMaxColor = mix(minColor, maxColor, step) / 255.;

--- a/modules/layers/src/screen-grid-layer/screen-grid-layer-vertex.glsl.js
+++ b/modules/layers/src/screen-grid-layer/screen-grid-layer-vertex.glsl.js
@@ -43,6 +43,7 @@ uniform vec2 colorDomain;
 uniform bool shouldUseMinMax;
 
 out vec4 vColor;
+out float vSampleCount;
 
 vec4 quantizeScale(vec2 domain, vec4 range[RANGE_COUNT], float value) {
   vec4 outColor = vec4(0., 0., 0., 0.);
@@ -64,6 +65,8 @@ vec4 quantizeScale(vec2 domain, vec4 range[RANGE_COUNT], float value) {
 }
 
 void main(void) {
+  vSampleCount = instanceCounts.a;
+
   float weight = instanceCounts.r ;
   float maxWeight = aggregationData.maxCount.r;
   float step = weight / maxWeight;

--- a/modules/layers/src/screen-grid-layer/screen-grid-layer.js
+++ b/modules/layers/src/screen-grid-layer/screen-grid-layer.js
@@ -51,7 +51,8 @@ const defaultProps = {
   getPosition: {type: 'accessor', value: d => d.position},
   getWeight: {type: 'accessor', value: d => [1, 0, 0]},
 
-  gpuAggregation: true
+  gpuAggregation: true,
+  aggregation: 'SUM'
 };
 
 export default class ScreenGridLayer extends Layer {
@@ -215,7 +216,7 @@ export default class ScreenGridLayer extends Layer {
     const cellSizeChanged =
       props.cellSizePixels !== oldProps.cellSizePixels ||
       props.cellMarginPixels !== oldProps.cellMarginPixels;
-    const dataChanged = changeFlags.dataChanged;
+    const dataChanged = changeFlags.dataChanged || props.aggregation !== oldProps.aggregation;
     const viewportChanged = changeFlags.viewportChanged;
 
     if (cellSizeChanged || dataChanged || viewportChanged) {
@@ -316,6 +317,9 @@ export default class ScreenGridLayer extends Layer {
 
     const {positions, weights} = this.state;
     const {viewport} = this.context;
+
+    weights.color.operation =
+      AGGREGATION_OPERATION[this.props.aggregation.toUpperCase()] || AGGREGATION_OPERATION.SUM;
 
     let projectPoints = false;
     let gridTransformMatrix = null;


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #2541 
<!-- For other PRs without open issue -->
#### Background
- Add a new experimental prop `aggregation`, to use Sum, Mean, Min or Max as aggregation operation. Default behavior is un-changed, we use `Sum` as aggregation operation.
- When performing `Min`, cell's that do not have any data points will have max float value, so update shaders to discard all cells, that do not have any data points.
<!-- For all the PRs -->
#### Change List
- ScreenGridLayer: add support Min/Max/Mean aggregation
