### PR TITLE
Fix external gl context usage

### DIFF
--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -434,8 +434,9 @@ export default class Deck {
       height,
       useDevicePixels,
       autoResizeDrawingBuffer,
+      gl,
       onCreateContext: opts =>
-        gl || createGLContext(Object.assign({}, glOptions, opts, {canvas: this.canvas, debug})),
+        createGLContext(Object.assign({}, glOptions, opts, {canvas: this.canvas, debug})),
       onInitialize: this._onRendererInitialized,
       onRender: this._onRenderFrame,
       onBeforeRender: props.onBeforeRender,


### PR DESCRIPTION
External gl context must be supplied to `AnimationLoop` as a prop for polyfill to work. This breaks the mapbox custom layer use case.
