### PR TITLE
In docs, "renderSubLayer" -> "renderSubLayers"

### DIFF
--- a/modules/experimental-layers/src/tile-layer/tile-layer.md
+++ b/modules/experimental-layers/src/tile-layer/tile-layer.md
@@ -79,7 +79,7 @@ The maximum cache size for a tile layer. If not defined, it is calculated using 
 
 - Default: `(err) => console.error(err)`
 
-##### `renderSubLayer` (Function)
+##### `renderSubLayers` (Function)
 
 Renders a sub-layer with the `data` prop being the resolved value of `getTileData`, and other props that are passed in the `TileLayer`
 


### PR DESCRIPTION
#### Background
Typo in documentation (or maybe you'd want to change the code to match the docs? Either way.)

#### Change List
- "renderSubLayer" -> "renderSubLayers"
