### PR TITLE
Fix multiple argument support in ScatterplotLayer

### DIFF
--- a/docs/developer-guide/prop-types.md
+++ b/docs/developer-guide/prop-types.md
@@ -57,7 +57,7 @@ Each prop in `defaultProps` may be an object in the following shape:
 - `async` (boolean, optional) - if `true`, the prop can either be a [Promise](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise) that resolves to its actual value, or an url string (loaded using the base Layer's [fetch](/docs/api-reference/layer.md) prop).
 - `validate` (function, optional) - receives `value` as argument and returns `true` if the value is valid. Validation of layer props is only invoked in debug mode. This function is automatically populated if the prop has a built-in type.
 - `equal` (function, optional) - receives `value1`, `value2` as argument and returns `true` if the two values are equal. Comparison of layer props is invoked during layer update and the result is passed to `changeFlags.propsChanged`. This function is automatically populated if the prop has a built-in type.
-- `deprecatedFor` (string, optional) - mark this prop as deprecated. The value is the new prop name that this prop has been deprecated for. If the old prop is supplied instead of the new one, its value will be transferred to the new prop. The user will get a warning about the deprecation.
+- `deprecatedFor` (string|array, optional) - mark this prop as deprecated. The value is the new prop name(s) that this prop has been deprecated for. If the old prop is supplied instead of the new one, its value will be transferred to the new prop. The user will get a warning about the deprecation.
 - Any additional options, see individual types below.
 
 ### Built-in Types

--- a/examples/layer-browser/src/examples/core-layers.js
+++ b/examples/layer-browser/src/examples/core-layers.js
@@ -280,7 +280,8 @@ const ScatterplotLayerExample = {
   props: {
     id: 'scatterplotLayer',
     getPosition: d => d.COORDINATES,
-    getColor: d => [255, 128, 0],
+    getFillColor: d => [255, 128, 0],
+    getLineColor: d => [0, 128, 255],
     getRadius: d => d.SPACES,
     opacity: 1,
     pickable: true,

--- a/modules/core/src/lifecycle/create-props.js
+++ b/modules/core/src/lifecycle/create-props.js
@@ -47,20 +47,23 @@ export function createProps() {
   return propsInstance;
 }
 
+/* eslint-disable max-depth */
 function checkDeprecatedProps(propsInstance, deprecatedProps) {
   for (const name in deprecatedProps) {
     if (hasOwnProperty(propsInstance, name)) {
       const nameStr = `${propsInstance._component.constructor.name}: ${name}`;
-      const newPropName = deprecatedProps[name];
 
-      if (newPropName && !hasOwnProperty(propsInstance, newPropName)) {
-        propsInstance[newPropName] = propsInstance[name];
+      for (const newPropName of deprecatedProps[name]) {
+        if (!hasOwnProperty(propsInstance, newPropName)) {
+          propsInstance[newPropName] = propsInstance[name];
+        }
       }
 
-      log.deprecated(nameStr, newPropName)();
+      log.deprecated(nameStr, deprecatedProps[name].join('/'))();
     }
   }
 }
+/* eslint-enable max-depth */
 
 // Return precalculated defaultProps and propType objects if available
 // build them if needed

--- a/modules/core/src/lifecycle/prop-types.js
+++ b/modules/core/src/lifecycle/prop-types.js
@@ -80,7 +80,9 @@ export function parsePropTypes(propDefs) {
 
   for (const [propName, propDef] of Object.entries(propDefs)) {
     if (propDef && propDef.deprecatedFor) {
-      deprecatedProps[propName] = propDef.deprecatedFor;
+      deprecatedProps[propName] = Array.isArray(propDef.deprecatedFor)
+        ? propDef.deprecatedFor
+        : [propDef.deprecatedFor];
     } else {
       const propType = parsePropType(propName, propDef);
       propTypes[propName] = propType;

--- a/modules/layers/src/geojson-layer/geojson-layer.js
+++ b/modules/layers/src/geojson-layer/geojson-layer.js
@@ -273,45 +273,42 @@ export default class GeoJsonLayer extends CompositeLayer {
     const pointLayer =
       drawPoints &&
       new subLayers.PointLayer(
-        Object.assign(
-          {},
-          this.getSubLayerProps({
-            id: 'points',
-            updateTriggers: {
-              getFillColor: updateTriggers.getFillColor,
-              getLineColor: updateTriggers.getLineColor,
-              getRadius: updateTriggers.getRadius,
-              getLineWidth: updateTriggers.getLineWidth
-            }
-          }),
-          {
-            data: pointFeatures,
-
-            fp64,
-            stroked,
-            filled,
-            radiusScale: pointRadiusScale,
-            radiusMinPixels: pointRadiusMinPixels,
-            radiusMaxPixels: pointRadiusMaxPixels,
-            lineWidthScale,
-            lineWidthMinPixels,
-            lineWidthMaxPixels,
-
-            getPosition: getCoordinates,
-            getFillColor: unwrappingAccessor(getFillColor),
-            getLineColor: unwrappingAccessor(getLineColor),
-            getRadius: unwrappingAccessor(getRadius),
-            getLineWidth: unwrappingAccessor(getLineWidth),
-
-            transitions: transitions && {
-              getPosition: transitions.geometry,
-              getFillColor: transitions.getFillColor,
-              getLineColor: transitions.getLineColor,
-              getRadius: transitions.getRadius,
-              getLineWidth: transitions.getLineWidth
-            }
+        this.getSubLayerProps({
+          id: 'points',
+          updateTriggers: {
+            getFillColor: updateTriggers.getFillColor,
+            getLineColor: updateTriggers.getLineColor,
+            getRadius: updateTriggers.getRadius,
+            getLineWidth: updateTriggers.getLineWidth
           }
-        )
+        }),
+        {
+          data: pointFeatures,
+
+          fp64,
+          stroked,
+          filled,
+          radiusScale: pointRadiusScale,
+          radiusMinPixels: pointRadiusMinPixels,
+          radiusMaxPixels: pointRadiusMaxPixels,
+          lineWidthScale,
+          lineWidthMinPixels,
+          lineWidthMaxPixels,
+
+          getPosition: getCoordinates,
+          getFillColor: unwrappingAccessor(getFillColor),
+          getLineColor: unwrappingAccessor(getLineColor),
+          getRadius: unwrappingAccessor(getRadius),
+          getLineWidth: unwrappingAccessor(getLineWidth),
+
+          transitions: transitions && {
+            getPosition: transitions.geometry,
+            getFillColor: transitions.getFillColor,
+            getLineColor: transitions.getLineColor,
+            getRadius: transitions.getRadius,
+            getLineWidth: transitions.getLineWidth
+          }
+        }
       );
 
     return [

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer.js
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {Layer, log} from '@deck.gl/core';
+import {Layer} from '@deck.gl/core';
 import GL from '@luma.gl/constants';
 import {Model, Geometry, fp64} from 'luma.gl';
 const {fp64LowPart} = fp64;
@@ -43,45 +43,15 @@ const defaultProps = {
   getRadius: {type: 'accessor', value: 1},
   getFillColor: {type: 'accessor', value: DEFAULT_COLOR},
   getLineColor: {type: 'accessor', value: DEFAULT_COLOR},
-  getLineWidth: {type: 'accessor', value: 1}
+  getLineWidth: {type: 'accessor', value: 1},
+
+  // deprecated
+  strokeWidth: {deprecatedFor: 'getLineWidth'},
+  outline: {deprecatedFor: 'stroked'},
+  getColor: {deprecatedFor: ['getFillColor', 'getLineColor']}
 };
 
 export default class ScatterplotLayer extends Layer {
-  constructor(props) {
-    const {
-      getColor,
-      getLineColor,
-      getFillColor,
-      getLineWidth,
-      strokeWidth,
-      stroked,
-      outline
-    } = props;
-
-    const overrideProps = {};
-
-    if (getColor) {
-      if (!getLineColor) {
-        overrideProps.getLineColor = getColor;
-      }
-      if (!getFillColor) {
-        overrideProps.getFillColor = getColor;
-      }
-    }
-
-    if (getLineWidth === undefined && strokeWidth !== undefined) {
-      log.deprecated('ScatterplotLayer: `strokeWidth`', '`getLineWidth`')();
-      overrideProps.getLineWidth = strokeWidth;
-    }
-
-    if (stroked === undefined && outline !== undefined) {
-      log.deprecated('ScatterplotLayer: `stroked`', '`outline`')();
-      overrideProps.stroked = outline;
-    }
-
-    super(props, overrideProps);
-  }
-
   getShaders(id) {
     const projectModule = this.use64bitProjection() ? 'project64' : 'project32';
     return {vs, fs, modules: [projectModule, 'picking']};


### PR DESCRIPTION
For #2584 

#### Change List
- Allow `deprecatedFor` to be an array
- Remove ad-hoc ScatterPlotLayer constructor
- Revert GeoJsonLayer to using multiple arguments in creating ScatterPlotLayer
