### PR TITLE
specify types for defaultProps in PathMarkerLayer

### DIFF
--- a/modules/experimental-layers/src/path-marker-layer/create-path-markers.js
+++ b/modules/experimental-layers/src/path-marker-layer/create-path-markers.js
@@ -34,7 +34,10 @@ export default function createPathMarkers({
     const lineLength = getLineLength(vPoints);
 
     // Ask for where to put markers
-    const percentages = getMarkerPercentages(object, {lineLength});
+    const percentages =
+      typeof getMarkerPercentages === 'function'
+        ? getMarkerPercentages(object, {lineLength})
+        : getMarkerPercentages;
 
     // Create the markers
     for (const percentage of percentages) {

--- a/modules/experimental-layers/src/path-marker-layer/create-path-markers.js
+++ b/modules/experimental-layers/src/path-marker-layer/create-path-markers.js
@@ -25,7 +25,7 @@ export default function createPathMarkers({
   for (const object of data) {
     const path = getPath(object);
     const direction = getDirection(object) || DEFAULT_DIRECTION;
-    const color = getColor(object);
+    const color = typeof getColor === 'function' ? getColor(object) : getColor;
 
     const vPoints = path.map(p => new Vector2(p));
     const vPointsReverse = vPoints.slice(0).reverse();

--- a/modules/experimental-layers/src/path-marker-layer/create-path-markers.js
+++ b/modules/experimental-layers/src/path-marker-layer/create-path-markers.js
@@ -15,16 +15,16 @@ const DEFAULT_DIRECTION = {forward: true, backward: false};
 export default function createPathMarkers({
   data,
   getPath = x => x.path,
-  getDirection = x => x.direction,
-  getColor = x => DEFAULT_COLOR,
-  getMarkerPercentages = x => [0.5],
+  getDirection = DEFAULT_DIRECTION,
+  getColor = DEFAULT_COLOR,
+  getMarkerPercentages = [0.5],
   projectFlat
 }) {
   const markers = [];
 
   for (const object of data) {
     const path = getPath(object);
-    const direction = getDirection(object) || DEFAULT_DIRECTION;
+    const direction = typeof getDirection === 'function' ? getDirection(object) : getDirection;
     const color = typeof getColor === 'function' ? getColor(object) : getColor;
 
     const vPoints = path.map(p => new Vector2(p));

--- a/modules/experimental-layers/src/path-marker-layer/path-marker-layer.js
+++ b/modules/experimental-layers/src/path-marker-layer/path-marker-layer.js
@@ -22,18 +22,21 @@ const defaultProps = Object.assign({}, PathOutlineLayer.defaultProps, {
   MarkerLayer: DEFAULT_MARKER_LAYER,
   markerLayerProps: DEFAULT_MARKER_LAYER_PROPS,
 
-  sizeScale: 100,
+  sizeScale: {type: 'number', value: 100, min: 1},
   fp64: false,
 
-  hightlightIndex: -1,
+  hightlightIndex: {type: 'number', value: -1},
   highlightPoint: null,
 
-  getPath: x => x.path,
-  getColor: x => x.color,
-  getMarkerColor: x => [0, 0, 0, 255],
-  getDirection: x => x.direction,
-  getMarkerPercentages: (object, {lineLength}) =>
-    lineLength > DISTANCE_FOR_MULTI_ARROWS ? [0.25, 0.5, 0.75] : [0.5]
+  getPath: {type: 'accessor', value: x => x.path},
+  getColor: {type: 'accessor', value: x => x.color},
+  getMarkerColor: {type: 'accessor', value: [0, 0, 0, 255]},
+  getDirection: {type: 'accessor', value: x => x.direction},
+  getMarkerPercentages: {
+    type: 'accessor',
+    value: (object, {lineLength}) =>
+      lineLength > DISTANCE_FOR_MULTI_ARROWS ? [0.25, 0.5, 0.75] : [0.5]
+  }
 });
 
 export default class PathMarkerLayer extends CompositeLayer {

--- a/modules/experimental-layers/src/path-marker-layer/path-marker-layer.js
+++ b/modules/experimental-layers/src/path-marker-layer/path-marker-layer.js
@@ -22,16 +22,15 @@ const defaultProps = Object.assign({}, PathOutlineLayer.defaultProps, {
   MarkerLayer: DEFAULT_MARKER_LAYER,
   markerLayerProps: DEFAULT_MARKER_LAYER_PROPS,
 
-  sizeScale: {type: 'number', value: 100, min: 1},
+  sizeScale: {type: 'number', value: 100, min: 0},
   fp64: false,
 
   hightlightIndex: {type: 'number', value: -1},
   highlightPoint: null,
 
   getPath: {type: 'accessor', value: x => x.path},
-  getColor: {type: 'accessor', value: x => x.color},
   getMarkerColor: {type: 'accessor', value: [0, 0, 0, 255]},
-  getDirection: {type: 'accessor', value: x => x.direction},
+  getDirection: {type: 'accessor', value: {forward: true, backward: false}},
   getMarkerPercentages: {
     type: 'accessor',
     value: (object, {lineLength}) =>


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #2477 
<!-- For other PRs without open issue -->
#### Background
In PathMarkerLayer, the defaultProps don't have types specified. We need to specify types for those props.
<!-- For all the PRs -->
#### Change List
- Add type to the defaultProps in the PathMarkerLayer

note: tested in layer browser
