### PR TITLE
Fix AttributeTransitionManager crash when data is empty

### DIFF
--- a/modules/core/src/lib/attribute-transition-manager.js
+++ b/modules/core/src/lib/attribute-transition-manager.js
@@ -48,6 +48,7 @@ export default class AttributeTransitionManager {
   // Check the latest attributes for updates.
   update({attributes, transitions = {}, numInstances}) {
     this.opts = transitions;
+    // Transform class will crash if elementCount is 0
     this.numInstances = numInstances || 1;
 
     if (!this.isSupported) {

--- a/modules/core/src/lib/attribute-transition-manager.js
+++ b/modules/core/src/lib/attribute-transition-manager.js
@@ -48,7 +48,7 @@ export default class AttributeTransitionManager {
   // Check the latest attributes for updates.
   update({attributes, transitions = {}, numInstances}) {
     this.opts = transitions;
-    this.numInstances = numInstances;
+    this.numInstances = numInstances || 1;
 
     if (!this.isSupported) {
       return;

--- a/test/modules/core/lib/attribute-transition-manager.spec.js
+++ b/test/modules/core/lib/attribute-transition-manager.spec.js
@@ -67,17 +67,17 @@ if (isWebGL2(gl)) {
     manager.update({attributes, transitions: {}, numInstances: 4});
     t.notOk(manager.hasAttribute('indices'), 'no transition for indices');
     t.notOk(manager.hasAttribute('instanceSizes'), 'no transition for instanceSizes');
-    t.notOk(manager.hasAttribute('instancePositions'), 'no transition for instanceSizes');
+    t.notOk(manager.hasAttribute('instancePositions'), 'no transition for instancePositions');
     t.notOk(manager.transform, 'transform is not constructed');
 
-    manager.update({attributes, transitions: {getSize: 1000, getElevation: 1000}, numInstances: 4});
+    manager.update({attributes, transitions: {getSize: 1000, getElevation: 1000}, numInstances: 0});
     t.notOk(manager.hasAttribute('indices'), 'no transition for indices');
     t.ok(manager.hasAttribute('instanceSizes'), 'added transition for instanceSizes');
     t.ok(manager.hasAttribute('instancePositions'), 'added transition for instancePositions');
     t.ok(manager.transform, 'a new transform is constructed');
 
     const sizeTransition = manager.attributeTransitions.instanceSizes;
-    t.is(sizeTransition.buffer.getElementCount(), 4, 'buffer has correct size');
+    t.is(sizeTransition.buffer.getElementCount(), 1, 'buffer has correct size');
 
     let lastTransform = manager.transform;
     delete attributes.instancePositions;
@@ -90,6 +90,7 @@ if (isWebGL2(gl)) {
       'a new transform is constructed'
     );
     t.notOk(lastTransform.model.program._handle, 'last transform is deleted');
+    t.is(sizeTransition.buffer.getElementCount(), 4, 'buffer has correct size');
 
     attributes.instanceSizes.update({value: new Float32Array(5).fill(1)});
     manager.update({attributes, transitions: {getSize: 1000}, numInstances: 5});


### PR DESCRIPTION
#### Background

If `data` is an url, before it is loaded, `data.length` is 0. The `Transform` class throws an error if `elementCount` is 0: https://github.com/uber/luma.gl/blob/6.3-release/modules/core/src/core/transform.js#L289

#### Change List
- Force data length to be non-zero
- Add test case
