### PR TITLE
Add experimental onMetrics callback

### DIFF
--- a/docs/api-reference/deck.md
+++ b/docs/api-reference/deck.md
@@ -271,9 +271,9 @@ Called once every second with performance metrics.
 Callback arguments:
 
 * `stats` (Object)
-  - `fps` (Number)
-  - `redraw` (Number) - number of times the WebGLContext was rerendered.
-  - `deck.setProps` (Number) - number of times `setProps` was called.
+  + `fps` (Number)
+  + `redraw` (Number) - number of times the WebGLContext was rerendered.
+  + `deck.setProps` (Number) - number of times `setProps` was called.
 
 
 ## Methods

--- a/docs/api-reference/deck.md
+++ b/docs/api-reference/deck.md
@@ -264,6 +264,18 @@ Callback Arguments:
 Callback, called once after gl context and Deck components (`ViewManager`, `LayerManager`, etc) are created. Can be used to trigger viewport transitions.
 
 
+##### `_onMetrics` (Function, optional) **Experimental**
+
+Called once every second with performance metrics.
+
+Callback arguments:
+
+* `stats` (Object)
+  - `fps` (Number)
+  - `redraw` (Number) - number of times the WebGLContext was rerendered.
+  - `deck.setProps` (Number) - number of times `setProps` was called.
+
+
 ## Methods
 
 ##### `finalize`

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -107,6 +107,7 @@ const defaultProps = {
   onLayerClick: null,
   onLayerHover: null,
   onLoad: noop,
+  _onMetrics: null,
 
   getCursor,
 
@@ -565,6 +566,14 @@ export default class Deck {
       const table = this.stats.getStatsTable();
       this.stats.reset();
       log.table(3, table)();
+
+      // Experimental: report metrics
+      if (this.props._onMetrics) {
+        for (const key in table) {
+          table[key] = table[key].total;
+        }
+        this.props._onMetrics(table);
+      }
     }
 
     this._updateCanvasSize();
@@ -586,7 +595,7 @@ export default class Deck {
       return;
     }
 
-    this.stats.bump('render-fps');
+    this.stats.bump('redraw');
     if (this.props._customRender) {
       this.props._customRender();
     } else {


### PR DESCRIPTION
#### Background

This is to support performance instrumentation in streetscape.gl.

#### Change List
- Add experimental `onMetrics` prop to `Deck`
- Update documentation
