### PR TITLE
Fix bitmap artifacts

### DIFF
--- a/modules/layers/src/bitmap-layer/bitmap-layer.js
+++ b/modules/layers/src/bitmap-layer/bitmap-layer.js
@@ -32,7 +32,9 @@ import fs from './bitmap-layer-fragment';
 const DEFAULT_TEXTURE_PARAMETERS = {
   [GL.TEXTURE_MIN_FILTER]: GL.LINEAR_MIPMAP_LINEAR,
   // GL.LINEAR is the default value but explicitly set it here
-  [GL.TEXTURE_MAG_FILTER]: GL.LINEAR
+  [GL.TEXTURE_MAG_FILTER]: GL.LINEAR,
+  [GL.TEXTURE_WRAP_S]: GL.CLAMP_TO_EDGE,
+  [GL.TEXTURE_WRAP_T]: GL.CLAMP_TO_EDGE
 };
 
 const defaultProps = {


### PR DESCRIPTION
BitmapLayer has artifacts when rendering multiple layers side by side.

![Screen Shot 2019-03-28 at 7 36 42 PM](https://user-images.githubusercontent.com/2927808/55205627-dd36b000-5190-11e9-8d29-e3dc3d5f22d3.png)


#### Change List
- forces only sampling pixels from the actual texture
