### PR TITLE
Update composite layer API

### DIFF
--- a/docs/api-reference/composite-layer.md
+++ b/docs/api-reference/composite-layer.md
@@ -146,12 +146,30 @@ Returns an properties object used to generate a sublayer, with the following key
 
 ##### `shouldRenderSubLayer`
 
+Called to determine if a sublayer should be rendered.
+A composite layer can override this method to change the default behavior.
+
 Parameters:
 
 * `id` (String) - the sublayer id
 * `data` (Array) - the sublayer data
 
-Returns `true` if the sublayer should be rendered. The default implementation returns `true` if either `data` is not empty or the `_subLayerProps` prop contains override for this sublayer.
+Returns `true` if the sublayer should be rendered. The base class implementation returns `true` if either `data` is not empty or the `_subLayerProps` prop contains override for this sublayer.
+
+
+##### `getSubLayerClass`
+
+Called to retrieve the constructor of a sublayer.
+A composite layer can override this method to change the default behavior.
+
+Parameters:
+
+* `id` (String) - the sublayer id
+* `DefaultLayerClass` - the default constructor used for this sublayer.
+
+Returns:
+
+Constructor for this sublayer. The base class implementation checks if `type` is specified for the sublayer in `_subLayerProps`, otherwise returns the default.
 
 
 ## Source

--- a/docs/api-reference/composite-layer.md
+++ b/docs/api-reference/composite-layer.md
@@ -42,16 +42,40 @@ Inherits from all [Base Layer](/docs/api-reference/layer.md) properties.
 
 Key is the id of a sublayer and value is an object used to override the props of the sublayer. For a list of ids rendered by each composite layer, consult the *Sub Layers* section in each layer's documentation.
 
+Example: make only the point features in a GeoJsonLayer respond to hover and click
+
 ```js
+import {GeoJsonLayer} from '@deck.gl/layers';
+
 new GeoJsonLayer({
-  ...
-  pickable: true,
-  subLayerProps: {
+  // ...other props
+  pickable: false,
+  _subLayerProps: {
     points: {
-      pickable: false
+      pickable: true
     }
   }
-})
+});
+```
+
+Example: use IconLayer instead of ScatterplotLayer to render the point features in a GeoJsonLayer
+
+```js
+import {IconLayer, GeoJsonLayer} from '@deck.gl/layers';
+
+new GeoJsonLayer({
+  // ...other props
+  _subLayerProps: {
+    points: {
+      type: IconLayer,
+      iconAtlas: './icon-atlas.png',
+      iconMapping: './icon-mapping.json',
+      getIcon: d => d.sourceFeature.feature.properties.marker,
+      getColor: [255, 200, 0],
+      getSize: 32
+    }
+  }
+});
 ```
 
 

--- a/docs/layers/text-layer.md
+++ b/docs/layers/text-layer.md
@@ -233,7 +233,7 @@ Screen space offset relative to the `coordinates` in pixel unit.
 
 The TextLayer renders the following sublayers:
 
-* `characters` - a `MultiIconLayer` rendering all the characters.
+* `characters` - an `IconLayer` rendering all the characters.
 
 
 ## Source

--- a/modules/core/src/lib/composite-layer.js
+++ b/modules/core/src/lib/composite-layer.js
@@ -60,6 +60,15 @@ export default class CompositeLayer extends Layer {
     return (data && data.length) || (overridingProps && overridingProps[id]);
   }
 
+  // Returns sub layer class for a specific sublayer
+  getSubLayerClass(id, DefaultLayerClass) {
+    const {_subLayerProps: overridingProps} = this.props;
+
+    return (
+      (overridingProps && overridingProps[id] && overridingProps[id].type) || DefaultLayerClass
+    );
+  }
+
   // Returns sub layer props for a specific sublayer
   getSubLayerProps(sublayerProps) {
     const {

--- a/modules/layers/src/grid-layer/grid-layer.js
+++ b/modules/layers/src/grid-layer/grid-layer.js
@@ -310,9 +310,7 @@ export default class GridLayer extends CompositeLayer {
     return isElevationValueInDomain ? elevationScaleFunc(ev) : -1;
   }
 
-  // for subclassing, override this method to return
-  // customized sub layer props
-  getSubLayerProps() {
+  renderLayers() {
     const {
       elevationScale,
       fp64,
@@ -323,38 +321,32 @@ export default class GridLayer extends CompositeLayer {
       transitions
     } = this.props;
 
-    // return props to the sublayer constructor
-    return super.getSubLayerProps({
-      id: 'grid-cell',
-      data: this.state.layerData,
+    const SubLayerClass = this.getSubLayerClass('grid-cell', GridCellLayer);
 
-      fp64,
-      cellSize,
-      coverage,
-      lightSettings,
-      elevationScale,
-      extruded,
+    return new SubLayerClass(
+      {
+        fp64,
+        cellSize,
+        coverage,
+        lightSettings,
+        elevationScale,
+        extruded,
 
-      getColor: this._onGetSublayerColor.bind(this),
-      getElevation: this._onGetSublayerElevation.bind(this),
-      transitions: transitions && {
-        getColor: transitions.getColorValue,
-        getElevation: transitions.getElevationValue
+        getColor: this._onGetSublayerColor.bind(this),
+        getElevation: this._onGetSublayerElevation.bind(this),
+        transitions: transitions && {
+          getColor: transitions.getColorValue,
+          getElevation: transitions.getElevationValue
+        }
       },
-      updateTriggers: this.getUpdateTriggers()
-    });
-  }
-
-  // for subclassing, override this method to return
-  // customized sub layer class
-  getSubLayerClass() {
-    return GridCellLayer;
-  }
-
-  renderLayers() {
-    const SubLayerClass = this.getSubLayerClass();
-
-    return new SubLayerClass(this.getSubLayerProps());
+      this.getSubLayerProps({
+        id: 'grid-cell',
+        updateTriggers: this.getUpdateTriggers()
+      }),
+      {
+        data: this.state.layerData
+      }
+    );
   }
 }
 

--- a/modules/layers/src/hexagon-layer/hexagon-layer.js
+++ b/modules/layers/src/hexagon-layer/hexagon-layer.js
@@ -310,9 +310,7 @@ export default class HexagonLayer extends CompositeLayer {
     return isElevationValueInDomain ? elevationScaleFunc(ev) : -1;
   }
 
-  // for subclassing, override this method to return
-  // customized sub layer props
-  getSubLayerProps() {
+  renderLayers() {
     const {
       radius,
       elevationScale,
@@ -323,40 +321,34 @@ export default class HexagonLayer extends CompositeLayer {
       transitions
     } = this.props;
 
-    // return props to the sublayer constructor
-    return super.getSubLayerProps({
-      id: 'hexagon-cell',
-      data: this.state.hexagons,
+    const SubLayerClass = this.getSubLayerClass('hexagon-cell', HexagonCellLayer);
 
-      fp64,
-      hexagonVertices: this.state.hexagonVertices,
-      radius,
-      elevationScale,
-      angle: Math.PI / 2,
-      extruded,
-      coverage,
-      lightSettings,
+    return new SubLayerClass(
+      {
+        fp64,
+        radius,
+        elevationScale,
+        angle: Math.PI / 2,
+        extruded,
+        coverage,
+        lightSettings,
 
-      getColor: this._onGetSublayerColor.bind(this),
-      getElevation: this._onGetSublayerElevation.bind(this),
-      transitions: transitions && {
-        getColor: transitions.getColorValue,
-        getElevation: transitions.getElevationValue
+        getColor: this._onGetSublayerColor.bind(this),
+        getElevation: this._onGetSublayerElevation.bind(this),
+        transitions: transitions && {
+          getColor: transitions.getColorValue,
+          getElevation: transitions.getElevationValue
+        }
       },
-      updateTriggers: this.getUpdateTriggers()
-    });
-  }
-
-  // for subclassing, override this method to return
-  // customized sub layer class
-  getSubLayerClass() {
-    return HexagonCellLayer;
-  }
-
-  renderLayers() {
-    const SubLayerClass = this.getSubLayerClass();
-
-    return new SubLayerClass(this.getSubLayerProps());
+      this.getSubLayerProps({
+        id: 'hexagon-cell',
+        updateTriggers: this.getUpdateTriggers()
+      }),
+      {
+        data: this.state.hexagons,
+        hexagonVertices: this.state.hexagonVertices
+      }
+    );
   }
 }
 

--- a/modules/layers/src/polygon-layer/polygon-layer.js
+++ b/modules/layers/src/polygon-layer/polygon-layer.js
@@ -144,10 +144,28 @@ export default class PolygonLayer extends CompositeLayer {
 
     const {paths} = this.state;
 
+    const FillLayer = this.getSubLayerClass('fill', SolidPolygonLayer);
+    const StrokeLayer = this.getSubLayerClass('stroke', PathLayer);
+
     // Filled Polygon Layer
     const polygonLayer =
       this.shouldRenderSubLayer('fill', paths) &&
-      new SolidPolygonLayer(
+      new FillLayer(
+        {
+          extruded,
+          elevationScale,
+
+          fp64,
+          filled,
+          wireframe,
+
+          getElevation,
+          getFillColor,
+          getLineColor,
+
+          lightSettings,
+          transitions
+        },
         this.getSubLayerProps({
           id: 'fill',
           updateTriggers: {
@@ -159,20 +177,7 @@ export default class PolygonLayer extends CompositeLayer {
         }),
         {
           data,
-          extruded,
-          elevationScale,
-
-          fp64,
-          filled,
-          wireframe,
-
-          getPolygon,
-          getElevation,
-          getFillColor,
-          getLineColor,
-
-          lightSettings,
-          transitions
+          getPolygon
         }
       );
 
@@ -181,18 +186,8 @@ export default class PolygonLayer extends CompositeLayer {
       !extruded &&
       stroked &&
       this.shouldRenderSubLayer('stroke', paths) &&
-      new PathLayer(
-        this.getSubLayerProps({
-          id: 'stroke',
-          updateTriggers: {
-            getWidth: updateTriggers.getLineWidth,
-            getColor: updateTriggers.getLineColor,
-            getDashArray: updateTriggers.getLineDashArray
-          }
-        }),
+      new StrokeLayer(
         {
-          data: paths,
-
           fp64,
           widthScale: lineWidthScale,
           widthMinPixels: lineWidthMinPixels,
@@ -207,10 +202,21 @@ export default class PolygonLayer extends CompositeLayer {
             getPath: transitions.getPolygon
           },
 
-          getPath: x => x.path,
           getColor: this._getAccessor(getLineColor),
           getWidth: this._getAccessor(getLineWidth),
           getDashArray: this._getAccessor(getLineDashArray)
+        },
+        this.getSubLayerProps({
+          id: 'stroke',
+          updateTriggers: {
+            getWidth: updateTriggers.getLineWidth,
+            getColor: updateTriggers.getLineColor,
+            getDashArray: updateTriggers.getLineDashArray
+          }
+        }),
+        {
+          data: paths,
+          getPath: x => x.path
         }
       );
 

--- a/modules/layers/src/text-layer/text-layer.js
+++ b/modules/layers/src/text-layer/text-layer.js
@@ -207,46 +207,52 @@ export default class TextLayer extends CompositeLayer {
       updateTriggers
     } = this.props;
 
-    return [
-      new MultiIconLayer(
-        this.getSubLayerProps({
-          id: 'characters',
-          data,
-          sdf,
-          iconAtlas,
-          iconMapping,
-          getIcon: d => d.text,
-          getPosition: d => getPosition(d.object),
-          getShiftInQueue: d => this.getLetterOffset(d),
-          getLengthOfQueue: d => this.getTextLength(d),
-          getColor: this._getAccessor(getColor),
-          getSize: this._getAccessor(getSize),
-          getAngle: this._getAccessor(getAngle),
-          getAnchorX: this.getAnchorXFromTextAnchor(getTextAnchor),
-          getAnchorY: this.getAnchorYFromAlignmentBaseline(getAlignmentBaseline),
-          getPixelOffset: this._getAccessor(getPixelOffset),
-          fp64,
-          sizeScale: sizeScale * scale,
+    const SubLayerClass = this.getSubLayerClass('characters', MultiIconLayer);
 
-          transitions: transitions && {
-            getPosition: transitions.getPosition,
-            getAngle: transitions.getAngle,
-            getColor: transitions.getColor,
-            getSize: transitions.getSize,
-            getPixelOffset: updateTriggers.getPixelOffset
-          },
-          updateTriggers: {
-            getPosition: updateTriggers.getPosition,
-            getAngle: updateTriggers.getAngle,
-            getColor: updateTriggers.getColor,
-            getSize: updateTriggers.getSize,
-            getPixelOffset: updateTriggers.getPixelOffset,
-            getAnchorX: updateTriggers.getTextAnchor,
-            getAnchorY: updateTriggers.getAlignmentBaseline
-          }
-        })
-      )
-    ];
+    return new SubLayerClass(
+      {
+        sdf,
+        iconAtlas,
+        iconMapping,
+
+        getPosition: d => getPosition(d.object),
+        getColor: this._getAccessor(getColor),
+        getSize: this._getAccessor(getSize),
+        getAngle: this._getAccessor(getAngle),
+        getAnchorX: this.getAnchorXFromTextAnchor(getTextAnchor),
+        getAnchorY: this.getAnchorYFromAlignmentBaseline(getAlignmentBaseline),
+        getPixelOffset: this._getAccessor(getPixelOffset),
+        fp64,
+        sizeScale: sizeScale * scale,
+
+        transitions: transitions && {
+          getPosition: transitions.getPosition,
+          getAngle: transitions.getAngle,
+          getColor: transitions.getColor,
+          getSize: transitions.getSize,
+          getPixelOffset: updateTriggers.getPixelOffset
+        }
+      },
+      this.getSubLayerProps({
+        id: 'characters',
+        updateTriggers: {
+          getPosition: updateTriggers.getPosition,
+          getAngle: updateTriggers.getAngle,
+          getColor: updateTriggers.getColor,
+          getSize: updateTriggers.getSize,
+          getPixelOffset: updateTriggers.getPixelOffset,
+          getAnchorX: updateTriggers.getTextAnchor,
+          getAnchorY: updateTriggers.getAlignmentBaseline
+        }
+      }),
+      {
+        data,
+
+        getIcon: d => d.text,
+        getShiftInQueue: d => this.getLetterOffset(d),
+        getLengthOfQueue: d => this.getTextLength(d)
+      }
+    );
   }
 }
 


### PR DESCRIPTION
RFC: https://github.com/uber/deck.gl/pull/2600

#### Change List
- Add `compositeLayer.getSubLayerClass` method
- Update all core composite layers' `renderLayers` method. Some sublayer props are no longer passed to `compositeLayer.getSubLayerProps` for perf reasons (reduce `Object.assign` cost) but there's no functional changes.
