### PR TITLE
Don't fire panmove if drag started somewhere else

### DIFF
--- a/modules/core/src/controllers/controller.js
+++ b/modules/core/src/controllers/controller.js
@@ -263,7 +263,7 @@ export default class Controller {
       return false;
     }
     const pos = this.getCenter(event);
-    if (!this.isPointInBounds(pos) || !this.isDragging()) {
+    if (!this.isDragging()) {
       return false;
     }
     const newControllerState = this.controllerState.pan({pos});

--- a/modules/core/src/controllers/controller.js
+++ b/modules/core/src/controllers/controller.js
@@ -263,6 +263,9 @@ export default class Controller {
       return false;
     }
     const pos = this.getCenter(event);
+    if (!this.isPointInBounds(pos) || !this.isDragging()) {
+      return false;
+    }
     const newControllerState = this.controllerState.pan({pos});
     return this.updateViewport(newControllerState, NO_TRANSITION_PROPS, {isDragging: true});
   }


### PR DESCRIPTION
Fixing a bug. When there are multiple views each with its own controller, panning outside of the current viewport would cause the controller inside the current viewport to fire "panmove", which would throw an error. Adding checks here so panmove doesn't get fired.

fixes #2779 
<!-- For all the PRs -->
#### Change List
- ` modules/core/src/controllers/controller.js`