### PR TITLE
remove logging fontAlas time

### DIFF
--- a/modules/layers/src/text-layer/text-layer.js
+++ b/modules/layers/src/text-layer/text-layer.js
@@ -87,8 +87,6 @@ export default class TextLayer extends CompositeLayer {
   }
 
   updateFontAtlas() {
-    const startTime = Date.now();
-
     const {gl} = this.context;
     const {sdf, fontFamily, characterSet} = this.props;
 
@@ -107,8 +105,6 @@ export default class TextLayer extends CompositeLayer {
       fontFamily,
       characterSet
     });
-
-    log.log(`Make font atlas in ${Date.now() - startTime} milliseconds.`)();
 
     this.setState({
       scale,


### PR DESCRIPTION
#### Background
- This debug log is to help evaluate the time difference between with and without SDF applied to `TextLayer`

#### Change List
- delete logging generating fontAtlas time
