### PR TITLE
In docs: pickObjects -> pickMultipleObjects

### DIFF
--- a/docs/api-reference/deck.md
+++ b/docs/api-reference/deck.md
@@ -307,7 +307,7 @@ Returns:
 Performs deep picking. Finds all close pickable and visible object at the given screen coordinate, even if those objects are occluded by other objects.
 
 ```js
-deck.pickObject({x, y, radius, layerIds, depth})
+deck.pickMultipleObjects({x, y, radius, layerIds, depth})
 ```
 
 * `x` (Number) - x position in pixels


### PR DESCRIPTION
For #2658 (second section)

#### Background
Code example uses wrong method name: Now it matches section title, and the signature is correct.

#### Change List
- At one location, pickObject -> pickMultipleObjects
