### PR TITLE
Prevent mutation of color variables passed to color setters

### DIFF
--- a/modules/layers/src/path-layer/path-tesselator.js
+++ b/modules/layers/src/path-layer/path-tesselator.js
@@ -22,6 +22,10 @@ const {Tesselator} = experimental;
 import {fp64 as fp64Module} from 'luma.gl';
 const {fp64LowPart} = fp64Module;
 
+// colorArray is used to copy over color values if the passed color is an RGB
+// array instead of RGBA
+const colorArray = [0, 0, 0, 255];
+
 // This class is set up to allow querying one attribute at a time
 // the way the AttributeManager expects it
 export default class PathTesselator extends Tesselator {
@@ -64,10 +68,13 @@ export default class PathTesselator extends Tesselator {
           size: 4,
           getValue: object => {
             const color = accessor(object);
-            if (isNaN(color[3])) {
-              color[3] = 255;
+            if (color.length === 4) {
+              return color;
             }
-            return color;
+            colorArray[0] = color[0];
+            colorArray[1] = color[1];
+            colorArray[2] = color[2];
+            return colorArray;
           }
         });
 

--- a/modules/layers/src/solid-polygon-layer/polygon-tesselator.js
+++ b/modules/layers/src/solid-polygon-layer/polygon-tesselator.js
@@ -70,9 +70,9 @@ export default class PolygonTesselator extends Tesselator {
           target,
           size: 4,
           getValue: object => {
-            const color = accessor(object);
-            if (isNaN(color[3])) {
-              color[3] = 255;
+            let color = accessor(object);
+            if (color.length < 4) {
+              color = [...color, 255];
             }
             return color;
           }

--- a/modules/layers/src/solid-polygon-layer/polygon-tesselator.js
+++ b/modules/layers/src/solid-polygon-layer/polygon-tesselator.js
@@ -29,6 +29,10 @@ const {Tesselator} = experimental;
 import {fp64 as fp64Module} from 'luma.gl';
 const {fp64LowPart} = fp64Module;
 
+// colorArray is used to copy over color values if the passed color is an RGB
+// array instead of RGBA
+const colorArray = [0, 0, 0, 255];
+
 // This class is set up to allow querying one attribute at a time
 // the way the AttributeManager expects it
 export default class PolygonTesselator extends Tesselator {
@@ -70,11 +74,14 @@ export default class PolygonTesselator extends Tesselator {
           target,
           size: 4,
           getValue: object => {
-            let color = accessor(object);
-            if (color.length < 4) {
-              color = [...color, 255];
+            const color = accessor(object);
+            if (color.length === 4) {
+              return color;
             }
-            return color;
+            colorArray[0] = color[0];
+            colorArray[1] = color[1];
+            colorArray[2] = color[2];
+            return colorArray;
           }
         });
 


### PR DESCRIPTION
**Background**
  #2732

**Changes**
Instead of mutating the color variables when missing the alpha value, return a new color array instead.
