### PR TITLE
SolidPolygonLayer cleanup

### DIFF
--- a/modules/core/src/lib/attribute-manager.js
+++ b/modules/core/src/lib/attribute-manager.js
@@ -233,6 +233,17 @@ export default class AttributeManager {
         this._updateAttribute({attribute, numInstances, data, props, context});
       }
 
+      if (attribute.userData.shaderAttributes) {
+        const shaderAttributes = attribute.userData.shaderAttributes;
+        for (const shaderAttributeName in shaderAttributes) {
+          shaderAttributes[shaderAttributeName].update({
+            buffer: attribute.buffer,
+            value: attribute.value,
+            constant: attribute.constant
+          });
+        }
+      }
+
       this.needsRedraw |= attribute.needsRedraw();
     }
 

--- a/modules/core/src/lib/attribute.js
+++ b/modules/core/src/lib/attribute.js
@@ -167,7 +167,11 @@ export default class LayerAttribute extends Attribute {
     if (this.userData.shaderAttributes) {
       const shaderAttributes = this.userData.shaderAttributes;
       for (const shaderAttributeName in shaderAttributes) {
-        shaderAttributes[shaderAttributeName].update({buffer: this.buffer});
+        shaderAttributes[shaderAttributeName].update({
+          buffer: this.buffer,
+          value: this.value,
+          constant: this.constant
+        });
       }
     }
 

--- a/modules/core/src/lib/attribute.js
+++ b/modules/core/src/lib/attribute.js
@@ -164,17 +164,6 @@ export default class LayerAttribute extends Attribute {
       updated = false;
     }
 
-    if (this.userData.shaderAttributes) {
-      const shaderAttributes = this.userData.shaderAttributes;
-      for (const shaderAttributeName in shaderAttributes) {
-        shaderAttributes[shaderAttributeName].update({
-          buffer: this.buffer,
-          value: this.value,
-          constant: this.constant
-        });
-      }
-    }
-
     state.needsUpdate = false;
     state.needsRedraw = true;
 

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -390,10 +390,13 @@ export default class Layer extends Component {
       ignoreUnknownAttributes: true
     });
 
-    const model = this.getSingleModel();
-    if (model) {
+    const models = this.getModels();
+
+    if (models.length > 0) {
       const changedAttributes = attributeManager.getChangedAttributes({clearChangedFlags: true});
-      model.setAttributes(changedAttributes);
+      for (let i = 0, len = models.length; i < len; ++i) {
+        this._setModelAttributes(models[i], changedAttributes);
+      }
     }
   }
 
@@ -441,6 +444,21 @@ export default class Layer extends Component {
         ? pickingColorCache.subarray(0, numInstances * size)
         : pickingColorCache
     );
+  }
+
+  _setModelAttributes(model, changedAttributes) {
+    if (model.userData.excludeAttributes) {
+      const filteredAttributes = {};
+      const excludeAttributes = model.userData.excludeAttributes;
+      for (const attributeName in changedAttributes) {
+        if (!excludeAttributes[attributeName]) {
+          filteredAttributes[attributeName] = changedAttributes[attributeName];
+        }
+      }
+      model.setAttributes(filteredAttributes);
+    } else {
+      model.setAttributes(changedAttributes);
+    }
   }
 
   // Sets the specified instanced picking color to null picking color. Used for multi picking.

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-main.glsl.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-main.glsl.js
@@ -19,47 +19,6 @@
 // THE SOFTWARE.
 
 export default `\
-#define SHADER_NAME solid-polygon-layer-vertex-shader
-
-attribute vec2 vertexPositions;
-
-#ifdef IS_SIDE_VERTEX
-attribute vec3 instancedPositions;
-attribute vec2 instancedPositions64xyLow;
-attribute vec3 nextPositions;
-attribute vec2 nextPositions64xyLow;
-attribute float instancedElevations;
-attribute vec4 instancedFillColors;
-attribute vec4 instancedLineColors;
-attribute vec3 instancedPickingColors;
-attribute float vertexValid;
-#else
-attribute vec3 positions;
-attribute vec2 positions64xyLow;
-attribute float elevations;
-attribute vec4 fillColors;
-attribute vec4 lineColors;
-attribute vec3 pickingColors;
-#endif
-
-uniform bool extruded;
-uniform bool isWireframe;
-uniform float elevationScale;
-uniform float opacity;
-
-varying vec4 vColor;
-varying float isValid;
-
-void main(void) {
-#ifdef IS_SIDE_VERTEX
-  vec3 positions = instancedPositions;
-  vec2 positions64xyLow = instancedPositions64xyLow;
-  float elevations = instancedElevations;
-  vec4 fillColors = instancedFillColors;
-  vec4 lineColors = instancedLineColors;
-  vec3 pickingColors = instancedPickingColors;
-#endif
-
   vec3 pos;
   vec2 pos64xyLow;
   vec3 normal;
@@ -99,5 +58,4 @@ void main(void) {
 
   // Set color to be rendered to picking fbo (also used to check for selection highlight).
   picking_setPickingColor(pickingColors);
-}
 `;

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-side.glsl.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-side.glsl.js
@@ -1,0 +1,56 @@
+// Copyright (c) 2015 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import main from './solid-polygon-layer-vertex-main.glsl';
+
+export default `\
+#define SHADER_NAME solid-polygon-layer-vertex-shader-side
+#define IS_SIDE_VERTEX
+
+attribute vec2 vertexPositions;
+
+attribute vec3 instancePositions;
+attribute vec2 instancePositions64xyLow;
+attribute vec3 nextPositions;
+attribute vec2 nextPositions64xyLow;
+attribute float instanceElevations;
+attribute vec4 instanceFillColors;
+attribute vec4 instanceLineColors;
+attribute vec3 instancePickingColors;
+attribute float vertexValid;
+
+uniform bool extruded;
+uniform bool isWireframe;
+uniform float elevationScale;
+uniform float opacity;
+
+varying vec4 vColor;
+varying float isValid;
+
+void main(void) {
+  vec3 positions = instancePositions;
+  vec2 positions64xyLow = instancePositions64xyLow;
+  float elevations = instanceElevations;
+  vec4 fillColors = instanceFillColors;
+  vec4 lineColors = instanceLineColors;
+  vec3 pickingColors = instancePickingColors;
+  ${main}
+}
+`;

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-side.glsl.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-side.glsl.js
@@ -24,7 +24,6 @@ export default `\
 #define SHADER_NAME solid-polygon-layer-vertex-shader-side
 #define IS_SIDE_VERTEX
 
-attribute vec2 vertexPositions;
 
 attribute vec3 instancePositions;
 attribute vec2 instancePositions64xyLow;
@@ -34,23 +33,21 @@ attribute float instanceElevations;
 attribute vec4 instanceFillColors;
 attribute vec4 instanceLineColors;
 attribute vec3 instancePickingColors;
-attribute float vertexValid;
 
-uniform bool extruded;
-uniform bool isWireframe;
-uniform float elevationScale;
-uniform float opacity;
-
-varying vec4 vColor;
-varying float isValid;
+${main}
 
 void main(void) {
-  vec3 positions = instancePositions;
-  vec2 positions64xyLow = instancePositions64xyLow;
-  float elevations = instanceElevations;
-  vec4 fillColors = instanceFillColors;
-  vec4 lineColors = instanceLineColors;
-  vec3 pickingColors = instancePickingColors;
-  ${main}
+  PolygonProps props;
+
+  props.positions = instancePositions;
+  props.positions64xyLow = instancePositions64xyLow;
+  props.elevations = instanceElevations;
+  props.fillColors = instanceFillColors;
+  props.lineColors = instanceLineColors;
+  props.pickingColors = instancePickingColors;
+  props.nextPositions = nextPositions;
+  props.nextPositions64xyLow = nextPositions64xyLow;
+
+  calculatePosition(props);
 }
 `;

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-top.glsl.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-top.glsl.js
@@ -1,0 +1,46 @@
+// Copyright (c) 2015 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import main from './solid-polygon-layer-vertex-main.glsl';
+
+export default `\
+#define SHADER_NAME solid-polygon-layer-vertex-shader
+
+attribute vec2 vertexPositions;
+
+attribute vec3 positions;
+attribute vec2 positions64xyLow;
+attribute float elevations;
+attribute vec4 fillColors;
+attribute vec4 lineColors;
+attribute vec3 pickingColors;
+
+uniform bool extruded;
+uniform bool isWireframe;
+uniform float elevationScale;
+uniform float opacity;
+
+varying vec4 vColor;
+varying float isValid;
+
+void main(void) {
+  ${main}
+}
+`;

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-top.glsl.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-top.glsl.js
@@ -23,8 +23,6 @@ import main from './solid-polygon-layer-vertex-main.glsl';
 export default `\
 #define SHADER_NAME solid-polygon-layer-vertex-shader
 
-attribute vec2 vertexPositions;
-
 attribute vec3 positions;
 attribute vec2 positions64xyLow;
 attribute float elevations;
@@ -32,15 +30,18 @@ attribute vec4 fillColors;
 attribute vec4 lineColors;
 attribute vec3 pickingColors;
 
-uniform bool extruded;
-uniform bool isWireframe;
-uniform float elevationScale;
-uniform float opacity;
-
-varying vec4 vColor;
-varying float isValid;
+${main}
 
 void main(void) {
-  ${main}
+  PolygonProps props;
+
+  props.positions = positions;
+  props.positions64xyLow = positions64xyLow;
+  props.elevations = elevations;
+  props.fillColors = fillColors;
+  props.lineColors = lineColors;
+  props.pickingColors = pickingColors;
+
+  calculatePosition(props);
 }
 `;

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex.glsl.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex.glsl.js
@@ -22,19 +22,25 @@ export default `\
 #define SHADER_NAME solid-polygon-layer-vertex-shader
 
 attribute vec2 vertexPositions;
-attribute float vertexValid;
-attribute vec3 positions;
-attribute vec2 positions64xyLow;
 
 #ifdef IS_SIDE_VERTEX
+attribute vec3 instancedPositions;
+attribute vec2 instancedPositions64xyLow;
 attribute vec3 nextPositions;
 attribute vec2 nextPositions64xyLow;
-#endif
-
+attribute float instancedElevations;
+attribute vec4 instancedFillColors;
+attribute vec4 instancedLineColors;
+attribute vec3 instancedPickingColors;
+attribute float vertexValid;
+#else
+attribute vec3 positions;
+attribute vec2 positions64xyLow;
 attribute float elevations;
 attribute vec4 fillColors;
 attribute vec4 lineColors;
 attribute vec3 pickingColors;
+#endif
 
 uniform bool extruded;
 uniform bool isWireframe;
@@ -45,6 +51,15 @@ varying vec4 vColor;
 varying float isValid;
 
 void main(void) {
+#ifdef IS_SIDE_VERTEX
+  vec3 positions = instancedPositions;
+  vec2 positions64xyLow = instancedPositions64xyLow;
+  float elevations = instancedElevations;
+  vec4 fillColors = instancedFillColors;
+  vec4 lineColors = instancedLineColors;
+  vec3 pickingColors = instancedPickingColors;
+#endif
+
   vec3 pos;
   vec2 pos64xyLow;
   vec3 normal;

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -288,7 +288,6 @@ export default class SolidPolygonLayer extends Layer {
     let sideModel;
 
     if (filled) {
-      const vertexCount = this.state.polygonTesselator.get('indices').length;
       topModel = new Model(
         gl,
         Object.assign({}, this.getShaders(false), {
@@ -303,14 +302,13 @@ export default class SolidPolygonLayer extends Layer {
             isWireframe: false,
             isSideVertex: false
           },
-          vertexCount,
+          vertexCount: 0,
           isIndexed: true,
           shaderCache: this.context.shaderCache
         })
       );
     }
     if (extruded) {
-      const instanceCount = this.state.polygonTesselator.instanceCount - 1;
       sideModel = new Model(
         gl,
         Object.assign({}, this.getShaders(true), {
@@ -326,7 +324,7 @@ export default class SolidPolygonLayer extends Layer {
               }
             }
           }),
-          instanceCount,
+          instanceCount: 0,
           isInstanced: 1,
           shaderCache: this.context.shaderCache
         })

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -98,9 +98,14 @@ export default class SolidPolygonLayer extends Layer {
           positions: {
             size: 3
           },
+          instancedPositions: {
+            size: 3,
+            divisor: 1
+          },
           nextPositions: {
             size: 3,
-            offset: 12
+            offset: 12,
+            divisor: 1
           }
         }
       },
@@ -111,14 +116,20 @@ export default class SolidPolygonLayer extends Layer {
           positions64xyLow: {
             size: 2
           },
+          instancedPositions64xyLow: {
+            size: 2,
+            divisor: 1
+          },
           nextPositions64xyLow: {
             size: 2,
-            offset: 8
+            offset: 8,
+            divisor: 1
           }
         }
       },
       vertexValid: {
         size: 1,
+        divisor: 1,
         type: GL.UNSIGNED_BYTE,
         update: this.calculateVertexValid,
         noAlloc
@@ -127,7 +138,16 @@ export default class SolidPolygonLayer extends Layer {
         size: 1,
         transition: ATTRIBUTE_TRANSITION,
         accessor: 'getElevation',
-        update: this.calculateElevations
+        update: this.calculateElevations,
+        shaderAttributes: {
+          elevations: {
+            size: 1
+          },
+          instancedElevations: {
+            size: 1,
+            divisor: 1
+          }
+        }
       },
       fillColors: {
         alias: 'colors',
@@ -136,7 +156,16 @@ export default class SolidPolygonLayer extends Layer {
         transition: ATTRIBUTE_TRANSITION,
         accessor: 'getFillColor',
         update: this.calculateFillColors,
-        defaultValue: DEFAULT_COLOR
+        defaultValue: DEFAULT_COLOR,
+        shaderAttributes: {
+          fillColors: {
+            size: 4
+          },
+          instancedFillColors: {
+            size: 4,
+            divisor: 1
+          }
+        }
       },
       lineColors: {
         alias: 'colors',
@@ -145,9 +174,31 @@ export default class SolidPolygonLayer extends Layer {
         transition: ATTRIBUTE_TRANSITION,
         accessor: 'getLineColor',
         update: this.calculateLineColors,
-        defaultValue: DEFAULT_COLOR
+        defaultValue: DEFAULT_COLOR,
+        shaderAttributes: {
+          lineColors: {
+            size: 4
+          },
+          instancedLineColors: {
+            size: 4,
+            divisor: 1
+          }
+        }
       },
-      pickingColors: {size: 3, type: GL.UNSIGNED_BYTE, update: this.calculatePickingColors}
+      pickingColors: {
+        size: 3,
+        type: GL.UNSIGNED_BYTE,
+        update: this.calculatePickingColors,
+        shaderAttributes: {
+          pickingColors: {
+            size: 3
+          },
+          instancedPickingColors: {
+            size: 3,
+            divisor: 1
+          }
+        }
+      }
     });
     /* eslint-enable max-len */
   }
@@ -249,10 +300,7 @@ export default class SolidPolygonLayer extends Layer {
 
         if (attributeName !== 'indices') {
           // Apply layout override to the attribute.
-          newAttributes[attributeName] = Object.assign({}, attribute, {
-            isInstanced: true,
-            buffer: attribute.getBuffer()
-          });
+          newAttributes[attributeName] = attribute;
         }
       }
       sideModel.setAttributes(newAttributes);
@@ -296,7 +344,10 @@ export default class SolidPolygonLayer extends Layer {
             vertexCount: 4,
             attributes: {
               // top right - top left - bootom left - bottom right
-              vertexPositions: {size: 2, value: new Float32Array([1, 1, 0, 1, 0, 0, 1, 0])}
+              vertexPositions: {
+                size: 2,
+                value: new Float32Array([1, 1, 0, 1, 0, 0, 1, 0])
+              }
             }
           }),
           uniforms: {

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -205,7 +205,7 @@ export default class SolidPolygonLayer extends Layer {
 
   draw({uniforms}) {
     const {extruded, filled, wireframe, elevationScale} = this.props;
-    const {topModel, sideModel} = this.state;
+    const {topModel, sideModel, polygonTesselator} = this.state;
 
     const renderUniforms = Object.assign({}, uniforms, {
       extruded: Boolean(extruded),
@@ -214,6 +214,7 @@ export default class SolidPolygonLayer extends Layer {
 
     // Note: the order is important
     if (sideModel) {
+      sideModel.setInstanceCount(polygonTesselator.instanceCount - 1);
       sideModel.setUniforms(renderUniforms);
       if (wireframe) {
         sideModel.setDrawMode(GL.LINE_STRIP);
@@ -224,7 +225,9 @@ export default class SolidPolygonLayer extends Layer {
         sideModel.render({isWireframe: false});
       }
     }
+
     if (topModel) {
+      topModel.setVertexCount(polygonTesselator.get('indices').length);
       topModel.render(renderUniforms);
     }
   }
@@ -273,14 +276,6 @@ export default class SolidPolygonLayer extends Layer {
       this.setState({
         numInstances: polygonTesselator.instanceCount
       });
-
-      if (this.state.topModel) {
-        this.state.topModel.setVertexCount(polygonTesselator.get('indices').length);
-      }
-
-      if (this.state.sideModel) {
-        this.state.sideModel.setInstanceCount(polygonTesselator.instanceCount - 1);
-      }
 
       this.getAttributeManager().invalidateAll();
     }

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -286,29 +286,6 @@ export default class SolidPolygonLayer extends Layer {
     }
   }
 
-  updateAttributes(props) {
-    super.updateAttributes(props);
-    const attributes = this.getAttributeManager().getChangedAttributes({clearChangedFlags: true});
-    const {topModel, sideModel} = this.state;
-
-    if (topModel) {
-      topModel.setAttributes(attributes);
-    }
-    if (sideModel) {
-      // Remove one to account for the offset
-      const newAttributes = {};
-      for (const attributeName in attributes) {
-        const attribute = attributes[attributeName];
-
-        if (attributeName !== 'indices') {
-          // Apply layout override to the attribute.
-          newAttributes[attributeName] = attribute;
-        }
-      }
-      sideModel.setAttributes(newAttributes);
-    }
-  }
-
   _getModels(gl) {
     const {id, filled, extruded} = this.props;
 
@@ -359,6 +336,8 @@ export default class SolidPolygonLayer extends Layer {
           shaderCache: this.context.shaderCache
         })
       );
+
+      sideModel.userData.excludeAttributes = {indices: true};
     }
 
     return {

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -25,7 +25,8 @@ import {Model, Geometry, hasFeature, FEATURES} from 'luma.gl';
 // Polygon geometry generation is managed by the polygon tesselator
 import PolygonTesselator from './polygon-tesselator';
 
-import vs from './solid-polygon-layer-vertex.glsl';
+import vsTop from './solid-polygon-layer-vertex-top.glsl';
+import vsSide from './solid-polygon-layer-vertex-side.glsl';
 import fs from './solid-polygon-layer-fragment.glsl';
 
 const DEFAULT_COLOR = [0, 0, 0, 255];
@@ -60,15 +61,12 @@ const ATTRIBUTE_TRANSITION = {
 };
 
 export default class SolidPolygonLayer extends Layer {
-  getShaders(isSide) {
+  getShaders(vs) {
     const projectModule = this.use64bitProjection() ? 'project64' : 'project32';
     return {
       vs,
       fs,
-      modules: [projectModule, 'lighting', 'picking'],
-      defines: {
-        IS_SIDE_VERTEX: isSide
-      }
+      modules: [projectModule, 'lighting', 'picking']
     };
   }
 
@@ -98,7 +96,7 @@ export default class SolidPolygonLayer extends Layer {
           positions: {
             size: 3
           },
-          instancedPositions: {
+          instancePositions: {
             size: 3,
             divisor: 1
           },
@@ -116,7 +114,7 @@ export default class SolidPolygonLayer extends Layer {
           positions64xyLow: {
             size: 2
           },
-          instancedPositions64xyLow: {
+          instancePositions64xyLow: {
             size: 2,
             divisor: 1
           },
@@ -143,7 +141,7 @@ export default class SolidPolygonLayer extends Layer {
           elevations: {
             size: 1
           },
-          instancedElevations: {
+          instanceElevations: {
             size: 1,
             divisor: 1
           }
@@ -161,7 +159,7 @@ export default class SolidPolygonLayer extends Layer {
           fillColors: {
             size: 4
           },
-          instancedFillColors: {
+          instanceFillColors: {
             size: 4,
             divisor: 1
           }
@@ -179,7 +177,7 @@ export default class SolidPolygonLayer extends Layer {
           lineColors: {
             size: 4
           },
-          instancedLineColors: {
+          instanceLineColors: {
             size: 4,
             divisor: 1
           }
@@ -193,7 +191,7 @@ export default class SolidPolygonLayer extends Layer {
           pickingColors: {
             size: 3
           },
-          instancedPickingColors: {
+          instancePickingColors: {
             size: 3,
             divisor: 1
           }
@@ -290,7 +288,7 @@ export default class SolidPolygonLayer extends Layer {
     if (filled) {
       topModel = new Model(
         gl,
-        Object.assign({}, this.getShaders(false), {
+        Object.assign({}, this.getShaders(vsTop), {
           id: `${id}-top`,
           geometry: new Geometry({
             drawMode: GL.TRIANGLES,
@@ -311,7 +309,7 @@ export default class SolidPolygonLayer extends Layer {
     if (extruded) {
       sideModel = new Model(
         gl,
-        Object.assign({}, this.getShaders(true), {
+        Object.assign({}, this.getShaders(vsSide), {
           id: `${id}-side`,
           geometry: new Geometry({
             drawMode: GL.LINES,

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -94,14 +94,14 @@ export default class SolidPolygonLayer extends Layer {
         update: this.calculatePositions,
         shaderAttributes: {
           positions: {
-            size: 3
+            offset: 0,
+            divisor: 0
           },
           instancePositions: {
-            size: 3,
+            offset: 0,
             divisor: 1
           },
           nextPositions: {
-            size: 3,
             offset: 12,
             divisor: 1
           }
@@ -112,14 +112,14 @@ export default class SolidPolygonLayer extends Layer {
         update: this.calculatePositionsLow,
         shaderAttributes: {
           positions64xyLow: {
-            size: 2
+            offset: 0,
+            divisor: 0
           },
           instancePositions64xyLow: {
-            size: 2,
+            offset: 0,
             divisor: 1
           },
           nextPositions64xyLow: {
-            size: 2,
             offset: 8,
             divisor: 1
           }
@@ -139,10 +139,9 @@ export default class SolidPolygonLayer extends Layer {
         update: this.calculateElevations,
         shaderAttributes: {
           elevations: {
-            size: 1
+            divisor: 0
           },
           instanceElevations: {
-            size: 1,
             divisor: 1
           }
         }
@@ -157,10 +156,9 @@ export default class SolidPolygonLayer extends Layer {
         defaultValue: DEFAULT_COLOR,
         shaderAttributes: {
           fillColors: {
-            size: 4
+            divisor: 0
           },
           instanceFillColors: {
-            size: 4,
             divisor: 1
           }
         }
@@ -175,10 +173,9 @@ export default class SolidPolygonLayer extends Layer {
         defaultValue: DEFAULT_COLOR,
         shaderAttributes: {
           lineColors: {
-            size: 4
+            divisor: 0
           },
           instanceLineColors: {
-            size: 4,
             divisor: 1
           }
         }
@@ -189,10 +186,9 @@ export default class SolidPolygonLayer extends Layer {
         update: this.calculatePickingColors,
         shaderAttributes: {
           pickingColors: {
-            size: 3
+            divisor: 0
           },
           instancePickingColors: {
-            size: 3,
             divisor: 1
           }
         }


### PR DESCRIPTION
#### Background
Removes the `updateAttributes` override in SolidPolygonLayer.
#### Change List
- `AttributeManger.update` now iterates over all models in `getModels()` array to update attributes of all models associated with a layer.
- `shaderAttributes` support constant values.
- `SolidPolygonLayer` `vertexCount` and `instanceCount` are now updated whenever the `polygonTesselator` runs, so that no longer needs to happen in `updateAttributes`.
- All instanced vs non-instanced attributes are separated and given different names so they don't need to be hijacked.
- If `Model.userData.excludeAttributes` exists, it will be used to filter out attributes for that model. This is used to exclude `indices` from `sideModel` for its non-indexed rendering.
