### PR TITLE
Fix attribute transition

### DIFF
--- a/modules/core/src/lib/attribute-transition-manager.js
+++ b/modules/core/src/lib/attribute-transition-manager.js
@@ -2,6 +2,7 @@ import GL from '@luma.gl/constants';
 import {Buffer, Transform} from '@luma.gl/core';
 import {getShaders, getBuffers, padBuffer} from './attribute-transition-utils';
 import Attribute from './attribute';
+import BaseAttribute from './base-attribute';
 import Transition from '../transitions/transition';
 import log from '../utils/log';
 import assert from '../utils/assert';
@@ -226,16 +227,17 @@ export default class AttributeTransitionManager {
 
     let toState;
     if (attribute.constant) {
-      toState = {constant: true, value: attribute.value, size};
+      toState = new BaseAttribute(this.gl, {constant: true, value: attribute.value, size});
     } else {
-      toState = {
+      toState = new BaseAttribute(this.gl, {
         constant: false,
         buffer: attribute.getBuffer(),
+        divisor: 0,
         size,
         // attribute's `value` does not match the content of external buffer,
         // will need to call buffer.getData if needed
         value: attribute.externalBuffer ? null : attribute.value
-      };
+      });
     }
     const fromState = transition.buffer || toState;
     const toLength = this.numInstances * size;

--- a/modules/core/src/lib/attribute-transition-utils.js
+++ b/modules/core/src/lib/attribute-transition-utils.js
@@ -64,7 +64,8 @@ export function getBuffers(transitions) {
   const feedbackBuffers = {};
   for (const attributeName in transitions) {
     const {fromState, toState, buffer} = transitions[attributeName];
-    sourceBuffers[`${attributeName}From`] = fromState;
+    sourceBuffers[`${attributeName}From`] =
+      fromState instanceof Buffer ? [fromState, {divisor: 0}] : fromState;
     sourceBuffers[`${attributeName}To`] = toState;
     feedbackBuffers[`${attributeName}`] = buffer;
   }
@@ -90,11 +91,11 @@ export function padBuffer({
   const data = new Float32Array(toLength);
   const fromData = fromState.getData({});
 
-  const {value, buffer, size, constant} = toState;
-  const toData = value || buffer.getData({});
+  const {size, constant} = toState;
+  const toData = constant ? toState.getValue : toState.getBuffer().getData({});
 
   const getMissingData = constant
-    ? (i, chunk) => getData(value, chunk)
+    ? (i, chunk) => getData(toData, chunk)
     : (i, chunk) => getData(toData.subarray(i, i + size), chunk);
 
   padArray({

--- a/modules/core/src/lib/attribute-transition-utils.js
+++ b/modules/core/src/lib/attribute-transition-utils.js
@@ -92,7 +92,7 @@ export function padBuffer({
   const fromData = fromState.getData({});
 
   const {size, constant} = toState;
-  const toData = constant ? toState.getValue : toState.getBuffer().getData({});
+  const toData = constant ? toState.getValue() : toState.getBuffer().getData({});
 
   const getMissingData = constant
     ? (i, chunk) => getData(toData, chunk)

--- a/test/apps/attribute-transition/app.js
+++ b/test/apps/attribute-transition/app.js
@@ -3,13 +3,7 @@
 import React, {Component} from 'react';
 import {render} from 'react-dom';
 import {StaticMap} from 'react-map-gl';
-import DeckGL, {
-  COORDINATE_SYSTEM,
-  MapView,
-  ScatterplotLayer,
-  PolygonLayer,
-  MapController
-} from 'deck.gl';
+import DeckGL, {COORDINATE_SYSTEM, ScatterplotLayer, PolygonLayer, MapController} from 'deck.gl';
 
 import DataGenerator from './data-generator';
 
@@ -83,14 +77,12 @@ class Root extends Component {
     return (
       <div>
         <DeckGL
-          views={new MapView({id: 'map'})}
           controller={MapController}
           viewState={viewState}
           onViewStateChange={evt => this.setState({viewState: evt.viewState})}
           layers={layers}
         >
           <StaticMap
-            viewId="map"
             {...viewState}
             mapStyle="mapbox://styles/mapbox/light-v9"
             mapboxApiAccessToken={MAPBOX_TOKEN}


### PR DESCRIPTION
#### Background

Attribute transition is throwing `Found instanced attributes on non-instanced model transform-model` error. E.g. `instancePositionsFrom` and `instancePositionsTo` are not supposed to be instanced in the transform feedback model, but they are auto-inferred to be based on their names.

#### Change List
- Stop using attribute descriptors in AttributeTransitionManager.
