### PR TITLE
Pass the missing startZoomPosition into Orthographic Controller interactiveState

### DIFF
--- a/docs/api-reference/orthographic-view.md
+++ b/docs/api-reference/orthographic-view.md
@@ -15,6 +15,8 @@ To render, `OrthographicView` needs to be used together with a `viewState` with 
 * `zoom` (`Number`, optional) - The zoom level of the viewport. Default `1`.
 * `minZoom` (`Number`, optional) - The min zoom level of the viewport. Default `0`.
 * `maxZoom` (`Number`, optional) - The max zoom level of the viewport. Default `10`.
+* `enagleZooming` (`Boolean`, optional) - Enable to zoom the viewport. Default `true`.
+* `enablePanning` (`Boolean`, optional) - Enable to pan the viewport. Default `true`.
 
 For more information on using `View` classes, consult the [Views](/docs/developer-guide/views.md) article.
 

--- a/docs/api-reference/orthographic-view.md
+++ b/docs/api-reference/orthographic-view.md
@@ -15,8 +15,6 @@ To render, `OrthographicView` needs to be used together with a `viewState` with 
 * `zoom` (`Number`, optional) - The zoom level of the viewport. Default `1`.
 * `minZoom` (`Number`, optional) - The min zoom level of the viewport. Default `0`.
 * `maxZoom` (`Number`, optional) - The max zoom level of the viewport. Default `10`.
-* `enagleZooming` (`Boolean`, optional) - Enable to zoom the viewport. Default `true`.
-* `enablePanning` (`Boolean`, optional) - Enable to pan the viewport. Default `true`.
 
 For more information on using `View` classes, consult the [Views](/docs/developer-guide/views.md) article.
 

--- a/modules/core/src/controllers/orthographic-controller.js
+++ b/modules/core/src/controllers/orthographic-controller.js
@@ -20,9 +20,6 @@ class OrthographicState extends ViewState {
     minZoom = DEFAULT_MIN_ZOOM,
     maxZoom = DEFAULT_MAX_ZOOM,
 
-    enableZooming = true,
-    enablePanning = true,
-
     /** Interaction states */
     /* The point on the view being grabbed when the operation first started */
     startPanPosition,
@@ -39,9 +36,7 @@ class OrthographicState extends ViewState {
       offset,
       zoom,
       minZoom,
-      maxZoom,
-      enableZooming,
-      enablePanning
+      maxZoom
     });
     this._interactiveState = {
       startPanPosition,
@@ -74,10 +69,6 @@ class OrthographicState extends ViewState {
    * @param {[Number, Number]} pos - position on screen where the pointer is
    */
   pan({pos}) {
-    const {enablePanning} = this._viewportProps;
-    if (!enablePanning) {
-      return this;
-    }
     const {startPanPosition, startPanOffset} = this._interactiveState;
     const delta = new Vector2(pos).subtract(startPanPosition);
     return this._getUpdatedState({
@@ -145,10 +136,6 @@ class OrthographicState extends ViewState {
    * @param {[number, number]} pos - current mouse cursor screen position
    */
   zoom({pos, startPos, scale}) {
-    const {enableZooming} = this._viewportProps;
-    if (!enableZooming) {
-      return this;
-    }
     const {zoom, width, height, offset} = this._viewportProps;
     let {startZoom, startZoomPosition} = this._interactiveState;
     if (!Number.isFinite(startZoom)) {

--- a/modules/core/src/controllers/orthographic-controller.js
+++ b/modules/core/src/controllers/orthographic-controller.js
@@ -20,6 +20,9 @@ class OrthographicState extends ViewState {
     minZoom = DEFAULT_MIN_ZOOM,
     maxZoom = DEFAULT_MAX_ZOOM,
 
+    enableZooming = true,
+    enablePanning = true,
+
     /** Interaction states */
     /* The point on the view being grabbed when the operation first started */
     startPanPosition,
@@ -36,11 +39,14 @@ class OrthographicState extends ViewState {
       offset,
       zoom,
       minZoom,
-      maxZoom
+      maxZoom,
+      enableZooming,
+      enablePanning
     });
     this._interactiveState = {
       startPanPosition,
       startPanOffset,
+      startZoomPosition,
       startZoom
     };
   }
@@ -68,6 +74,10 @@ class OrthographicState extends ViewState {
    * @param {[Number, Number]} pos - position on screen where the pointer is
    */
   pan({pos}) {
+    const {enablePanning} = this._viewportProps;
+    if (!enablePanning) {
+      return this;
+    }
     const {startPanPosition, startPanOffset} = this._interactiveState;
     const delta = new Vector2(pos).subtract(startPanPosition);
     return this._getUpdatedState({
@@ -135,6 +145,10 @@ class OrthographicState extends ViewState {
    * @param {[number, number]} pos - current mouse cursor screen position
    */
   zoom({pos, startPos, scale}) {
+    const {enableZooming} = this._viewportProps;
+    if (!enableZooming) {
+      return this;
+    }
     const {zoom, width, height, offset} = this._viewportProps;
     let {startZoom, startZoomPosition} = this._interactiveState;
     if (!Number.isFinite(startZoom)) {


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background
The startZoomPosition should be passed down to the interactiveState in Orthographic Controller.

<!-- For all the PRs -->
#### Change List
-
