### PR TITLE
fix paths to examples in docs

### DIFF
--- a/docs/developer-guide/primitive-layers.md
+++ b/docs/developer-guide/primitive-layers.md
@@ -43,7 +43,7 @@ A choice to make is whether your WebGL primitives (draw calls) should be instanc
 * **Instanced layer** - This type of layer renders the same geometry many times. Usually the simplest way to go when creating a layer that renders a lot of similar objects (think ScatterplotLayer, ArcLayers etc).
 
 ```js
-  /// examples/sample-layers/mesh-layer/mesh-layer.js
+  /// modules/experimental-layers/src/mesh-layer/mesh-layer.js
   import {Model, Geometry} from 'luma.gl';
 
   _getModel(gl) {
@@ -65,7 +65,7 @@ A choice to make is whether your WebGL primitives (draw calls) should be instanc
 * **Dynamic geometry layer** - This is needed when dealing with data that needs to be rendered using multiple similar but unique geometries, such as polygons (i.e. the geometries are not copies of each other that that only differ in terms of parameters).
 
 ```js
-  /// examples/trips/trips-layer/trips-layer.js
+  /// modules/experimental-layers/src/trips-layer/trips-layer.js
   import {Model, Geometry} from 'luma.gl';
 
   _getModel(gl) {


### PR DESCRIPTION
#### Background
These have been moved to `modules/experimental-layers` and are no longer under `examples`.

... Though there is a note at the top of the referenced file:
> Note: This file will either be moved back to deck.gl or reformatted to web-monorepo standards

If they will only be in their current location temporarily, then this PR might not make sense?

Another option might be to add an actual link to the source code of the examples. Your call.

#### Change List
- Replace `examples/sample-layers` with `modules/experimental-layers/src` in two places.
