### PR TITLE
expose font settings as TextLayer props

### DIFF
--- a/docs/layers/text-layer.md
+++ b/docs/layers/text-layer.md
@@ -50,59 +50,6 @@ const App = ({data, viewport}) => {
 };
 ```
 
-## Example: rendering with sdf (Signed Distance Fields)
-
-You may consider using [`sdf` (Signed Distance Fields)](http://cs.brown.edu/people/pfelzens/papers/dt-final.pdf)
-option when rendering with very large or small font sizes, which will provide a sharper look. `TextLayer` integrates 
-with [`TinySDF`](https://github.com/mapbox/tiny-sdf) which implements the `sdf` algorithm. You can enable `sdf` by 
-setting `sdf` to true or pass customized options, which will be used in `TinySDF`.
-
-```js
-import DeckGL from 'deck.gl';
-import TextLayer from './text-layer';
-
-const App = ({data, viewport}) => {
-  /**
-   * Data format:
-   * [
-   *   {name: 'Colma (COLM)', address: '365 D Street, Colma CA 94014', coordinates: [-122.466233, 37.684638]},
-   *   ...
-   * ]
-   */
-
-  const layer = new TextLayer({
-    id: 'text-layer',
-    data,
-   
-   // sdf object will be used to construct `TinySDF` instance
-   // https://github.com/mapbox/tiny-sdf
-    sdf: {
-      fontSize: 64,
-      buffer: 1,
-      radius: 3,
-      cutoff: 0.25,
-      fontWeight: 'normal'
-    },
-
-    pickable: true,
-    getPosition: d => d.coordinates,
-    getText: d => d.name,
-    getSize: 32,
-    getAngle: 0,
-    getTextAnchor: 'middle',
-    getAlignmentBaseline: 'center',
-    onHover: ({object, x, y}) => {
-      const tooltip = `${object.name}\n${object.address}`;
-      /* Update tooltip
-         http://deck.gl/#/documentation/developer-guide/adding-interactivity?section=example-display-a-tooltip-for-hovered-object
-      */
-    }
-  });
-
-  return <DeckGL {...viewport} layers={[layer]} />;
-};
-```
-
 ## Properties
 
 Inherits from all [Base Layer](/docs/api-reference/layer.md) and [CompositeLayer](/docs/api-reference/composite-layer.md) properties.
@@ -131,27 +78,25 @@ Specifies a prioritized list of one or more font family names and/or generic fam
 
 Specifies a list of characters to include in the font. By default, only characters in the Ascii code range 32-128 are included. Use this prop if you need to display special characters.
 
-##### `sdf` (Boolean | Object, optional)
+##### `fontWeight` (Number | String, optional)
 
-* Default: `false`
+* Default: `normal`.
 
-To use [`sdf` (Signed Distance Fields)](http://cs.brown.edu/people/pfelzens/papers/dt-final.pdf) to 
-generate font, set `sdf` to be true or use customized parameters. The parameters will be used in constructing
-[`TinySDF`](https://github.com/mapbox/tiny-sdf) instance.  
+css `font-weight`.
 
-Default `sdf` preset is
+##### `fontSettings` (Object, optional)
 
-```js
-{
- fontSize: 64,
- buffer: 2,
- radius: 3,
- cutoff: 0.25,
- 
- fontFamily: props.fontFamily, // from layer property 
- fontWeight: 'normal'
-}
-```
+Advance options for fine tuning the appearance and performance of the generated shared `fontAtlas`.
+
+Options:
+
+* `fontSize` (Number): Font size in pixels. Default is `64`. This option is only applied for generating `fontAtlas`, it does not impact the size of displayed text labels. Larger `fontSize` will give you a sharper look when rendering text labels with very large font sizes. But larger `fontSize` requires more time and space to generate the `fontAtlas`.
+* `buffer` (Number): Whitespace buffer around each side of the character. Default is `2`. In general, bigger `fontSize` requires bigger `buffer`. Increase `buffer` will add more space between each character when layout `characterSet` in `fontAtlas`. This option could be tuned to provide sufficient space for drawing each character and avoiding overlapping of neighboring characters. But the cost of bigger `buffer` is more time and space to generate `fontAtlas`.
+* `sdf` (Boolean): Flag to enable / disable `sdf`. Default is `false`. [`sdf` (Signed Distance Fields)](http://cs.brown.edu/people/pfelzens/papers/dt-final.pdf) will provide a sharper look when rendering with very large or small font sizes. `TextLayer` integrates with [`TinySDF`](https://github.com/mapbox/tiny-sdf) which implements the `sdf` algorithm.
+* `radius` (Number): How many pixels around the glyph shape to use for encoding distance. Default is `3`. Bigger radius can have more halo effect.
+* `cutoff` (Number): How much of the radius (relative) is used for the inside part the glyph. Default is `0.25`. Bigger `cutoff` makes character thinner. Smaller `cutoff` makes character look thicker.
+
+`radius` and `cutoff` will be applied only when `sdf` enabled.
 
 ### Data Accessors
 

--- a/examples/layer-browser/src/examples/core-layers.js
+++ b/examples/layer-browser/src/examples/core-layers.js
@@ -425,12 +425,70 @@ const TextLayerExample = {
       name: 'fontFamily',
       type: 'category',
       value: ['Monaco', 'Helvetica', 'Garamond', 'Palatino', 'Courier', 'Courier New']
+    },
+    fontWeight: {
+      type: 'category',
+      max: 100,
+      value: [
+        'normal',
+        'bold',
+        'bolder',
+        'lighter',
+        '100',
+        '200',
+        '300',
+        '400',
+        '500',
+        '600',
+        '700',
+        '800',
+        '900'
+      ]
+    },
+    fontSettings: {
+      type: 'compound',
+      elements: ['fontSize', 'buffer', 'sdf', 'radius', 'cutoff']
+    },
+    fontSize: {
+      type: 'number',
+      max: 100,
+      onUpdate: (newValue, newSettings, change) => {
+        change('fontSettings', {...newSettings.fontSettings, fontSize: newValue});
+      }
+    },
+    buffer: {
+      type: 'number',
+      max: 100,
+      onUpdate: (newValue, newSettings, change) => {
+        change('fontSettings', {...newSettings.fontSettings, buffer: newValue});
+      }
+    },
+    sdf: {
+      type: 'boolean',
+      onUpdate: (newValue, newSettings, change) => {
+        change('fontSettings', {...newSettings.fontSettings, sdf: newValue});
+      }
+    },
+    radius: {
+      type: 'number',
+      max: 20,
+      onUpdate: (newValue, newSettings, change) => {
+        change('fontSettings', {...newSettings.fontSettings, radius: newValue});
+      }
+    },
+    cutoff: {
+      type: 'number',
+      max: 1,
+      onUpdate: (newValue, newSettings, change) => {
+        change('fontSettings', {...newSettings.fontSettings, cutoff: newValue});
+      }
     }
   },
   props: {
     id: 'textgetAnchorX-layer',
     sizeScale: 1,
     fontFamily: 'Monaco',
+    fontSettings: {},
     getText: x => x.LOCATION_NAME,
     getPosition: x => x.COORDINATES,
     getColor: x => [153, 0, 0],

--- a/modules/layers/src/text-layer/font-atlas.js
+++ b/modules/layers/src/text-layer/font-atlas.js
@@ -10,9 +10,6 @@ const MAX_CANVAS_WIDTH = 1024;
 const BASELINE_SCALE = 0.9;
 const HEIGHT_SCALE = 1.2;
 
-export const DEFAULT_PADDING = 2;
-export const DEFAULT_FONT_SIZE = 64;
-
 function getDefaultCharacterSet() {
   const charSet = [];
   for (let i = 32; i < 128; i++) {
@@ -22,6 +19,16 @@ function getDefaultCharacterSet() {
 }
 
 export const DEFAULT_CHAR_SET = getDefaultCharacterSet();
+export const DEFAULT_FONT_FAMILY = 'Monaco, monospace';
+export const DEFAULT_FONT_WEIGHT = 'normal';
+
+export const DEFAULT_FONT_SETTINGS = {
+  fontSize: 64,
+  buffer: 2,
+  sdf: false,
+  cutoff: 0.25,
+  radius: 3
+};
 
 function populateAlphaChannel(alphaChannel, imageData) {
   // populate distance value from tinySDF to image alpha channel
@@ -30,8 +37,8 @@ function populateAlphaChannel(alphaChannel, imageData) {
   }
 }
 
-function setTextStyle(ctx, fontFamily, fontSize) {
-  ctx.font = `${fontSize}px ${fontFamily}`;
+function setTextStyle(ctx, fontFamily, fontSize, fontWeight) {
+  ctx.font = `${fontWeight} ${fontSize}px ${fontFamily}`;
   ctx.fillStyle = '#000';
   ctx.textBaseline = 'baseline';
   ctx.textAlign = 'left';
@@ -43,9 +50,11 @@ function buildMapping({ctx, fontHeight, buffer, characterSet, maxCanvasWidth}) {
   let x = 0;
   Array.from(characterSet).forEach(char => {
     // measure texts
+    // TODO - use Advanced text metrics when they are adopted:
+    // https://developer.mozilla.org/en-US/docs/Web/API/TextMetrics
     const {width} = ctx.measureText(char);
 
-    if (x + width > maxCanvasWidth) {
+    if (x + width + buffer * 2 > maxCanvasWidth) {
       x = 0;
       row++;
     }
@@ -64,67 +73,59 @@ function buildMapping({ctx, fontHeight, buffer, characterSet, maxCanvasWidth}) {
   return {mapping, canvasHeight};
 }
 
-export function makeFontAtlas(
-  gl,
-  {
-    sdf,
+export function makeFontAtlas(gl, fontSettings) {
+  const mergedFontSettings = Object.assign(
+    {
+      fontFamily: DEFAULT_FONT_FAMILY,
+      fontWeight: DEFAULT_FONT_WEIGHT,
+      characterSet: DEFAULT_CHAR_SET
+    },
+    DEFAULT_FONT_SETTINGS,
+    fontSettings
+  );
+
+  const {
     fontFamily,
-    fontSize = DEFAULT_FONT_SIZE,
-    characterSet = DEFAULT_CHAR_SET,
-    padding = DEFAULT_PADDING
-  }
-) {
+    fontWeight,
+    characterSet,
+    fontSize,
+    buffer,
+    sdf,
+    radius,
+    cutoff
+  } = mergedFontSettings;
+
   const canvas = document.createElement('canvas');
   const ctx = canvas.getContext('2d');
 
   // build mapping
-  // TODO - use Advanced text metrics when they are adopted:
-  // https://developer.mozilla.org/en-US/docs/Web/API/TextMetrics
-  const fontSettings = {
-    fontSize: sdf ? sdf.fontSize : fontSize,
-    fontFamily: sdf ? sdf.fontFamily : fontFamily,
-    fontHeight: (sdf ? sdf.fontSize : fontSize) * HEIGHT_SCALE,
-    buffer: sdf ? sdf.buffer : padding
-  };
-
-  setTextStyle(ctx, fontSettings.fontFamily, fontSettings.fontSize);
+  setTextStyle(ctx, fontFamily, fontSize, fontWeight);
+  const fontHeight = fontSize * HEIGHT_SCALE;
   const {canvasHeight, mapping} = buildMapping({
     ctx,
-    fontHeight: fontSettings.fontHeight,
-    buffer: fontSettings.buffer,
+    fontHeight,
+    buffer,
     characterSet,
     maxCanvasWidth: MAX_CANVAS_WIDTH
   });
 
   canvas.width = MAX_CANVAS_WIDTH;
   canvas.height = canvasHeight;
-  setTextStyle(ctx, fontSettings.fontFamily, fontSettings.fontSize);
+  setTextStyle(ctx, fontFamily, fontSize, fontWeight);
 
   // layout characters
   if (sdf) {
-    const tinySDF = new TinySDF(
-      fontSettings.fontSize,
-      fontSettings.buffer,
-      sdf.radius,
-      sdf.cutoff,
-      fontSettings.fontFamily,
-      sdf.fontWeight
-    );
-    setTextStyle(tinySDF.ctx, fontFamily, fontSize);
+    const tinySDF = new TinySDF(fontSize, buffer, radius, cutoff, fontFamily, fontWeight);
     // used to store distance values from tinySDF
     const imageData = ctx.createImageData(tinySDF.size, tinySDF.size);
 
     for (const char of characterSet) {
       populateAlphaChannel(tinySDF.draw(char), imageData);
-      ctx.putImageData(
-        imageData,
-        mapping[char].x - fontSettings.buffer,
-        mapping[char].y - fontSettings.buffer
-      );
+      ctx.putImageData(imageData, mapping[char].x - buffer, mapping[char].y - buffer);
     }
   } else {
     for (const char of characterSet) {
-      ctx.fillText(char, mapping[char].x, mapping[char].y + fontSettings.fontSize * BASELINE_SCALE);
+      ctx.fillText(char, mapping[char].x, mapping[char].y + fontSize * BASELINE_SCALE);
     }
   }
 


### PR DESCRIPTION
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #1550 

<!-- For all the PRs -->
#### Change List
- change TextLayer API
- expose fontSettings for generating `fontAtlas` as layer props
- extend layer browser example to include `fontSettings` options

[RFC](https://github.com/uber/deck.gl/pull/2627)
Should cover this [PR](https://github.com/uber/deck.gl/pull/2609) 
