### PR TITLE
Restore source transpilation in local example config

### DIFF
--- a/examples/webpack.config.local.js
+++ b/examples/webpack.config.local.js
@@ -73,6 +73,19 @@ function makeLocalDevConfig(EXAMPLE_DIR = LIB_DIR, linkToLuma) {
           test: /\.js$/,
           use: ['source-map-loader'],
           enforce: 'pre'
+        },
+        {
+          // Compile source using buble
+          test: /\.js$/,
+          loader: 'buble-loader',
+          include: [`${ROOT_DIR}/modules`],
+          options: {
+            objectAssign: 'Object.assign',
+            transforms: {
+              dangerousForOf: true,
+              modules: false
+            }
+          }
         }
       ]
     }


### PR DESCRIPTION
The removal of the rule breaks custom layer examples - `class A extends Layer` breaks if the app is transpiled while `Layer` is es6.