### PR TITLE
Multi-depth picking fix

### DIFF
--- a/modules/layers/src/path-layer/path-layer.js
+++ b/modules/layers/src/path-layer/path-layer.js
@@ -312,7 +312,7 @@ export default class PathLayer extends Layer {
 
   clearPickingColor(color) {
     const pickedPathIndex = this.decodePickingColor(color);
-    const {bufferLayout} = this.state;
+    const {bufferLayout} = this.state.pathTesselator;
     const numVertices = bufferLayout[pickedPathIndex];
 
     let startInstanceIndex = 0;

--- a/test/modules/core/lib/pick-layers.spec.js
+++ b/test/modules/core/lib/pick-layers.spec.js
@@ -267,15 +267,15 @@ const TEST_CASES = [
         }
       ],
       pickMultipleObjects: [
-        // {
-        //   parameters: {
-        //     x: 260,
-        //     y: 300
-        //   },
-        //   results: {
-        //     count: 1
-        //   }
-        // },
+        {
+          parameters: {
+            x: 260,
+            y: 300
+          },
+          results: {
+            count: 1
+          }
+        },
         {
           parameters: {
             x: 10,
@@ -366,15 +366,15 @@ const TEST_CASES = [
         }
       ],
       pickMultipleObjects: [
-        // {
-        //   parameters: {
-        //     x: 260,
-        //     y: 300
-        //   },
-        //   results: {
-        //     count: 1
-        //   }
-        // },
+        {
+          parameters: {
+            x: 260,
+            y: 300
+          },
+          results: {
+            count: 2
+          }
+        },
         {
           parameters: {
             x: 10,


### PR DESCRIPTION
For #2700 
This was fixed separately for master and 6.3-release branches in #2532 and #2534. We did not consolidate the changes correctly when creating the 6.4-release branch.

#### Change List
- Fix PathLayer's reference to `pathTesselator`
- Restore multi-depth picking tests
