### PR TITLE
Avoid creating small objects when checking redraw flags

### DIFF
--- a/modules/core/src/lib/attribute-manager.js
+++ b/modules/core/src/lib/attribute-manager.js
@@ -146,9 +146,9 @@ export default class AttributeManager {
   //
   // @param {String} [clearRedrawFlags=false] - whether to clear the flag
   // @return {false|String} - reason a redraw is needed.
-  getNeedsRedraw({clearRedrawFlags = false} = {}) {
+  getNeedsRedraw(opts = {clearRedrawFlags: false}) {
     const redraw = this.needsRedraw;
-    this.needsRedraw = this.needsRedraw && !clearRedrawFlags;
+    this.needsRedraw = this.needsRedraw && !opts.clearRedrawFlags;
     return redraw && this.id;
   }
 
@@ -284,9 +284,10 @@ export default class AttributeManager {
   /**
    * Returns changed attribute descriptors
    * This indicates which WebGLBuffers need to be updated
+   * @param opts.clearChangedFlags {Boolean}
    * @return {Object} attributes - descriptors
    */
-  getChangedAttributes({clearChangedFlags = false}) {
+  getChangedAttributes(opts = {clearChangedFlags: false}) {
     const {attributes, attributeTransitionManager} = this;
 
     const changedAttributes = Object.assign({}, attributeTransitionManager.getAttributes());
@@ -294,10 +295,7 @@ export default class AttributeManager {
 
     for (const attributeName in attributes) {
       const attribute = attributes[attributeName];
-      if (
-        attribute.needsRedraw({clearChangedFlags: true}) &&
-        !attributeTransitionManager.hasAttribute(attributeName)
-      ) {
+      if (attribute.needsRedraw(opts) && !attributeTransitionManager.hasAttribute(attributeName)) {
         changedAttributes[attributeName] = attribute;
       }
     }

--- a/modules/core/src/lib/deck-renderer.js
+++ b/modules/core/src/lib/deck-renderer.js
@@ -80,9 +80,9 @@ export default class DeckRenderer {
     }
   }
 
-  needsRedraw(clearRedrawFlags) {
+  needsRedraw(opts = {clearRedrawFlags: false}) {
     const redraw = this._needsRedraw;
-    if (clearRedrawFlags) {
+    if (opts.clearRedrawFlags) {
       this._needsRedraw = false;
     }
     return redraw;

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -241,21 +241,22 @@ export default class Deck {
   // Public API
   // Check if a redraw is needed
   // Returns `false` or a string summarizing the redraw reason
-  needsRedraw({clearRedrawFlags = true} = {}) {
+  // opts.clearRedrawFlags (Boolean) - clear the redraw flag. Default `true`
+  needsRedraw(opts = {clearRedrawFlags: false}) {
     if (this.props._animate) {
       return 'Deck._animate';
     }
 
     let redraw = this._needsRedraw;
 
-    if (clearRedrawFlags) {
+    if (opts.clearRedrawFlags) {
       this._needsRedraw = false;
     }
 
-    const viewManagerNeedsRedraw = this.viewManager.needsRedraw({clearRedrawFlags});
-    const layerManagerNeedsRedraw = this.layerManager.needsRedraw({clearRedrawFlags});
-    const effectManagerNeedsRedraw = this.effectManager.needsRedraw({clearRedrawFlags});
-    const deckRendererNeedsRedraw = this.deckRenderer.needsRedraw({clearRedrawFlags});
+    const viewManagerNeedsRedraw = this.viewManager.needsRedraw(opts);
+    const layerManagerNeedsRedraw = this.layerManager.needsRedraw(opts);
+    const effectManagerNeedsRedraw = this.effectManager.needsRedraw(opts);
+    const deckRendererNeedsRedraw = this.deckRenderer.needsRedraw(opts);
 
     redraw =
       redraw ||

--- a/modules/core/src/lib/effect-manager.js
+++ b/modules/core/src/lib/effect-manager.js
@@ -17,9 +17,9 @@ export default class EffectManager {
     this.applyDefaultLightingEffect();
   }
 
-  needsRedraw(clearRedrawFlags) {
+  needsRedraw(opts = {clearRedrawFlags: false}) {
     const redraw = this._needsRedraw;
-    if (clearRedrawFlags) {
+    if (opts.clearRedrawFlags) {
       this._needsRedraw = false;
     }
     return redraw;

--- a/modules/core/src/lib/layer-manager.js
+++ b/modules/core/src/lib/layer-manager.js
@@ -112,8 +112,8 @@ export default class LayerManager {
   }
 
   // Check if a redraw is needed
-  needsRedraw({clearRedrawFlags = true} = {}) {
-    return this._checkIfNeedsRedraw(clearRedrawFlags);
+  needsRedraw(opts = {clearRedrawFlags: false}) {
+    return this._checkIfNeedsRedraw(opts);
   }
 
   // Check if a deep update of all layers is needed
@@ -214,16 +214,16 @@ export default class LayerManager {
   // PRIVATE METHODS
   //
 
-  _checkIfNeedsRedraw(clearRedrawFlags) {
+  _checkIfNeedsRedraw(opts) {
     let redraw = this._needsRedraw;
-    if (clearRedrawFlags) {
+    if (opts.clearRedrawFlags) {
       this._needsRedraw = false;
     }
 
     // This layers list doesn't include sublayers, relying on composite layers
     for (const layer of this.layers) {
       // Call every layer to clear their flags
-      const layerNeedsRedraw = layer.getNeedsRedraw({clearRedrawFlags});
+      const layerNeedsRedraw = layer.getNeedsRedraw(opts);
       redraw = redraw || layerNeedsRedraw;
     }
 

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -122,8 +122,8 @@ export default class Layer extends Component {
   }
 
   // Checks state of attributes and model
-  getNeedsRedraw({clearRedrawFlags = false} = {}) {
-    return this._getNeedsRedraw(clearRedrawFlags);
+  getNeedsRedraw(opts = {clearRedrawFlags: false}) {
+    return this._getNeedsRedraw(opts);
   }
 
   // Checks if layer attributes needs updating
@@ -789,7 +789,7 @@ ${flags.viewportChanged ? 'viewport' : ''}\
   }
 
   // Checks state of attributes and model
-  _getNeedsRedraw(clearRedrawFlags) {
+  _getNeedsRedraw(opts) {
     // this method may be called by the render loop as soon a the layer
     // has been created, so guard against uninitialized state
     if (!this.internalState) {
@@ -798,23 +798,22 @@ ${flags.viewportChanged ? 'viewport' : ''}\
 
     let redraw = false;
     redraw = redraw || (this.internalState.needsRedraw && this.id);
-    this.internalState.needsRedraw = this.internalState.needsRedraw && !clearRedrawFlags;
+    this.internalState.needsRedraw = this.internalState.needsRedraw && !opts.clearRedrawFlags;
 
     // TODO - is attribute manager needed? - Model should be enough.
     const attributeManager = this.getAttributeManager();
-    const attributeManagerNeedsRedraw =
-      attributeManager && attributeManager.getNeedsRedraw({clearRedrawFlags});
-    const modelNeedsRedraw = this._modelNeedsRedraw(clearRedrawFlags);
+    const attributeManagerNeedsRedraw = attributeManager && attributeManager.getNeedsRedraw(opts);
+    const modelNeedsRedraw = this._modelNeedsRedraw(opts);
     redraw = redraw || attributeManagerNeedsRedraw || modelNeedsRedraw;
 
     return redraw;
   }
 
-  _modelNeedsRedraw(clearRedrawFlags) {
+  _modelNeedsRedraw(opts) {
     let redraw = false;
 
     for (const model of this.getModels()) {
-      let modelNeedsRedraw = model.getNeedsRedraw({clearRedrawFlags});
+      let modelNeedsRedraw = model.getNeedsRedraw(opts);
       if (modelNeedsRedraw && typeof modelNeedsRedraw !== 'string') {
         modelNeedsRedraw = `model ${model.id}`;
       }

--- a/modules/core/src/lib/view-manager.js
+++ b/modules/core/src/lib/view-manager.js
@@ -62,17 +62,12 @@ export default class ViewManager {
   }
 
   // Check if a redraw is needed
-  needsRedraw({clearRedrawFlags = true} = {}) {
+  needsRedraw(opts = {clearRedrawFlags: false}) {
     const redraw = this._needsRedraw;
-    if (clearRedrawFlags) {
+    if (opts.clearRedrawFlags) {
       this._needsRedraw = false;
     }
     return redraw;
-  }
-
-  // Layers will be redrawn (in next animation frame)
-  setNeedsRedraw(reason) {
-    this._needsRedraw = this._needsRedraw || reason;
   }
 
   // Layers will be updated deeply (in next animation frame)

--- a/test/modules/core/views/view-manager.spec.js
+++ b/test/modules/core/views/view-manager.spec.js
@@ -52,10 +52,10 @@ test('ViewManager#needsRedraw', t => {
 
   viewManager.getViewports();
 
-  let redrawReason = viewManager.needsRedraw({clearRedrawFlags: false});
+  let redrawReason = viewManager.needsRedraw();
   t.equals(typeof redrawReason, 'string', 'Viewport needs redrawing');
 
-  redrawReason = viewManager.needsRedraw();
+  redrawReason = viewManager.needsRedraw({clearRedrawFlags: true});
   t.equals(typeof redrawReason, 'string', 'Viewport still needs redrawing');
 
   redrawReason = viewManager.needsRedraw();


### PR DESCRIPTION
#### Change List
- avoid recursively creating small objects in `deck.needsRedraw`
- all `clearRedrawFlags` are now default to `false`
