### PR TITLE
OrthographicView updates

### DIFF
--- a/docs/api-reference/orthographic-view.md
+++ b/docs/api-reference/orthographic-view.md
@@ -8,12 +8,9 @@ The [`OrthographicView`] class is a subclass of [View](/docs/api-reference/view.
 
 To render, `OrthographicView` needs to be used together with a `viewState` with the following parameters:
 
-* `eye` (`Number[3]`, optional) - The eye position in world coordinates. Default `[0, 0, 1]`.
-* `lookAt` (`Number[3]`, optional) - The position being looked at. Default `[0, 0, 0]`.
-* `up` (`Number[3]`, optional) - The up direction. Default `[0, 1, 0]`.
-* `offset` (`Number[2]`, optional) - The offset of the viewport. Default `[0, 1]`.
-* `zoom` (`Number`, optional) - The zoom level of the viewport. Default `1`.
-* `minZoom` (`Number`, optional) - The min zoom level of the viewport. Default `0`.
+* `offset` (`Number[2]`, optional) - The offset of the viewport, in screen pixels. Default `[0, 0]` (the coordinate origin is projected to the center of the viewport).
+* `zoom` (`Number`, optional) - The zoom level of the viewport. Default `0` (one unit distance maps to one pixel on screen).
+* `minZoom` (`Number`, optional) - The min zoom level of the viewport. Default `-10`.
 * `maxZoom` (`Number`, optional) - The max zoom level of the viewport. Default `10`.
 
 For more information on using `View` classes, consult the [Views](/docs/developer-guide/views.md) article.
@@ -22,17 +19,16 @@ For more information on using `View` classes, consult the [Views](/docs/develope
 ## Constructor
 
 ```js
-new OrthographicView({left: 0, top: 0, width: 500, height: 500});
+new OrthographicView({controller: true});
 ```
 
 The `OrthographicView` constructor takes the same parameters as the [View](/docs/api-reference/view.md) superclass constructor, plus the following orthographic projection matrix arguments:
 
+* `eye` (`Number[3]`, optional) - The eye position in world coordinates. Default `[0, 0, 1]`.
+* `lookAt` (`Number[3]`, optional) - The position being looked at. Default `[0, 0, 0]`.
+* `up` (`Number[3]`, optional) - The up direction. Default `[0, 1, 0]`.
 * `near` (`Number`, optional) - Distance of near clipping plane. Default to `1`.
 * `far` (`Number`, optional) - Distance of far clipping plane. Default to `100`.
-* `left` (`Number`, optional) - Left bound of the frustum. Automatically calculated if not provided.
-* `top` (`Number`, optional) - Top bound of the frustum. Automatically calculated if not provided.
-* `right` (`Number`, optional) - Right bound of the frustum. Automatically calculated if not provided.
-* `bottom` (`Number`, optional) - Bottom bound of the frustum. Automatically calculated if not provided.
 
 
 ## Methods

--- a/docs/api-reference/orthographic-view.md
+++ b/docs/api-reference/orthographic-view.md
@@ -9,7 +9,7 @@ The [`OrthographicView`] class is a subclass of [View](/docs/api-reference/view.
 To render, `OrthographicView` needs to be used together with a `viewState` with the following parameters:
 
 * `offset` (`Number[2]`, optional) - The offset of the viewport, in screen pixels. Default `[0, 0]` (the coordinate origin is projected to the center of the viewport).
-* `zoom` (`Number`, optional) - The zoom level of the viewport. Default `0` (one unit distance maps to one pixel on screen).
+* `zoom` (`Number`, optional) - The zoom level of the viewport. `zoom: 0` maps one unit distance to one pixel on screen, and increasing `zoom` by `1` scales the same object to twice as large. Default `0`.
 * `minZoom` (`Number`, optional) - The min zoom level of the viewport. Default `-10`.
 * `maxZoom` (`Number`, optional) - The max zoom level of the viewport. Default `10`.
 

--- a/examples/experimental/bezier/app.js
+++ b/examples/experimental/bezier/app.js
@@ -7,7 +7,6 @@ import BezierGraphLayer from './bezier-graph-layer';
 import SAMPLE_GRAPH from './sample-graph.json';
 
 const INITIAL_VIEW_STATE = {
-  offset: [0, 0],
   zoom: 1
 };
 

--- a/modules/core/src/controllers/orthographic-controller.js
+++ b/modules/core/src/controllers/orthographic-controller.js
@@ -4,9 +4,13 @@ import ViewState from './view-state';
 import {Vector2, clamp} from 'math.gl';
 
 const MOVEMENT_SPEED = 10; // per keyboard click
-// TODO - make default unlimited in the next major version
-const DEFAULT_MIN_ZOOM = 0;
-const DEFAULT_MAX_ZOOM = 10;
+
+const DEFAULT_STATE = {
+  zoom: 0,
+  offset: [0, 0],
+  minZoom: -10,
+  maxZoom: 10
+};
 
 const zoom2Scale = zoom => Math.pow(2, zoom);
 
@@ -15,10 +19,10 @@ class OrthographicState extends ViewState {
     /* Viewport arguments */
     width, // Width of viewport
     height, // Height of viewport
-    offset, // Offset to the origin
-    zoom, // Zoom level of the view
-    minZoom = DEFAULT_MIN_ZOOM,
-    maxZoom = DEFAULT_MAX_ZOOM,
+    offset = DEFAULT_STATE.offset, // Offset to the origin
+    zoom = DEFAULT_STATE.zoom, // Zoom level of the view
+    minZoom = DEFAULT_STATE.minZoom,
+    maxZoom = DEFAULT_STATE.maxZoom,
 
     /** Interaction states */
     /* The point on the view being grabbed when the operation first started */
@@ -155,11 +159,12 @@ class OrthographicState extends ViewState {
 
     const centerX = width / 2 - offset[0];
     const centerY = height / 2 - offset[1];
-    const dX = (startZoomPosition[0] - centerX) * (startScale / newScale - 1);
-    const dY = (startZoomPosition[1] - centerY) * (startScale / newScale - 1);
+    const dX = (startZoomPosition[0] - centerX) * (newScale / startScale - 1);
+    const dY = (startZoomPosition[1] - centerY) * (newScale / startScale - 1);
+
     return this._getUpdatedState({
       zoom: newZoom,
-      offset: [offset[0] - dX, offset[1] - dY]
+      offset: [offset[0] + dX, offset[1] + dY]
     });
   }
 

--- a/modules/core/src/lib/view-manager.js
+++ b/modules/core/src/lib/view-manager.js
@@ -280,7 +280,7 @@ export default class ViewManager {
 
   _updateController(view, viewState, viewport, controller) {
     if (view.controller) {
-      const controllerProps = Object.assign({}, view.controller, view.defaultState, viewState, {
+      const controllerProps = Object.assign({}, view.controller, viewState, {
         id: view.id,
         x: viewport.x,
         y: viewport.y,

--- a/modules/core/src/shaderlib/project/viewport-uniforms.js
+++ b/modules/core/src/shaderlib/project/viewport-uniforms.js
@@ -197,7 +197,6 @@ function calculateViewportUniforms({
   wrapLongitude
 }) {
   const coordinateZoom = viewport.zoom;
-  assert(coordinateZoom >= 0);
 
   const {
     projectionCenter,

--- a/modules/core/src/views/orthographic-view.js
+++ b/modules/core/src/views/orthographic-view.js
@@ -13,14 +13,7 @@ export default class OrthographicView extends View {
 
   _getViewport({x, y, width, height, viewState}) {
     // Get view matrix parameters from view state
-    const {
-      // view matrix arguments
-      eye = [0, 0, 1], // Defines eye position
-      lookAt = [0, 0, 0], // Which point is camera looking at, default origin
-      up = [0, 1, 0], // Defines up direction, default positive y axis,
-      offset = [0, 1],
-      zoom = 1
-    } = viewState;
+    const {offset = [0, 0], zoom = 0} = viewState;
 
     // Make sure Matrix4.ortho doesn't crash on 0 width/height
     width = width || 1;
@@ -31,6 +24,11 @@ export default class OrthographicView extends View {
     // Get projection matrix parameters from the view itself
     // NOTE: automatically calculated from width and height if not provided
     const {
+      // view matrix arguments
+      eye = [0, 0, 1], // Defines eye position
+      lookAt = [0, 0, 0], // Which point is camera looking at, default origin
+      up = [0, 1, 0], // Defines up direction, default positive y axis,
+
       // projection matrix arguments
       left = (-width / 2 + offset[0]) / scale, // Left bound of the frustum
       top = (-height / 2 + offset[1]) / scale, // Top bound of the frustum

--- a/test/render/test-cases.js
+++ b/test/render/test-cases.js
@@ -141,10 +141,7 @@ export const TEST_CASES = [
     name: 'bezier-curve-2d',
     views: [new OrthographicView()],
     viewState: {
-      left: -WIDTH / 2,
-      top: -HEIGHT / 2,
-      right: WIDTH / 2,
-      bottom: HEIGHT / 2
+      zoom: 1
     },
     layers: [
       new BezierCurveLayer({


### PR DESCRIPTION
For #2622 

#### Change List

Bug fixes:

- Fix crash when `offset` is not present in `viewState`
- Fix bug where zoom center does not stay under the pointer
- Fix project module error when `zoom < 0`

Breaking changes:

- Default `zoom`: `0`
- Default `minZoom`: `-10`
- Default `maxZoom`: `10`
- `eye`, `lookAt` and `up` are moved to view props from view state

Doc updates:

- Document new default values
- Remove `left` `top` `right` `bottom` from view props - the controller does not work with these props, and incorrectly set bounds will break the view. We should remove them in v7.0.
