### PR TITLE
Only pick once per animation frame

### DIFF
--- a/docs/api-reference/deck.md
+++ b/docs/api-reference/deck.md
@@ -215,25 +215,23 @@ Returns:
 
 * The application can return an updated view state. If a view state is returned, it will be used instead of the passed in `viewState` to update the application's internal view state (see `initialViewState`).
 
-##### `onLayerHover` (Function, optional)
+##### `onHover` (Function, optional)
 
-Callback - called when the object under the pointer changes.
+Callback - called when the pointer moves over the canvas.
 
 Callback Arguments:
 
-* `info` - the [`info`](/docs/developer-guide/interactivity.md#the-picking-info-object) object for the topmost picked layer at the coordinate, null when no object is picked.
-* `pickedInfos` - an array of info objects for all pickable layers that are affected.
-* `event` - the original [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) object
+* `info` - the [picking info](/docs/developer-guide/interactivity.md#the-picking-info-object) describing the object being dragged.
+* `event` - the original gesture event
 
-##### `onLayerClick` (Function, optional)
+##### `onClick` (Function, optional)
 
 Callback - called when clicking on the canvas.
 
 Callback Arguments:
 
-* `info` - the [`info`](/docs/developer-guide/interactivity.md#the-picking-info-object) object for the topmost picked layer at the coordinate, null when no object is picked.
-* `pickedInfos` - an array of info objects for all pickable layers that are affected.
-* `event` - the original [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) object
+* `info` - the [picking info](/docs/developer-guide/interactivity.md#the-picking-info-object) describing the object being dragged.
+* `event` - the original gesture event
 
 ##### `onDragStart` (Function, optional)
 

--- a/docs/api-reference/layer.md
+++ b/docs/api-reference/layer.md
@@ -119,7 +119,7 @@ This callback will be called when the mouse enters/leaves an object of this deck
 * [`info`](/docs/developer-guide/interactivity.md#the-picking-info-object)
 * `event` - the source event
 
-If this callback returns a truthy value, the `hover` event is marked as handled and will not bubble up to the [`onLayerHover`](/docs/api-reference/react/deckgl.md#-onlayerhover-function-optional-) callback of the `DeckGL` canvas.
+If this callback returns a truthy value, the `hover` event is marked as handled and will not bubble up to the [`onHover`](/docs/api-reference/react/deckgl.md#-onhover-function-optional-) callback of the `DeckGL` canvas.
 
 Requires `pickable` to be true.
 
@@ -130,7 +130,7 @@ This callback will be called when the mouse clicks over an object of this deck.g
 * [`info`](/docs/developer-guide/interactivity.md#the-picking-info-object)
 * `event` - the source event
 
-If this callback returns a truthy value, the `click` event is marked as handled and will not bubble up to the [`onLayerClick`](/docs/api-reference/react/deckgl.md#-onlayerclick-function-optional-) callback of the `DeckGL` canvas.
+If this callback returns a truthy value, the `click` event is marked as handled and will not bubble up to the [`onClick`](/docs/api-reference/react/deckgl.md#-onclick-function-optional-) callback of the `DeckGL` canvas.
 
 Requires `pickable` to be true.
 

--- a/docs/api-reference/mapbox/mapbox-layer.md
+++ b/docs/api-reference/mapbox/mapbox-layer.md
@@ -40,7 +40,7 @@ myScatterplotLayer.setProps({
 
 ### Use a Layer from an Existing Deck's Layer Stack
 
-This option allows one to take full advantage of the `Deck` API, e.g. top-level props such as `pickingRadius`, `onLayerHover`, and adding/removing/updating layers in a reactive fashion by setting the `layers` array.
+This option allows one to take full advantage of the `Deck` API, e.g. top-level props such as `pickingRadius`, `onHover`, and adding/removing/updating layers in a reactive fashion by setting the `layers` array.
 
 ```js
 import {MapboxLayer} from '@deck.gl/mapbox';

--- a/docs/developer-guide/interactivity.md
+++ b/docs/developer-guide/interactivity.md
@@ -152,32 +152,40 @@ Also note that by directly calling `queryObject`, integrating deck.gl into an ex
 
 ## Using the Built-in Event-Handling
 
-For applications that have basic event handling needs, deck.gl has built-in support for handling the two most basic mouse events: `hover` and `click`. When the application registers callbacks, deck.gl automatically tracks these events, runs the picking engine and calls application callbacks with a single parameter `info` which contains the resulting picking info object.
+For applications that have basic event handling needs, deck.gl has built-in support for handling selected pointer events. When the application registers callbacks, deck.gl automatically tracks these events, runs the picking engine and calls application callbacks with a single parameter `info` which contains the resulting picking info object.
+
+The following event handlers are supported:
+
+- `onHover`
+- `onClick`
+- `onDragStart`
+- `onDrag`
+- `onDragEnd`
+
+A event handler function is called with two parameters: `info` that contains the object being interacted with, and `event` that contains the pointer event.
 
 There are two ways to subscribe to the built-in picking event handling:
 
-* Set callback for each pickable layer by setting [`onHover`](/docs/api-reference/layer.md#-onhover-function-optional-) and [`onClick`](/docs/api-reference/layer.md#-onclick-function-optional-) props:
+* Specify callbacks for each pickable layer by passing [event handler props](/docs/api-reference/layer.md#interaction-properties):
 
 ```js
 const layer = new ScatterplotLayer({
     ...
     pickable: true,
-    onHover: info => console.log('Hovered:', info),
-    onClick: info => console.log('Clicked:', info)
+    onHover: (info, event) => console.log('Hovered:', info, event),
+    onClick: (info, event) => console.log('Clicked:', info, event)
 });
 ```
 
-* Set callback for all pickable layers by setting [`onLayerHover`](/docs/api-reference/react/deckgl.md#-onlayerhover-function-optional-) and [`onLayerClick`](/docs/api-reference/react/deckgl.md#-onlayerclick-function-optional-) props of the `DeckGL` canvas:
+* Specify callbacks for all pickable layers by setting [event handler props](/docs/api-reference/react/deckgl.md#event-callbacks) of the `DeckGL` canvas:
 
 ```js
 <DeckGL
     ...
-    onLayerHover={this._onHover}
-    onLayerClick={this._onClick}
+    onHover={this._onHover}
+    onClick={this._onClick}
 />
 ```
-
-The callbacks for `hover` and `click` events are called with a single parameter `info` that contains the mouse or touch event and what was hovered, including which layer was selected. Thus event handlers registered directly on the `DeckGL` components are also able to distinguish between clicks in different layers.
 
 ### Behavior of Built-in Event Handling
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -12,6 +12,12 @@
   + `MeshLayer` is renamed to `SimpleMeshLayer` and moved to `@deck.gl/mesh-layers`.
   + `TileLayer` and `TripsLayer` are moved to `@deck.gl/geo-layers`.
 
+#### Deck Class
+
+**Breaking Changes**
+
+- `onLayerHover` and `onLayerClick` props are replaced with `onHover` and `onClick`. The first argument passed to the callback will always be an [picking info](/docs/developer-guide/interactivity.md#the-picking-info-object) object, and the second argument is the pointer event. This change makes these two events consistent with other event callbacks.
+
 #### Layers
 
 **Deprecations**

--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -291,8 +291,8 @@ export default class App extends PureComponent {
           onViewStateChange={this._onViewStateChange}
           effects={effects ? this._effects : []}
           pickingRadius={pickingRadius}
-          onLayerHover={this._onHover}
-          onLayerClick={this._onClick}
+          onHover={this._onHover}
+          onClick={this._onClick}
           useDevicePixels={useDevicePixels}
           debug={true}
           drawPickingColors={drawPickingColors}

--- a/modules/core/src/lib/constants.js
+++ b/modules/core/src/lib/constants.js
@@ -45,6 +45,7 @@ export const COORDINATE_SYSTEM = {
 };
 
 export const EVENTS = {
+  click: {handler: 'onClick'},
   panstart: {handler: 'onDragStart'},
   panmove: {handler: 'onDrag'},
   panend: {handler: 'onDragEnd'}

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -441,6 +441,9 @@ export default class Deck {
     return views;
   }
 
+  // The `pointermove` event may fire multiple times in between two animation frames,
+  // it's a waste of time to run picking without rerender. Instead we save the last pick
+  // request and only do it once on the next animation frame.
   _requestPick({event, callback, mode, immediate}) {
     const {_pickRequest} = this;
     if (event.type === 'pointerleave') {
@@ -468,6 +471,7 @@ export default class Deck {
     }
   }
 
+  // Actually run picking
   _pickAndCallback() {
     const {_pickRequest} = this;
 

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -441,14 +441,14 @@ export default class Deck {
     return views;
   }
 
-  _requestPick(options, immediate) {
+  _requestPick({event, callback, mode, immediate}) {
     const {_pickRequest} = this;
-    if (options.event.type === 'pointerleave') {
+    if (event.type === 'pointerleave') {
       _pickRequest.x = -1;
       _pickRequest.y = -1;
       _pickRequest.radius = 0;
     } else {
-      const pos = options.event.offsetCenter;
+      const pos = event.offsetCenter;
       // Do not trigger callbacks when click/hover position is invalid. Doing so will cause a
       // assertion error when attempting to unproject the position.
       if (!pos) {
@@ -459,9 +459,9 @@ export default class Deck {
       _pickRequest.radius = this.props.pickingRadius;
     }
 
-    _pickRequest.callback = options.callback;
-    _pickRequest.event = options.event;
-    _pickRequest.mode = options.mode;
+    _pickRequest.callback = callback;
+    _pickRequest.event = event;
+    _pickRequest.mode = mode;
 
     if (immediate) {
       this._pickAndCallback();
@@ -704,14 +704,12 @@ export default class Deck {
   }
 
   _onPointerDown(event) {
-    this._requestPick(
-      {
-        callback: this.props.onHover,
-        event,
-        mode: 'hover'
-      },
-      true
-    );
+    this._requestPick({
+      callback: this.props.onHover,
+      event,
+      mode: 'hover',
+      immediate: true
+    });
   }
 
   _onPointerMove(event) {

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -705,7 +705,7 @@ export default class Deck {
 
   _onPointerDown(event) {
     this._requestPick({
-      callback: this.props.onHover,
+      callback: null,
       event,
       mode: 'hover',
       immediate: true


### PR DESCRIPTION
@xintongxia has observed that the `pointermove` event sometimes fires multiple times between two animation frames. I do not see this locally in Chrome, but it's steadily reproducible in Safari.

Edit: upgraded to Chrome 73 from 72 and the issue is showing up.

I'm fairly certain the above behavior is causing this bug: https://github.com/uber/deck.gl/issues/2550

Note that the proposed new system no longer support the legacy event handling behavior (pick on both hover and click). When we introduced additional event handlers (onDrag*) in 6.3, we kept the existing click/hover behavior to avoid breaking change. The old `onLayerHover(info, infos, srcEvent)` and `onLayerClick(info, infos, srcEvent)` callbacks no longer pass a meaningful second argument (leftover from the v5 layer-by-layer picking system) and do not align with the rest of the event API (on*(info, event) for both deck and layers). They have been removed in this PR.

#### Change List
- Delay picking to the next animation frame
- Replace `onLayerClick` and `onLayerHover` with `onClick` and `onHover`
