### PR TITLE
Fix onHover behavior

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -16,7 +16,7 @@
 
 **Breaking Changes**
 
-- `onLayerHover` and `onLayerClick` props are replaced with `onHover` and `onClick`. The first argument passed to the callback will always be an [picking info](/docs/developer-guide/interactivity.md#the-picking-info-object) object, and the second argument is the pointer event. This change makes these two events consistent with other event callbacks.
+- `onLayerHover` and `onLayerClick` props are replaced with `onHover` and `onClick`. The first argument passed to the callback will always be a valid [picking info](/docs/developer-guide/interactivity.md#the-picking-info-object) object, and the second argument is the pointer event. This change makes these two events behave consistently with other event callbacks.
 
 #### Layers
 

--- a/examples/layer-browser/src/components/layer-info.js
+++ b/examples/layer-browser/src/components/layer-info.js
@@ -15,22 +15,24 @@ export default class LayerInfo extends PureComponent {
 
     return (
       <div id="layer-info">
-        {hovered && (
-          <div>
-            <h4>Hover</h4>
-            <span>
-              Layer: {hovered.layer.id} Object: {this._infoToString(hovered)}
-            </span>
-          </div>
-        )}
-        {clicked && (
-          <div>
-            <h4>Click</h4>
-            <span>
-              Layer: {clicked.layer.id} Object: {this._infoToString(clicked)}
-            </span>
-          </div>
-        )}
+        {hovered &&
+          hovered.object && (
+            <div>
+              <h4>Hover</h4>
+              <span>
+                Layer: {hovered.layer.id} Object: {this._infoToString(hovered)}
+              </span>
+            </div>
+          )}
+        {clicked &&
+          clicked.object && (
+            <div>
+              <h4>Click</h4>
+              <span>
+                Layer: {clicked.layer.id} Object: {this._infoToString(clicked)}
+              </span>
+            </div>
+          )}
         {queried && (
           <div>
             <h4>Pick Result</h4>

--- a/modules/core/src/lib/deck-picker.js
+++ b/modules/core/src/lib/deck-picker.js
@@ -215,17 +215,12 @@ export default class DeckPicker {
       }
     }
 
-    if (result.length === 0 && infos) {
-      // result should always contain something
-      result.push(infos.get(null));
-    }
-
     // reset only affected buffers
     Object.keys(affectedLayers).forEach(layerId =>
       layers[layerId].restorePickingColors(affectedLayers[layerId])
     );
 
-    return result;
+    return {result, emptyInfo: infos && infos.get(null)};
   }
 
   // Pick all objects within the given bounding box

--- a/modules/core/src/lib/deck-picker.js
+++ b/modules/core/src/lib/deck-picker.js
@@ -350,11 +350,8 @@ export default class DeckPicker {
     infos.forEach(info => {
       let handled = false;
       switch (mode) {
-        case 'click':
-          handled = info.layer.onClick(info, pickingEvent);
-          break;
         case 'hover':
-          handled = info.layer.onHover(info, pickingEvent);
+          handled = info.layer && info.layer.onHover(info, pickingEvent);
           break;
         case 'query':
           break;

--- a/modules/core/src/lib/deck-picker.js
+++ b/modules/core/src/lib/deck-picker.js
@@ -136,6 +136,7 @@ export default class DeckPicker {
   }
 
   // Pick the closest object at the given (x,y) coordinate
+  // eslint-disable-next-line max-statements
   pickClosestObject({layers, viewports, x, y, radius, depth = 1, mode, onViewportActive}) {
     this.updatePickingBuffer();
     // Convert from canvas top-left to WebGL bottom-left coordinates
@@ -153,6 +154,7 @@ export default class DeckPicker {
       deviceHeight: height
     });
 
+    let infos;
     const result = [];
     const affectedLayers = {};
 
@@ -188,7 +190,7 @@ export default class DeckPicker {
       }
 
       // This logic needs to run even if no object is picked.
-      const infos = processPickInfo({
+      infos = processPickInfo({
         pickInfo,
         lastPickedInfo: this.lastPickedInfo,
         mode,
@@ -211,6 +213,11 @@ export default class DeckPicker {
       if (!pickInfo.pickedColor) {
         break;
       }
+    }
+
+    if (result.length === 0 && infos) {
+      // result should always contain something
+      result.push(infos.get(null));
     }
 
     // reset only affected buffers
@@ -348,10 +355,14 @@ export default class DeckPicker {
     const pickingEvent = this.pickingEvent;
 
     infos.forEach(info => {
+      if (!info.layer) {
+        return;
+      }
+
       let handled = false;
       switch (mode) {
         case 'hover':
-          handled = info.layer && info.layer.onHover(info, pickingEvent);
+          handled = info.layer.onHover(info, pickingEvent);
           break;
         case 'query':
           break;

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -314,7 +314,7 @@ export default class Deck {
       activateViewport,
       mode: 'query',
       depth: 1
-    });
+    }).result;
     this.stats.get('pickObject Time').timeEnd();
     return selectedInfos.length ? selectedInfos[0] : null;
   }
@@ -332,7 +332,7 @@ export default class Deck {
       activateViewport,
       mode: 'query',
       depth
-    });
+    }).result;
     this.stats.get('pickMultipleObjects Time').timeEnd();
     return selectedInfos;
   }
@@ -497,7 +497,7 @@ export default class Deck {
 
     if (_pickRequest.mode) {
       // perform picking
-      const selectedInfos = this.deckPicker.pickObject(
+      const {result, emptyInfo} = this.deckPicker.pickObject(
         Object.assign(
           {
             layers: this.layerManager.getLayers(),
@@ -508,9 +508,9 @@ export default class Deck {
           _pickRequest
         )
       );
-      if (_pickRequest.callback && selectedInfos.length) {
-        const firstInfo = selectedInfos.find(info => info.index >= 0) || selectedInfos[0];
-        _pickRequest.callback(firstInfo, _pickRequest.event);
+      if (_pickRequest.callback) {
+        const pickedInfo = result.find(info => info.index >= 0) || emptyInfo;
+        _pickRequest.callback(pickedInfo, _pickRequest.event);
       }
       _pickRequest.mode = null;
     }

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -508,9 +508,8 @@ export default class Deck {
           _pickRequest
         )
       );
-      if (_pickRequest.callback && selectedInfos) {
+      if (_pickRequest.callback && selectedInfos.length) {
         const firstInfo = selectedInfos.find(info => info.index >= 0) || selectedInfos[0];
-        // As per documentation, send null value when no valid object is picked.
         _pickRequest.callback(firstInfo, _pickRequest.event);
       }
       _pickRequest.mode = null;

--- a/modules/core/src/lib/picking/pick-info.js
+++ b/modules/core/src/lib/picking/pick-info.js
@@ -87,6 +87,9 @@ export function processPickInfo({
   // Please be very careful when changing this pattern
   const infos = new Map();
 
+  // Make sure infos always contain something even if no layer is affected
+  infos.set(null, baseInfo);
+
   affectedLayers.forEach(layer => {
     let info = Object.assign({}, baseInfo);
 
@@ -119,11 +122,6 @@ export function processPickInfo({
       layer.setNeedsRedraw();
     }
   });
-
-  if (infos.size === 0) {
-    // Always populate infos, even if no layer is affected
-    infos.set(null, baseInfo);
-  }
 
   return infos;
 }

--- a/modules/core/src/lib/picking/pick-info.js
+++ b/modules/core/src/lib/picking/pick-info.js
@@ -120,6 +120,11 @@ export function processPickInfo({
     }
   });
 
+  if (infos.size === 0) {
+    // Always populate infos, even if no layer is affected
+    infos.set(null, baseInfo);
+  }
+
   return infos;
 }
 

--- a/test/modules/core/lib/pick-layers.spec.js
+++ b/test/modules/core/lib/pick-layers.spec.js
@@ -405,8 +405,12 @@ test(`pickingTest`, t => {
     for (const pickingMethod in pickingMethods) {
       for (const pickingCase of pickingMethods[pickingMethod]) {
         pickInfos = deck[pickingMethod](pickingCase.parameters);
+        t.ok(pickInfos, `${testCase.id}: ${pickingMethod} should return non-empty result)`);
+        if (!Array.isArray(pickInfos)) {
+          pickInfos = [pickInfos];
+        }
         t.equal(
-          !pickInfos ? 0 : !Array.isArray(pickInfos) ? 1 : pickInfos.length,
+          pickInfos.filter(info => info.index >= 0).length,
           pickingCase.results.count,
           `${testCase.id}: ${pickingMethod} should find expected number of objects`
         );

--- a/test/modules/core/lib/pick-layers.spec.js
+++ b/test/modules/core/lib/pick-layers.spec.js
@@ -405,12 +405,8 @@ test(`pickingTest`, t => {
     for (const pickingMethod in pickingMethods) {
       for (const pickingCase of pickingMethods[pickingMethod]) {
         pickInfos = deck[pickingMethod](pickingCase.parameters);
-        t.ok(pickInfos, `${testCase.id}: ${pickingMethod} should return non-empty result)`);
-        if (!Array.isArray(pickInfos)) {
-          pickInfos = [pickInfos];
-        }
         t.equal(
-          pickInfos.filter(info => info.index >= 0).length,
+          !pickInfos ? 0 : !Array.isArray(pickInfos) ? 1 : pickInfos.length,
           pickingCase.results.count,
           `${testCase.id}: ${pickingMethod} should find expected number of objects`
         );


### PR DESCRIPTION
#### Background

The new `onHover` callback (replaces `onLayerHover`) should always return a non-empty first argument per documentation.

#### Change List

- `pickObject` returns a valid picking info object (with `index: -1` and current pixel information) even if nothing is picked
- Fix layer browser crash
