### PR TITLE
Remove internally created canvas when deck is finalized

### DIFF
--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -180,6 +180,11 @@ export default class Deck {
     if (this.eventManager) {
       this.eventManager.destroy();
     }
+
+    if (!this.props.canvas && this.canvas) {
+      // remove internally created canvas
+      this.canvas.parentElement.removeChild(this.canvas);
+    }
   }
 
   setProps(props) {

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -181,9 +181,10 @@ export default class Deck {
       this.eventManager.destroy();
     }
 
-    if (!this.props.canvas && this.canvas) {
+    if (!this.props.canvas && !this.props.gl && this.canvas) {
       // remove internally created canvas
       this.canvas.parentElement.removeChild(this.canvas);
+      this.canvas = null;
     }
   }
 


### PR DESCRIPTION
#### Background

For https://github.com/uber/deck.gl/issues/1913 - currently multiple test cases in the browser test create `Deck` instances and they do not get cleaned up after the tests are done. This is interfering with the new snapshot tests.

#### Change List

- If the canvas is not externally provided, it should be removed when `Deck` instance is finalized.
