### PR TITLE
Minor doc fixes

### DIFF
--- a/docs/api-reference/standalone/deckgl.md
+++ b/docs/api-reference/standalone/deckgl.md
@@ -1,6 +1,6 @@
 # DeckGL (Scripting Interface)
 
-`DeckGL` extends the core [Deck](/docs/api-reference/deck.md) class with some additional features such as Mapbox integration. It offers a convenient way to use deck.gl in prototype environments such as [Codepen](https://codepen.io), [JSFiddle](https://jsfiddle.net) and [Observable](https://obervablehq.com). 
+`DeckGL` extends the core [Deck](/docs/api-reference/deck.md) class with some additional features such as Mapbox integration. It offers a convenient way to use deck.gl in prototype environments such as [Codepen](https://codepen.io), [JSFiddle](https://jsfiddle.net) and [Observable](https://observablehq.com). 
 
 Make sure to read the [Using deck.gl Scripting API](/docs/get-started/using-standalone.md) article.
 
@@ -18,7 +18,9 @@ new deck.DeckGL({
     new deck.ScatterplotLayer({
       data: [
         {position: [-122.45, 37.8], color: [255, 0, 0], radius: 100}
-      ]
+      ],
+      getColor: d => d.color,
+      getRadius: d => d.radius
     })
   ]
 });

--- a/docs/get-started/using-standalone.md
+++ b/docs/get-started/using-standalone.md
@@ -42,7 +42,7 @@ const deckgl = new Deck({
 
 ## Using the Scripting API
 
-deck.gl also offers a standalone bundled version of the library - a native JavaScript scripting interface like that of d3.js. You can now use deck.gl in prototype environments such as [Codepen](https://codepen.io), [JSFiddle](https://jsfiddle.net) and [Observable](https://obervablehq.com). This effort aims to make it easier for designers, creative coders and data scientists everywhere to leverage WebGL for interactive visualizations.
+deck.gl also offers a standalone bundled version of the library - a native JavaScript scripting interface like that of d3.js. You can now use deck.gl in prototype environments such as [Codepen](https://codepen.io), [JSFiddle](https://jsfiddle.net) and [Observable](https://observablehq.com). This effort aims to make it easier for designers, creative coders and data scientists everywhere to leverage WebGL for interactive visualizations.
 
 To use deck.gl in a scripting environment, include the standalone version in a `script` tag:
 


### PR DESCRIPTION
For #2892 

- Mention the props getFillColor and getRadius in the Standalone doc example for ScatterPlotLayer.

- Fix broken links for observablehq