### PR TITLE
update the unit of getLineWidth(ScatterplotLayer) in doc

### DIFF
--- a/docs/layers/scatterplot-layer.md
+++ b/docs/layers/scatterplot-layer.md
@@ -161,7 +161,7 @@ The rgba color of each object, in `r, g, b, [a]`. Each component is in the 0-255
 
 * Default: `1`
 
-The width of the outline of the object in pixels.
+The width of the outline of each object, in meters.
 
 * If a number is provided, it is used as the outline width for all objects.
 * If a function is provided, it is called on each object to retrieve its outline width.


### PR DESCRIPTION
…rs in docs

<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #2544 
<!-- For other PRs without open issue -->
#### Background
the unit of getLineWidth of ScatterplotLayer should be meters, not pixels
<!-- For all the PRs -->
#### Change List
- change pixels to meters in the documentation
