### PR TITLE
Remove references to PolygonLayer demos in new H3 layer doc pages.

### DIFF
--- a/docs/layers/h3-cluster-layer.md
+++ b/docs/layers/h3-cluster-layer.md
@@ -1,5 +1,3 @@
-<!-- INJECT:"PolygonLayerDemo" -->
-
 <p class="badges">
   <img src="https://img.shields.io/badge/@deck.gl/geo--layers-lightgrey.svg?style=flat-square" alt="@deck.gl/geo-layers" />
   <img src="https://img.shields.io/badge/fp64-yes-blue.svg?style=flat-square" alt="64-bit" />

--- a/docs/layers/h3-hexagon-layer.md
+++ b/docs/layers/h3-hexagon-layer.md
@@ -1,5 +1,3 @@
-<!-- INJECT:"PolygonLayerDemo" -->
-
 <p class="badges">
   <img src="https://img.shields.io/badge/@deck.gl/geo--layers-lightgrey.svg?style=flat-square" alt="@deck.gl/geo-layers" />
   <img src="https://img.shields.io/badge/fp64-yes-blue.svg?style=flat-square" alt="64-bit" />


### PR DESCRIPTION
For #2892 (see Firefox testing issues list).

Remove references to PolygonLayer demos in new H3 layer doc pages.  Better to have no embedded demo than the incorrect one.
Filed issue #2979 to add missing H3 layer embedded examples in a future release.