### PR TITLE
Add deprecated flag to prop types

### DIFF
--- a/docs/developer-guide/prop-types.md
+++ b/docs/developer-guide/prop-types.md
@@ -53,7 +53,8 @@ The property types system enables layers to opt-in to specifying types, and also
 Each prop in `defaultProps` may be an object in the following shape:
 
 - `type` (string, required)
-- `value` (any, required)
+- `value` (any, required) - the default value if this prop is not supplied
+- `getValue` (function, optional) - called to get the default value if this prop is not supplied. Receives a single argument `props`. Overrides `value`.
 - `async` (boolean, optional) - if `true`, the prop can either be a [Promise](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise) that resolves to its actual value, or an url string (loaded using the base Layer's [fetch](/docs/api-reference/layer.md) prop).
 - `validate` (function, optional) - receives `value` as argument and returns `true` if the value is valid. Validation of layer props is only invoked in debug mode. This function is automatically populated if the prop has a built-in type.
 - `equal` (function, optional) - receives `value1`, `value2` as argument and returns `true` if the two values are equal. Comparison of layer props is invoked during layer update and the result is passed to `changeFlags.propsChanged`. This function is automatically populated if the prop has a built-in type.

--- a/docs/developer-guide/prop-types.md
+++ b/docs/developer-guide/prop-types.md
@@ -54,10 +54,10 @@ Each prop in `defaultProps` may be an object in the following shape:
 
 - `type` (string, required)
 - `value` (any, required) - the default value if this prop is not supplied
-- `getValue` (function, optional) - called to get the default value if this prop is not supplied. Receives a single argument `props`. Overrides `value`.
 - `async` (boolean, optional) - if `true`, the prop can either be a [Promise](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise) that resolves to its actual value, or an url string (loaded using the base Layer's [fetch](/docs/api-reference/layer.md) prop).
 - `validate` (function, optional) - receives `value` as argument and returns `true` if the value is valid. Validation of layer props is only invoked in debug mode. This function is automatically populated if the prop has a built-in type.
 - `equal` (function, optional) - receives `value1`, `value2` as argument and returns `true` if the two values are equal. Comparison of layer props is invoked during layer update and the result is passed to `changeFlags.propsChanged`. This function is automatically populated if the prop has a built-in type.
+- `deprecatedFor` (string, optional) - mark this prop as deprecated. The value is the new prop name that this prop has been deprecated for. If the old prop is supplied instead of the new one, its value will be transferred to the new prop. The user will get a warning about the deprecation.
 - Any additional options, see individual types below.
 
 ### Built-in Types

--- a/modules/core/src/lifecycle/prop-types.js
+++ b/modules/core/src/lifecycle/prop-types.js
@@ -76,12 +76,15 @@ function arrayEqual(array1, array2) {
 export function parsePropTypes(propDefs) {
   const propTypes = {};
   const defaultProps = {};
+  const defaultPropCallbacks = {};
+
   for (const [propName, propDef] of Object.entries(propDefs)) {
     const propType = parsePropType(propName, propDef);
     propTypes[propName] = propType;
     defaultProps[propName] = propType.value;
+    defaultPropCallbacks[propName] = propType.getValue;
   }
-  return {propTypes, defaultProps};
+  return {propTypes, defaultProps, defaultPropCallbacks};
 }
 
 // Parses one property definition entry. Either contains:

--- a/modules/core/src/lifecycle/prop-types.js
+++ b/modules/core/src/lifecycle/prop-types.js
@@ -76,15 +76,18 @@ function arrayEqual(array1, array2) {
 export function parsePropTypes(propDefs) {
   const propTypes = {};
   const defaultProps = {};
-  const defaultPropCallbacks = {};
+  const deprecatedProps = {};
 
   for (const [propName, propDef] of Object.entries(propDefs)) {
-    const propType = parsePropType(propName, propDef);
-    propTypes[propName] = propType;
-    defaultProps[propName] = propType.value;
-    defaultPropCallbacks[propName] = propType.getValue;
+    if (propDef && propDef.deprecatedFor) {
+      deprecatedProps[propName] = propDef.deprecatedFor;
+    } else {
+      const propType = parsePropType(propName, propDef);
+      propTypes[propName] = propType;
+      defaultProps[propName] = propType.value;
+    }
   }
-  return {propTypes, defaultProps, defaultPropCallbacks};
+  return {propTypes, defaultProps, deprecatedProps};
 }
 
 // Parses one property definition entry. Either contains:

--- a/modules/layers/src/arc-layer/arc-layer.js
+++ b/modules/layers/src/arc-layer/arc-layer.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {Layer, log} from '@deck.gl/core';
+import {Layer} from '@deck.gl/core';
 
 import GL from '@luma.gl/constants';
 import {Model, Geometry, fp64} from 'luma.gl';
@@ -38,21 +38,13 @@ const defaultProps = {
   getSourceColor: {type: 'accessor', value: DEFAULT_COLOR},
   getTargetColor: {type: 'accessor', value: DEFAULT_COLOR},
   getStrokeWidth: {type: 'accessor', value: 1},
-  widthScale: {type: 'number', value: 1, min: 0}
+  widthScale: {type: 'number', value: 1, min: 0},
+
+  // deprecated
+  strokeWidth: {deprecatedFor: 'getStrokeWidth'}
 };
 
 export default class ArcLayer extends Layer {
-  constructor(props) {
-    let overrideProps = null;
-    if (Number.isFinite(props.strokeWidth)) {
-      log.deprecated('ArcLayer: `strokeWidth`', '`getStrokeWidth`')();
-      overrideProps = {
-        getStrokeWidth: props.strokeWidth
-      };
-    }
-    super(props, overrideProps);
-  }
-
   getShaders() {
     return this.use64bitProjection()
       ? {vs: vs64, fs, modules: ['project64', 'picking']}

--- a/modules/layers/src/line-layer/line-layer.js
+++ b/modules/layers/src/line-layer/line-layer.js
@@ -34,19 +34,16 @@ const defaultProps = {
   getSourcePosition: {type: 'accessor', value: x => x.sourcePosition},
   getTargetPosition: {type: 'accessor', value: x => x.targetPosition},
   getColor: {type: 'accessor', value: DEFAULT_COLOR},
-  getStrokeWidth: {type: 'accessor', value: 1}
+  getStrokeWidth: {type: 'accessor', getValue: props => props.strokeWidth || 1}
 };
 
 export default class LineLayer extends Layer {
-  constructor(props) {
-    let overrideProps = null;
-    if (Number.isFinite(props.strokeWidth)) {
+  constructor(...props) {
+    super(...props);
+
+    if (Number.isFinite(this.props.strokeWidth)) {
       log.deprecated('LineLayer: `strokeWidth`', '`getStrokeWidth`')();
-      overrideProps = {
-        getStrokeWidth: props.strokeWidth
-      };
     }
-    super(props, overrideProps);
   }
 
   getShaders() {

--- a/modules/layers/src/line-layer/line-layer.js
+++ b/modules/layers/src/line-layer/line-layer.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {Layer, log} from '@deck.gl/core';
+import {Layer} from '@deck.gl/core';
 import GL from '@luma.gl/constants';
 import {Model, Geometry, fp64} from 'luma.gl';
 const {fp64LowPart} = fp64;
@@ -34,18 +34,13 @@ const defaultProps = {
   getSourcePosition: {type: 'accessor', value: x => x.sourcePosition},
   getTargetPosition: {type: 'accessor', value: x => x.targetPosition},
   getColor: {type: 'accessor', value: DEFAULT_COLOR},
-  getStrokeWidth: {type: 'accessor', getValue: props => props.strokeWidth || 1}
+  getStrokeWidth: {type: 'accessor', value: 1},
+
+  // deprecated
+  strokeWidth: {deprecatedFor: 'getStrokeWidth'}
 };
 
 export default class LineLayer extends Layer {
-  constructor(...props) {
-    super(...props);
-
-    if (Number.isFinite(this.props.strokeWidth)) {
-      log.deprecated('LineLayer: `strokeWidth`', '`getStrokeWidth`')();
-    }
-  }
-
   getShaders() {
     const projectModule = this.use64bitProjection() ? 'project64' : 'project32';
     return {vs, fs, modules: [projectModule, 'picking']};

--- a/test/modules/core/lifecycle/props.spec.js
+++ b/test/modules/core/lifecycle/props.spec.js
@@ -161,14 +161,25 @@ test('compareProps#tests', t => {
 
 test('createProps', t => {
   class A {}
-  A.defaultProps = {a: 1, data: []};
+  A.defaultProps = {
+    a: 1,
+    data: [],
+    c: {type: 'number', getValue: props => props.c0 || 0}
+  };
 
   class B extends A {}
   B.defaultProps = {b: 2};
 
-  const mergedProps = createProps.apply(new B());
+  let mergedProps = createProps.call(new B(), {data: [0, 1]});
 
   t.equal(mergedProps.a, 1, 'base class props merged');
   t.equal(mergedProps.b, 2, 'sub class props merged');
+  t.deepEqual(mergedProps.data, [0, 1], 'user props merged');
+  t.equal(mergedProps.c, 0, 'default prop value used');
+
+  mergedProps = createProps.call(new B(), {c0: 4});
+
+  t.deepEqual(mergedProps.c, 4, 'user props merged');
+
   t.end();
 });

--- a/test/modules/core/lifecycle/props.spec.js
+++ b/test/modules/core/lifecycle/props.spec.js
@@ -164,7 +164,8 @@ test('createProps', t => {
   A.defaultProps = {
     a: 1,
     data: [],
-    c: {type: 'number', getValue: props => props.c0 || 0}
+    c: {type: 'number', value: 0},
+    c0: {deprecatedFor: 'c'}
   };
 
   class B extends A {}


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/2584

#### Change List

- Support `getValue` callback in prop type definition
- Fix `LineLayer` constructor support for multiple arguments
- Tests
