### PR TITLE
reset blend params after mapbox render

### DIFF
--- a/modules/mapbox/src/deck-utils.js
+++ b/modules/mapbox/src/deck-utils.js
@@ -9,9 +9,12 @@ export function getDeckInstance({map, gl, deck}) {
   const deckProps = {
     useDevicePixels: true,
     _customRender: () => map.triggerRepaint(),
+    // TODO: import these defaults from a single source of truth
     parameters: {
       depthMask: true,
-      depthTest: true
+      depthTest: true,
+      blendFunc: [gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA],
+      blendEquation: gl.FUNC_ADD
     },
     userData: {
       isExternal: false,


### PR DESCRIPTION
After Mapbox renders, the GL context is not restored to its previous state. Let's reset the blend parameters after Mapbox renders in order to ensure a restored state.