### PR TITLE
Revert min-pixels prop default

### DIFF
--- a/docs/layers/arc-layer.md
+++ b/docs/layers/arc-layer.md
@@ -108,7 +108,7 @@ The scaling multiplier for the width of each line. This prop is a very efficient
 
 ##### `widthMinPixels` (Number, optional)
 
-* Default: `1`
+* Default: `0`
 
 The minimum line width in pixels. This prop can be used to prevent the line from getting too thin when zoomed out.
 

--- a/docs/layers/icon-layer.md
+++ b/docs/layers/icon-layer.md
@@ -196,7 +196,7 @@ The units of the size specified by `getSize`, one of `'meters'`, `'pixels'`. Whe
 
 ##### `sizeMinPixels` (Number, optional)
 
-* Default: `1`
+* Default: `0`
 
 The minimum size in pixels.
 

--- a/docs/layers/line-layer.md
+++ b/docs/layers/line-layer.md
@@ -109,7 +109,7 @@ The scaling multiplier for the width of each line. This prop is a very efficient
 
 ##### `widthMinPixels` (Number, optional)
 
-* Default: `1`
+* Default: `0`
 
 The minimum line width in pixels. This prop can be used to prevent the line from getting to thin when zoomed out.
 

--- a/docs/layers/path-layer.md
+++ b/docs/layers/path-layer.md
@@ -97,13 +97,13 @@ The path width multiplier that multiplied to all paths.
 
 * Default: `0`
 
-The minimum path width in pixels.
+The minimum path width in pixels. This prop can be used to prevent the path from getting too thin when zoomed out.
 
 ##### `widthMaxPixels` (Number, optional)
 
 * Default: Number.MAX_SAFE_INTEGER
 
-The maximum path width in pixels.
+The maximum path width in pixels. This prop can be used to prevent the path from getting too thick when zoomed in.
 
 ##### `rounded` (Boolean, optional)
 

--- a/docs/layers/scatterplot-layer.md
+++ b/docs/layers/scatterplot-layer.md
@@ -116,27 +116,27 @@ Draw the filled area of a point.
 
 ##### `radiusMinPixels` (Number, optional)
 
-* Default: `1`
+* Default: `0`
 
-The minimum radius in pixels.
+The minimum radius in pixels. This prop can be used to prevent the circle from getting too small when zoomed out.
 
 ##### `radiusMaxPixels` (Number, optional)
 
 * Default: `Number.MAX_SAFE_INTEGER`
 
-The maximum radius in pixels.
+The maximum radius in pixels. This prop can be used to prevent the circle from getting too big when zoomed in.
 
 ##### `lineWidthMinPixels` (Number, optional)
 
-* Default: `1`
+* Default: `0`
 
-The minimum line width in pixels.
+The minimum line width in pixels. This prop can be used to prevent the stroke from getting too thin when zoomed out.
 
 ##### `lineWidthMaxPixels` (Number, optional)
 
 * Default: `Number.MAX_SAFE_INTEGER`
 
-The maximum line width in pixels.
+The maximum line width in pixels. This prop can be used to prevent the path from getting too thick when zoomed in.
 
 
 ##### `fp64` (Boolean, optional)

--- a/docs/layers/text-layer.md
+++ b/docs/layers/text-layer.md
@@ -98,7 +98,7 @@ The units of the size specified by `getSize`, one of `'meters'`, `'pixels'`. Whe
 
 ##### `sizeMinPixels` (Number, optional)
 
-* Default: `1`
+* Default: `0`
 
 The minimum size in pixels.
 

--- a/modules/layers/src/arc-layer/arc-layer.js
+++ b/modules/layers/src/arc-layer/arc-layer.js
@@ -43,7 +43,7 @@ const defaultProps = {
 
   widthUnits: 'pixels',
   widthScale: {type: 'number', value: 1, min: 0},
-  widthMinPixels: {type: 'number', value: 1, min: 0},
+  widthMinPixels: {type: 'number', value: 0, min: 0},
   widthMaxPixels: {type: 'number', value: Number.MAX_SAFE_INTEGER, min: 0},
 
   // Deprecated, remove in v8

--- a/modules/layers/src/line-layer/line-layer.js
+++ b/modules/layers/src/line-layer/line-layer.js
@@ -38,7 +38,7 @@ const defaultProps = {
 
   widthUnits: 'pixels',
   widthScale: {type: 'number', value: 1, min: 0},
-  widthMinPixels: {type: 'number', value: 1, min: 0},
+  widthMinPixels: {type: 'number', value: 0, min: 0},
   widthMaxPixels: {type: 'number', value: Number.MAX_SAFE_INTEGER, min: 0},
 
   // Deprecated, remove in v8

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer.js
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer.js
@@ -30,12 +30,12 @@ const DEFAULT_COLOR = [0, 0, 0, 255];
 
 const defaultProps = {
   radiusScale: {type: 'number', min: 0, value: 1},
-  radiusMinPixels: {type: 'number', min: 0, value: 1}, //  min point radius in pixels
+  radiusMinPixels: {type: 'number', min: 0, value: 0}, //  min point radius in pixels
   radiusMaxPixels: {type: 'number', min: 0, value: Number.MAX_SAFE_INTEGER}, // max point radius in pixels
 
   lineWidthUnits: 'meters',
   lineWidthScale: {type: 'number', min: 0, value: 1},
-  lineWidthMinPixels: {type: 'number', min: 0, value: 1},
+  lineWidthMinPixels: {type: 'number', min: 0, value: 0},
   lineWidthMaxPixels: {type: 'number', min: 0, value: Number.MAX_SAFE_INTEGER},
 
   stroked: false,


### PR DESCRIPTION
#### Background

Prior to introducing `widthUnits`, we agreed to change the default value of `widthMinPixels` from `0` to `1`. This decision was never fully implemented, and we have a bunch of inconsistencies between layers and their docs.

I find the resulting behavior very confusing when combined with `widthUnits: 'pixels'` (default in ArcLayer and LineLayer). In this case, `getWidth` is supposed to return width in pixels, but it is ineffective when returning a number smaller than 1. I would argue that this is unexpected behavior as the user did not specify `widthMinPixels` themselves.

I see two solutions to this:

- Default `*MinPixels` to `1` only if using meter units, otherwise `0`;
- Keep the defaults `0` and do not make any breaking change for v7.
