### PR TITLE
fix "Inherits all Viewport/View methods"

### DIFF
--- a/docs/api-reference/orthographic-view.md
+++ b/docs/api-reference/orthographic-view.md
@@ -33,7 +33,7 @@ The `OrthographicView` constructor takes the same parameters as the [View](/docs
 
 ## Methods
 
-Inherits all [Viewport methods](/docs/api-reference/view.md#methods).
+Inherits all [View methods](/docs/api-reference/view.md#methods).
 
 
 ## Remarks


### PR DESCRIPTION
#### Background
I could be confused, but OrthographicView is a subclass of View, rather than of Viewport, and the link points to View, too.

#### Change List
- s/Viewport/View/
