### PR TITLE
Improve picking color generation

### DIFF
--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -406,19 +406,22 @@ export default class Layer extends Component {
     const {value, size} = attribute;
 
     if (value[0] === 1) {
-      // already populated
+      // This can happen when data has changed, but the attribute value typed array
+      // has sufficient size and does not need to be re-allocated.
+      // This attribute is already populated, we do not have to recalculate it
       return;
     }
 
     const cacheSize = pickingColorCache.length / size;
 
+    // Copy the last calculated picking color sequence into the attribute
     value.set(
       numInstances < cacheSize
         ? pickingColorCache.subarray(0, numInstances * size)
         : pickingColorCache
     );
 
-    // add 1 to index to seperate from no selection
+    // If the attribute is larger than the cache, populate the missing chunk
     for (let i = cacheSize; i < numInstances; i++) {
       const pickingColor = this.encodePickingColor(i);
       value[i * size + 0] = pickingColor[0];
@@ -427,6 +430,7 @@ export default class Layer extends Component {
     }
 
     if (cacheSize < numInstances) {
+      // Save the largest picking color sequence
       pickingColorCache = value;
     }
   }

--- a/modules/layers/src/path-layer/path-layer.js
+++ b/modules/layers/src/path-layer/path-layer.js
@@ -307,7 +307,10 @@ export default class PathLayer extends Layer {
   // Override the default picking colors calculation
   calculatePickingColors(attribute) {
     const {pathTesselator} = this.state;
-    attribute.value = pathTesselator.get('pickingColors', attribute.value, this.encodePickingColor);
+    const pickingColor = [];
+    attribute.value = pathTesselator.get('pickingColors', attribute.value, index =>
+      this.encodePickingColor(index, pickingColor)
+    );
   }
 
   clearPickingColor(color) {

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -358,10 +358,9 @@ export default class SolidPolygonLayer extends Layer {
 
   // Override the default picking colors calculation
   calculatePickingColors(attribute) {
-    attribute.value = this.state.polygonTesselator.get(
-      'pickingColors',
-      attribute.value,
-      this.encodePickingColor
+    const pickingColor = [];
+    attribute.value = this.state.polygonTesselator.get('pickingColors', attribute.value, index =>
+      this.encodePickingColor(index, pickingColor)
     );
   }
 

--- a/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer.js
+++ b/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer.js
@@ -113,9 +113,10 @@ export default class MultiIconLayer extends IconLayer {
     const {data, getPickingIndex} = this.props;
     const {value} = attribute;
     let i = 0;
+    const pickingColor = [];
     for (const point of data) {
       const index = getPickingIndex(point);
-      const pickingColor = this.encodePickingColor(index);
+      this.encodePickingColor(index, pickingColor);
 
       value[i++] = pickingColor[0];
       value[i++] = pickingColor[1];

--- a/test/bench/layer.bench.js
+++ b/test/bench/layer.bench.js
@@ -31,11 +31,18 @@ const testLayer = new ScatterplotLayer({data: data.points});
 // add tests
 
 export default function layerBench(suite) {
-  return suite.group('LAYER UTILS').add('encoding picking color', () => {
-    testIdx++;
-    if ((testIdx + 1) >> 24) {
-      testIdx = 0;
-    }
-    testLayer.encodePickingColor(testIdx);
-  });
+  return suite
+    .group('LAYER UTILS')
+    .add('encoding picking color', () => {
+      testIdx++;
+      if ((testIdx + 1) >> 24) {
+        testIdx = 0;
+      }
+      testLayer.encodePickingColor(testIdx);
+    })
+    .add('calculate instance picking colors', () => {
+      const numInstances = 1e6;
+      const target = new Uint8ClampedArray(numInstances * 3);
+      testLayer.calculateInstancePickingColors({value: target, size: 3}, {numInstances});
+    });
 }


### PR DESCRIPTION
Calculate picking color for 1M instances, before: 45 iterations/s; after: 412 iterations/s

Since `layer.calculateInstancePickingColors` always produces the same sequence, we can save the largest generated array and copy its value into others.

We can potentially make all `instancePickingColors` attributes share the same WebGLBuffer, but that would introduce more complexity around:
- Retrieving the shared buffer by GL context
- Creating a temporary buffer when performing multi-depth picking

#### Change List
- Optimize `layer.calculateInstancePickingColors`
- Benchmark case
