### PR TITLE
Fix pixel projection in shaders (PR 1/2)

### DIFF
--- a/docs/developer-guide/coordinate-systems.md
+++ b/docs/developer-guide/coordinate-systems.md
@@ -1,12 +1,10 @@
 # Coordinate Systems
 
-By default, deck.gl layers interprets positions in the [Web Mercator](https://en.wikipedia.org/wiki/Web_Mercator) coordinate system, so when working with geospatial data (i.e with longitude and latitude encoded positions) deck.gl will automatically interpret any positions correctly.
+By default, deck.gl layers interprets positions in the [Web Mercator](https://en.wikipedia.org/wiki/Web_Mercator) coordinate system (i.e. `[longitude, latitude, altitude]`), so when working with geospatial data (i.e with longitude and latitude encoded positions) deck.gl will automatically interpret any positions correctly.
 
-In addition, deck.gl layers can be configured to use "meter offset" based local coordinate systems, which can be quite convenient when modelling geographical data on small scales (e.g. city block level).
+In addition, deck.gl layers can be configured to use a selection of alternative coordinate systems, supporting data from e.g. LIDAR sensors, and non-geospatial use cases.
 
-Naturally, non-geospatial coordinates can also be used when working with non-geospatial data sets.
-
-Of note is that each deck.gl layer can define its own coordinate system. Within the data supplied to a single layer, all positions must be specified in the coordinate system, however data supplied to other layers can be specified in other coordinate system.
+Each deck.gl layer can define its own coordinate system. Within the data supplied to a single layer, all positions must be specified in the same coordinate system. Layers using different coordinate systems can be composed together, which is very useful when dealing with datasets from different sources.
 
 
 ## Supported Coordinate Systems

--- a/docs/shader-modules/project.md
+++ b/docs/shader-modules/project.md
@@ -48,10 +48,12 @@ The projection module makes it easy to write vertex shaders that follow deck.gl'
 
 The functions converts positions/vectors between 4 coordinate spaces:
 
-* World space (`world`): the [coordinate system](/docs/developer-guide/coordinate-systems.md) defined by the layer, not necessarily linear or uniform.
-* Common space (`common`): an normalized intermediate 3D space that deck.gl uses for consistent processing of geometries. It is safe to add/subtract/scale positions and vectors in this space.
-* Screen space (`pixel`): top-left coordinate system runs from `[0, 0]` to `[viewportWidth, viewportHeight]` (see remarks below).
-* [Clip space](https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_model_view_projection#Clip_space) (`clipspace`): output of the vertex shader
+| Name | Short Name | Description |
+|------|------|-------------|
+| World space | `world` | The [coordinate system](/docs/developer-guide/coordinate-systems.md) defined by the layer, not necessarily linear or uniform. |
+| Common space | `common` | A normalized intermediate 3D space that deck.gl uses for consistent processing of geometries, guaranteed to be linear and uniform. Therefore, it is safe to add/rotate/scale positions and vectors in this space. |
+| Screen space | `pixel` | Top-left coordinate system runs from `[0, 0]` to `[viewportWidth, viewportHeight]` (see remarks below). |
+| [Clip space](https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_model_view_projection#Clip_space) | `clipspace` | Output of the vertex shader. |
 
 The GLSL functions of the `project` shader module uses the following naming convention:
 
@@ -59,13 +61,13 @@ The GLSL functions of the `project` shader module uses the following naming conv
 project_[<source_space>]_<object_type>_[to_<target_space>]
 ```
 
-* `source_space`: the coordinate space of the input. If not specified, the input is always in the world space.
+* `source_space`: the short name of the coordinate space of the input. If not specified, the input is always in the `world` space.
 * `object_type`: one of the following
   - `position`: absolute position of a point
   - `offset`: the delta between two positions
   - `normal`: the normal vector of a surface
   - `size`: the measurement of a geometry. This is different from `offset` in that `size` is uniform on all axes (e.g. [x, y, z] in meters in `LNGLAT` world space) and `offset` may not be (e.g. [dLon, dLat, dAlt] in degrees, degrees, and meters respectively in `LNGLAT` world space).
-* `target_space`: the coordinate space of the output. If not specified, the output is always in the common space.
+* `target_space`: the short name of the coordinate space of the output. If not specified, the output is always in the `common` space.
 
 ### project_position
 
@@ -134,6 +136,6 @@ Converts the coordinates of a point from the common space to the clip space, whi
 
 ## Remarks
 
-* For consistent results, the screen space pixels are logical pixels, not device pixels, i.e. it multiplies `pixels` with `project_uDevicePixelRatio`.
+* For consistent results, the screen space pixels are logical pixels, not device pixels, i.e. functions in the project module multiply `pixels` with `project_uDevicePixelRatio`.
 * The pixels offsets will be divided by the `w` coordinate of `gl_Position`. This is simply the GPUs standard treatment of any coordinate. This means that there will be more pixels closer to the camera and less pixels further away from the camer. Setting the `focalDistance` uniform controls this.
 * To avoid pixel sizes scaling with distance from camera, simply set `focalDistance` to 1 and multiply clipspace offset with `gl_Position.w`

--- a/docs/shader-modules/project.md
+++ b/docs/shader-modules/project.md
@@ -108,13 +108,13 @@ Converts the given number of pixels to a clipspace offset that can be added to a
 
 Converts screen-space pixels to world distance.
 
-`float project_pixel_to_world_distance(float pixels)`
+`float project_pixel_to_worldspace(float pixels)`
 
 ### project_size_to_pixels
 
 Converts size in meters to screen-space pixels.
 
-`float project_world_distance_to_pixels(float distance)`
+`float project_size_to_pixels(float distance)`
 
 ## Remarks
 

--- a/docs/shader-modules/project.md
+++ b/docs/shader-modules/project.md
@@ -2,7 +2,9 @@
 
 The `project` shader module is part of the core of deck.gl. It makes it easy to write shaders that support all of deck.gl's projection modes and it supports some advanced rendering techniques such as pixel space rendering etc.
 
-Note that the `project` module has a `project64` counterpart that enables 64 bit projections, providing an increase in precision, at the cost of performance. Note that starting with deck.gl v6.1, the improved default 32 bit projection mode provides sufficient precision for most use cases.
+The `project` module has two extensions:
+- [project32](/docs/api-reference/shader-modules/project32.md) shorthand functions for projecting directly from worldspace to clipspace.
+- [project64](/docs/api-reference/shader-modules/project64.md) counterpart of `project32` that enables 64 bit projections, providing an increase in precision, at the cost of performance.
 
 
 ## Usage
@@ -19,21 +21,16 @@ attribute float instanceSize;
 void main(void) {
   vec3 center = project_position(instanceCenter);
   vec3 vertex = positions * project_size(instanceSize);
-  gl_Position = project_to_clipspace(center + vertex);
+  gl_Position = project_common_position_to_clipspace(center + vertex);
 }
 ```
 
 ## getUniforms
 
-The JavaScript uniforms are extracted mainly from the viewport with a few additional parameters (which deck.gl supplies from `LayerManager` state or `Layer` props of course).
-
-Provided by `LayerManager`:
+The JavaScript uniforms are extracted from both contextual and per-layer props. The following information are used:
 
 * `viewport`
 * `devicePixelRatio`
-
-Provided by `Layer` props:
-
 * `coordinateSystem`
 * `coordinateOrigin`
 * `modelMatrix`
@@ -41,83 +38,102 @@ Provided by `Layer` props:
 
 ## GLSL Uniforms
 
-Uniform names are not considered part of the official API of shader modules and can potentially change between minor releases, but are documented for applications that need this level of access. Use the module's public GLSL functions instead of directly accessing uniforms when possible.
+Uniforms are considered private to each shader module. They may change in between patch releases. Always use documented functions instead of accessing module uniforms directly.
 
-| Uniform | Type | Description |
-| --- | --- | --- |
-| project_uModelMatrix | mat4 | model matrix (identity if not supplied) |
-| project_uViewProjectionMatrix | mat4 | combined view projection matrix |
-| project_uViewportSize | vec2 | size of viewport in pixels |
-| project_uDevicePixelRatio | float | device pixel ratio of current viewport (value depends on `useDevicePixels` prop) |
-| project_uFocalDistance | float | distance where "pixel sizes" are display in 1:1 ratio (modulo `devicePixelRatio`) |
-| project_uCameraPosition | vec3 | position of camera in world space |
-| project_uCoordinateSystem | float | COORDINATE_SYSTEM enum |
-| project_uCenter | float | coordinate origin in world space |
-| project_uScale | float | Web Mercator scale (2^zoom) |
-| project_uDistancePerMeter | vec3 | Web Mercator pixels per meter near the current viewport center |
-| project_uDistancePerDegree | vec3 | Web Mercator pixels per degree near the current viewport center |
-
+The uniforms of the `project` shader module are prefixed with `project_` in their names.
 
 ## GLSL Functions
 
 The projection module makes it easy to write vertex shaders that follow deck.gl's projection methods, enabling your layer to accept coordinates in both [longitude,latitude,altitude] or [metersX,metersY,metersZ] format. To support the basic features expected of a deck.gl layer, such as various viewport types and coordinate systems, your own shaders should always use the built-in projection functions.
 
+The functions converts positions/vectors between 4 coordinate spaces:
+
+* World space (`world`): the [coordinate system](/docs/developer-guide/coordinate-systems.md) defined by the layer, not necessarily linear or uniform.
+* Common space (`common`): an normalized intermediate 3D space that deck.gl uses for consistent processing of geometries. It is safe to add/subtract/scale positions and vectors in this space.
+* Screen space (`pixel`): top-left coordinate system runs from `[0, 0]` to `[viewportWidth, viewportHeight]` (see remarks below).
+* [Clip space](https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_model_view_projection#Clip_space) (`clipspace`): output of the vertex shader
+
+The GLSL functions of the `project` shader module uses the following naming convention:
+
+```
+project_[<source_space>]_<object_type>_[to_<target_space>]
+```
+
+* `source_space`: the coordinate space of the input. If not specified, the input is always in the world space.
+* `object_type`: one of the following
+  - `position`: absolute position of a point
+  - `offset`: the delta between two positions
+  - `normal`: the normal vector of a surface
+  - `size`: the measurement of a geometry. This is different from `offset` in that `size` is uniform on all axes (e.g. [x, y, z] in meters in `LNGLAT` world space) and `offset` may not be (e.g. [dLon, dLat, dAlt] in degrees, degrees, and meters respectively in `LNGLAT` world space).
+* `target_space`: the coordinate space of the output. If not specified, the output is always in the common space.
+
 ### project_position
 
-`vec2 project_position(vec2 position)`
-`vec3 project_position(vec3 position)`
-`vec4 project_position(vec4 position)`
+```glsl
+vec2 project_position(vec2 position)
+vec3 project_position(vec3 position)
+vec4 project_position(vec4 position)
+```
 
-Projects positions (coordinates) to worldspace coordinates. The coordinates are interpreted according to `coordinateSystem` and `modelMatrix` is applied.
+Converts the coordinates of a point from the world space to the common space. The coordinates are interpreted according to `coordinateSystem` and `modelMatrix` is applied.
 
 
 ### project_size
 
-`float project_size(float meters)`
-`vec2 project_size(vec2 meters)`
-`vec3 project_size(vec3 meters)`
-`vec4 project_size(vec4 meters)`
+```glsl
+float project_size(float meters)
+vec2 project_size(vec2 meters)
+vec3 project_size(vec3 meters)
+vec4 project_size(vec4 meters)
+```
 
-Projects sizes in meters to worldspace offsets. These offsets can be added directly to values returned by `project_position`.
+Converts the size of a geometry from the world space (meters if geospatial, and absolute units otherwise) to the common space.
+
+### project_size_to_pixel
+
+```glsl
+float project_size_to_pixel(float size)
+```
+
+Converts the size of a geometry from the world space (meters if geospatial, and absolute units otherwise) to the common space. The result corresponds to the number of screen pixels when the given size is viewed with a top-down camera.
+
+### project_pixel_size
+
+```glsl
+float project_pixel_size(float pixels)
+```
+
+Converts the size of a geometry from the screen space to the common space.
+
+### project_pixel_size_to_clipspace
+
+```glsl
+vec2 project_pixel_size_to_clipspace(vec2 pixels)
+```
+
+Converts the size of a geometry from the screen space to the clip space.
 
 
 ### project_normal
 
-`vec3 project_normal(vec3 vector)`
+```glsl
+vec3 project_normal(vec3 vector)
+```
 
-Projects position deltas in the current coordinate system to worldspace normals.
-
-
-### project_to_clipspace
-
-Projects world space coordinates to clipspace, which can be assigned to `gl_Position` as the "return value" from the vertex shader.
-
-`vec4 project_to_clipspace(vec4 position)`
+Converts position deltas from the world space to normalized vector in the common space.
 
 
-### project_pixel_to_clipspace
+### project_common_position_to_clipspace
 
-Converts the given number of pixels to a clipspace offset that can be added to a clipspace position (typically added to values returned by `project_to_clipspace`).
+```glsl
+vec4 project_common_position_to_clipspace(vec4 position)
+```
 
-`vec4 project_pixel_to_clipspace(vec2 pixels)`
+Converts the coordinates of a point from the common space to the clip space, which can be assigned to `gl_Position` as the "return value" from the vertex shader.
 
-* `pixels` (`vec2`) - adjustment in logical pixels. Returns values in clip space offsets that can be added directly to `gl_Position`
-
-
-### project_pixel_to_worldspace
-
-Converts screen-space pixels to world distance.
-
-`float project_pixel_to_worldspace(float pixels)`
-
-### project_size_to_pixels
-
-Converts size in meters to screen-space pixels.
-
-`float project_size_to_pixels(float distance)`
 
 ## Remarks
 
-* For consistent results, pixels are logical pixels, not device pixels, i.e. this method multiplies `pixels` with `project_uDevicePixelRatio`.
+* For consistent results, the screen space pixels are logical pixels, not device pixels, i.e. it multiplies `pixels` with `project_uDevicePixelRatio`.
 * The pixels offsets will be divided by the `w` coordinate of `gl_Position`. This is simply the GPUs standard treatment of any coordinate. This means that there will be more pixels closer to the camera and less pixels further away from the camer. Setting the `focalDistance` uniform controls this.
 * To avoid pixel sizes scaling with distance from camera, simply set `focalDistance` to 1 and multiply clipspace offset with `gl_Position.w`

--- a/docs/shader-modules/project.md
+++ b/docs/shader-modules/project.md
@@ -18,7 +18,7 @@ attribute float instanceSize;
 
 void main(void) {
   vec3 center = project_position(instanceCenter);
-  vec3 vertex = positions * project_scale(instanceSize);
+  vec3 vertex = positions * project_size(instanceSize);
   gl_Position = project_to_clipspace(center + vertex);
 }
 ```
@@ -54,8 +54,8 @@ Uniform names are not considered part of the official API of shader modules and 
 | project_uCoordinateSystem | float | COORDINATE_SYSTEM enum |
 | project_uCenter | float | coordinate origin in world space |
 | project_uScale | float | Web Mercator scale (2^zoom) |
-| project_uPixelsPerMeter | vec3 | Web Mercator pixels per meter near the current viewport center |
-| project_uPixelsPerDegree | vec3 | Web Mercator pixels per degree near the current viewport center |
+| project_uDistancePerMeter | vec3 | Web Mercator pixels per meter near the current viewport center |
+| project_uDistancePerDegree | vec3 | Web Mercator pixels per degree near the current viewport center |
 
 
 ## GLSL Functions
@@ -71,12 +71,12 @@ The projection module makes it easy to write vertex shaders that follow deck.gl'
 Projects positions (coordinates) to worldspace coordinates. The coordinates are interpreted according to `coordinateSystem` and `modelMatrix` is applied.
 
 
-### project_scale
+### project_size
 
-`float project_scale(float meters)`
-`vec2 project_scale(vec2 meters)`
-`vec3 project_scale(vec3 meters)`
-`vec4 project_scale(vec4 meters)`
+`float project_size(float meters)`
+`vec2 project_size(vec2 meters)`
+`vec3 project_size(vec3 meters)`
+`vec4 project_size(vec4 meters)`
 
 Projects sizes in meters to worldspace offsets. These offsets can be added directly to values returned by `project_position`.
 
@@ -95,14 +95,26 @@ Projects world space coordinates to clipspace, which can be assigned to `gl_Posi
 `vec4 project_to_clipspace(vec4 position)`
 
 
-### project_pixels_to_clipspace
+### project_pixel_to_clipspace
 
 Converts the given number of pixels to a clipspace offset that can be added to a clipspace position (typically added to values returned by `project_to_clipspace`).
 
-`vec4 project_pixels_to_clipspace(vec2 pixels)`
+`vec4 project_pixel_to_clipspace(vec2 pixels)`
 
 * `pixels` (`vec2`) - adjustment in logical pixels. Returns values in clip space offsets that can be added directly to `gl_Position`
 
+
+### project_pixel_to_worldspace
+
+Converts screen-space pixels to world distance.
+
+`float project_pixel_to_world_distance(float pixels)`
+
+### project_size_to_pixels
+
+Converts size in meters to screen-space pixels.
+
+`float project_world_distance_to_pixels(float distance)`
 
 ## Remarks
 

--- a/docs/shader-modules/project32.md
+++ b/docs/shader-modules/project32.md
@@ -10,15 +10,15 @@ The `project32` shader module is an extension of the [project](/docs/api-referen
 
 ```glsl
 vec4 project_position_to_clipspace(vec3 position, vec2 position64xyLow, vec3 offset)
-vec4 project_position_to_clipspace(vec3 position, vec2 position64xyLow, vec3 offset, out vec4 worldPosition)
+vec4 project_position_to_clipspace(vec3 position, vec2 position64xyLow, vec3 offset, out vec4 commonPosition)
 ```
 
 Parameters:
 
 * `position` - vertex position in the layer's coordinate system.
 * `position64xyLow` - always ignored
-* `offset` - meter offset from the coordinate
-* `worldPosition` - projected position in the world space
+* `offset` - offset from the coordinate, in common space
+* `commonPosition` - projected position in the common space
 
 Returns:
 Projected position in the clipspace.

--- a/docs/shader-modules/project32.md
+++ b/docs/shader-modules/project32.md
@@ -1,6 +1,6 @@
 # project32 (Shader Module)
 
-The `project32` shader module is an extension of the `project` shader module that adds some projection utilities.
+The `project32` shader module is an extension of the [project](/docs/api-reference/shader-modules/project.md) shader module that adds some projection utilities.
 
 ## GLSL Functions
 
@@ -8,9 +8,10 @@ The `project32` shader module is an extension of the `project` shader module tha
 
 32 bit implementation of the `project_position_to_clipspace` interface.
 
-`vec4 project_position_to_clipspace(vec3 position, vec2 position64xyLow, vec3 offset)`
-
-`vec4 project_position_to_clipspace(vec3 position, vec2 position64xyLow, vec3 offset, out vec4 worldPosition)`
+```glsl
+vec4 project_position_to_clipspace(vec3 position, vec2 position64xyLow, vec3 offset)
+vec4 project_position_to_clipspace(vec3 position, vec2 position64xyLow, vec3 offset, out vec4 worldPosition)
+```
 
 Parameters:
 

--- a/docs/shader-modules/project64.md
+++ b/docs/shader-modules/project64.md
@@ -1,6 +1,6 @@
 # project64 (Shader Module)
 
-The `project64` shader module is an extension of the `project` shader module that does projection using 64 bit floating point. This slows down the layer.
+The `project64` shader module is an extension of the [project](/docs/api-reference/shader-modules/project.md) shader module that does projection using 64 bit floating point. It provides an increase in precision, at the cost of performance. Note that starting with deck.gl v6.1, the improved default 32 bit projection mode provides sufficient precision for most use cases.
 
 
 ## getUniforms
@@ -10,12 +10,9 @@ The uniforms needed by `project64` are extracted from the `project` module unifo
 
 ## GLSL Uniforms
 
-Uniform names are not considered part of the official API of shader modules and can potentially change between minor releases, but are documented for applications that need this level of access. Use the module's public GLSL functions instead of directly accessing uniforms when possible.
+Uniforms are considered private to each shader module. They may change in between patch releases. Always use documented functions instead of accessing module uniforms directly.
 
-| Uniform | Type | Description |
-| --- | --- | --- |
-| project_uViewProjectionMatrixFP64 | uniform vec2[16] | 64-bit view projection matrix |
-| project64_uScale | uniform vec2 | 64-bit Web Mercator scale |
+The uniforms of the `project64` shader module are prefixed with `project64_` in their names.
 
 ## GLSL Functions
 
@@ -24,9 +21,10 @@ Uniform names are not considered part of the official API of shader modules and 
 
 64 bit implementation of the `project_position_to_clipspace` interface.
 
-`vec4 project_position_to_clipspace(vec3 position, vec2 position64xyLow, vec3 offset)`
-
-`vec4 project_position_to_clipspace(vec3 position, vec2 position64xyLow, vec3 offset, out vec4 worldPosition)`
+```glsl
+vec4 project_position_to_clipspace(vec3 position, vec2 position64xyLow, vec3 offset)
+vec4 project_position_to_clipspace(vec3 position, vec2 position64xyLow, vec3 offset, out vec4 worldPosition)
+```
 
 Parameters:
 
@@ -43,16 +41,19 @@ Projected position in the clipspace.
 
 64 bit counterpart of the `project` modules `project_position`
 
-`void project_position_fp64(vec4 position_fp64, out vec2 out_val[2])`
+```glsl
+void project_position_fp64(vec4 position_fp64, out vec2 out_val[2])
+void project_position_fp64(vec2 position, vec2 position64xyLow, out vec2 out_val[2])
+```
 
-`void project_position_fp64(vec2 position, vec2 position64xyLow, out vec2 out_val[2])`
 
+### project_common_position_to_clipspace_fp64
 
-### project_to_clipspace_fp64
+64 bit counterpart of the `project` modules `project_common_position_to_clipspace`
 
-64 bit counterpart of the `project` modules `project_to_clipspace`
-
-`vec4 project_to_clipspace_fp64(vec2 vertex_pos_modelspace[4])`
+```glsl
+vec4 project_to_clipspace_fp64(vec2 vertex_pos_modelspace[4])
+```
 
 
 ## Remarks

--- a/docs/shader-modules/project64.md
+++ b/docs/shader-modules/project64.md
@@ -23,15 +23,15 @@ The uniforms of the `project64` shader module are prefixed with `project64_` in 
 
 ```glsl
 vec4 project_position_to_clipspace(vec3 position, vec2 position64xyLow, vec3 offset)
-vec4 project_position_to_clipspace(vec3 position, vec2 position64xyLow, vec3 offset, out vec4 worldPosition)
+vec4 project_position_to_clipspace(vec3 position, vec2 position64xyLow, vec3 offset, out vec4 commonPosition)
 ```
 
 Parameters:
 
 * `position` - vertex position in the layer's coordinate system.
 * `position64xyLow` - low part of the vertex position's xy
-* `offset` - meter offset from the coordinate
-* `worldPosition` - projected position in the world space
+* `offset` - offset from the coordinate, in common space
+* `commonPosition` - projected position in the common space
 
 Returns:
 Projected position in the clipspace.

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -34,7 +34,12 @@ The old experimental prop `lightSettings` in many 3D layers is no longer support
 
 #### project Shader Module
 
-`project_scale` was replaced by `project_size`.
+**Deprecations**
+
+- `project_scale` -> `project_size`
+- `project_to_clipspace` -> `project_common_position_to_clipspace`
+- `project_to_clipspace_fp64` -> `project_common_position_to_clipspace_fp64`
+- `project_pixel_to_clipspace` -> `project_pixel_size_to_clipspace`
 
 
 ## Upgrading from deck.gl v6.3 to v6.4

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -32,6 +32,10 @@
 
 The old experimental prop `lightSettings` in many 3D layers is no longer supported. The new and improved settings are split into two places: a [material](https://github.com/uber/luma.gl/tree/master/docs/api-reference/core/materials) prop for each 3D layer and a shared set of lights specified by [LightingEffect](/docs/effects/lighting-effect.md) with the [effects prop of Deck](/docs/api-reference/deck.md#effects).
 
+#### project Shader Module
+
+`project_scale` was replaced by `project_size`.
+
 
 ## Upgrading from deck.gl v6.3 to v6.4
 

--- a/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-cell-layer-vertex.glsl.js
+++ b/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-cell-layer-vertex.glsl.js
@@ -94,11 +94,11 @@ void main(void) {
     1.0);
 
   // extrude positions
-  vec4 position_worldspace;
-  gl_Position = project_position_to_clipspace(extrudedPosition, extrudedPosition64xyLow, offset, position_worldspace);
+  vec4 position_commonspace;
+  gl_Position = project_position_to_clipspace(extrudedPosition, extrudedPosition64xyLow, offset, position_commonspace);
 
    if (extruded > 0.5) {
-    vec3 lightColor = lighting_getLightColor(color.rgb, project_uCameraPosition, position_worldspace.xyz, normals);
+    vec3 lightColor = lighting_getLightColor(color.rgb, project_uCameraPosition, position_commonspace.xyz, normals);
     vColor = vec4(lightColor, color.a * opacity);
   } else {
     vColor = vec4(color.rgb, color.a * opacity);

--- a/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-cell-layer-vertex.glsl.js
+++ b/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-cell-layer-vertex.glsl.js
@@ -62,7 +62,7 @@ void main(void) {
   vec4 color = mix(minColor, maxColor, step) / 255.;
 
   // TODO: discard when noRender is true
-  float finalCellSize = noRender ? 0.0 : project_scale(cellSize);
+  float finalCellSize = noRender ? 0.0 : project_size(cellSize);
 
 
   float elevation = 0.0;

--- a/modules/core/src/lib/constants.js
+++ b/modules/core/src/lib/constants.js
@@ -27,7 +27,6 @@ export const COORDINATE_SYSTEM = {
   // Positions are interpreted as [lng, lat, elevation]
   // lng lat are degrees, elevation is meters. distances as meters.
   LNGLAT: 1,
-  LNGLAT_EXPERIMENTAL: 1,
   LNGLAT_DEPRECATED: 5,
 
   // Positions are interpreted as meter offsets, distances as meters

--- a/modules/core/src/shaderlib/project/project.js
+++ b/modules/core/src/shaderlib/project/project.js
@@ -36,30 +36,5 @@ export default {
   dependencies: [fp32],
   vs: projectShader,
   getUniforms,
-  deprecations: [
-    // Removed custom picking uinforms
-    // These don't really belong here but we need to check them for all shaders
-    // the project module is by default included for all
-    {type: 'uniform vec3', old: 'selectedPickingColor', new: "luma.gl's picking module"},
-    {type: 'uniform float', old: 'renderPickingBuffer', new: "luma.gl's picking module"},
-    {type: 'uniform float', old: 'pickingEnabled', new: "luma.gl's picking module"},
-
-    // Removed project uniforms
-    {type: 'uniform float', old: 'projectionMode', new: 'project_uCoordinateSystem'},
-    {type: 'uniform vec4', old: 'projectionCenter', new: 'project_uCenter'},
-    {type: 'uniform vec2', old: 'projectionOrigin'},
-    {type: 'uniform mat4', old: 'modelMatrix', new: 'project_uModelMatrix'},
-    {type: 'uniform mat4', old: 'viewMatrix'},
-    {type: 'uniform mat4', old: 'projectionMatrix', new: 'project_uViewProjectionMatrix'},
-    {type: 'uniform vec3', old: 'projectionPixelsPerUnit', new: 'project_uPixelsPerUnit'},
-    {type: 'uniform float', old: 'projectionScale', new: 'project_uScale'},
-    {type: 'uniform vec2', old: 'viewportSize', new: 'project_uViewportSize'},
-    {type: 'uniform float', old: 'devicePixelRatio', new: 'project_uDevicePixelRatio'},
-    {type: 'uniform vec3', old: 'cameraPos', new: 'project_uCameraPosition'},
-
-    // Removed project functions
-    {type: 'function', old: 'scale', new: 'project_scale'},
-    {type: 'function', old: 'preproject', new: 'project_position'},
-    {type: 'function', old: 'project', new: 'project_to_clipspace'}
-  ]
+  deprecations: [{type: 'function', old: 'project_scale', new: 'project_size'}]
 };

--- a/modules/core/src/shaderlib/project/project.js
+++ b/modules/core/src/shaderlib/project/project.js
@@ -36,5 +36,10 @@ export default {
   dependencies: [fp32],
   vs: projectShader,
   getUniforms,
-  deprecations: [{type: 'function', old: 'project_scale', new: 'project_size'}]
+  deprecations: [
+    // Deprecated, remove in v8
+    {type: 'function', old: 'project_scale', new: 'project_size'},
+    {type: 'function', old: 'project_to_clipspace', new: 'project_common_position_to_clipspace'},
+    {type: 'function', old: 'project_pixel_to_clipspace', new: 'project_pixel_size_to_clipspace'}
+  ]
 };

--- a/modules/core/src/shaderlib/project/viewport-uniforms.js
+++ b/modules/core/src/shaderlib/project/viewport-uniforms.js
@@ -239,11 +239,9 @@ function calculateViewportUniforms({
 
     // Distance at which screen pixels are projected
     project_uFocalDistance: viewport.focalDistance || 1,
-    project_uDistancePerMeter: distanceScales.pixelsPerMeter,
-    project_uDistancePerDegree: distanceScales.pixelsPerDegree,
-    project_uDistancePerUnit: distanceScales.pixelsPerMeter,
-    project_uDistancePerUnit2: DEFAULT_PIXELS_PER_UNIT2,
-    project_uPixelsPerDistance: viewport.pixelScale || viewport.scale,
+    project_uCommonUnitsPerMeter: distanceScales.pixelsPerMeter,
+    project_uCommonUnitsPerWorldUnit: distanceScales.pixelsPerMeter,
+    project_uCommonUnitsPerWorldUnit2: DEFAULT_PIXELS_PER_UNIT2,
     project_uScale: viewport.scale, // This is the mercator scale (2 ** zoom)
 
     project_uViewProjectionMatrix: viewProjectionMatrix,
@@ -256,16 +254,16 @@ function calculateViewportUniforms({
 
   switch (shaderCoordinateSystem) {
     case PROJECT_COORDINATE_SYSTEM.METER_OFFSETS:
-      uniforms.project_uDistancePerUnit = distanceScalesAtOrigin.pixelsPerMeter;
-      uniforms.project_uDistancePerUnit2 = distanceScalesAtOrigin.pixelsPerMeter2;
+      uniforms.project_uCommonUnitsPerWorldUnit = distanceScalesAtOrigin.pixelsPerMeter;
+      uniforms.project_uCommonUnitsPerWorldUnit2 = distanceScalesAtOrigin.pixelsPerMeter2;
       break;
 
     case PROJECT_COORDINATE_SYSTEM.LNGLAT_AUTO_OFFSET:
       uniforms.project_uCoordinateOrigin = shaderCoordinateOrigin;
     // eslint-disable-line no-fallthrough
     case PROJECT_COORDINATE_SYSTEM.LNGLAT_OFFSETS:
-      uniforms.project_uDistancePerUnit = distanceScalesAtOrigin.pixelsPerDegree;
-      uniforms.project_uDistancePerUnit2 = distanceScalesAtOrigin.pixelsPerDegree2;
+      uniforms.project_uCommonUnitsPerWorldUnit = distanceScalesAtOrigin.pixelsPerDegree;
+      uniforms.project_uCommonUnitsPerWorldUnit2 = distanceScalesAtOrigin.pixelsPerDegree2;
       break;
 
     default:

--- a/modules/core/src/shaderlib/project/viewport-uniforms.js
+++ b/modules/core/src/shaderlib/project/viewport-uniforms.js
@@ -240,7 +240,7 @@ function calculateViewportUniforms({
     // Distance at which screen pixels are projected
     project_uFocalDistance: viewport.focalDistance || 1,
     project_uCommonUnitsPerMeter: distanceScales.pixelsPerMeter,
-    project_uCommonUnitsPerWorldUnit: distanceScales.pixelsPerMeter,
+    project_uCommonUnitsPerWorldUnit: distanceScales.pixelsPerDegree,
     project_uCommonUnitsPerWorldUnit2: DEFAULT_PIXELS_PER_UNIT2,
     project_uScale: viewport.scale, // This is the mercator scale (2 ** zoom)
 

--- a/modules/core/src/shaderlib/project/viewport-uniforms.js
+++ b/modules/core/src/shaderlib/project/viewport-uniforms.js
@@ -239,10 +239,11 @@ function calculateViewportUniforms({
 
     // Distance at which screen pixels are projected
     project_uFocalDistance: viewport.focalDistance || 1,
-    project_uPixelsPerMeter: distanceScales.pixelsPerMeter,
-    project_uPixelsPerDegree: distanceScales.pixelsPerDegree,
-    project_uPixelsPerUnit: distanceScales.pixelsPerMeter,
-    project_uPixelsPerUnit2: DEFAULT_PIXELS_PER_UNIT2,
+    project_uDistancePerMeter: distanceScales.pixelsPerMeter,
+    project_uDistancePerDegree: distanceScales.pixelsPerDegree,
+    project_uDistancePerUnit: distanceScales.pixelsPerMeter,
+    project_uDistancePerUnit2: DEFAULT_PIXELS_PER_UNIT2,
+    project_uPixelsPerDistance: viewport.pixelScale || viewport.scale,
     project_uScale: viewport.scale, // This is the mercator scale (2 ** zoom)
 
     project_uViewProjectionMatrix: viewProjectionMatrix,
@@ -255,16 +256,16 @@ function calculateViewportUniforms({
 
   switch (shaderCoordinateSystem) {
     case PROJECT_COORDINATE_SYSTEM.METER_OFFSETS:
-      uniforms.project_uPixelsPerUnit = distanceScalesAtOrigin.pixelsPerMeter;
-      uniforms.project_uPixelsPerUnit2 = distanceScalesAtOrigin.pixelsPerMeter2;
+      uniforms.project_uDistancePerUnit = distanceScalesAtOrigin.pixelsPerMeter;
+      uniforms.project_uDistancePerUnit2 = distanceScalesAtOrigin.pixelsPerMeter2;
       break;
 
     case PROJECT_COORDINATE_SYSTEM.LNGLAT_AUTO_OFFSET:
-      uniforms.project_coordinate_origin = shaderCoordinateOrigin;
+      uniforms.project_uCoordinateOrigin = shaderCoordinateOrigin;
     // eslint-disable-line no-fallthrough
     case PROJECT_COORDINATE_SYSTEM.LNGLAT_OFFSETS:
-      uniforms.project_uPixelsPerUnit = distanceScalesAtOrigin.pixelsPerDegree;
-      uniforms.project_uPixelsPerUnit2 = distanceScalesAtOrigin.pixelsPerDegree2;
+      uniforms.project_uDistancePerUnit = distanceScalesAtOrigin.pixelsPerDegree;
+      uniforms.project_uDistancePerUnit2 = distanceScalesAtOrigin.pixelsPerDegree2;
       break;
 
     default:

--- a/modules/core/src/shaderlib/project32/project32.js
+++ b/modules/core/src/shaderlib/project32/project32.js
@@ -26,7 +26,7 @@ vec4 project_position_to_clipspace(
 ) {
   vec3 projectedPosition = project_position(position, position64xyLow);
   worldPosition = vec4(projectedPosition + offset, 1.0);
-  return project_to_clipspace(worldPosition);
+  return project_common_position_to_clipspace(worldPosition);
 }
 
 vec4 project_position_to_clipspace(

--- a/modules/core/src/shaderlib/project32/project32.js
+++ b/modules/core/src/shaderlib/project32/project32.js
@@ -22,18 +22,18 @@ import project from '../project/project';
 
 const vs = `
 vec4 project_position_to_clipspace(
-  vec3 position, vec2 position64xyLow, vec3 offset, out vec4 worldPosition
+  vec3 position, vec2 position64xyLow, vec3 offset, out vec4 commonPosition
 ) {
   vec3 projectedPosition = project_position(position, position64xyLow);
-  worldPosition = vec4(projectedPosition + offset, 1.0);
-  return project_common_position_to_clipspace(worldPosition);
+  commonPosition = vec4(projectedPosition + offset, 1.0);
+  return project_common_position_to_clipspace(commonPosition);
 }
 
 vec4 project_position_to_clipspace(
   vec3 position, vec2 position64xyLow, vec3 offset
 ) {
-  vec4 worldPosition;
-  return project_position_to_clipspace(position, position64xyLow, offset, worldPosition);
+  vec4 commonPosition;
+  return project_position_to_clipspace(position, position64xyLow, offset, commonPosition);
 }
 `;
 

--- a/modules/core/src/shaderlib/project64/project64.glsl.js
+++ b/modules/core/src/shaderlib/project64/project64.glsl.js
@@ -70,7 +70,7 @@ vec4 project_common_position_to_clipspace_fp64(vec2 vertex_pos_modelspace[4]) {
 }
 
 vec4 project_position_to_clipspace(
-  vec3 position, vec2 position64xyLow, vec3 offset, out vec4 worldPosition
+  vec3 position, vec2 position64xyLow, vec3 offset, out vec4 commonPosition
 ) {
   // This is the local offset to the instance position
   vec2 offset64[4];
@@ -82,23 +82,23 @@ vec4 project_position_to_clipspace(
   vec2 projectedPosition64xy[2];
   project_position_fp64(position.xy, position64xyLow, projectedPosition64xy);
 
-  vec2 worldPosition64[4];
-  worldPosition64[0] = sum_fp64(offset64[0], projectedPosition64xy[0]);
-  worldPosition64[1] = sum_fp64(offset64[1], projectedPosition64xy[1]);
-  worldPosition64[2] = sum_fp64(offset64[2], vec2(z, 0.0));
-  worldPosition64[3] = vec2(1.0, 0.0);
+  vec2 commonPosition64[4];
+  commonPosition64[0] = sum_fp64(offset64[0], projectedPosition64xy[0]);
+  commonPosition64[1] = sum_fp64(offset64[1], projectedPosition64xy[1]);
+  commonPosition64[2] = sum_fp64(offset64[2], vec2(z, 0.0));
+  commonPosition64[3] = vec2(1.0, 0.0);
 
-  worldPosition = vec4(projectedPosition64xy[0].x, projectedPosition64xy[1].x, z, 1.0);
+  commonPosition = vec4(projectedPosition64xy[0].x, projectedPosition64xy[1].x, z, 1.0);
 
-  return project_common_position_to_clipspace_fp64(worldPosition64);
+  return project_common_position_to_clipspace_fp64(commonPosition64);
 }
 
 vec4 project_position_to_clipspace(
   vec3 position, vec2 position64xyLow, vec3 offset
 ) {
-  vec4 worldPosition;
+  vec4 commonPosition;
   return project_position_to_clipspace(
-    position, position64xyLow, offset, worldPosition
+    position, position64xyLow, offset, commonPosition
   );
 }
 

--- a/modules/core/src/shaderlib/project64/project64.glsl.js
+++ b/modules/core/src/shaderlib/project64/project64.glsl.js
@@ -57,7 +57,7 @@ void project_position_fp64(vec2 position, vec2 position64xyLow, out vec2 out_val
   project_position_fp64(position64xy, out_val);
 }
 
-vec4 project_to_clipspace_fp64(vec2 vertex_pos_modelspace[4]) {
+vec4 project_common_position_to_clipspace_fp64(vec2 vertex_pos_modelspace[4]) {
   vec2 vertex_pos_clipspace[4];
   mat4_vec4_mul_fp64(project_uViewProjectionMatrixFP64, vertex_pos_modelspace,
     vertex_pos_clipspace);
@@ -90,7 +90,7 @@ vec4 project_position_to_clipspace(
 
   worldPosition = vec4(projectedPosition64xy[0].x, projectedPosition64xy[1].x, z, 1.0);
 
-  return project_to_clipspace_fp64(worldPosition64);
+  return project_common_position_to_clipspace_fp64(worldPosition64);
 }
 
 vec4 project_position_to_clipspace(
@@ -100,5 +100,10 @@ vec4 project_position_to_clipspace(
   return project_position_to_clipspace(
     position, position64xyLow, offset, worldPosition
   );
+}
+
+// Deprecated, remove in v8
+vec4 project_to_clipspace_fp64(vec2 vertex_pos_modelspace[4]) {
+  return project_common_position_to_clipspace_fp64(vertex_pos_modelspace);
 }
 `;

--- a/modules/core/src/shaderlib/project64/project64.glsl.js
+++ b/modules/core/src/shaderlib/project64/project64.glsl.js
@@ -76,7 +76,7 @@ vec4 project_position_to_clipspace(
   vec2 offset64[4];
   vec4_fp64(vec4(offset, 0.0), offset64);
 
-  float z = project_scale(position.z);
+  float z = project_size(position.z);
 
   // Apply web mercator projection (depends on coordinate system imn use)
   vec2 projectedPosition64xy[2];

--- a/modules/core/src/shaderlib/project64/project64.js
+++ b/modules/core/src/shaderlib/project64/project64.js
@@ -31,8 +31,11 @@ export default {
   vs: project64Shader,
   getUniforms,
   deprecations: [
-    {type: 'uniform vec2', old: 'projectionFP64[16]', new: 'project_uViewProjectionMatrixFP64'},
-    {type: 'uniform vec2', old: 'projectionScaleFP64', new: 'project64_uScale'}
+    {
+      type: 'function',
+      old: 'project_to_clipspace_fp64',
+      new: 'project_common_position_to_clipspace_fp64'
+    }
   ]
 };
 

--- a/modules/core/src/viewports/web-mercator-viewport.js
+++ b/modules/core/src/viewports/web-mercator-viewport.js
@@ -122,8 +122,6 @@ export default class WebMercatorViewport extends Viewport {
     this.bearing = bearing;
     this.altitude = altitude;
 
-    // One mercator world pixel maps to one screen pixel
-    this.pixelScale = 1;
     this.orthographic = orthographic;
 
     // Bind methods

--- a/modules/core/src/viewports/web-mercator-viewport.js
+++ b/modules/core/src/viewports/web-mercator-viewport.js
@@ -122,6 +122,8 @@ export default class WebMercatorViewport extends Viewport {
     this.bearing = bearing;
     this.altitude = altitude;
 
+    // One mercator world pixel maps to one screen pixel
+    this.pixelScale = 1;
     this.orthographic = orthographic;
 
     // Bind methods

--- a/modules/geo-layers/src/great-circle-layer/great-circle-vertex.glsl.js
+++ b/modules/geo-layers/src/great-circle-layer/great-circle-vertex.glsl.js
@@ -110,13 +110,13 @@ void main(void) {
 
   // Multiply out width and clamp to limits
   // mercator pixels are interpreted as screen pixels
-  float width = clamp(
-    project_scale(instanceWidths * widthScale),
+  float widthPixels = clamp(
+    project_size_to_pixels(instanceWidths * widthScale),
     widthMinPixels, widthMaxPixels
   );
 
   // extrude
-  vec2 offset = getExtrusionOffset((next.xy - curr.xy) * indexDir, positions.y, width);
+  vec2 offset = getExtrusionOffset((next.xy - curr.xy) * indexDir, positions.y, widthPixels);
   gl_Position = curr + vec4(offset, 0.0, 0.0);
 
   vec4 color = mix(instanceSourceColors, instanceTargetColors, segmentRatio) / 255.0;

--- a/modules/geo-layers/src/great-circle-layer/great-circle-vertex.glsl.js
+++ b/modules/geo-layers/src/great-circle-layer/great-circle-vertex.glsl.js
@@ -46,7 +46,7 @@ vec2 getExtrusionOffset(vec2 line_clipspace, float offset_direction, float width
   dir_screenspace = vec2(-dir_screenspace.y, dir_screenspace.x);
 
   vec2 offset_screenspace = dir_screenspace * offset_direction * width / 2.0;
-  vec2 offset_clipspace = project_pixel_to_clipspace(offset_screenspace).xy;
+  vec2 offset_clipspace = project_pixel_size_to_clipspace(offset_screenspace);
 
   return offset_clipspace;
 }

--- a/modules/geo-layers/src/great-circle-layer/great-circle-vertex.glsl.js
+++ b/modules/geo-layers/src/great-circle-layer/great-circle-vertex.glsl.js
@@ -111,7 +111,7 @@ void main(void) {
   // Multiply out width and clamp to limits
   // mercator pixels are interpreted as screen pixels
   float widthPixels = clamp(
-    project_size_to_pixels(instanceWidths * widthScale),
+    project_size_to_pixel(instanceWidths * widthScale),
     widthMinPixels, widthMaxPixels
   );
 

--- a/modules/layers/src/arc-layer/arc-layer-vertex-64.glsl.js
+++ b/modules/layers/src/arc-layer/arc-layer-vertex-64.glsl.js
@@ -118,12 +118,12 @@ void main(void) {
 
   // Multiply out width and clamp to limits
   // mercator pixels are interpreted as screen pixels
-  float width = clamp(
-    project_scale(instanceWidths * widthScale),
+  float widthPixels = clamp(
+    project_size_to_pixels(instanceWidths * widthScale),
     widthMinPixels, widthMaxPixels
   );
 
-  vec2 offset = getExtrusionOffset(next_pos_clipspace.xy - curr_pos_clipspace.xy, positions.y, width);
+  vec2 offset = getExtrusionOffset(next_pos_clipspace.xy - curr_pos_clipspace.xy, positions.y, widthPixels);
 
   gl_Position = curr_pos_clipspace + vec4(offset, 0.0, 0.0);
 

--- a/modules/layers/src/arc-layer/arc-layer-vertex-64.glsl.js
+++ b/modules/layers/src/arc-layer/arc-layer-vertex-64.glsl.js
@@ -60,7 +60,7 @@ vec2 getExtrusionOffset(vec2 line_clipspace, float offset_direction, float width
   dir_screenspace = vec2(-dir_screenspace.y, dir_screenspace.x);
 
   vec2 offset_screenspace = dir_screenspace * offset_direction * width / 2.0;
-  vec2 offset_clipspace = project_pixel_to_clipspace(offset_screenspace).xy;
+  vec2 offset_clipspace = project_pixel_size_to_clipspace(offset_screenspace);
 
   return offset_clipspace;
 }

--- a/modules/layers/src/arc-layer/arc-layer-vertex-64.glsl.js
+++ b/modules/layers/src/arc-layer/arc-layer-vertex-64.glsl.js
@@ -113,13 +113,13 @@ void main(void) {
   get_pos_fp64(projected_source_coord, projected_target_coord, nextSegmentRatio,
     next_pos_modelspace);
 
-  vec4 curr_pos_clipspace = project_to_clipspace_fp64(curr_pos_modelspace);
-  vec4 next_pos_clipspace = project_to_clipspace_fp64(next_pos_modelspace);
+  vec4 curr_pos_clipspace = project_common_position_to_clipspace_fp64(curr_pos_modelspace);
+  vec4 next_pos_clipspace = project_common_position_to_clipspace_fp64(next_pos_modelspace);
 
   // Multiply out width and clamp to limits
   // mercator pixels are interpreted as screen pixels
   float widthPixels = clamp(
-    project_size_to_pixels(instanceWidths * widthScale),
+    project_size_to_pixel(instanceWidths * widthScale),
     widthMinPixels, widthMaxPixels
   );
 

--- a/modules/layers/src/arc-layer/arc-layer-vertex.glsl.js
+++ b/modules/layers/src/arc-layer/arc-layer-vertex.glsl.js
@@ -93,13 +93,13 @@ void main(void) {
 
   vec3 currPos = getPos(source, target, segmentRatio);
   vec3 nextPos = getPos(source, target, nextSegmentRatio);
-  vec4 curr = project_to_clipspace(vec4(currPos, 1.0));
-  vec4 next = project_to_clipspace(vec4(nextPos, 1.0));
+  vec4 curr = project_common_position_to_clipspace(vec4(currPos, 1.0));
+  vec4 next = project_common_position_to_clipspace(vec4(nextPos, 1.0));
 
   // Multiply out width and clamp to limits
   // mercator pixels are interpreted as screen pixels
   float widthPixels = clamp(
-    project_size_to_pixels(instanceWidths * widthScale),
+    project_size_to_pixel(instanceWidths * widthScale),
     widthMinPixels, widthMaxPixels
   );
 

--- a/modules/layers/src/arc-layer/arc-layer-vertex.glsl.js
+++ b/modules/layers/src/arc-layer/arc-layer-vertex.glsl.js
@@ -98,13 +98,13 @@ void main(void) {
 
   // Multiply out width and clamp to limits
   // mercator pixels are interpreted as screen pixels
-  float width = clamp(
-    project_scale(instanceWidths * widthScale),
+  float widthPixels = clamp(
+    project_size_to_pixels(instanceWidths * widthScale),
     widthMinPixels, widthMaxPixels
   );
 
   // extrude
-  vec2 offset = getExtrusionOffset((next.xy - curr.xy) * indexDir, positions.y, width);
+  vec2 offset = getExtrusionOffset((next.xy - curr.xy) * indexDir, positions.y, widthPixels);
   gl_Position = curr + vec4(offset, 0.0, 0.0);
 
   vec4 color = mix(instanceSourceColors, instanceTargetColors, segmentRatio) / 255.;

--- a/modules/layers/src/arc-layer/arc-layer-vertex.glsl.js
+++ b/modules/layers/src/arc-layer/arc-layer-vertex.glsl.js
@@ -58,7 +58,7 @@ vec2 getExtrusionOffset(vec2 line_clipspace, float offset_direction, float width
   dir_screenspace = vec2(-dir_screenspace.y, dir_screenspace.x);
 
   vec2 offset_screenspace = dir_screenspace * offset_direction * width / 2.0;
-  vec2 offset_clipspace = project_pixel_to_clipspace(offset_screenspace).xy;
+  vec2 offset_clipspace = project_pixel_size_to_clipspace(offset_screenspace);
 
   return offset_clipspace;
 }

--- a/modules/layers/src/column-layer/column-layer-vertex.glsl.js
+++ b/modules/layers/src/column-layer/column-layer-vertex.glsl.js
@@ -65,16 +65,16 @@ void main(void) {
   vec2 centroidPosition64xyLow = instancePositions64xyLow;
   vec3 pos = vec3(project_size(rotationMatrix * positions.xy + offset) * dotRadius, 0.);
 
-  vec4 position_worldspace;
-  gl_Position = project_position_to_clipspace(centroidPosition, centroidPosition64xyLow, pos, position_worldspace);
+  vec4 position_commonspace;
+  gl_Position = project_position_to_clipspace(centroidPosition, centroidPosition64xyLow, pos, position_commonspace);
 
   // Light calculations
   // Worldspace is the linear space after Mercator projection
 
-  vec3 normals_worldspace = project_normal(vec3(rotationMatrix * normals.xy, normals.z));
+  vec3 normals_commonspace = project_normal(vec3(rotationMatrix * normals.xy, normals.z));
 
   if (extruded) {
-    vec3 lightColor = lighting_getLightColor(instanceColors.rgb, project_uCameraPosition, position_worldspace.xyz, normals_worldspace);
+    vec3 lightColor = lighting_getLightColor(instanceColors.rgb, project_uCameraPosition, position_commonspace.xyz, normals_commonspace);
     vColor = vec4(lightColor, instanceColors.a * opacity) / 255.0;
   } else {
     vColor = vec4(instanceColors.rgb, instanceColors.a * opacity) / 255.0;

--- a/modules/layers/src/column-layer/column-layer-vertex.glsl.js
+++ b/modules/layers/src/column-layer/column-layer-vertex.glsl.js
@@ -63,7 +63,7 @@ void main(void) {
   // project center of column
   vec3 centroidPosition = vec3(instancePositions.xy, instancePositions.z + elevation);
   vec2 centroidPosition64xyLow = instancePositions64xyLow;
-  vec3 pos = vec3(project_scale(rotationMatrix * positions.xy + offset) * dotRadius, 0.);
+  vec3 pos = vec3(project_size(rotationMatrix * positions.xy + offset) * dotRadius, 0.);
 
   vec4 position_worldspace;
   gl_Position = project_position_to_clipspace(centroidPosition, centroidPosition64xyLow, pos, position_worldspace);

--- a/modules/layers/src/icon-layer/icon-layer-vertex.glsl.js
+++ b/modules/layers/src/icon-layer/icon-layer-vertex.glsl.js
@@ -56,7 +56,7 @@ void main(void) {
  
   // project meters to pixels and clamp to limits 
   float sizePixels = clamp(
-    project_scale(instanceSizes * sizeScale), 
+    project_size_to_pixels(instanceSizes * sizeScale), 
     sizeMinPixels, sizeMaxPixels
   );
 

--- a/modules/layers/src/icon-layer/icon-layer-vertex.glsl.js
+++ b/modules/layers/src/icon-layer/icon-layer-vertex.glsl.js
@@ -69,7 +69,7 @@ void main(void) {
   pixelOffset.y *= -1.0;
 
   gl_Position = project_position_to_clipspace(instancePositions, instancePositions64xyLow, vec3(0.0));
-  gl_Position += project_pixel_to_clipspace(pixelOffset);
+  gl_Position.xy += project_pixel_size_to_clipspace(pixelOffset);
 
   vTextureCoords = mix(
     instanceIconFrames.xy,

--- a/modules/layers/src/icon-layer/icon-layer-vertex.glsl.js
+++ b/modules/layers/src/icon-layer/icon-layer-vertex.glsl.js
@@ -56,7 +56,7 @@ void main(void) {
  
   // project meters to pixels and clamp to limits 
   float sizePixels = clamp(
-    project_size_to_pixels(instanceSizes * sizeScale), 
+    project_size_to_pixel(instanceSizes * sizeScale), 
     sizeMinPixels, sizeMaxPixels
   );
 

--- a/modules/layers/src/line-layer/line-layer-vertex.glsl.js
+++ b/modules/layers/src/line-layer/line-layer-vertex.glsl.js
@@ -56,9 +56,8 @@ void main(void) {
   vec4 target = project_position_to_clipspace(instanceTargetPositions, instanceSourceTargetPositions64xyLow.zw, vec3(0.));
 
   // Multiply out width and clamp to limits
-  // mercator pixels are interpreted as screen pixels
-  float width = clamp(
-    project_scale(instanceWidths * widthScale),
+  float widthPixels = clamp(
+    project_size_to_pixels(instanceWidths * widthScale),
     widthMinPixels, widthMaxPixels
   );
   
@@ -67,7 +66,7 @@ void main(void) {
   vec4 p = mix(source, target, segmentIndex);
 
   // extrude
-  vec2 offset = getExtrusionOffset(target.xy - source.xy, positions.y, width);
+  vec2 offset = getExtrusionOffset(target.xy - source.xy, positions.y, widthPixels);
   gl_Position = p + vec4(offset, 0.0, 0.0);
 
   // Color

--- a/modules/layers/src/line-layer/line-layer-vertex.glsl.js
+++ b/modules/layers/src/line-layer/line-layer-vertex.glsl.js
@@ -57,7 +57,7 @@ void main(void) {
 
   // Multiply out width and clamp to limits
   float widthPixels = clamp(
-    project_size_to_pixels(instanceWidths * widthScale),
+    project_size_to_pixel(instanceWidths * widthScale),
     widthMinPixels, widthMaxPixels
   );
   

--- a/modules/layers/src/line-layer/line-layer-vertex.glsl.js
+++ b/modules/layers/src/line-layer/line-layer-vertex.glsl.js
@@ -45,7 +45,7 @@ vec2 getExtrusionOffset(vec2 line_clipspace, float offset_direction, float width
   dir_screenspace = vec2(-dir_screenspace.y, dir_screenspace.x);
 
   vec2 offset_screenspace = dir_screenspace * offset_direction * width / 2.0;
-  vec2 offset_clipspace = project_pixel_to_clipspace(offset_screenspace).xy;
+  vec2 offset_clipspace = project_pixel_size_to_clipspace(offset_screenspace);
 
   return offset_clipspace;
 }

--- a/modules/layers/src/path-layer/path-layer-vertex-64.glsl.js
+++ b/modules/layers/src/path-layer/path-layer-vertex-64.glsl.js
@@ -57,8 +57,9 @@ float flipIfTrue(bool flag) {
 
 vec3 lineJoin(vec2 prevPoint64[2], vec2 currPoint64[2], vec2 nextPoint64[2]) {
 
-  float width = clamp(project_scale(instanceStrokeWidths * widthScale),
+  float widthPixels = clamp(project_size_to_pixels(instanceStrokeWidths * widthScale),
     widthMinPixels, widthMaxPixels) / 2.0;
+  float width = project_pixel_to_worldspace(widthPixels);
 
   vec2 deltaA64[2];
   vec2 deltaB64[2];
@@ -199,7 +200,7 @@ void main() {
   vec2 currPosition64xyLow = mix(instanceStartEndPositions64xyLow.xy, instanceStartEndPositions64xyLow.zw, isEnd);
   vec2 projected_curr_position[2];
   project_position_fp64(currPosition.xy, currPosition64xyLow, projected_curr_position);
-  float projected_curr_position_z = project_scale(currPosition.z);
+  float projected_curr_position_z = project_size(currPosition.z);
 
   // Calculate previous position
 

--- a/modules/layers/src/path-layer/path-layer-vertex-64.glsl.js
+++ b/modules/layers/src/path-layer/path-layer-vertex-64.glsl.js
@@ -57,9 +57,9 @@ float flipIfTrue(bool flag) {
 
 vec3 lineJoin(vec2 prevPoint64[2], vec2 currPoint64[2], vec2 nextPoint64[2]) {
 
-  float widthPixels = clamp(project_size_to_pixels(instanceStrokeWidths * widthScale),
+  float widthPixels = clamp(project_size_to_pixel(instanceStrokeWidths * widthScale),
     widthMinPixels, widthMaxPixels) / 2.0;
-  float width = project_pixel_to_worldspace(widthPixels);
+  float width = project_pixel_size(widthPixels);
 
   vec2 deltaA64[2];
   vec2 deltaB64[2];
@@ -227,6 +227,6 @@ void main() {
   vertex_pos_modelspace[2] = vec2(pos.z + projected_curr_position_z, 0.0);
   vertex_pos_modelspace[3] = vec2(1.0, 0.0);
 
-  gl_Position = project_to_clipspace_fp64(vertex_pos_modelspace);
+  gl_Position = project_common_position_to_clipspace_fp64(vertex_pos_modelspace);
 }
 `;

--- a/modules/layers/src/path-layer/path-layer-vertex.glsl.js
+++ b/modules/layers/src/path-layer/path-layer-vertex.glsl.js
@@ -185,13 +185,13 @@ vec3 lineJoin(vec3 prevPoint, vec3 currPoint, vec3 nextPoint) {
   bool isEnd = positions.x > EPSILON;
   bool isJoint = positions.z > EPSILON;
 
-  float width = clamp(project_scale(instanceStrokeWidths * widthScale),
+  float widthPixels = clamp(project_size_to_pixels(instanceStrokeWidths * widthScale),
     widthMinPixels, widthMaxPixels) / 2.0;
 
   return lineJoin(
     prevPoint, currPoint, nextPoint,
     relativePosition, isEnd, isJoint,
-    width
+    project_pixel_to_worldspace(widthPixels)
   );
 }
 

--- a/modules/layers/src/path-layer/path-layer-vertex.glsl.js
+++ b/modules/layers/src/path-layer/path-layer-vertex.glsl.js
@@ -185,13 +185,13 @@ vec3 lineJoin(vec3 prevPoint, vec3 currPoint, vec3 nextPoint) {
   bool isEnd = positions.x > EPSILON;
   bool isJoint = positions.z > EPSILON;
 
-  float widthPixels = clamp(project_size_to_pixels(instanceStrokeWidths * widthScale),
+  float widthPixels = clamp(project_size_to_pixel(instanceStrokeWidths * widthScale),
     widthMinPixels, widthMaxPixels) / 2.0;
 
   return lineJoin(
     prevPoint, currPoint, nextPoint,
     relativePosition, isEnd, isJoint,
-    project_pixel_to_worldspace(widthPixels)
+    project_pixel_size(widthPixels)
   );
 }
 
@@ -229,6 +229,6 @@ void main() {
 
   vec3 pos = lineJoin(prevPosition, currPosition, nextPosition);
 
-  gl_Position = project_to_clipspace(vec4(pos, 1.0));
+  gl_Position = project_common_position_to_clipspace(vec4(pos, 1.0));
 }
 `;

--- a/modules/layers/src/point-cloud-layer/point-cloud-layer-vertex.glsl.js
+++ b/modules/layers/src/point-cloud-layer/point-cloud-layer-vertex.glsl.js
@@ -41,7 +41,7 @@ void main(void) {
   // Find the center of the point and add the current vertex
   vec4 position_commonspace;
   gl_Position = project_position_to_clipspace(instancePositions, instancePositions64xyLow, vec3(0.), position_commonspace);
-  gl_Position += project_pixel_to_clipspace(positions.xy * radiusPixels);
+  gl_Position.xy += project_pixel_size_to_clipspace(positions.xy * radiusPixels);
 
   // Apply lighting
   vec3 lightColor = lighting_getLightColor(instanceColors.rgb, project_uCameraPosition, position_commonspace.xyz, project_normal(instanceNormals));

--- a/modules/layers/src/point-cloud-layer/point-cloud-layer-vertex.glsl.js
+++ b/modules/layers/src/point-cloud-layer/point-cloud-layer-vertex.glsl.js
@@ -39,12 +39,12 @@ void main(void) {
   unitPosition = positions.xy;
 
   // Find the center of the point and add the current vertex
-  vec4 position_worldspace;
-  gl_Position = project_position_to_clipspace(instancePositions, instancePositions64xyLow, vec3(0.), position_worldspace);
+  vec4 position_commonspace;
+  gl_Position = project_position_to_clipspace(instancePositions, instancePositions64xyLow, vec3(0.), position_commonspace);
   gl_Position += project_pixel_to_clipspace(positions.xy * radiusPixels);
 
   // Apply lighting
-  vec3 lightColor = lighting_getLightColor(instanceColors.rgb, project_uCameraPosition, position_worldspace.xyz, project_normal(instanceNormals));
+  vec3 lightColor = lighting_getLightColor(instanceColors.rgb, project_uCameraPosition, position_commonspace.xyz, project_normal(instanceNormals));
 
   // Apply opacity to instance color, or return instance picking color
   vColor = vec4(lightColor, instanceColors.a * opacity) / 255.0;

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer-vertex.glsl.js
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer-vertex.glsl.js
@@ -49,13 +49,13 @@ varying float innerUnitRadius;
 void main(void) {
   // Multiply out radius and clamp to limits
   float outerRadiusPixels = clamp(
-    project_size_to_pixels(radiusScale * instanceRadius),
+    project_size_to_pixel(radiusScale * instanceRadius),
     radiusMinPixels, radiusMaxPixels
   );
   
   // Multiply out line width and clamp to limits
   float lineWidthPixels = clamp(
-    project_size_to_pixels(lineWidthScale * instanceLineWidths),
+    project_size_to_pixel(lineWidthScale * instanceLineWidths),
     lineWidthMinPixels, lineWidthMaxPixels
   );
 
@@ -67,7 +67,7 @@ void main(void) {
 
   innerUnitRadius = 1.0 - stroked * lineWidthPixels / outerRadiusPixels;
   
-  vec3 offset = positions * project_pixel_to_worldspace(outerRadiusPixels);
+  vec3 offset = positions * project_pixel_size(outerRadiusPixels);
   gl_Position = project_position_to_clipspace(instancePositions, instancePositions64xyLow, offset);
 
   // Apply opacity to instance color, or return instance picking color

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer-vertex.glsl.js
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer-vertex.glsl.js
@@ -49,25 +49,25 @@ varying float innerUnitRadius;
 void main(void) {
   // Multiply out radius and clamp to limits
   float outerRadiusPixels = clamp(
-    project_scale(radiusScale * instanceRadius),
+    project_size_to_pixels(radiusScale * instanceRadius),
     radiusMinPixels, radiusMaxPixels
   );
   
   // Multiply out line width and clamp to limits
-  float lineWidth = clamp(
-    project_scale(lineWidthScale * instanceLineWidths), 
+  float lineWidthPixels = clamp(
+    project_size_to_pixels(lineWidthScale * instanceLineWidths),
     lineWidthMinPixels, lineWidthMaxPixels
   );
 
   // outer radius needs to offset by half stroke width
-  outerRadiusPixels += stroked * lineWidth / 2.0;
+  outerRadiusPixels += stroked * lineWidthPixels / 2.0;
 
   // position on the containing square in [-1, 1] space
   unitPosition = positions.xy;
 
-  innerUnitRadius = 1.0 - stroked * lineWidth / outerRadiusPixels;
+  innerUnitRadius = 1.0 - stroked * lineWidthPixels / outerRadiusPixels;
   
-  vec3 offset = positions * outerRadiusPixels;
+  vec3 offset = positions * project_pixel_to_worldspace(outerRadiusPixels);
   gl_Position = project_position_to_clipspace(instancePositions, instancePositions64xyLow, offset);
 
   // Apply opacity to instance color, or return instance picking color

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-main.glsl.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-main.glsl.js
@@ -63,8 +63,8 @@ void calculatePosition(PolygonProps props) {
   }
   pos.z *= elevationScale;
 
-  vec4 position_worldspace;
-  gl_Position = project_position_to_clipspace(pos, pos64xyLow, vec3(0.), position_worldspace);
+  vec4 position_commonspace;
+  gl_Position = project_position_to_clipspace(pos, pos64xyLow, vec3(0.), position_commonspace);
 
   if (extruded) {
 #ifdef IS_SIDE_VERTEX
@@ -74,7 +74,7 @@ void calculatePosition(PolygonProps props) {
     normal = vec3(0.0, 0.0, 1.0);
 #endif
 
-    vec3 lightColor = lighting_getLightColor(colors.rgb, project_uCameraPosition, position_worldspace.xyz, normal);
+    vec3 lightColor = lighting_getLightColor(colors.rgb, project_uCameraPosition, position_commonspace.xyz, normal);
     vColor = vec4(lightColor, colors.a * opacity) / 255.0;
   } else {
     vColor = vec4(colors.rgb, colors.a * opacity) / 255.0;

--- a/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer-vertex.glsl.js
+++ b/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer-vertex.glsl.js
@@ -76,7 +76,7 @@ void main(void) {
   pixelOffset.y *= -1.0;
 
   gl_Position = project_position_to_clipspace(instancePositions, instancePositions64xyLow, vec3(0.0));
-  gl_Position += project_pixel_to_clipspace(pixelOffset);
+  gl_Position.xy += project_pixel_size_to_clipspace(pixelOffset);
 
   vTextureCoords = mix(
     instanceIconFrames.xy,

--- a/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer-vertex.glsl.js
+++ b/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer-vertex.glsl.js
@@ -61,7 +61,7 @@ void main(void) {
  
   // project meters to pixels and clamp to limits 
   float sizePixels = clamp(
-    project_scale(instanceSizes * sizeScale),
+    project_size_to_pixels(instanceSizes * sizeScale),
     sizeMinPixels, sizeMaxPixels
   );
 

--- a/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer-vertex.glsl.js
+++ b/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer-vertex.glsl.js
@@ -61,7 +61,7 @@ void main(void) {
  
   // project meters to pixels and clamp to limits 
   float sizePixels = clamp(
-    project_size_to_pixels(instanceSizes * sizeScale),
+    project_size_to_pixel(instanceSizes * sizeScale),
     sizeMinPixels, sizeMaxPixels
   );
 

--- a/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.js
+++ b/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.js
@@ -54,8 +54,8 @@ const vs = `
     vec3 pos = (instanceModelMatrix * POSITION.xyz) * sizeScale + instanceTranslation;
     pos = project_size(pos);
 
-    vec4 worldPosition;
-    gl_Position = project_position_to_clipspace(instancePositions, instancePositions64xy, pos, worldPosition);
+    vec4 position_commonspace;
+    gl_Position = project_position_to_clipspace(instancePositions, instancePositions64xy, pos, position_commonspace);
     picking_setPickingColor(instancePickingColors);
   }
 `;

--- a/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.js
+++ b/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.js
@@ -52,7 +52,7 @@ const vs = `
     vColor = instanceColors;
 
     vec3 pos = (instanceModelMatrix * POSITION.xyz) * sizeScale + instanceTranslation;
-    pos = project_scale(pos);
+    pos = project_size(pos);
 
     vec4 worldPosition;
     gl_Position = project_position_to_clipspace(instancePositions, instancePositions64xy, pos, worldPosition);

--- a/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer-vertex.glsl.js
+++ b/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer-vertex.glsl.js
@@ -23,7 +23,7 @@ varying vec4 vColor;
 
 void main(void) {
   vec3 pos = (instanceModelMatrix * positions) * sizeScale + instanceTranslation;
-  pos = project_scale(pos);
+  pos = project_size(pos);
 
   vec4 worldPosition;
   gl_Position = project_position_to_clipspace(instancePositions, instancePositions64xy, pos, worldPosition);

--- a/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer-vertex.glsl.js
+++ b/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer-vertex.glsl.js
@@ -25,14 +25,14 @@ void main(void) {
   vec3 pos = (instanceModelMatrix * positions) * sizeScale + instanceTranslation;
   pos = project_size(pos);
 
-  vec4 worldPosition;
-  gl_Position = project_position_to_clipspace(instancePositions, instancePositions64xy, pos, worldPosition);
+  vec4 position_commonspace;
+  gl_Position = project_position_to_clipspace(instancePositions, instancePositions64xy, pos, position_commonspace);
 
   // TODO - transform normals
 
   vTexCoord = texCoords;
   vColor = instanceColors;
-  // vLightWeight = lighting_getLightWeight(worldPosition.xyz, project_normal(normals));
+  // vLightWeight = lighting_getLightWeight(position_commonspace.xyz, project_normal(normals));
 
   picking_setPickingColor(instancePickingColors);
 }

--- a/test/apps/carto-wip/time-sliced-scatterplot-layer/time-sliced-scatterplot-layer-vertex-64.glsl.js
+++ b/test/apps/carto-wip/time-sliced-scatterplot-layer/time-sliced-scatterplot-layer-vertex-64.glsl.js
@@ -47,7 +47,7 @@ varying float innerUnitRadius;
 void main(void) {
   // Multiply out radius and clamp to limits
   float outerRadiusPixels = clamp(
-    project_scale(radiusScale * instanceRadius),
+    project_size_to_pixels(radiusScale * instanceRadius),
     radiusMinPixels, radiusMaxPixels
   );
 
@@ -74,7 +74,7 @@ void main(void) {
   vertex_pos_modelspace[0] = sum_fp64(vertex_pos_localspace[0], projected_coord_xy[0]);
   vertex_pos_modelspace[1] = sum_fp64(vertex_pos_localspace[1], projected_coord_xy[1]);
   vertex_pos_modelspace[2] = sum_fp64(vertex_pos_localspace[2],
-    vec2(project_scale(instancePositions.z), 0.0));
+    vec2(project_size(instancePositions.z), 0.0));
   vertex_pos_modelspace[3] = vec2(1.0, 0.0);
 
   gl_Position = project_to_clipspace_fp64(vertex_pos_modelspace);

--- a/test/apps/carto-wip/time-sliced-scatterplot-layer/time-sliced-scatterplot-layer-vertex.glsl.js
+++ b/test/apps/carto-wip/time-sliced-scatterplot-layer/time-sliced-scatterplot-layer-vertex.glsl.js
@@ -45,7 +45,7 @@ varying float innerUnitRadius;
 void main(void) {
   // Multiply out radius and clamp to limits
   float outerRadiusPixels = clamp(
-    project_scale(radiusScale * instanceRadius),
+    project_size_to_pixels(radiusScale * instanceRadius),
     radiusMinPixels, radiusMaxPixels
   );
   // outline is centered at the radius

--- a/test/modules/core/lib/layer.spec.js
+++ b/test/modules/core/lib/layer.spec.js
@@ -279,9 +279,6 @@ test('Layer#use64bitPositions', t => {
   layer = new SubLayer({coordinateSystem: COORDINATE_SYSTEM.LNGLAT});
   t.true(layer.use64bitPositions(), 'returns true for COORDINATE_SYSTEM.LNGLAT');
 
-  layer = new SubLayer({coordinateSystem: COORDINATE_SYSTEM.LNGLAT_EXPERIMENTAL});
-  t.true(layer.use64bitPositions(), 'returns true for COORDINATE_SYSTEM.LNGLAT_EXPERIMENTAL');
-
   layer = new SubLayer({coordinateSystem: COORDINATE_SYSTEM.LNGLAT_DEPRECATED});
   t.false(layer.use64bitPositions(), 'returns false for COORDINATE_SYSTEM.LNGLAT_DEPRECATED');
 

--- a/test/modules/core/shaderlib/project/project-glsl.spec.js
+++ b/test/modules/core/shaderlib/project/project-glsl.spec.js
@@ -185,10 +185,10 @@ const TEST_CASES = [
     ]
   },
   {
-    title: 'LNGLAT_EXPERIMENTAL mode - auto offset',
+    title: 'LNGLAT mode - auto offset',
     params: {
       viewport: TEST_VIEWPORT_HIGH_ZOOM,
-      coordinateSystem: COORDINATE_SYSTEM.LNGLAT_EXPERIMENTAL
+      coordinateSystem: COORDINATE_SYSTEM.LNGLAT
     },
     tests: [
       {

--- a/test/modules/core/shaderlib/project/project-glsl.spec.js
+++ b/test/modules/core/shaderlib/project/project-glsl.spec.js
@@ -114,7 +114,7 @@ void main()
   )}));
 }
 `,
-  project_to_clipspace: pos => `\
+  project_common_position_to_clipspace: pos => `\
 varying vec4 outValue;
 
 void main()
@@ -124,7 +124,7 @@ void main()
   )}, ${pos[2].toFixed(MAX_FRACTION_DIGITS)}, ${pos[3].toFixed(
     MAX_FRACTION_DIGITS
   )}), vec2(0., 0.));
-  outValue = project_to_clipspace(pos);
+  outValue = project_common_position_to_clipspace(pos);
 }
 `
 };
@@ -165,22 +165,22 @@ const TEST_CASES = [
         )
       },
       {
-        name: 'project_to_clipspace',
-        func: ({project_position, project_to_clipspace}) =>
-          project_to_clipspace(project_position([-122.45, 37.78, 0, 1], [0, 0])),
+        name: 'project_common_position_to_clipspace',
+        func: ({project_position, project_common_position_to_clipspace}) =>
+          project_common_position_to_clipspace(project_position([-122.45, 37.78, 0, 1], [0, 0])),
         mapResult: coords => clipspaceToScreen(TEST_VIEWPORT, coords),
         output: TEST_VIEWPORT.project([-122.45, 37.78, 0]),
         precision: PIXEL_TOLERANCE,
-        vs: TRANSFORM_VS.project_to_clipspace([-122.45, 37.78, 0, 1])
+        vs: TRANSFORM_VS.project_common_position_to_clipspace([-122.45, 37.78, 0, 1])
       },
       {
-        name: 'project_to_clipspace (non-zero z)',
-        func: ({project_position, project_to_clipspace}) =>
-          project_to_clipspace(project_position([-122.45, 37.78, 100, 1], [0, 0])),
+        name: 'project_common_position_to_clipspace (non-zero z)',
+        func: ({project_position, project_common_position_to_clipspace}) =>
+          project_common_position_to_clipspace(project_position([-122.45, 37.78, 100, 1], [0, 0])),
         mapResult: coords => clipspaceToScreen(TEST_VIEWPORT, coords),
         output: TEST_VIEWPORT.project([-122.45, 37.78, 100]),
         precision: PIXEL_TOLERANCE,
-        vs: TRANSFORM_VS.project_to_clipspace([-122.45, 37.78, 100, 1])
+        vs: TRANSFORM_VS.project_common_position_to_clipspace([-122.45, 37.78, 100, 1])
       }
     ]
   },
@@ -202,22 +202,22 @@ const TEST_CASES = [
         vs: TRANSFORM_VS.project_position([-122.05, 37.92, 0, 1])
       },
       {
-        name: 'project_to_clipspace',
-        func: ({project_position, project_to_clipspace}) =>
-          project_to_clipspace(project_position([-122.05, 37.92, 0, 1], [0, 0])),
+        name: 'project_common_position_to_clipspace',
+        func: ({project_position, project_common_position_to_clipspace}) =>
+          project_common_position_to_clipspace(project_position([-122.05, 37.92, 0, 1], [0, 0])),
         mapResult: coords => clipspaceToScreen(TEST_VIEWPORT_HIGH_ZOOM, coords),
         output: TEST_VIEWPORT_HIGH_ZOOM.project([-122.05, 37.92, 0]),
         precision: PIXEL_TOLERANCE,
-        vs: TRANSFORM_VS.project_to_clipspace([-122.05, 37.92, 0, 1])
+        vs: TRANSFORM_VS.project_common_position_to_clipspace([-122.05, 37.92, 0, 1])
       },
       {
-        name: 'project_to_clipspace (non-zero z)',
-        func: ({project_position, project_to_clipspace}) =>
-          project_to_clipspace(project_position([-122.05, 37.92, 100, 1], [0, 0])),
+        name: 'project_common_position_to_clipspace (non-zero z)',
+        func: ({project_position, project_common_position_to_clipspace}) =>
+          project_common_position_to_clipspace(project_position([-122.05, 37.92, 100, 1], [0, 0])),
         mapResult: coords => clipspaceToScreen(TEST_VIEWPORT_HIGH_ZOOM, coords),
         output: TEST_VIEWPORT_HIGH_ZOOM.project([-122.05, 37.92, 100]),
         precision: PIXEL_TOLERANCE,
-        vs: TRANSFORM_VS.project_to_clipspace([-122.05, 37.92, 100, 1])
+        vs: TRANSFORM_VS.project_common_position_to_clipspace([-122.05, 37.92, 100, 1])
       }
     ]
   },
@@ -244,13 +244,13 @@ const TEST_CASES = [
         vs: TRANSFORM_VS.project_position([1000, 1000, 0, 1])
       },
       {
-        name: 'project_to_clipspace',
-        func: ({project_position, project_to_clipspace}) =>
-          project_to_clipspace(project_position([1000, 1000, 0, 1], [0, 0])),
+        name: 'project_common_position_to_clipspace',
+        func: ({project_position, project_common_position_to_clipspace}) =>
+          project_common_position_to_clipspace(project_position([1000, 1000, 0, 1], [0, 0])),
         mapResult: coords => clipspaceToScreen(TEST_VIEWPORT, coords),
         output: TEST_VIEWPORT.project([-122.0385984916185, 37.92899265369385, 100]),
         precision: PIXEL_TOLERANCE,
-        vs: TRANSFORM_VS.project_to_clipspace([1000, 1000, 0, 1])
+        vs: TRANSFORM_VS.project_common_position_to_clipspace([1000, 1000, 0, 1])
       }
     ]
   },
@@ -273,13 +273,13 @@ const TEST_CASES = [
         vs: TRANSFORM_VS.project_position([0.05, 0.08, 0, 1])
       },
       {
-        name: 'project_to_clipspace',
-        func: ({project_position, project_to_clipspace}) =>
-          project_to_clipspace(project_position([0.05, 0.08, 0, 1], [0, 0])),
+        name: 'project_common_position_to_clipspace',
+        func: ({project_position, project_common_position_to_clipspace}) =>
+          project_common_position_to_clipspace(project_position([0.05, 0.08, 0, 1], [0, 0])),
         mapResult: coords => clipspaceToScreen(TEST_VIEWPORT, coords),
         output: TEST_VIEWPORT.project([-122, 38, 0]),
         precision: PIXEL_TOLERANCE,
-        vs: TRANSFORM_VS.project_to_clipspace([0.05, 0.08, 0, 1])
+        vs: TRANSFORM_VS.project_common_position_to_clipspace([0.05, 0.08, 0, 1])
       }
     ]
   },
@@ -298,13 +298,13 @@ const TEST_CASES = [
         vs: TRANSFORM_VS.project_position([200, 200, 0, 1])
       },
       {
-        name: 'project_to_clipspace',
-        func: ({project_position, project_to_clipspace}) =>
-          project_to_clipspace(project_position([200, 200, 0, 1], [0, 0])),
+        name: 'project_common_position_to_clipspace',
+        func: ({project_position, project_common_position_to_clipspace}) =>
+          project_common_position_to_clipspace(project_position([200, 200, 0, 1], [0, 0])),
         mapResult: coords => clipspaceToScreen(TEST_VIEWPORT, coords),
         output: TEST_VIEWPORT_ORTHO.project([-200, 200, 10]),
         precision: PIXEL_TOLERANCE,
-        vs: TRANSFORM_VS.project_to_clipspace([200, 200, 0, 1])
+        vs: TRANSFORM_VS.project_common_position_to_clipspace([200, 200, 0, 1])
       }
     ]
   }

--- a/test/modules/core/shaderlib/project/project-glsl.spec.js
+++ b/test/modules/core/shaderlib/project/project-glsl.spec.js
@@ -72,30 +72,30 @@ const OUT_BUFFER = new Buffer(gl, 16);
 const MAX_FRACTION_DIGITS = 5;
 
 const TRANSFORM_VS = {
-  project_scale: meter => `\
+  project_size: meter => `\
 varying float outValue;
 
 void main()
 {
-  outValue = project_scale(${meter.toFixed(MAX_FRACTION_DIGITS)});
+  outValue = project_size(${meter.toFixed(MAX_FRACTION_DIGITS)});
 }
 `,
-  project_scale_vec2: meter => `\
+  project_size_vec2: meter => `\
   varying vec2 outValue;
 
   void main()
   {
-    outValue = project_scale(vec2(${meter[0].toFixed(MAX_FRACTION_DIGITS)}, ${meter[1].toFixed(
+    outValue = project_size(vec2(${meter[0].toFixed(MAX_FRACTION_DIGITS)}, ${meter[1].toFixed(
     MAX_FRACTION_DIGITS
   )}));
   }
   `,
-  project_scale_vec3: meter => `\
+  project_size_vec3: meter => `\
   varying vec3 outValue;
 
   void main()
   {
-    outValue = project_scale(vec3(${meter[0].toFixed(MAX_FRACTION_DIGITS)}, ${meter[1].toFixed(
+    outValue = project_size(vec3(${meter[0].toFixed(MAX_FRACTION_DIGITS)}, ${meter[1].toFixed(
     MAX_FRACTION_DIGITS
   )}, ${meter[2].toFixed(MAX_FRACTION_DIGITS)}));
   }
@@ -137,22 +137,22 @@ const TEST_CASES = [
     },
     tests: [
       {
-        name: 'project_scale(float)',
-        func: ({project_scale}) => project_scale(1),
+        name: 'project_size(float)',
+        func: ({project_size}) => project_size(1),
         output: TEST_VIEWPORT.getDistanceScales().pixelsPerMeter[2],
-        vs: TRANSFORM_VS.project_scale(1)
+        vs: TRANSFORM_VS.project_size(1)
       },
       {
-        name: 'project_scale(vec2)',
-        func: ({project_scale_vec2}) => project_scale_vec2([1, 1]),
+        name: 'project_size(vec2)',
+        func: ({project_size_vec2}) => project_size_vec2([1, 1]),
         output: TEST_VIEWPORT.getDistanceScales().pixelsPerMeter.slice(0, 2),
-        vs: TRANSFORM_VS.project_scale_vec2([1, 1])
+        vs: TRANSFORM_VS.project_size_vec2([1, 1])
       },
       {
-        name: 'project_scale(vec3)',
-        func: ({project_scale_vec3}) => project_scale_vec3([1, 1, 1]),
+        name: 'project_size(vec3)',
+        func: ({project_size_vec3}) => project_size_vec3([1, 1, 1]),
         output: TEST_VIEWPORT.getDistanceScales().pixelsPerMeter,
-        vs: TRANSFORM_VS.project_scale_vec3([1, 1, 1])
+        vs: TRANSFORM_VS.project_size_vec3([1, 1, 1])
       },
       {
         name: 'project_position',

--- a/test/modules/core/shaderlib/project/viewport-uniforms.spec.js
+++ b/test/modules/core/shaderlib/project/viewport-uniforms.spec.js
@@ -47,7 +47,7 @@ const UNIFORMS = {
 
   // Distance at which screen pixels are projected
   project_uFocalDistance: Number,
-  project_uPixelsPerUnit: Array,
+  project_uDistancePerUnit: Array,
   project_uScale: Number, // This is the mercator scale (2 ** zoom)
 
   project_uModelMatrix: Array,

--- a/test/modules/core/shaderlib/project/viewport-uniforms.spec.js
+++ b/test/modules/core/shaderlib/project/viewport-uniforms.spec.js
@@ -47,7 +47,7 @@ const UNIFORMS = {
 
   // Distance at which screen pixels are projected
   project_uFocalDistance: Number,
-  project_uDistancePerUnit: Array,
+  project_uCommonUnitsPerWorldUnit: Array,
   project_uScale: Number, // This is the mercator scale (2 ** zoom)
 
   project_uModelMatrix: Array,


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/2824

This PR clarifies the following 4 coordinate spaces:

| Before | After | Description |
|----|----|----|
| User space | World space | The coordinate system defined by the layer, not necessarily linear or uniform. |
| World space | Common space | An normalized intermediate 3D space that deck.gl uses for consistent processing of geometries. It is safe to add/subtract/scale positions and vectors in this space. |
| Screen space (sometimes used interchangeably with world) | Screen space | top-left coordinate system runs from `[0, 0]` to `[viewportWidth, viewportHeight]` (see remarks below) |
| Clip space | Clip space | Output of the vertex shader |

#### Change List
- Rename `project` shader module function `project_scale` to `project_size`
- Rename `project` shader module uniforms and functions to match new coordinate space naming convention
- Make sure all vertex shader variables are named to reflect the coordinate space they are in.
- Make sure all size clamping are performed in screen space.
