### PR TITLE
specify default props for trips layer

### DIFF
--- a/modules/experimental-layers/src/trips-layer/README.md
+++ b/modules/experimental-layers/src/trips-layer/README.md
@@ -15,7 +15,7 @@ Returns an array of navigation points on a single path.
 Each navigation point is defined as an array of three numbers: `[longitude, latitude, timestamp]`.
 Points should be sorted by timestamp.
 
-##### `getColor` (Function, optional)
+##### `getColor` (Function|Array, optional)
 
 - Default: `d => d.color`
 

--- a/modules/experimental-layers/src/trips-layer/trips-layer.js
+++ b/modules/experimental-layers/src/trips-layer/trips-layer.js
@@ -6,10 +6,10 @@ import tripsVertex from './trips-layer-vertex.glsl';
 import tripsFragment from './trips-layer-fragment.glsl';
 
 const defaultProps = {
-  trailLength: 120,
-  currentTime: 0,
-  getPath: d => d.path,
-  getColor: d => d.color
+  trailLength: {type: 'number', value: 120, min: 0},
+  currentTime: {type: 'number', value: 0, min: 0},
+  getPath: {type: 'accessor', value: d => d.path},
+  getColor: {type: 'accessor', value: d => d.color}
 };
 
 export default class TripsLayer extends Layer {


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #2477 
<!-- For other PRs without open issue -->
#### Background
In trips layer, the defaultProps don't have types specified. We need to specify type for those props.
<!-- For all the PRs -->
#### Change List
- Add type to the defaultProps in path outline layer

note: compared the rendering result of trips example with that in 6.3-release
