### PR TITLE
Fix layer.clone bug

### DIFF
--- a/modules/core/src/lifecycle/component.js
+++ b/modules/core/src/lifecycle/component.js
@@ -34,9 +34,10 @@ export default class Component {
   clone(newProps) {
     const {props} = this;
 
-    // Async props cannot be copied with Object.assign. Extract the plain value.
+    // Async props cannot be copied with Object.assign, copy them separately
     const asyncProps = {};
 
+    // See async props definition in create-props.js
     for (const key in props._asyncPropDefaultValues) {
       if (key in props._asyncPropResolvedValues) {
         asyncProps[key] = props._asyncPropResolvedValues[key];
@@ -45,6 +46,7 @@ export default class Component {
       }
     }
 
+    // Some custom layer implementation may not support multiple arguments in the constructor
     return new this.constructor(Object.assign({}, props, asyncProps, newProps));
   }
 

--- a/modules/core/src/lifecycle/component.js
+++ b/modules/core/src/lifecycle/component.js
@@ -32,7 +32,20 @@ export default class Component {
 
   // clone this layer with modified props
   clone(newProps) {
-    return new this.constructor(Object.assign({}, this.props, newProps));
+    const {props} = this;
+
+    // Async props cannot be copied with Object.assign. Extract the plain value.
+    const asyncProps = {};
+
+    for (const key in props._asyncPropDefaultValues) {
+      if (key in props._asyncPropResolvedValues) {
+        asyncProps[key] = props._asyncPropResolvedValues[key];
+      } else if (key in props._asyncPropOriginalValues) {
+        asyncProps[key] = props._asyncPropOriginalValues[key];
+      }
+    }
+
+    return new this.constructor(Object.assign({}, props, asyncProps, newProps));
   }
 
   get stats() {

--- a/test/modules/core/lib/layer.spec.js
+++ b/test/modules/core/lib/layer.spec.js
@@ -102,6 +102,17 @@ test('Layer#constructor', t => {
   t.end();
 });
 
+test('Layer#clone', t => {
+  const layer = new SubLayer({id: 'test-layer', data: [0, 1]});
+  const newLayer = layer.clone({pickable: true});
+
+  t.is(newLayer.constructor.name, 'SubLayer', 'cloned layer has correct type');
+  t.is(newLayer.props.id, 'test-layer', 'cloned layer has correct id');
+  t.deepEquals(newLayer.props.data, [0, 1], 'cloned layer has correct data');
+
+  t.end();
+});
+
 test('Layer#constructor(multi prop objects)', t => {
   for (const tc of LAYER_CONSTRUCT_MULTIPROP_TEST_CASES) {
     const layer = new Layer(...tc.props);


### PR DESCRIPTION
#### Background
`layer.clone()` always results in `data` prop being an empty array.


#### Change List
- Fix async prop cloning
- Add test case
