### PR TITLE
PathLayer: fix rightDeltas attribute generation when using flat vertices

### DIFF
--- a/modules/layers/src/path-layer/path-tesselator.js
+++ b/modules/layers/src/path-layer/path-tesselator.js
@@ -108,8 +108,9 @@ export default class PathTesselator extends Tesselator {
     let nextPoint;
 
     for (let i = context.vertexStart, ptIndex = 1; ptIndex < numPoints; i++, ptIndex++) {
-      nextPoint = this.getPointOnPath(path, ptIndex + 1);
-      if (!nextPoint) {
+      if (ptIndex + 1 < numPoints) {
+        nextPoint = this.getPointOnPath(path, ptIndex + 1);
+      } else {
         nextPoint = isPathClosed ? this.getPointOnPath(path, 1) : endPoint;
       }
 

--- a/test/modules/layers/path-tesselator.spec.js
+++ b/test/modules/layers/path-tesselator.spec.js
@@ -104,6 +104,7 @@ test('PathTesselator#constructor', t => {
       );
 
       t.ok(ArrayBuffer.isView(tesselator.get('leftDeltas')), 'PathTesselator.get leftDeltas');
+      t.ok(tesselator.get('leftDeltas').every(Number.isFinite), 'Valid leftDeltas attribute');
       t.deepEquals(
         tesselator.get('leftDeltas').slice(0, 6),
         [0, 0, 0, 1, 1, 0],
@@ -116,6 +117,7 @@ test('PathTesselator#constructor', t => {
         [1, 1, 0, 0, 0, 0],
         'rightDeltas are filled'
       );
+      t.ok(tesselator.get('rightDeltas').every(Number.isFinite), 'Valid rightDeltas attribute');
       t.deepEquals(
         tesselator.get('rightDeltas').slice(-3),
         [1, 1, 0],


### PR DESCRIPTION
When index is out of bounds, `this.getPointOnPath` returns `undefined` for nested vertices, and `[undefined, undefined, undefined]` for flat vertices. This leads to `NaN`s in the `rightDeltas` array.

#### Change List
- Explicitly check if index is within bounds
- Add test cases
