### PR TITLE
[Discussion] User external h3

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -3,16 +3,12 @@ const getBabelConfig = require('ocular-dev-tools/config/babel.config');
 module.exports = api => {
   const config = getBabelConfig(api);
 
-  config.plugins.push(
-    'version-inline',
-    'inline-webgl-constants',
-    [
-      'remove-glsl-comments',
-      {
-        patterns: ['**/*.glsl.js']
-      }
-    ]
-  );
+  config.plugins.push('version-inline', 'inline-webgl-constants', [
+    'remove-glsl-comments',
+    {
+      patterns: ['**/*.glsl.js']
+    }
+  ]);
 
   return config;
 };

--- a/docs/layers/h3-cluster-layer.md
+++ b/docs/layers/h3-cluster-layer.md
@@ -13,6 +13,7 @@ The `H3ClusterLayer` renders regions represented by hexagon sets from the [H3](h
 
 ```js
 import DeckGL, {H3ClusterLayer} from 'deck.gl';
+import * as h3 from 'h3-js';
 
 const App = ({data, viewport}) => {
 
@@ -37,6 +38,7 @@ const App = ({data, viewport}) => {
    */
   const layer = new H3ClusterLayer({
     id: 'h3-cluster-layer',
+    h3,
     data,
     stroked: true,
     filled: true,
@@ -61,6 +63,16 @@ const App = ({data, viewport}) => {
 ## Properties
 
 Inherits from all [Base Layer](/docs/api-reference/layer.md), [CompositeLayer](/docs/api-reference/composite-layer.md), and [PolygonLayer](/docs/api-reference/polygon-layer.md) properties, plus the following:
+
+### H3
+
+##### `h3` (Object)
+
+The H3 interface. This allows users to use a version of the [H3 Core Library](https://github.com/uber/h3) that matches the source data.
+The `h3` object is expected to contain the following methods:
+
+* `h3SetToMultiPolygon`
+
 
 ### Data Accessors
 

--- a/docs/layers/h3-hexagon-layer.md
+++ b/docs/layers/h3-hexagon-layer.md
@@ -13,6 +13,7 @@ The `H3HexagonLayer` renders hexagons from the [H3](https://uber.github.io/h3/) 
 
 ```js
 import DeckGL, {H3HexagonLayer} from 'deck.gl';
+import * as h3 from 'h3-js';
 
 const App = ({data, viewport}) => {
 
@@ -28,6 +29,7 @@ const App = ({data, viewport}) => {
    */
   const layer = new H3HexagonLayer({
     id: 'h3-hexagon-layer',
+    h3,
     data,
     extruded: true,
     pickable: true,
@@ -49,6 +51,18 @@ const App = ({data, viewport}) => {
 ## Properties
 
 Inherits from all [Base Layer](/docs/api-reference/layer.md) and [CompositeLayer](/docs/api-reference/composite-layer.md) properties.
+
+### H3
+
+##### `h3` (Object)
+
+The H3 interface. This allows users to use a version of the [H3 Core Library](https://github.com/uber/h3) that matches the source data.
+The `h3` object is expected to contain the following methods:
+
+* `h3GetResolution`
+* `h3ToGeo`
+* `geoToH3`
+* `h3ToGeoBoundary`
 
 ### Render Options
 

--- a/examples/layer-browser/src/examples/additional-layers.js
+++ b/examples/layer-browser/src/examples/additional-layers.js
@@ -134,6 +134,7 @@ const S2LayerExample = {
 const H3ClusterLayerExample = {
   layer: H3ClusterLayer,
   props: {
+    h3,
     data: ['882830829bfffff'],
     getHexagons: d => h3.kRing(d, 6),
     getLineWidth: 100,
@@ -145,6 +146,7 @@ const H3ClusterLayerExample = {
 const H3HexagonLayerExample = {
   layer: H3HexagonLayer,
   props: {
+    h3,
     data: h3.kRing('882830829bfffff', 4),
     getHexagon: d => d,
     getColor: (d, {index}) => [255, index * 5, 0],

--- a/modules/geo-layers/package.json
+++ b/modules/geo-layers/package.json
@@ -31,8 +31,10 @@
     "prepublishOnly": "npm run build-bundle && npm run build-bundle -- --env.dev"
   },
   "dependencies": {
-    "h3-js": "^3.0.0",
     "s2-geometry": "^1.2.10"
+  },
+  "devDependencies": {
+    "h3-js": "^3.0.0"
   },
   "peerDependencies": {
     "@deck.gl/core": "^7.0.0-alpha.3",

--- a/modules/geo-layers/src/h3-layers/h3-cluster-layer.js
+++ b/modules/geo-layers/src/h3-layers/h3-cluster-layer.js
@@ -1,10 +1,9 @@
-import {h3SetToMultiPolygon} from 'h3-js';
-
 import {CompositeLayer, createIterable} from '@deck.gl/core';
 import {PolygonLayer} from '@deck.gl/layers';
 
 const defaultProps = Object.assign(
   {
+    h3: {type: 'object', value: {}},
     getHexagons: {type: 'accessor', value: d => d.hexagons}
   },
   PolygonLayer.defaultProps
@@ -16,14 +15,14 @@ export default class H3ClusterLayer extends CompositeLayer {
       changeFlags.dataChanged ||
       (changeFlags.updateTriggers && changeFlags.updateTriggers.getHexagons)
     ) {
-      const {data, getHexagons} = props;
+      const {h3, data, getHexagons} = props;
       const polygons = [];
 
       const {iterable, objectInfo} = createIterable(data);
       for (const object of iterable) {
         objectInfo.index++;
         const hexagons = getHexagons(object, objectInfo);
-        const multiPolygon = h3SetToMultiPolygon(hexagons, true);
+        const multiPolygon = h3.h3SetToMultiPolygon(hexagons, true);
 
         for (const polygon of multiPolygon) {
           polygons.push({polygon, object, index: objectInfo.index});

--- a/modules/geo-layers/src/h3-layers/h3-cluster-layer.js
+++ b/modules/geo-layers/src/h3-layers/h3-cluster-layer.js
@@ -3,7 +3,7 @@ import {PolygonLayer} from '@deck.gl/layers';
 
 const defaultProps = Object.assign(
   {
-    h3: {type: 'object', value: {}},
+    h3: {},
     getHexagons: {type: 'accessor', value: d => d.hexagons}
   },
   PolygonLayer.defaultProps

--- a/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
+++ b/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
@@ -8,7 +8,7 @@ function getHexagonCentroid(getHexagon, h3ToGeo, object, objectInfo) {
 }
 
 const defaultProps = {
-  h3: {type: 'object', value: {}},
+  h3: {},
   getHexagon: {type: 'accessor', value: x => x.hexagon}
 };
 

--- a/scripts/bundle.config.js
+++ b/scripts/bundle.config.js
@@ -17,7 +17,6 @@ const PACKAGE_INFO = require(resolve(PACKAGE_ROOT, 'package.json'));
 function getExternals(packageInfo) {
   let externals = {
     // Hard coded externals
-    'h3-js': 'h3',
     's2-geometry': 's2'
   };
   const {peerDependencies = {}} = packageInfo;

--- a/test/modules/geo-layers/h3-layers.spec.js
+++ b/test/modules/geo-layers/h3-layers.spec.js
@@ -23,12 +23,23 @@ import {experimental} from '@deck.gl/core';
 const {count} = experimental;
 import {testLayer, generateLayerTests} from '@deck.gl/test-utils';
 import {H3HexagonLayer, H3ClusterLayer} from '@deck.gl/geo-layers';
+import {geoToH3, h3ToGeo, h3ToGeoBoundary, h3GetResolution, h3SetToMultiPolygon} from 'h3-js';
 import data from 'deck.gl-test/data/h3-sf.json';
+
+// TODO - `import * as h3` breaks compareProps when trying to convert h3 to string
+const h3 = {
+  geoToH3,
+  h3ToGeo,
+  h3ToGeoBoundary,
+  h3GetResolution,
+  h3SetToMultiPolygon
+};
 
 test('H3HexagonLayer', t => {
   const testCases = generateLayerTests({
     Layer: H3HexagonLayer,
     sampleProps: {
+      h3,
       data,
       getHexagon: d => d.hexagons[0]
     },
@@ -45,6 +56,7 @@ test('H3ClusterLayer', t => {
   const testCases = generateLayerTests({
     Layer: H3ClusterLayer,
     sampleProps: {
+      h3,
       data,
       getHexagons: d => d.hexagons
       // getElevation: d => d.size

--- a/test/render/test-cases.js
+++ b/test/render/test-cases.js
@@ -1141,6 +1141,7 @@ export const TEST_CASES = [
     },
     layers: [
       new H3HexagonLayer({
+        h3,
         data: h3.kRing('882830829bfffff', 4),
         getHexagon: d => d,
         getColor: (d, {index}) => [255, index * 5, 0],
@@ -1160,6 +1161,7 @@ export const TEST_CASES = [
     },
     layers: [
       new H3ClusterLayer({
+        h3,
         data: ['882830829bfffff'],
         getHexagons: d => h3.kRing(d, 6),
         getLineWidth: 100,


### PR DESCRIPTION
This change avoids installing and bundling h3-js if the layers are not used, and also allows users to install an alternative implementation of h3 (e.g. an earlier version from the internal module)

#### Change List
- Add required `h3` props to `H3HexagonLayer` and `H3ClusterLayer`.
