### PR TITLE
Support flat data input to polygon layer

### DIFF
--- a/docs/layers/path-layer.md
+++ b/docs/layers/path-layer.md
@@ -100,7 +100,7 @@ Only effective if `getDashArray` is specified. If `true`, adjust gaps for the da
 
 * Default: `object => object.path`
 
-This accessor returns the path corresponding to an object in the `data` stream.
+Called on each object in the `data` stream to retrieve its corresponding path.
 
 A path can be one of the following formats:
 

--- a/docs/layers/path-layer.md
+++ b/docs/layers/path-layer.md
@@ -100,12 +100,12 @@ Only effective if `getDashArray` is specified. If `true`, adjust gaps for the da
 
 * Default: `object => object.path`
 
-Returns the specified path for the object.
+This accessor returns the path corresponding to an object in the `data` stream.
 
 A path can be one of the following formats:
 
 * An array of points (`[x, y, z]`). Compatible with the GeoJSON [LineString](https://tools.ietf.org/html/rfc7946#section-3.1.4) specification.
-* A flat array or [TypedArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) of numbers, in the shape of `[x0, y0, z0, x1, y1, z1, ...]`. By default, each coordinate is assumed to contain 3 consecutive numbers. If each coordinate contains only two numbers (x, y), set the `positionFormat` prop to `XY`:
+* A flat array or [TypedArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) of numbers, in the shape of `[x0, y0, z0, x1, y1, z1, ...]`. By default, each coordinate is assumed to contain 3 consecutive numbers. If each coordinate contains only two numbers (x, y), set the `positionFormat` prop of the layer to `XY`:
 
 ```js
 new PathLayer({

--- a/docs/layers/polygon-layer.md
+++ b/docs/layers/polygon-layer.md
@@ -172,11 +172,16 @@ Be aware that this prop will likely be changed in a future version of deck.gl.
 
 * default: `object => object.polygon`
 
-Like any deck.gl layer, the polygon accepts a data prop which is expected to
-be an iterable container of objects, and an accessor
-that extracts a polygon (simple or complex) from each object.
+This accessor returns the polygon corresponding to an object in the `data` stream.
 
-This accessor returns the polygon corresponding to an object in the `data` stream. A polygon is expected to be an array of coordinates following either the GeoJSON [LineString](https://tools.ietf.org/html/rfc7946#section-3.1.4) ("simple polygon") or [Polygon](https://tools.ietf.org/html/rfc7946#section-3.1.6) (polygon with holes) specification. Each vertex can optionally supply a third component `z` which specifies the altitude of the vertex.
+A polygon can be one of the following formats:
+
+* An array of points (`[x, y, z]`) - a.k.a. a "loop".
+* An array of loops. The first loop is the exterior boundary and the following loops are the holes. Compatible with the GeoJSON [Polygon](https://tools.ietf.org/html/rfc7946#section-3.1.6) specification.
+* A flat array or [TypedArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) of numbers, in the shape of `[x0, y0, z0, x1, y1, z1, ...]`, is equivalent to a single loop. By default, each coordinate is assumed to contain 3 consecutive numbers. If each coordinate contains only two numbers (x, y), set the `positionFormat` prop of the layer to `XY`.
+* An object of shape `{positions, loopStartIndices}`, where `positions` is a flat array or [TypedArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) of numbers, and `loopStartIndices` is an array containing the starting index of each loop in the `positions` array.
+
+If the optional third component `z` is supplied for a position, it specifies the altitude of the vertex:
 
 <div>
   <img src="https://user-images.githubusercontent.com/18344164/48512983-cca32e80-e8ae-11e8-9107-c380925cf861.gif" />

--- a/docs/layers/polygon-layer.md
+++ b/docs/layers/polygon-layer.md
@@ -172,14 +172,16 @@ Be aware that this prop will likely be changed in a future version of deck.gl.
 
 * default: `object => object.polygon`
 
-This accessor returns the polygon corresponding to an object in the `data` stream.
+Called on each object in the `data` stream to retrieve its corresponding polygon.
 
 A polygon can be one of the following formats:
 
 * An array of points (`[x, y, z]`) - a.k.a. a "loop".
-* An array of loops. The first loop is the exterior boundary and the following loops are the holes. Compatible with the GeoJSON [Polygon](https://tools.ietf.org/html/rfc7946#section-3.1.6) specification.
-* A flat array or [TypedArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) of numbers, in the shape of `[x0, y0, z0, x1, y1, z1, ...]`, is equivalent to a single loop. By default, each coordinate is assumed to contain 3 consecutive numbers. If each coordinate contains only two numbers (x, y), set the `positionFormat` prop of the layer to `XY`.
-* An object of shape `{positions, loopStartIndices}`, where `positions` is a flat array or [TypedArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) of numbers, and `loopStartIndices` is an array containing the starting index of each loop in the `positions` array.
+* An array of loops. The first loop is the exterior boundary and the successive loops are the holes. Compatible with the GeoJSON [Polygon](https://tools.ietf.org/html/rfc7946#section-3.1.6) specification.
+* A flat array or [TypedArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) of coordinates, in the shape of `[x0, y0, z0, x1, y1, z1, ...]`, is equivalent to a single loop. By default, each coordinate is assumed to contain 3 consecutive numbers. If each coordinate contains only two numbers (x, y), set the `positionFormat` prop of the layer to `XY`.
+* An object of shape `{positions, loopStartIndices}`.
+  - `positions` (Array|TypedArray) - a flat array of coordinates.
+  - `loopStartIndices` (Array) - the starting index of each loop in the `positions` array. The first loop is the exterior boundary and the successive loops are the holes.
 
 If the optional third component `z` is supplied for a position, it specifies the altitude of the vertex:
 

--- a/docs/layers/polygon-layer.md
+++ b/docs/layers/polygon-layer.md
@@ -62,14 +62,6 @@ const App = ({data, viewport}) => {
 };
 ```
 
-If a cartographic projection mode is used, height will be interpreted as meters,
-otherwise will be in unit coordinates.
-
-* The polypgons can be simple or complex (complex polygons are polygons with holes).
-* A simple polygon specified as an array of vertices, each vertice being an array of two or three numbers
-* A complex polygon is specified as an array of simple polygons, the first polygon
-  representing the outer outline, and the remaining polygons representing holes. These polygons are expected to not intersect.
-
 ## Properties
 
 Inherits from all [Base Layer](/docs/api-reference/layer.md) properties.
@@ -176,12 +168,32 @@ Called on each object in the `data` stream to retrieve its corresponding polygon
 
 A polygon can be one of the following formats:
 
-* An array of points (`[x, y, z]`) - a.k.a. a "loop".
-* An array of loops. The first loop is the exterior boundary and the successive loops are the holes. Compatible with the GeoJSON [Polygon](https://tools.ietf.org/html/rfc7946#section-3.1.6) specification.
-* A flat array or [TypedArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) of coordinates, in the shape of `[x0, y0, z0, x1, y1, z1, ...]`, is equivalent to a single loop. By default, each coordinate is assumed to contain 3 consecutive numbers. If each coordinate contains only two numbers (x, y), set the `positionFormat` prop of the layer to `XY`.
-* An object of shape `{positions, loopStartIndices}`.
-  - `positions` (Array|TypedArray) - a flat array of coordinates.
-  - `loopStartIndices` (Array) - the starting index of each loop in the `positions` array. The first loop is the exterior boundary and the successive loops are the holes.
+* An array of points (`[x, y, z]`) - a.k.a. a "ring".
+* An array of rings. The first ring is the exterior boundary and the successive rings are the holes. Compatible with the GeoJSON [Polygon](https://tools.ietf.org/html/rfc7946#section-3.1.6) specification.
+* A flat array or [TypedArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) of coordinates, in the shape of `[x0, y0, z0, x1, y1, z1, ...]`, is equivalent to a single ring. By default, each coordinate is assumed to contain 3 consecutive numbers. If each coordinate contains only two numbers (x, y), set the `positionFormat` prop of the layer to `XY`.
+* An object of shape `{positions, holeIndices}`.
+  - `positions` (Array|TypedArray) - a flat array of coordinates. By default, each coordinate is assumed to contain 3 consecutive numbers. If each coordinate contains only two numbers (x, y), set the `positionFormat` prop of the layer to `XY`.
+  - `holeIndices` (Array) - the starting index of each hole in the `positions` array. The first ring is the exterior boundary and the successive rings are the holes.
+
+```js
+// All of the following are valid polygons
+const polygons = [
+  // Simple polygon (array of points)
+  [[-122.4, 37.7, 0], [-122.4, 37.8, 5], [-122.5, 37.8, 10], [-122.5, 37.7, 5], [-122.4, 37.7, 0]],
+  // Polygon with holes (array of rings)
+  [
+    [[-122.4, 37.7], [-122.4, 37.8], [-122.5, 37.8], [-122.5, 37.7], [-122.4, 37.7]],
+    [[-122.45, 37.73], [-122.47, 37.76], [-122.47, 37.71], [-122.45, 37.73]]
+  ],
+  // Flat simple polygon
+  [-122.4, 37.7, 0, -122.4, 37.8, 5, -122.5, 37.8, 10, -122.5, 37.7, 5, -122.4, 37.7, 0],
+  // Flat polygon with holes
+  {
+    positions: [-122.4, 37.7, 0, -122.4, 37.8, 0, -122.5, 37.8, 0, -122.5, 37.7, 0, -122.4, 37.7, 0, -122.45, 37.73, 0, -122.47, 37.76, 0, -122.47, 37.71, 0, -122.45, 37.73, 0],
+    holeIndices: [15]
+  }
+]
+```
 
 If the optional third component `z` is supplied for a position, it specifies the altitude of the vertex:
 
@@ -222,7 +234,10 @@ The width of the outline of the polygon, in meters. Only applies if `extruded: f
 
 * Default: `1000`
 
-The elevation to extrude each polygon with, in meters. Only applies if `extruded: true`.
+The elevation to extrude each polygon with. 
+If a cartographic projection mode is used, height will be interpreted as meters,
+otherwise will be in unit coordinates.
+Only applies if `extruded: true`.
 
 * If a number is provided, it is used as the elevation for all polygons.
 * If a function is provided, it is called on each polygon to retrieve its elevation.

--- a/docs/layers/solid-polygon-layer.md
+++ b/docs/layers/solid-polygon-layer.md
@@ -8,25 +8,21 @@
 The SolidPolygon Layer renders filled polygons.
 
 ```js
-import DeckGL, {SolidPolygonLayer} from 'deck.gl';
+import DeckGL, {_SolidPolygonLayer} from 'deck.gl';
 
-new PolygonLayer({
+new _SolidPolygonLayer({
   data: [
     [[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]],   // Simple polygon (array of coords)
     [                                           // Complex polygon with one hole
       [[0, 0], [0, 2], [2, 2], [2, 0], [0, 0]], // (array of array of coords)
       [[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]
     ]
-  ]
+  ],
+  getPolygon: d => d,
+  getColor: [255, 0, 0],
+  extruded: false
 });
 ```
-
-* The polypgons can be simple or complex (complex polygons are polygons with holes).
-* A simple polygon specified as an array of vertices, each vertice being an array
-  of two or three numbers
-* A complex polygon is specified as an array of simple polygons, the
-  first polygon representing the outer outline, and the remaining polygons
-  representing holes. These polygons are expected to not intersect.
 
 ## Properties
 
@@ -92,10 +88,12 @@ This accessor returns the polygon corresponding to an object in the `data` strea
 
 A polygon can be one of the following formats:
 
-* An array of points (`[x, y, z]`) - a.k.a. a "loop".
-* An array of loops. The first loop is the exterior boundary and the following loops are the holes. Compatible with the GeoJSON [Polygon](https://tools.ietf.org/html/rfc7946#section-3.1.6) specification.
-* A flat array or [TypedArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) of numbers, in the shape of `[x0, y0, z0, x1, y1, z1, ...]`, is equivalent to a single loop. By default, each coordinate is assumed to contain 3 consecutive numbers. If each coordinate contains only two numbers (x, y), set the `positionFormat` prop of the layer to `XY`.
-* An object of shape `{positions, loopStartIndices}`, where `positions` is a flat array or [TypedArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) of numbers, and `loopStartIndices` is an array containing the starting index of each loop in the `positions` array.
+* An array of points (`[x, y, z]`) - a.k.a. a "ring".
+* An array of rings. The first ring is the exterior boundary and the following rings are the holes. Compatible with the GeoJSON [Polygon](https://tools.ietf.org/html/rfc7946#section-3.1.6) specification.
+* A flat array or [TypedArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) of numbers, in the shape of `[x0, y0, z0, x1, y1, z1, ...]`, is equivalent to a single ring. By default, each coordinate is assumed to contain 3 consecutive numbers. If each coordinate contains only two numbers (x, y), set the `positionFormat` prop of the layer to `XY`.
+* An object of shape `{positions, holeIndices}`.
+  - `positions` (Array|TypedArray) - a flat array of coordinates. By default, each coordinate is assumed to contain 3 consecutive numbers. If each coordinate contains only two numbers (x, y), set the `positionFormat` prop of the layer to `XY`.
+  - `holeIndices` (Array) - the starting index of each hole in the `positions` array. The first ring is the exterior boundary and the successive rings are the holes.
 
 
 ##### `getFillColor` (Function|Array, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
@@ -111,7 +109,8 @@ The rgba fill color of each object's polygon, in `r, g, b, [a]`. Each component 
 
 * Default: `[0, 0, 0, 255]`
 
-The rgba stroke color of each object's polygon, in `r, g, b, [a]`. Each component is in the 0-255 range.
+The rgba wireframe color of each object's polygon, in `r, g, b, [a]`. Each component is in the 0-255 range.
+Only applies if `extruded: true`.
 
 * If an array is provided, it is used as the stroke color for all polygons.
 * If a function is provided, it is called on each object to retrieve its stroke color.
@@ -120,10 +119,10 @@ The rgba stroke color of each object's polygon, in `r, g, b, [a]`. Each componen
 
 * Default: `1000`
 
-The elevation of each object's polygon.
-
+The elevation to extrude each polygon with. 
 If a cartographic projection mode is used, height will be interpreted as meters,
 otherwise will be in unit coordinates.
+Only applies if `extruded: true`.
 
 * If a number is provided, it is used as the elevation for all polygons.
 * If a function is provided, it is called on each object to retrieve its elevation.

--- a/docs/layers/solid-polygon-layer.md
+++ b/docs/layers/solid-polygon-layer.md
@@ -88,11 +88,15 @@ Be aware that this prop will likely be changed in a future version of deck.gl.
 
 * Default: `object => object.polygon`
 
-Like any deck.gl layer, the polygon accepts a data prop which is expected to
-be an iterable container of objects, and an accessor
-that extracts a polygon (simple or complex) from each object.
-
 This accessor returns the polygon corresponding to an object in the `data` stream.
+
+A polygon can be one of the following formats:
+
+* An array of points (`[x, y, z]`) - a.k.a. a "loop".
+* An array of loops. The first loop is the exterior boundary and the following loops are the holes. Compatible with the GeoJSON [Polygon](https://tools.ietf.org/html/rfc7946#section-3.1.6) specification.
+* A flat array or [TypedArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) of numbers, in the shape of `[x0, y0, z0, x1, y1, z1, ...]`, is equivalent to a single loop. By default, each coordinate is assumed to contain 3 consecutive numbers. If each coordinate contains only two numbers (x, y), set the `positionFormat` prop of the layer to `XY`.
+* An object of shape `{positions, loopStartIndices}`, where `positions` is a flat array or [TypedArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) of numbers, and `loopStartIndices` is an array containing the starting index of each loop in the `positions` array.
+
 
 ##### `getFillColor` (Function|Array, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 

--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -166,12 +166,11 @@ export default class App extends PureComponent {
   _renderExampleLayer(example, settings, index) {
     const {layer: Layer, props, getData} = example;
 
-    const layerProps = Object.assign({}, props, settings);
-
-    if (getData) {
-      Object.assign(layerProps, {data: getData()});
+    if (getData && !props.data) {
+      props.data = getData();
     }
 
+    const layerProps = Object.assign({}, props, settings);
     Object.assign(layerProps, {
       modelMatrix: this._getModelMatrix(index, layerProps.coordinateSystem)
     });

--- a/examples/layer-browser/src/examples/core-layers.js
+++ b/examples/layer-browser/src/examples/core-layers.js
@@ -139,13 +139,31 @@ const PolygonLayerExample = {
     getFillColor: f => [200 + Math.random() * 55, 0, 0],
     getLineColor: f => [0, 0, 0, 255],
     getLineDashArray: f => [20, 0],
-    getWidth: f => 20,
+    getLineWidth: f => 20,
     getElevation: f => Math.random() * 1000,
     opacity: 0.8,
     pickable: true,
     lineDashJustified: true,
     lightSettings: LIGHT_SETTINGS,
     elevationScale: 0.6
+  }
+};
+
+const PolygonLayerBinaryExample = {
+  ...PolygonLayerExample,
+  getData: () => {
+    const data = [];
+    dataSamples.polygons.forEach(polygon => {
+      // Convert each path from an array of points to an array of numbers
+      // TODO: flatten the entire data array
+      data.push(flattenVertices(polygon, {dimensions: 2}));
+    });
+    return data;
+  },
+  props: {
+    ...PolygonLayerExample.props,
+    getPolygon: d => d,
+    positionFormat: 'XY'
   }
 };
 
@@ -402,6 +420,7 @@ export default {
     GeoJsonLayer: GeoJsonLayerExample,
     'GeoJsonLayer (Extruded)': GeoJsonLayerExtrudedExample,
     PolygonLayer: PolygonLayerExample,
+    'PolygonLayer (Flat)': PolygonLayerBinaryExample,
     PathLayer: PathLayerExample,
     'PathLayer (Flat)': PathLayerBinaryExample,
     ScatterplotLayer: ScatterplotLayerExample,

--- a/examples/layer-browser/src/examples/core-layers.js
+++ b/examples/layer-browser/src/examples/core-layers.js
@@ -193,7 +193,6 @@ const PathLayerBinaryExample = {
   getData: () =>
     dataSamples.zigzag.map(({path}) => {
       // Convert each path from an array of points to an array of numbers
-      // TODO: flatten the entire data array
       return flattenVertices(path, {dimensions: 2});
     }),
   props: {

--- a/examples/layer-browser/src/examples/core-layers.js
+++ b/examples/layer-browser/src/examples/core-layers.js
@@ -151,15 +151,11 @@ const PolygonLayerExample = {
 
 const PolygonLayerBinaryExample = {
   ...PolygonLayerExample,
-  getData: () => {
-    const data = [];
-    dataSamples.polygons.forEach(polygon => {
-      // Convert each path from an array of points to an array of numbers
-      // TODO: flatten the entire data array
-      data.push(flattenVertices(polygon, {dimensions: 2}));
-    });
-    return data;
-  },
+  getData: () =>
+    dataSamples.polygons.map(polygon => {
+      // Convert each polygon from an array of points to an array of numbers
+      return flattenVertices(polygon, {dimensions: 2});
+    }),
   props: {
     ...PolygonLayerExample.props,
     getPolygon: d => d,
@@ -194,15 +190,12 @@ const PathLayerExample = {
 
 const PathLayerBinaryExample = {
   ...PathLayerExample,
-  getData: () => {
-    const data = [];
-    dataSamples.zigzag.forEach(({path}) => {
+  getData: () =>
+    dataSamples.zigzag.map(({path}) => {
       // Convert each path from an array of points to an array of numbers
       // TODO: flatten the entire data array
-      data.push(flattenVertices(path, {dimensions: 2}));
-    });
-    return data;
-  },
+      return flattenVertices(path, {dimensions: 2});
+    }),
   props: {
     ...PathLayerExample.props,
     getPath: d => d,

--- a/modules/core/src/lib/composite-layer.js
+++ b/modules/core/src/lib/composite-layer.js
@@ -67,6 +67,7 @@ export default class CompositeLayer extends Layer {
       coordinateSystem,
       coordinateOrigin,
       wrapLongitude,
+      positionFormat,
       modelMatrix
     } = this.props;
     const newProps = {
@@ -81,6 +82,7 @@ export default class CompositeLayer extends Layer {
       coordinateSystem,
       coordinateOrigin,
       wrapLongitude,
+      positionFormat,
       modelMatrix
     };
 

--- a/modules/core/src/lifecycle/props.js
+++ b/modules/core/src/lifecycle/props.js
@@ -133,6 +133,8 @@ function diffDataProps(props, oldProps) {
     // Otherwise, do a shallow equal on props
   } else if (props.data !== oldProps.data) {
     return 'A new data container was supplied';
+  } else if (props.positionFormat !== oldProps.positionFormat) {
+    return 'Position format changed';
   }
 
   return null;

--- a/modules/core/src/lifecycle/props.js
+++ b/modules/core/src/lifecycle/props.js
@@ -133,8 +133,6 @@ function diffDataProps(props, oldProps) {
     // Otherwise, do a shallow equal on props
   } else if (props.data !== oldProps.data) {
     return 'A new data container was supplied';
-  } else if (props.positionFormat !== oldProps.positionFormat) {
-    return 'Position format changed';
   }
 
   return null;

--- a/modules/layers/src/polygon-layer/polygon-layer.js
+++ b/modules/layers/src/polygon-layer/polygon-layer.js
@@ -87,13 +87,14 @@ export default class PolygonLayer extends CompositeLayer {
     const positionSize = positionFormat === 'XY' ? 2 : 3;
 
     for (const object of data) {
-      const {positions, loopStartIndices} = Polygon.normalize(getPolygon(object), positionSize);
+      const {positions, holeIndices} = Polygon.normalize(getPolygon(object), positionSize);
 
-      if (loopStartIndices) {
-        for (let i = 0; i < loopStartIndices.length; i++) {
+      if (holeIndices) {
+        // split the positions array by holeIndices
+        for (let i = 0; i <= holeIndices.length; i++) {
           const path = positions.subarray(
-            loopStartIndices[i],
-            loopStartIndices[i + 1] || positions.length
+            holeIndices[i - 1] || 0,
+            holeIndices[i] || positions.length
           );
           paths.push({path, object});
         }

--- a/modules/layers/src/polygon-layer/polygon-layer.js
+++ b/modules/layers/src/polygon-layer/polygon-layer.js
@@ -90,7 +90,9 @@ export default class PolygonLayer extends CompositeLayer {
       const {positions, holeIndices} = Polygon.normalize(getPolygon(object), positionSize);
 
       if (holeIndices) {
-        // split the positions array by holeIndices
+        // split the positions array into `holeIndices.length + 1` rings
+        // holeIndices[-1] falls back to 0
+        // holeIndices[holeIndices.length] falls back to positions.length
         for (let i = 0; i <= holeIndices.length; i++) {
           const path = positions.subarray(
             holeIndices[i - 1] || 0,

--- a/modules/layers/src/solid-polygon-layer/polygon-tesselator.js
+++ b/modules/layers/src/solid-polygon-layer/polygon-tesselator.js
@@ -141,7 +141,7 @@ export default class PolygonTesselator extends Tesselator {
     } = this;
 
     let i = vertexStart;
-    const {positions: polygonPositions, loopStartIndices} = polygon;
+    const {positions: polygonPositions, holeIndices} = polygon;
 
     for (let j = 0; j < geometrySize; j++) {
       const x = polygonPositions[j * positionSize];
@@ -159,22 +159,20 @@ export default class PolygonTesselator extends Tesselator {
       i++;
     }
 
-    /* We are reusing the some buffer for `nextPositions` by offsetting one vertex
+    /* We are reusing the some buffer for `nextPositions` by offseting one vertex
      * to the left. As a result,
-     * the last vertex of each loop overlaps with the first vertex of the next loop.
-     * `vertexValid` is used to mark the end of each loop so we don't draw these
+     * the last vertex of each ring overlaps with the first vertex of the next ring.
+     * `vertexValid` is used to mark the end of each ring so we don't draw these
      * segments:
       positions      A0 A1 A2 A3 A4 B0 B1 B2 C0 ...
       nextPositions  A1 A2 A3 A4 B0 B1 B2 C0 C1 ...
       vertexValid    1  1  1  1  0  1  1  0  1 ...
      */
-    if (loopStartIndices) {
-      for (let j = 1; j <= loopStartIndices.length; j++) {
-        const loopStartIndex = loopStartIndices[j] || geometrySize;
-        vertexValid[vertexStart + loopStartIndex - 1] = 0;
+    if (holeIndices) {
+      for (let j = 0; j < holeIndices.length; j++) {
+        vertexValid[vertexStart + holeIndices[j] - 1] = 0;
       }
-    } else {
-      vertexValid[vertexStart + geometrySize - 1] = 0;
     }
+    vertexValid[vertexStart + geometrySize - 1] = 0;
   }
 }

--- a/modules/layers/src/solid-polygon-layer/polygon-tesselator.js
+++ b/modules/layers/src/solid-polygon-layer/polygon-tesselator.js
@@ -32,11 +32,12 @@ const {fp64LowPart} = fp64Module;
 // This class is set up to allow querying one attribute at a time
 // the way the AttributeManager expects it
 export default class PolygonTesselator extends Tesselator {
-  constructor({data, getGeometry, fp64, IndexType = Uint32Array}) {
+  constructor({data, getGeometry, fp64, positionFormat, IndexType = Uint32Array}) {
     super({
       data,
       getGeometry,
       fp64,
+      positionFormat,
       attributes: {
         positions: {size: 3},
         positions64xyLow: {size: 2, fp64Only: true},
@@ -91,11 +92,11 @@ export default class PolygonTesselator extends Tesselator {
 
   /* Implement base Tesselator interface */
   getGeometrySize(polygon) {
-    return Polygon.getVertexCount(polygon);
+    return Polygon.getVertexCount(polygon, this.positionSize);
   }
 
   updateGeometryAttributes(polygon, context) {
-    polygon = Polygon.normalize(polygon);
+    polygon = Polygon.normalize(polygon, this.positionSize, context.geometrySize);
 
     this._updateIndices(polygon, context);
     this._updatePositions(polygon, context);
@@ -110,11 +111,11 @@ export default class PolygonTesselator extends Tesselator {
     let i = indexStart;
 
     // 1. get triangulated indices for the internal areas
-    const indices = Polygon.getSurfaceIndices(polygon);
+    const indices = Polygon.getSurfaceIndices(polygon, this.positionSize);
 
     // make sure the buffer is large enough
     if (currentLength < i + indices.length) {
-      currentLength *= 2;
+      currentLength = (i + indices.length) * 2;
       target = typedArrayManager.allocate(target, currentLength, {
         type: target.constructor,
         size: 1,
@@ -132,40 +133,48 @@ export default class PolygonTesselator extends Tesselator {
   }
 
   // Flatten out all the vertices of all the sub subPolygons
-  _updatePositions(polygon, {vertexStart}) {
+  _updatePositions(polygon, {vertexStart, geometrySize}) {
     const {
       attributes: {positions, positions64xyLow, vertexValid},
-      fp64
+      fp64,
+      positionSize
     } = this;
 
     let i = vertexStart;
-    polygon.forEach(loop => {
-      loop.forEach(vertex => {
-        // eslint-disable-line
-        const x = vertex[0];
-        const y = vertex[1];
-        const z = vertex[2] || 0;
+    const {positions: polygonPositions, loopStartIndices} = polygon;
 
-        positions[i * 3] = x;
-        positions[i * 3 + 1] = y;
-        positions[i * 3 + 2] = z;
-        if (fp64) {
-          positions64xyLow[i * 2] = fp64LowPart(x);
-          positions64xyLow[i * 2 + 1] = fp64LowPart(y);
-        }
-        vertexValid[i] = 1;
-        i++;
-      });
-      /* We are reusing the some buffer for `nextPositions` by offsetting one vertex
-       * to the left. As a result,
-       * the last vertex of each loop overlaps with the first vertex of the next loop.
-       * `vertexValid` is used to mark the end of each loop so we don't draw these
-       * segments:
-        positions      A0 A1 A2 A3 A4 B0 B1 B2 C0 ...
-        nextPositions  A1 A2 A3 A4 B0 B1 B2 C0 C1 ...
-        vertexValid    1  1  1  1  0  1  1  0  1 ...
-       */
-      vertexValid[i - 1] = 0;
-    });
+    for (let j = 0; j < geometrySize; j++) {
+      const x = polygonPositions[j * positionSize];
+      const y = polygonPositions[j * positionSize + 1];
+      const z = positionSize > 2 ? polygonPositions[j * positionSize + 2] : 0;
+
+      positions[i * 3] = x;
+      positions[i * 3 + 1] = y;
+      positions[i * 3 + 2] = z;
+      if (fp64) {
+        positions64xyLow[i * 2] = fp64LowPart(x);
+        positions64xyLow[i * 2 + 1] = fp64LowPart(y);
+      }
+      vertexValid[i] = 1;
+      i++;
+    }
+
+    /* We are reusing the some buffer for `nextPositions` by offsetting one vertex
+     * to the left. As a result,
+     * the last vertex of each loop overlaps with the first vertex of the next loop.
+     * `vertexValid` is used to mark the end of each loop so we don't draw these
+     * segments:
+      positions      A0 A1 A2 A3 A4 B0 B1 B2 C0 ...
+      nextPositions  A1 A2 A3 A4 B0 B1 B2 C0 C1 ...
+      vertexValid    1  1  1  1  0  1  1  0  1 ...
+     */
+    if (loopStartIndices) {
+      for (let j = 1; j <= loopStartIndices.length; j++) {
+        const loopStartIndex = loopStartIndices[j] || geometrySize;
+        vertexValid[vertexStart + loopStartIndex - 1] = 0;
+      }
+    } else {
+      vertexValid[vertexStart + geometrySize - 1] = 0;
+    }
   }
 }

--- a/modules/layers/src/solid-polygon-layer/polygon.js
+++ b/modules/layers/src/solid-polygon-layer/polygon.js
@@ -177,6 +177,9 @@ export function getVertexCount(polygon, positionSize) {
 
     if (holeIndices) {
       let vertexCount = 0;
+      // split the positions array into `holeIndices.length + 1` rings
+      // holeIndices[-1] falls back to 0
+      // holeIndices[holeIndices.length] falls back to positions.length
       for (let i = 0; i <= holeIndices.length; i++) {
         vertexCount += getFlatVertexCount(
           polygon.positions,
@@ -228,7 +231,9 @@ export function normalize(polygon, positionSize, vertexCount) {
 
     if (srcHoleIndices) {
       let targetIndex = 0;
-
+      // split the positions array into `holeIndices.length + 1` rings
+      // holeIndices[-1] falls back to 0
+      // holeIndices[holeIndices.length] falls back to positions.length
       for (let i = 0; i <= srcHoleIndices.length; i++) {
         targetIndex = copyFlatRing(
           positions,

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -188,6 +188,7 @@ export default class SolidPolygonLayer extends Layer {
       polygonTesselator.updateGeometry({
         data: props.data,
         getGeometry: props.getPolygon,
+        positionFormat: props.positionFormat,
         fp64: this.use64bitPositions()
       });
 

--- a/test/modules/layers/path-tesselator.spec.js
+++ b/test/modules/layers/path-tesselator.spec.js
@@ -26,20 +26,23 @@ const SAMPLE_DATA = [
   {path: [], width: 1, dashArray: [0, 0], color: [0, 0, 0]},
   {path: [[1, 1]], width: 1, dashArray: [0, 0], color: [0, 0, 0]},
   {path: [[1, 1], [2, 2], [3, 3]], width: 2, dashArray: [0, 0], color: [255, 0, 0]},
+  {path: new Float64Array([1, 1, 2, 2, 3, 3]), width: 1, dashArray: [0, 0], color: [0, 0, 0]},
   {path: [[1, 1], [2, 2], [3, 3], [1, 1]], width: 3, dashArray: [2, 1], color: [0, 0, 255]}
 ];
-const INSTANCE_COUNT = 5;
+const INSTANCE_COUNT = 7;
 
 const TEST_DATA = [
   {
     title: 'Plain array',
     data: SAMPLE_DATA,
-    getGeometry: d => d.path
+    getGeometry: d => d.path,
+    positionFormat: 'XY'
   },
   {
     title: 'Iterable',
     data: new Set(SAMPLE_DATA),
-    getGeometry: d => d.path
+    getGeometry: d => d.path,
+    positionFormat: 'XY'
   }
 ];
 
@@ -142,7 +145,7 @@ test('PolygonTesselator#methods', t => {
       d => d.width
     );
     t.ok(ArrayBuffer.isView(strokeWidths), 'PathTesselator.get strokeWidths');
-    t.deepEquals(strokeWidths, [2, 2, 3, 3, 3], 'strokeWidths are filled');
+    t.deepEquals(strokeWidths, [2, 2, 1, 1, 3, 3, 3], 'strokeWidths are filled');
 
     const dashArrays = tesselator.get(
       'dashArrays',
@@ -150,7 +153,7 @@ test('PolygonTesselator#methods', t => {
       d => d.dashArray
     );
     t.ok(ArrayBuffer.isView(dashArrays), 'PathTesselator.get dashArrays');
-    t.deepEquals(dashArrays, [0, 0, 0, 0, 2, 1, 2, 1, 2, 1], 'dashArrays are filled');
+    t.deepEquals(dashArrays, [0, 0, 0, 0, 0, 0, 0, 0, 2, 1, 2, 1, 2, 1], 'dashArrays are filled');
 
     const colors = tesselator.get(
       'colors',

--- a/test/modules/layers/polygon-tesselation.spec.js
+++ b/test/modules/layers/polygon-tesselation.spec.js
@@ -65,7 +65,7 @@ const SAMPLE_DATA = [
   {
     polygon: {
       positions: new Float64Array([0, 0, 2, 0, 2, 2, 0, 2, 0.5, 0.5, 1, 0.5, 0.5, 1]),
-      loopStartIndices: [0, 8]
+      holeIndices: [8]
     },
     name: 'object - with holes'
   }
@@ -110,9 +110,9 @@ test('polygon#fuctions', t => {
 
     const complexPolygon = Polygon.normalize(object.polygon, 2);
     t.ok(ArrayBuffer.isView(complexPolygon.positions), 'Polygon.normalize flattens positions');
-    if (complexPolygon.loopStartIndices) {
+    if (complexPolygon.holeIndices) {
       t.ok(
-        Array.isArray(complexPolygon.loopStartIndices),
+        Array.isArray(complexPolygon.holeIndices),
         'Polygon.normalize returns starting indices of rings'
       );
     }


### PR DESCRIPTION
For #2492 

#### Change List
- Support two new polygon input format: flat array and `{positions, loopStartIndices}`
- Forward `positionFormat` prop from composite layer to sublayer
- When `positionFormat` prop changes, set `dataChanged` flag
- `Polygon.normalize` now returns the complex flat format (`{positions, loopStartIndices}`)
- Layer browser example
- Tests
