### PR TITLE
Model attribute updaters

### DIFF
--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -390,10 +390,23 @@ export default class Layer extends Component {
       ignoreUnknownAttributes: true
     });
 
-    const model = this.getSingleModel();
+    let model;
+
+    model = this.getSingleModel();
     if (model) {
       const changedAttributes = attributeManager.getChangedAttributes({clearChangedFlags: true});
       model.setAttributes(changedAttributes);
+    }
+
+    if (props.modelAttributeUpdaters) {
+      const changedAttributes = attributeManager.getChangedAttributes({clearChangedFlags: true});
+      for (const modelName in props.modelAttributeUpdaters) {
+        model = this.state[modelName];
+        const updater = props.modelAttributeUpdaters[modelName];
+        if (model && updater) {
+          updater(this, model, changedAttributes);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Possible solution to the overriding up `updateAttributes` in the SolidPolygonLayer. Allow layers to have a `modelAttributeUpdaters` prop: an object keyed by the models name in the `state`, value is a function that will be called in `Layer.updateAttributes` to do any custom attribute updating.