### PR TITLE
Fixes typos in RFCs

### DIFF
--- a/dev-docs/RFCs/v7.x/binary-data-rfc.md
+++ b/dev-docs/RFCs/v7.x/binary-data-rfc.md
@@ -123,7 +123,7 @@ new PathLayer({
 
 deck.gl layers will look for each attribute name in the `props` and use a provided typed array (and upload it to a GPU Buffer) instead of attempting to build its own buffer from data.
 
-## Passing GPU Buffers directluy to layer attributes
+## Passing GPU Buffers directly to layer attributes
 
 deck.gl layers will look for each attribute name in the `props` and use a provided GPU Buffer instead of attempting to build its own buffer from data.
 

--- a/dev-docs/RFCs/v7.x/effects-manager-rfc.md
+++ b/dev-docs/RFCs/v7.x/effects-manager-rfc.md
@@ -27,11 +27,11 @@ Note: This would be a fairly delicate engineering task, best performed by someon
 
 The best example here might be the lighting support that we have built-in to all our extrusion enabled core layers. Fully configuring lighting support requires a big bundle of props to be sent to each layer.
 
-Since it is rare that one would use different l;ighting parameters on different layers, not only is it wasteful to keep sending these params to each layer, but also it adds a lot of unnecessary plumbing in the application code (declaring an object with shared lighting settings in some constants file, importing it in each file that instantiates a layer etc).
+Since it is rare that one would use different lighting parameters on different layers, not only is it wasteful to keep sending these params to each layer, but also it adds a lot of unnecessary plumbing in the application code (declaring an object with shared lighting settings in some constants file, importing it in each file that instantiates a layer etc).
 
 A solution to this could be to create a `LightingEffect` subclass that contain all the parameters. These params would automatically be provided to layers without having to be supplied in every instantiation. This is listed as a separate proposal below.
 
-Open questions if if individual layers still should have an ability to override effects (enable/disable and or completely override parameters)
+Open questions if individual layers still should have an ability to override effects (enable/disable and or completely override parameters)
 
 
 ## Proposal: MirrorEffect
@@ -66,10 +66,3 @@ Framebuffers are big and expensive, deck.gl should maintain them and make them a
 Many effects could just use the picking buffer we have already allocated, unless we need to keep it around.
 
 Resource management - framebuffers (shadow buffers) take a lot of space, we will want to extend seer integration to show us how much resources effects re consuming.
-
-
-
-
-
-
-

--- a/dev-docs/rfc-guidelines.md
+++ b/dev-docs/rfc-guidelines.md
@@ -13,7 +13,7 @@ It is recommended that an RFC follows roughly the following structure:
 * Motivation: Short explanation of why the proposed functionality/change is valuable
 * Marketing Pitch: A section that can be copied into the website "What's New" page that shows how this feature will be pitched to users. (The intention is of course to make the pitch easy to understand, and as compelling and applicable to as a wide audience as possible).
 * Technical Overview
-* Proposals. Hint: It is ideal if propsa;s can be written in the form of clean documentation additions, as this saves a lot of work and typing later when updating the docs to cover the new feature.
+* Proposals. Hint: It is ideal if proposals can be written in the form of clean documentation additions, as this saves a lot of work and typing later when updating the docs to cover the new feature.
 * Open Issues: The author should try to solve as many of these off-line as possible to reduce the burden on reviewers, but any remaining ones can be listed here.
 * Future Extensions: It is always encouraging to see that a proposed feature is not a dead end and that more can be built on it. Any bullets here can later be a seed for a second, successor RFC.
 * Alternatives (Options): Especially if alternative ideas have already been floated during discussions etc, it is nice to mention them and briefly explain why they were not chosen.


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background
As I was reading the documentation I found some typos and I would like to fix them.
#### Change List
- dev-docs/RFCs/v7.x/binary-data-rfc.md
- dev-docs/RFCs/v7.x/effects-manager-rfc.md
- dev-docs/rfc-guidelines.md

