### PR TITLE
PROPOSAL: Move Attribute from luma to deck

### DIFF
--- a/docs/api-reference/internal/attribute.md
+++ b/docs/api-reference/internal/attribute.md
@@ -1,0 +1,70 @@
+# Attribute (Internal)
+
+> This class is a target for refactor.
+
+This class helps deck.gl manage attributes. It integrates into the luma.gl `Model.setAttributes()` method by implementing the `Attribute.getValue()` method. luma.gl checks for the presence of this method on any attribute passed in.
+
+
+## Usage
+
+Create model object by passing shaders, uniforms, geometry and render it by passing updated uniforms.
+
+```js
+import {_Attribute as Attribute} from './attribute';
+```
+
+```js
+// construct the model.
+const positions = new Attribute({
+  id: 'vertexPositions',
+  size: 3,
+  value: new Float32Array([0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 0, 0])
+});
+
+// and on each frame update any uniforms (typically matrices) and call render.
+model.setAttributes({positions});
+model.draw();
+```
+
+## Methods
+
+### constructor
+
+The constructor for the Attribute class. Use this to create a new Attribute.
+
+`new Attribute(gl, options);`
+
+* `gl` - WebGL context.
+* `size` (*number*) - The number of components in each element the buffer (1-4).
+* `id` (*string*, optional) - Identifier of the attribute. Cannot be updated.
+* `type` (*GLenum*, optional) - Type of the attribute. If not supplied will be inferred from `value`. Cannot be updated.
+* `isIndexed` (*bool*, optional) - If the attribute is element index. Default `false`. Cannot be updated.
+* `constant` (*bool*, optional) - If the attribute is a constant. Default `false`.
+* `isInstanced` (*bool*, optional) - Whether buffer contains instance data. Default `false`.
+* `normalized` (*boolean*, optional) - Default `false`
+* `integer` (*boolean*, optional) - Default `false`
+* `offset` (*number*, optional) - where the data starts in the buffer. Default `0`.
+* `stride` (*number*, optional) - an additional offset between each element in the buffer. Default `0`.
+* `value` (*TypedArray*) - value of the attribute.
+    - If `constant` is `true`, the length of `value` should match `size`
+    - If `constant` is `false`, the length of `value` should be `size` multiplies the number of vertices.
+* `buffer` (*Buffer*) - an external buffer for the attribute.
+
+
+### delete
+
+Free WebGL resources associated with this attribute.
+
+
+### update
+
+```js
+attribute.update({value: newValue});
+```
+
+Update attribute options. See `constructor` for possible options.
+
+
+### getBuffer
+
+Returns a `Buffer` object associated with this attribute, if any.

--- a/docs/api-reference/internal/layer-manager.md
+++ b/docs/api-reference/internal/layer-manager.md
@@ -1,6 +1,6 @@
 # LayerManager Class (Internal)
 
-> The `LayerManager` class is an internal class that apps normally would not want to use. It was initially exposed primarily to enable deck.gl to be used without React, however as of deck.gl v5.0 you are more likely to want to use the new `Deck` class (or the [`DeckGL`](/docs/api-reference/react/deckgl.md) React Component). Those classes create a `LayerManager` under the hood to handle layer management, and you do not need to use this class directly.
+> The `LayerManager` class is gradually being refactor into a `ComponentManager` class and will be made part of the `lifecycle` directory. It is now an internal class, use the `Deck` class (or the [`DeckGL`](/docs/api-reference/react/deckgl.md) React Component) which creates a `LayerManager` under the hood.
 
 The `LayerManager` class handles updates, drawing and picking for a set of layers.
 
@@ -43,14 +43,14 @@ Returns:
 Returns an list of layers, optionally be filtered by a list of layer ids.
 
 ```js
-const layers = layerManager.getLayers({layerIds=[]});
+const layers = layerManager.getLayers({layerIds = []});
 ```
 
 Parameters:
 
 * `layerIds` (String[], optional) - A list of layer id strings. If supplied, the returned list will only contain layers whose `id` property matches (see note) one of the strings in the list.
 
-Returns: 
+Returns:
 
 * `Layer[]` - array of layer instances.
 

--- a/modules/core/src/lib/attribute.js
+++ b/modules/core/src/lib/attribute.js
@@ -1,10 +1,10 @@
 /* eslint-disable complexity */
-import assert from '../utils/assert';
 import GL from '@luma.gl/constants';
-import {Buffer, _Attribute as Attribute} from '@luma.gl/core';
-
+import {Buffer, } from '@luma.gl/core';
+import assert from '../utils/assert';
 import {createIterable} from '../utils/iterable-utils';
 import log from '../utils/log';
+import BaseAttribute from './base-attribute';
 
 const DEFAULT_STATE = {
   isExternalBuffer: false,
@@ -13,7 +13,7 @@ const DEFAULT_STATE = {
   allocedInstances: -1
 };
 
-export default class LayerAttribute extends Attribute {
+export default class Attribute extends BaseAttribute {
   constructor(gl, opts = {}) {
     super(gl, opts);
 

--- a/modules/core/src/lib/attribute.js
+++ b/modules/core/src/lib/attribute.js
@@ -1,6 +1,6 @@
 /* eslint-disable complexity */
 import GL from '@luma.gl/constants';
-import {Buffer, } from '@luma.gl/core';
+import {Buffer} from '@luma.gl/core';
 import assert from '../utils/assert';
 import {createIterable} from '../utils/iterable-utils';
 import log from '../utils/log';

--- a/modules/core/src/lib/base-attribute.js
+++ b/modules/core/src/lib/base-attribute.js
@@ -1,0 +1,144 @@
+/* eslint-disable complexity */
+import GL from '@luma.gl/constants';
+import {Buffer, hasFeature, FEATURES} from '@luma.gl/core';
+import {log, uid} from '@luma.gl/core';
+
+export default class BaseAttribute {
+  constructor(gl, opts = {}) {
+    const {id = uid('attribute'), type, isIndexed = false} = opts;
+
+    // Options that cannot be changed later
+    this.gl = gl;
+    this.id = id;
+    this.isIndexed = isIndexed;
+    this.target = isIndexed ? GL.ELEMENT_ARRAY_BUFFER : GL.ARRAY_BUFFER;
+    this.type = type;
+
+    if (isIndexed && !type) {
+      // If the attribute is indices, auto infer the correct type
+      // WebGL2 and WebGL1 w/ uint32 index extension support accepts Uint32Array, otherwise Uint16Array
+      this.type =
+        gl && hasFeature(gl, FEATURES.ELEMENT_INDEX_UINT32) ? GL.UNSIGNED_INT : GL.UNSIGNED_SHORT;
+    }
+
+    // Initialize the attribute descriptor, with WebGL and metadata fields
+    this.value = null;
+    this.externalBuffer = null;
+    this.buffer = null;
+    this.userData = {}; // Reserved for application
+    this.update(opts);
+
+    // Sanity - no app fields on our attributes. Use userData instead.
+    Object.seal(this);
+
+    // Check all fields and generate helpful error messages
+    this._validateAttributeDefinition();
+  }
+
+  delete() {
+    if (this.buffer) {
+      this.buffer.delete();
+      this.buffer = null;
+    }
+  }
+
+  update(opts) {
+    const {value, buffer, constant = this.constant || false} = opts;
+
+    this.constant = constant;
+
+    if (buffer) {
+      this.externalBuffer = buffer;
+      this.constant = false;
+
+      this.type = opts.type || buffer.accessor.type;
+      if (buffer.accessor.divisor !== undefined) {
+        this.divisor = buffer.accessor.divisor;
+      }
+      if (opts.divisor !== undefined) {
+        this.divisor = opts.divisor;
+      }
+    } else if (value) {
+      this.externalBuffer = null;
+      this.value = value;
+
+      if (!constant && this.gl) {
+        // Create buffer if needed
+        this.buffer =
+          this.buffer ||
+          new Buffer(
+            this.gl,
+            Object.assign({}, opts, {
+              id: this.id,
+              target: this.target,
+              type: this.type
+            })
+          );
+        this.buffer.setData({data: value});
+        this.type = this.buffer.accessor.type;
+      }
+    }
+
+    this._setAccessor(opts);
+  }
+
+  getBuffer() {
+    if (this.constant) {
+      return null;
+    }
+    return this.externalBuffer || this.buffer;
+  }
+
+  getValue() {
+    if (this.constant) {
+      return this.value;
+    }
+    const buffer = this.externalBuffer || this.buffer;
+    if (buffer) {
+      return [buffer, this];
+    }
+    return null;
+  }
+
+  // Sets all accessor props except type
+  // TODO - store on `this.accessor`
+  _setAccessor(opts) {
+    const {
+      // accessor props
+      size = this.size,
+      offset = this.offset || 0,
+      stride = this.stride || 0,
+      normalized = this.normalized || false,
+      integer = this.integer || false,
+      divisor = this.divisor || 0,
+      instanced,
+      isInstanced
+    } = opts;
+
+    this.size = size;
+    this.offset = offset;
+    this.stride = stride;
+    this.normalized = normalized;
+    this.integer = integer;
+
+    this.divisor = divisor;
+
+    if (isInstanced !== undefined) {
+      log.deprecated('Attribute.isInstanced')();
+      this.divisor = isInstanced ? 1 : 0;
+    }
+    if (instanced !== undefined) {
+      log.deprecated('Attribute.instanced')();
+      this.divisor = instanced ? 1 : 0;
+    }
+  }
+
+  _validateAttributeDefinition() {
+    // Can be undefined for buffers (auto deduced from shaders)
+    // or larger than 4 for uniform arrays
+    // assert(
+    //   this.size >= 1 && this.size <= 4,
+    //   `Attribute definition for ${this.id} invalid size`
+    // );
+  }
+}

--- a/test/modules/core/lib/base-attribute.spec.js
+++ b/test/modules/core/lib/base-attribute.spec.js
@@ -1,0 +1,254 @@
+import test from 'tape-catch'; // Avoid warnings on `gl` parameters
+/* eslint-disable no-shadow */ import {gl} from '@deck.gl/test-utils';
+
+import GL from '@luma.gl/constants';
+import {isWebGL2, Buffer, Framebuffer, Model, readPixelsToArray} from '@luma.gl/core';
+import BaseAttribute from '@deck.gl/core/lib/base-attribute';
+
+const value1 = new Float32Array([0, 0, 0, 0, 1, 2, 3, 4]);
+const value2 = new Float32Array([0, 0, 0, 0, 1, 2, 3, 4]);
+
+function isHeadlessGL(gl) {
+  return gl.getExtension('STACKGL_resize_drawingbuffer');
+}
+
+test('WebGL#BaseAttribute constructor/update/delete', t => {
+  let attribute = new BaseAttribute(gl, {size: 4, value: value1});
+  let {buffer} = attribute;
+
+  t.ok(attribute instanceof BaseAttribute, 'BaseAttribute construction successful');
+  t.ok(buffer instanceof Buffer, 'BaseAttribute creates buffer');
+  if (isWebGL2(gl)) {
+    t.deepEqual(buffer.getData(), value1, 'Buffer value is set');
+  }
+  t.is(attribute.target, GL.ARRAY_BUFFER, 'BaseAttribute target is inferred');
+  t.is(attribute.type, GL.FLOAT, 'BaseAttribute type is inferred');
+  t.is(attribute.divisor, 0, 'divisor prop is set');
+
+  attribute.delete();
+  t.notOk(buffer._handle, 'Buffer resource is released');
+  t.notOk(attribute.buffer, 'BaseAttribute buffer is deleted');
+
+  /* Indexed attribute */
+  buffer = new Buffer(gl, {data: value2});
+  attribute = new BaseAttribute(gl, {size: 4, isIndexed: true, buffer});
+
+  t.ok(attribute instanceof BaseAttribute, 'Indexed attribute construction successful');
+  t.notOk(
+    attribute.buffer,
+    'BaseAttribute does not create buffer when external buffer is supplied'
+  );
+  t.is(attribute.target, GL.ELEMENT_ARRAY_BUFFER, 'BaseAttribute target is inferred');
+
+  attribute.delete();
+  t.ok(buffer._handle, 'External buffer is not deleted');
+
+  attribute = new BaseAttribute(gl, {size: 1, isIndexed: true});
+  t.is(attribute.type, GL.UNSIGNED_INT, 'type is auto inferred');
+
+  attribute = new BaseAttribute(null, {size: 4, value: value1});
+  t.ok(
+    attribute instanceof BaseAttribute,
+    'BaseAttribute construction successful without GL context'
+  );
+
+  t.end();
+});
+
+test('WebGL#BaseAttribute update', t => {
+  const attribute = new BaseAttribute(gl, {size: 4, value: value1});
+  let {buffer} = attribute;
+
+  attribute.update({value: value2});
+  t.is(attribute.buffer, buffer, 'Buffer is reused');
+  if (isWebGL2(gl)) {
+    t.deepEqual(buffer.getData(), value2, 'Buffer value is updated');
+  }
+
+  attribute.update({divisor: 1});
+  t.is(attribute.divisor, 1, 'divisor prop is updated');
+
+  attribute.update({divisor: 0});
+  t.is(attribute.divisor, 0, 'divisor prop is updated');
+
+  // gpu aggregation use case
+  buffer = new Buffer(gl, {byteLength: 1024, accessor: {type: GL.FLOAT, divisor: 1}});
+  buffer = new Buffer(gl, {byteLength: 1024, accessor: {type: GL.FLOAT, divisor: 1}});
+  attribute.update({buffer});
+  t.is(attribute.divisor, 1, 'divisor prop is updated using buffer prop');
+
+  attribute.delete();
+
+  t.end();
+});
+
+test('WebGL#BaseAttribute getBuffer', t => {
+  const attribute = new BaseAttribute(gl, {size: 4, value: value1});
+  t.is(attribute.getBuffer(), attribute.buffer, 'getBuffer returns own buffer');
+
+  const buffer = new Buffer(gl, {data: value1});
+  attribute.update({buffer});
+  t.is(attribute.getBuffer(), buffer, 'getBuffer returns user supplied buffer');
+
+  attribute.update({value: value2});
+  t.is(attribute.getBuffer(), attribute.buffer, 'getBuffer returns own buffer');
+
+  attribute.update({constant: true, value: [0, 0, 0, 0]});
+  t.is(attribute.getBuffer(), null, 'getBuffer returns null for generic attributes');
+
+  attribute.update({buffer});
+  t.is(attribute.getBuffer(), buffer, 'getBuffer returns user supplied buffer');
+
+  attribute.delete();
+
+  t.end();
+});
+
+test('WebGL#BaseAttribute getValue', t => {
+  const attribute = new BaseAttribute(gl, {size: 4, value: value1});
+  t.is(attribute.getValue()[0], attribute.buffer, 'getValue returns own buffer');
+
+  const buffer = new Buffer(gl, {data: value1});
+  attribute.update({buffer});
+  t.is(attribute.getValue()[0], buffer, 'getValue returns user supplied buffer');
+
+  attribute.update({value: value2});
+  t.is(attribute.getValue()[0], attribute.buffer, 'getValue returns own buffer');
+
+  attribute.update({constant: true, value: value1});
+  t.is(attribute.getValue(), value1, 'getValue returns generic value');
+
+  attribute.update({buffer});
+  t.is(attribute.getValue()[0], buffer, 'getValue returns user supplied buffer');
+
+  attribute.delete();
+
+  t.end();
+});
+
+// If the vertex shader has more components than the array provides,
+// the extras are given values from the vector (0, 0, 0, 1) for the missing XYZW components.
+// https://www.khronos.org/opengl/wiki/Vertex_Specification#Vertex_format
+test('BaseAttribute#missing component', t => {
+  if (isHeadlessGL(gl)) {
+    // headless-gl does not seem to implement this behavior
+    t.comment('Skipping headless-gl');
+    t.end();
+    return;
+  }
+
+  const getModel = (gl, {attributeName, type, accessor}) =>
+    new Model(gl, {
+      vs: `
+  attribute vec3 position;
+  attribute ${type} ${attributeName};
+  varying vec4 vColor;
+  void main(void) {
+    vColor = vec4(${accessor});
+    gl_Position = vec4(position.xy, 0.0, 1.0);
+    gl_PointSize = 2.0;
+  }
+  `,
+      fs: `
+  precision highp float;
+  varying vec4 vColor;
+  void main(void) {
+    gl_FragColor = vColor;
+  }
+  `,
+      drawMode: GL.POINTS,
+      vertexCount: 4,
+      attributes: {
+        position: [
+          new Buffer(gl, new Float32Array([-1, -1, 0, 1, -1, 0, -1, 1, 0, 1, 1, 0])),
+          {size: 3}
+        ]
+      }
+    });
+
+  function getTestCases(gl) {
+    return [
+      // This doesn't work for vec2
+      // {
+      //   attributeName: 'texCoord',
+      //   type: 'vec2',
+      //   accessor: 'texCoord, 0.0, 1.0',
+      //   attributes: {
+      //     size: {
+      //       size: 1,
+      //       value: new Float32Array([0.5, 1, 0.25, 0])
+      //     }
+      //   },
+      //   output: [128, 0, 0, 255, 255, 0, 0, 255, 64, 0, 0, 255, 0, 0, 0, 255]
+      // },
+      {
+        attributeName: 'size',
+        type: 'vec3',
+        accessor: 'size, 1.0',
+        attributes: {
+          size: [new Buffer(gl, new Float32Array([0.5, 0, 1, 0.5, 0, 1, 0.5, 1])), {size: 2}]
+        },
+        output: [128, 0, 0, 255, 255, 128, 0, 255, 0, 255, 0, 255, 128, 255, 0, 255]
+      },
+      {
+        attributeName: 'size',
+        type: 'vec3',
+        accessor: 'size, 1.0',
+        attributes: {
+          size: [
+            new Buffer(gl, new Float32Array([0.5, 0, 1, 1, 0.5, 1, 0, 1, 1, 0.5, 1, 1])),
+            {size: 2, stride: 12}
+          ]
+        },
+        output: [128, 0, 0, 255, 255, 128, 0, 255, 0, 255, 0, 255, 128, 255, 0, 255]
+      },
+      {
+        attributeName: 'color',
+        type: 'vec4',
+        accessor: 'color / 255.0',
+        attributes: {
+          color: [
+            new Buffer(
+              gl,
+              new Uint8ClampedArray([32, 100, 40, 64, 64, 64, 128, 0, 0, 255, 18, 255])
+            ),
+            {size: 3}
+          ]
+        },
+        output: [32, 100, 40, 1, 64, 64, 64, 1, 128, 0, 0, 1, 255, 18, 255, 1]
+      }
+    ];
+  }
+
+  // Tests from luma.gl originally iterated over both WebGL1 and WebGL2 contexts
+  // for (const contextName in contexts) {
+  //   const gl = contexts[contextName];
+
+  if (gl) {
+    t.comment(isWebGL2(gl) ? 'WebGL2' : 'WebGL1');
+    const testCases = getTestCases(gl);
+
+    testCases.forEach(tc => {
+      const model = getModel(gl, tc);
+      const framebuffer = new Framebuffer(gl, {width: 2, height: 2});
+
+      model.draw({
+        framebuffer,
+        attributes: tc.attributes,
+        parameters: {viewport: [0, 0, 2, 2]}
+      });
+
+      t.deepEqual(
+        Array.from(readPixelsToArray(framebuffer)),
+        tc.output,
+        `${tc.type} missing components have expected values`
+      );
+
+      // Release resources
+      framebuffer.delete();
+      model.delete();
+    });
+  }
+
+  t.end();
+});

--- a/test/modules/core/lib/index.js
+++ b/test/modules/core/lib/index.js
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+import './base-attribute.spec';
 import './attribute.spec';
 import './attribute-manager.spec';
 import './attribute-transition-manager.spec';


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- luma `Model` now longer imports the `Attribute` class, it just [checks for `attribute.getValue()`](https://github.com/uber/luma.gl/blob/master/modules/core/src/core/model.js#L102) and calls it if present.
- No code in luma uses the `Attribute` class directly. 
- By copying it here, we can remove it in luma.
#### Change List
- Copy `Attribute` class to `lib` as `BaseAttribute`
- Extend `Attribute` from `BaseAttribute`
#### TODO
- if approved, I will move `attribute.spec` as well and update.