### PR TITLE
Use the same animation loop for render, attribute transitions and viewport transitions

### DIFF
--- a/modules/core/src/controllers/controller.js
+++ b/modules/core/src/controllers/controller.js
@@ -180,6 +180,10 @@ export default class Controller {
   }
   /* eslint-enable complexity, max-statements */
 
+  updateTransition(timestamp) {
+    this.transitionManager.updateTransition(timestamp);
+  }
+
   toggleEvents(eventNames, enabled) {
     if (this.eventManager) {
       eventNames.forEach(eventName => {

--- a/modules/core/src/lib/attribute-manager.js
+++ b/modules/core/src/lib/attribute-manager.js
@@ -266,9 +266,9 @@ export default class AttributeManager {
 
   // Update attribute transition to the current timestamp
   // Returns `true` if any transition is in progress
-  updateTransition() {
+  updateTransition(timestamp) {
     const {attributeTransitionManager} = this;
-    const transitionUpdated = attributeTransitionManager.setCurrentTime(Date.now());
+    const transitionUpdated = attributeTransitionManager.setCurrentTime(timestamp);
     this.needsRedraw = this.needsRedraw || transitionUpdated;
     return transitionUpdated;
   }

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -669,7 +669,9 @@ export default class Deck {
     // Update viewport transition if needed
     // Note: this can trigger `onViewStateChange`, and affect layers
     // We want to defer these changes to the next frame
-    this.viewManager.updateViewStates(animationProps);
+    if (this.viewManager) {
+      this.viewManager.updateViewStates(animationProps);
+    }
   }
 
   // Callbacks

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -655,7 +655,7 @@ export default class Deck {
 
     // Update layers if needed (e.g. some async prop has loaded)
     // Note: This can trigger a redraw
-    this.layerManager.updateLayers();
+    this.layerManager.updateLayers(animationProps);
 
     // Needs to be done before drawing
     this._updateAnimationProps(animationProps);
@@ -665,6 +665,11 @@ export default class Deck {
 
     // Redraw if necessary
     this.redraw(false);
+
+    // Update viewport transition if needed
+    // Note: this can trigger `onViewStateChange`, and affect layers
+    // We want to defer these changes to the next frame
+    this.viewManager.updateViewStates(animationProps);
   }
 
   // Callbacks

--- a/modules/core/src/lib/layer-manager.js
+++ b/modules/core/src/lib/layer-manager.js
@@ -45,6 +45,7 @@ const INITIAL_CONTEXT = Object.seal({
   layerManager: null,
   deck: null,
   gl: null,
+  time: -1,
 
   // Settings
   useDevicePixels: true, // Exposed in case custom layers need to adjust sizes
@@ -199,7 +200,10 @@ export default class LayerManager {
   }
 
   // Update layers from last cycle if `setNeedsUpdate()` has been called
-  updateLayers() {
+  updateLayers(animationProps = {}) {
+    if ('time' in animationProps) {
+      this.context.time = animationProps.time;
+    }
     // NOTE: For now, even if only some layer has changed, we update all layers
     // to ensure that layer id maps etc remain consistent even if different
     // sublayers are rendered
@@ -459,7 +463,6 @@ export default class LayerManager {
     }
 
     setPropOverrides(payload.itemKey, payload.valuePath.slice(1), payload.value);
-    const newLayers = this.layers.map(layer => new layer.constructor(layer.props));
-    this.updateLayers({newLayers});
+    this.updateLayers();
   }
 }

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -404,7 +404,7 @@ export default class Layer extends Component {
   updateTransition() {
     const attributeManager = this.getAttributeManager();
     if (attributeManager) {
-      attributeManager.updateTransition();
+      attributeManager.updateTransition(this.context.time);
     }
   }
 

--- a/modules/core/src/lib/view-manager.js
+++ b/modules/core/src/lib/view-manager.js
@@ -77,6 +77,14 @@ export default class ViewManager {
     this._needsRedraw = this._needsRedraw || reason;
   }
 
+  updateViewStates(animationProps = {}) {
+    if ('time' in animationProps) {
+      for (const viewId in this.controllers) {
+        this.controllers[viewId].updateTransition(animationProps.time);
+      }
+    }
+  }
+
   /** Get a set of viewports for a given width and height
    * TODO - Intention is for deck.gl to autodeduce width and height and drop the need for props
    * @param rect (object, optional) - filter the viewports

--- a/modules/core/src/lib/view-manager.js
+++ b/modules/core/src/lib/view-manager.js
@@ -77,6 +77,7 @@ export default class ViewManager {
     this._needsRedraw = this._needsRedraw || reason;
   }
 
+  // Checks each viewport for transition updates
   updateViewStates(animationProps = {}) {
     if ('time' in animationProps) {
       for (const viewId in this.controllers) {

--- a/modules/core/src/lib/view-manager.js
+++ b/modules/core/src/lib/view-manager.js
@@ -80,7 +80,10 @@ export default class ViewManager {
   updateViewStates(animationProps = {}) {
     if ('time' in animationProps) {
       for (const viewId in this.controllers) {
-        this.controllers[viewId].updateTransition(animationProps.time);
+        const controller = this.controllers[viewId];
+        if (controller) {
+          controller.updateTransition(animationProps.time);
+        }
       }
     }
   }

--- a/test/modules/core/lib/transition-manager.spec.js
+++ b/test/modules/core/lib/transition-manager.spec.js
@@ -174,11 +174,14 @@ test('TransitionManager#callbacks', t => {
     transitionManager.processViewStateChange(transitionProps);
   });
 
-  setTimeout(() => {
-    t.is(startCount, 2, 'onTransitionStart() called twice');
-    t.is(interruptCount, 1, 'onTransitionInterrupt() called once');
-    t.is(endCount, 1, 'onTransitionEnd() called once');
-    t.ok(updateCount > 2, 'onViewStateChange() called');
-    t.end();
-  }, 1000);
+  transitionManager.updateTransition(200);
+  transitionManager.updateTransition(400);
+  transitionManager.updateTransition(600);
+  transitionManager.updateTransition(800);
+
+  t.is(startCount, 2, 'onTransitionStart() called twice');
+  t.is(interruptCount, 1, 'onTransitionInterrupt() called once');
+  t.is(endCount, 1, 'onTransitionEnd() called once');
+  t.is(updateCount, 3, 'onViewStateChange() called');
+  t.end();
 });


### PR DESCRIPTION
#### Background

This PR is preparation for:

- Supporting externally provided world clock (replaces `Date.now()`) for more robust testing & video capture
- Fixing render synchronization issues in React

#### Change List

- Use `animationProps` from `AnimationLoop` to drive attribute transitions
- Use `animationProps` from `AnimationLoop` to drive viewport transitions
