### PR TITLE
replace deprecated props of scatterplot layer in examples

### DIFF
--- a/examples/experimental/bezier/bezier-graph-layer.js
+++ b/examples/experimental/bezier/bezier-graph-layer.js
@@ -32,9 +32,9 @@ export default class BezierGraphLayer extends CompositeLayer {
         data: nodes,
         coordinateSystem: COORDINATE_SYSTEM.IDENTITY,
         getPosition: d => d.position,
-        getRadius: d => 5,
-        getFillColor: d => [0, 0, 150, 255],
-        getLineColor: d => [255, 128, 0, 255],
+        getRadius: 5,
+        getFillColor: [0, 0, 150, 255],
+        getLineColor: [255, 128, 0, 255],
         // interaction:
         pickable: true,
         autoHighlight: true,

--- a/examples/experimental/bezier/bezier-graph-layer.js
+++ b/examples/experimental/bezier/bezier-graph-layer.js
@@ -34,7 +34,6 @@ export default class BezierGraphLayer extends CompositeLayer {
         getPosition: d => d.position,
         getRadius: 5,
         getFillColor: [0, 0, 150, 255],
-        getLineColor: [255, 128, 0, 255],
         // interaction:
         pickable: true,
         autoHighlight: true,

--- a/examples/experimental/bezier/bezier-graph-layer.js
+++ b/examples/experimental/bezier/bezier-graph-layer.js
@@ -33,7 +33,8 @@ export default class BezierGraphLayer extends CompositeLayer {
         coordinateSystem: COORDINATE_SYSTEM.IDENTITY,
         getPosition: d => d.position,
         getRadius: d => 5,
-        getColor: d => [0, 0, 150, 255],
+        getFillColor: d => [0, 0, 150, 255],
+        getLineColor: d => [255, 128, 0, 255],
         // interaction:
         pickable: true,
         autoHighlight: true,

--- a/examples/get-started/react-browserify/app.js
+++ b/examples/get-started/react-browserify/app.js
@@ -27,7 +27,6 @@ class Root extends Component {
           data={[{position: [-122.41669, 37.79]}]}
           radiusScale={100}
           getFillColor={[0, 0, 255]}
-          getLineColor={[255, 128, 0]}
         />
       </DeckGL>
     );

--- a/examples/get-started/react-browserify/app.js
+++ b/examples/get-started/react-browserify/app.js
@@ -26,7 +26,8 @@ class Root extends Component {
         <ScatterplotLayer
           data={[{position: [-122.41669, 37.79]}]}
           radiusScale={100}
-          getColor={x => [0, 0, 255]}
+          getFillColor={x => [0, 0, 255]}
+          getLineColor={x => [255, 128, 0]}
         />
       </DeckGL>
     );

--- a/examples/get-started/react-browserify/app.js
+++ b/examples/get-started/react-browserify/app.js
@@ -26,8 +26,8 @@ class Root extends Component {
         <ScatterplotLayer
           data={[{position: [-122.41669, 37.79]}]}
           radiusScale={100}
-          getFillColor={x => [0, 0, 255]}
-          getLineColor={x => [255, 128, 0]}
+          getFillColor={[0, 0, 255]}
+          getLineColor={[255, 128, 0]}
         />
       </DeckGL>
     );

--- a/examples/get-started/react-webpack-2/app.js
+++ b/examples/get-started/react-webpack-2/app.js
@@ -27,7 +27,6 @@ class Root extends Component {
           data={[{position: [-122.41669, 37.79]}]}
           radiusScale={100}
           getFillColor={[0, 0, 255]}
-          getLineColor={[255, 128, 0]}
         />
       </DeckGL>
     );

--- a/examples/get-started/react-webpack-2/app.js
+++ b/examples/get-started/react-webpack-2/app.js
@@ -26,7 +26,8 @@ class Root extends Component {
         <ScatterplotLayer
           data={[{position: [-122.41669, 37.79]}]}
           radiusScale={100}
-          getColor={x => [0, 0, 255]}
+          getFillColor={x => [0, 0, 255]}
+          getLineColor={x => [255, 128, 0]}
         />
       </DeckGL>
     );

--- a/examples/get-started/react-webpack-2/app.js
+++ b/examples/get-started/react-webpack-2/app.js
@@ -26,8 +26,8 @@ class Root extends Component {
         <ScatterplotLayer
           data={[{position: [-122.41669, 37.79]}]}
           radiusScale={100}
-          getFillColor={x => [0, 0, 255]}
-          getLineColor={x => [255, 128, 0]}
+          getFillColor={[0, 0, 255]}
+          getLineColor={[255, 128, 0]}
         />
       </DeckGL>
     );

--- a/examples/layer-browser/src/examples/perf-layers.js
+++ b/examples/layer-browser/src/examples/perf-layers.js
@@ -146,7 +146,8 @@ const ScatterplotLayerPerfExample = (id, getData) => ({
   props: {
     id: `scatterplotLayerPerf-${id}`,
     getPosition: d => d,
-    getColor: d => [0, 128, 0],
+    getFillColor: d => [0, 128, 0],
+    getLineColor: d => [0, 128, 255],
     // pickable: true,
     radiusMinPixels: 1,
     radiusMaxPixels: 5
@@ -159,7 +160,8 @@ const ScatterplotLayer64PerfExample = (id, getData) => ({
   props: {
     id: `scatterplotLayer64Perf-${id}`,
     getPosition: d => d,
-    getColor: d => [0, 128, 0],
+    getFillColor: d => [0, 128, 0],
+    getLineColor: d => [0, 128, 255],
     // pickable: true,
     radiusMinPixels: 1,
     radiusMaxPixels: 5,

--- a/examples/layer-browser/src/examples/perf-layers.js
+++ b/examples/layer-browser/src/examples/perf-layers.js
@@ -146,8 +146,8 @@ const ScatterplotLayerPerfExample = (id, getData) => ({
   props: {
     id: `scatterplotLayerPerf-${id}`,
     getPosition: d => d,
-    getFillColor: d => [0, 128, 0],
-    getLineColor: d => [0, 128, 255],
+    getFillColor: [0, 128, 0],
+    getLineColor: [0, 128, 255],
     // pickable: true,
     radiusMinPixels: 1,
     radiusMaxPixels: 5
@@ -160,8 +160,8 @@ const ScatterplotLayer64PerfExample = (id, getData) => ({
   props: {
     id: `scatterplotLayer64Perf-${id}`,
     getPosition: d => d,
-    getFillColor: d => [0, 128, 0],
-    getLineColor: d => [0, 128, 255],
+    getFillColor: [0, 128, 0],
+    getLineColor: [0, 128, 255],
     // pickable: true,
     radiusMinPixels: 1,
     radiusMaxPixels: 5,

--- a/examples/layer-browser/src/examples/perf-layers.js
+++ b/examples/layer-browser/src/examples/perf-layers.js
@@ -147,7 +147,6 @@ const ScatterplotLayerPerfExample = (id, getData) => ({
     id: `scatterplotLayerPerf-${id}`,
     getPosition: d => d,
     getFillColor: [0, 128, 0],
-    getLineColor: [0, 128, 255],
     // pickable: true,
     radiusMinPixels: 1,
     radiusMaxPixels: 5
@@ -161,7 +160,6 @@ const ScatterplotLayer64PerfExample = (id, getData) => ({
     id: `scatterplotLayer64Perf-${id}`,
     getPosition: d => d,
     getFillColor: [0, 128, 0],
-    getLineColor: [0, 128, 255],
     // pickable: true,
     radiusMinPixels: 1,
     radiusMaxPixels: 5,

--- a/examples/website/brushing/app.js
+++ b/examples/website/brushing/app.js
@@ -201,8 +201,8 @@ export class App extends Component {
         data: targets,
         brushRadius,
         mousePosition,
-        getLineWidth: 2,
-        stroked: true,
+        strokeWidth: 2,
+        outline: true,
         opacity: 1,
         enableBrushing: startBrushing,
         // only show rings when brushing

--- a/examples/website/brushing/app.js
+++ b/examples/website/brushing/app.js
@@ -193,8 +193,7 @@ export class App extends Component {
         pickable: false,
         // only show source points when brushing
         radiusScale: startBrushing ? 3000 : 0,
-        getFillColor: d => (d.gain > 0 ? TARGET_COLOR : SOURCE_COLOR),
-        getLineColor: d => (d.gain > 0 ? TARGET_COLOR : SOURCE_COLOR),
+        getColor: d => (d.gain > 0 ? TARGET_COLOR : SOURCE_COLOR),
         getTargetPosition: d => [d.position[0], d.position[1], 0]
       }),
       new ScatterplotBrushingLayer({
@@ -208,8 +207,7 @@ export class App extends Component {
         enableBrushing: startBrushing,
         // only show rings when brushing
         radiusScale: startBrushing ? 4000 : 0,
-        getFillColor: d => (d.net > 0 ? TARGET_COLOR : SOURCE_COLOR),
-        getLineColor: d => (d.net > 0 ? TARGET_COLOR : SOURCE_COLOR)
+        getColor: d => (d.net > 0 ? TARGET_COLOR : SOURCE_COLOR)
       }),
       new ScatterplotBrushingLayer({
         id: 'targets',
@@ -221,8 +219,7 @@ export class App extends Component {
         pickable: true,
         radiusScale: 3000,
         onHover: this._onHover,
-        getFillColor: d => (d.net > 0 ? TARGET_COLOR : SOURCE_COLOR),
-        getLineColor: d => (d.net > 0 ? TARGET_COLOR : SOURCE_COLOR)
+        getColor: d => (d.net > 0 ? TARGET_COLOR : SOURCE_COLOR)
       }),
       new ArcBrushingLayer({
         id: 'arc',

--- a/examples/website/brushing/app.js
+++ b/examples/website/brushing/app.js
@@ -193,7 +193,8 @@ export class App extends Component {
         pickable: false,
         // only show source points when brushing
         radiusScale: startBrushing ? 3000 : 0,
-        getColor: d => (d.gain > 0 ? TARGET_COLOR : SOURCE_COLOR),
+        getFillColor: d => (d.gain > 0 ? TARGET_COLOR : SOURCE_COLOR),
+        getLineColor: d => (d.gain > 0 ? TARGET_COLOR : SOURCE_COLOR),
         getTargetPosition: d => [d.position[0], d.position[1], 0]
       }),
       new ScatterplotBrushingLayer({
@@ -201,13 +202,14 @@ export class App extends Component {
         data: targets,
         brushRadius,
         mousePosition,
-        strokeWidth: 2,
-        outline: true,
+        getLineWidth: 2,
+        stroked: true,
         opacity: 1,
         enableBrushing: startBrushing,
         // only show rings when brushing
         radiusScale: startBrushing ? 4000 : 0,
-        getColor: d => (d.net > 0 ? TARGET_COLOR : SOURCE_COLOR)
+        getFillColor: d => (d.net > 0 ? TARGET_COLOR : SOURCE_COLOR),
+        getLineColor: d => (d.net > 0 ? TARGET_COLOR : SOURCE_COLOR)
       }),
       new ScatterplotBrushingLayer({
         id: 'targets',
@@ -219,7 +221,8 @@ export class App extends Component {
         pickable: true,
         radiusScale: 3000,
         onHover: this._onHover,
-        getColor: d => (d.net > 0 ? TARGET_COLOR : SOURCE_COLOR)
+        getFillColor: d => (d.net > 0 ? TARGET_COLOR : SOURCE_COLOR),
+        getLineColor: d => (d.net > 0 ? TARGET_COLOR : SOURCE_COLOR)
       }),
       new ArcBrushingLayer({
         id: 'arc',

--- a/examples/website/line/app.js
+++ b/examples/website/line/app.js
@@ -81,7 +81,8 @@ export class App extends Component {
         data: airports,
         radiusScale: 20,
         getPosition: d => d.coordinates,
-        getColor: [255, 140, 0],
+        getFillColor: [255, 140, 0],
+        getLineColor: [0, 0, 255],
         getRadius: d => getSize(d.type),
         pickable: true,
         onHover: this._onHover

--- a/examples/website/line/app.js
+++ b/examples/website/line/app.js
@@ -82,7 +82,6 @@ export class App extends Component {
         radiusScale: 20,
         getPosition: d => d.coordinates,
         getFillColor: [255, 140, 0],
-        getLineColor: [0, 0, 255],
         getRadius: d => getSize(d.type),
         pickable: true,
         onHover: this._onHover


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #2623 
<!-- For other PRs without open issue -->
#### Background
depreciation warning are found in website examples that use scatterplot layer. 
<!-- For all the PRs -->
#### Change List
- replace deprecated props with new ones
