### PR TITLE
Change point light class import name

### DIFF
--- a/modules/core/src/effects/lighting-effect.js
+++ b/modules/core/src/effects/lighting-effect.js
@@ -1,4 +1,4 @@
-import {AmbientLight, PointLight as BasePointLight, DirectionalLight} from '@luma.gl/core';
+import {AmbientLight, PointLight, DirectionalLight} from '@luma.gl/core';
 import Effect from '../lib/effect';
 import {projectPosition} from '../shaderlib/project/project-functions';
 import {COORDINATE_SYSTEM} from '../lib';
@@ -81,7 +81,7 @@ export default class LightingEffect extends Effect {
         fromCoordinateOrigin: [0, 0, 0]
       });
       projectedPointLights.push(
-        new BasePointLight({
+        new PointLight({
           color: pointLight.color,
           intensity: pointLight.intensity,
           position


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #2096 
<!-- For other PRs without open issue -->
#### Background
Planned to have a PointLight class in deck.gl with coordinate information, found which is not necessary, change the import name back.
<!-- For all the PRs -->
#### Change List
- fix point light class import name
