### PR TITLE
Clean up customRender prop handling

### DIFF
--- a/modules/core/src/lib/deck-renderer.js
+++ b/modules/core/src/lib/deck-renderer.js
@@ -54,7 +54,7 @@ export default class DeckRenderer {
     activateViewport,
     views,
     redrawReason = 'unknown reason',
-    customRender = false,
+    clearCanvas = true,
     effects = [],
     pass,
     stats
@@ -67,7 +67,7 @@ export default class DeckRenderer {
       views,
       onViewportActive: activateViewport,
       redrawReason,
-      customRender,
+      clearCanvas,
       effects,
       effectProps
     });

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -593,7 +593,7 @@ export default class Deck {
     this.props.onLoad();
   }
 
-  _drawLayers(redrawReason, opts) {
+  _drawLayers(redrawReason, renderOptions) {
     const {gl} = this.layerManager.context;
 
     setParameters(gl, this.props.parameters);
@@ -614,7 +614,7 @@ export default class Deck {
           redrawReason,
           effects: this.effectManager.getEffects()
         },
-        opts
+        renderOptions
       )
     );
 

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -549,17 +549,15 @@ export default class Deck {
 
     this.props.onWebGLInitialized(gl);
 
-    if (!this.props._customRender) {
-      this.eventManager = new EventManager(gl.canvas, {
-        events: {
-          pointerdown: this._onPointerDown,
-          pointermove: this._onPointerMove,
-          pointerleave: this._onPointerLeave
-        }
-      });
-      for (const eventType in EVENTS) {
-        this.eventManager.on(eventType, this._onEvent);
+    this.eventManager = new EventManager(gl.canvas, {
+      events: {
+        pointerdown: this._onPointerDown,
+        pointermove: this._onPointerMove,
+        pointerleave: this._onPointerLeave
       }
+    });
+    for (const eventType in EVENTS) {
+      this.eventManager.on(eventType, this._onEvent);
     }
 
     this.viewManager = new ViewManager({
@@ -612,7 +610,7 @@ export default class Deck {
       views: this.viewManager.getViews(),
       pass: 'screen',
       redrawReason,
-      customRender: Boolean(this.props._customRender),
+      clearCanvas: !this.props._customRender,
       effects: this.effectManager.getEffects()
     });
 

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -593,7 +593,7 @@ export default class Deck {
     this.props.onLoad();
   }
 
-  _drawLayers(redrawReason) {
+  _drawLayers(redrawReason, opts) {
     const {gl} = this.layerManager.context;
 
     setParameters(gl, this.props.parameters);
@@ -603,16 +603,20 @@ export default class Deck {
     const layers = this.layerManager.getLayers();
     const activateViewport = this.layerManager.activateViewport;
 
-    this.deckRenderer.renderLayers({
-      layers,
-      viewports: this.viewManager.getViewports(),
-      activateViewport,
-      views: this.viewManager.getViews(),
-      pass: 'screen',
-      redrawReason,
-      clearCanvas: !this.props._customRender,
-      effects: this.effectManager.getEffects()
-    });
+    this.deckRenderer.renderLayers(
+      Object.assign(
+        {
+          layers,
+          viewports: this.viewManager.getViewports(),
+          activateViewport,
+          views: this.viewManager.getViews(),
+          pass: 'screen',
+          redrawReason,
+          effects: this.effectManager.getEffects()
+        },
+        opts
+      )
+    );
 
     this.props.onAfterRender({gl});
   }

--- a/modules/core/src/passes/layers-pass.js
+++ b/modules/core/src/passes/layers-pass.js
@@ -18,12 +18,12 @@ export default class LayersPass extends Pass {
     parameters = {},
     pass = 'draw',
     redrawReason = '',
-    customRender,
+    clearCanvas = true,
     effects,
     effectProps
   }) {
     const gl = this.gl;
-    if (!customRender) {
+    if (clearCanvas) {
       this.clearCanvas(gl);
     }
 

--- a/modules/core/src/passes/pick-layers-pass.js
+++ b/modules/core/src/passes/pick-layers-pass.js
@@ -48,7 +48,15 @@ export default class PickLayersPass extends LayersPass {
             blend: true,
             blendFunc: [gl.ONE, gl.ZERO, gl.CONSTANT_ALPHA, gl.ZERO],
             blendEquation: gl.FUNC_ADD,
-            blendColor: [0, 0, 0, 0]
+            blendColor: [0, 0, 0, 0],
+
+            // When used as Mapbox custom layer, the context state may be dirty
+            // TODO - Remove when mapbox fixes this issue
+            // https://github.com/mapbox/mapbox-gl-js/issues/7801
+            depthMask: true,
+            depthTest: true,
+            depthRange: [0, 1],
+            colorMask: [true, true, true, true]
           }
         });
       }

--- a/modules/mapbox/src/deck-utils.js
+++ b/modules/mapbox/src/deck-utils.js
@@ -61,6 +61,7 @@ export function updateLayer(deck, layer) {
 
 export function drawLayer(deck, layer) {
   deck._drawLayers('mapbox-repaint', {
+    // TODO - accept layerFilter in drawLayers' renderOptions
     layers: getLayers(deck, deckLayer => shouldDrawLayer(layer.id, deckLayer)),
     clearCanvas: false
   });
@@ -93,17 +94,20 @@ function afterRender(deck, map) {
 
     // Draw non-Mapbox layers
     const mapboxLayerIds = Array.from(mapboxLayers, layer => layer.id);
-    deck._drawLayers('mapbox-repaint', {
-      layers: getLayers(deck, deckLayer => {
-        for (const id of mapboxLayerIds) {
-          if (shouldDrawLayer(id, deckLayer)) {
-            return false;
-          }
+    const layers = getLayers(deck, deckLayer => {
+      for (const id of mapboxLayerIds) {
+        if (shouldDrawLayer(id, deckLayer)) {
+          return false;
         }
-        return true;
-      }),
-      clearCanvas: false
+      }
+      return true;
     });
+    if (layers.length > 0) {
+      deck._drawLayers('mapbox-repaint', {
+        layers,
+        clearCanvas: false
+      });
+    }
   }
 
   deck.needsRedraw({clearRedrawFlags: true});

--- a/modules/mapbox/src/deck-utils.js
+++ b/modules/mapbox/src/deck-utils.js
@@ -1,5 +1,4 @@
 import {Deck} from '@deck.gl/core';
-import {withParameters} from '@luma.gl/core';
 
 export function getDeckInstance({map, gl, deck}) {
   // Only create one deck instance per context
@@ -43,8 +42,6 @@ export function getDeckInstance({map, gl, deck}) {
   map.__deck = deck;
   map.on('render', () => afterRender(deck, map));
 
-  initEvents(map, deck);
-
   return deck;
 }
 
@@ -66,6 +63,7 @@ export function drawLayer(deck, layer) {
   // set layerFilter to only allow the current layer
   deck.deckRenderer.layerFilter = params => shouldDrawLayer(layer.id, params.layer);
   deck._drawLayers('mapbox-repaint');
+  deck.deckPicker.layerFilter = null;
 }
 
 export function getViewState(map, extraProps) {
@@ -104,6 +102,7 @@ function afterRender(deck, map) {
       return true;
     };
     deck._drawLayers('mapbox-repaint');
+    deck.deckPicker.layerFilter = null;
   }
 
   deck.needsRedraw({clearRedrawFlags: true});
@@ -132,74 +131,4 @@ function updateLayers(deck) {
     layers.push(layer);
   });
   deck.setProps({layers});
-}
-
-// Triggers picking on a mouse event
-function handleMouseEvent(deck, event) {
-  // reset layerFilter to allow all layers during picking
-  deck.deckPicker.layerFilter = null;
-
-  let callback;
-  switch (event.type) {
-    case 'click':
-      callback = deck._onClick;
-      break;
-
-    case 'mousemove':
-    case 'pointermove':
-      callback = deck._onPointerMove;
-      break;
-
-    case 'mouseleave':
-    case 'pointerleave':
-      callback = deck._onPointerLeave;
-      break;
-
-    default:
-      return;
-  }
-
-  if (!event.offsetCenter) {
-    // Map from mapbox's MapMouseEvent object to mjolnir.js' Event object
-    event = {
-      offsetCenter: event.point,
-      srcEvent: event.originalEvent
-    };
-  }
-
-  // Work around for https://github.com/mapbox/mapbox-gl-js/issues/7801
-  const {gl} = deck.layerManager.context;
-  withParameters(
-    gl,
-    {
-      depthMask: true,
-      depthTest: true,
-      depthRange: [0, 1],
-      colorMask: [true, true, true, true]
-    },
-    () => callback(event)
-  );
-}
-
-// Register deck callbacks for pointer events
-function initEvents(map, deck) {
-  const pickingEventHandler = event => handleMouseEvent(deck, event);
-
-  if (deck.eventManager) {
-    // Replace default event handlers with our own ones
-    deck.eventManager.off({
-      click: deck._onClick,
-      pointermove: deck._onPointerMove,
-      pointerleave: deck._onPointerLeave
-    });
-    deck.eventManager.on({
-      click: pickingEventHandler,
-      pointermove: pickingEventHandler,
-      pointerleave: pickingEventHandler
-    });
-  } else {
-    map.on('click', pickingEventHandler);
-    map.on('mousemove', pickingEventHandler);
-    map.on('mouseleave', pickingEventHandler);
-  }
 }

--- a/modules/mapbox/src/deck-utils.js
+++ b/modules/mapbox/src/deck-utils.js
@@ -62,7 +62,7 @@ export function updateLayer(deck, layer) {
 export function drawLayer(deck, layer) {
   // set layerFilter to only allow the current layer
   deck.deckRenderer.layerFilter = params => shouldDrawLayer(layer.id, params.layer);
-  deck._drawLayers('mapbox-repaint');
+  deck._drawLayers('mapbox-repaint', {clearCanvas: false});
   deck.deckPicker.layerFilter = null;
 }
 
@@ -101,7 +101,7 @@ function afterRender(deck, map) {
       }
       return true;
     };
-    deck._drawLayers('mapbox-repaint');
+    deck._drawLayers('mapbox-repaint', {clearCanvas: false});
     deck.deckPicker.layerFilter = null;
   }
 


### PR DESCRIPTION
#### Background

The `_customRender` prop does 3 things:
1. it is called instead of `drawLayers` on each redraw
2. it prevents the render pass from clearing the canvas
3. it prevents Deck from registering pointer events

2 & 3 are not implied in the prop name, and makes it very difficult for the user of this prop to control side effects.

The `_customRender` prop is currently only used in mapbox integration.

#### Change List
- `Deck` always create `EventManager` regardless of `_customRender`
- Remove `customRender` logic from `DeckRenderer` and `LayersPass`
- Simplify mapbox integration event handling logic - always use deck events
- Remove `layerFilter` hack from mapbox integration (was not working)