### PR TITLE
fix effects comparing issue

### DIFF
--- a/modules/core/src/lib/effect-manager.js
+++ b/modules/core/src/lib/effect-manager.js
@@ -5,6 +5,8 @@ export default class EffectManager {
   constructor() {
     this.effects = [];
     this._needsRedraw = 'Initial render';
+    this.defaultLightingEffect = new LightingEffect();
+    this.needApplyDefaultLighting = false;
   }
 
   setProps(props) {
@@ -14,7 +16,7 @@ export default class EffectManager {
         this._needsRedraw = 'effects changed';
       }
     }
-    this.applyDefaultLightingEffect();
+    this.checkLightingEffect();
   }
 
   needsRedraw(opts = {clearRedrawFlags: false}) {
@@ -25,16 +27,21 @@ export default class EffectManager {
     return redraw;
   }
 
+  getEffects() {
+    let effects = this.effects;
+    if (this.needApplyDefaultLighting) {
+      effects = this.effects.slice();
+      effects.push(this.defaultLightingEffect);
+    }
+    return effects;
+  }
+
+  // Private
   setEffects(effects = []) {
     this.effects = effects;
   }
 
-  getEffects() {
-    return this.effects;
-  }
-
-  // Private
-  applyDefaultLightingEffect() {
+  checkLightingEffect() {
     let hasEffect = false;
     for (const effect of this.effects) {
       if (effect instanceof LightingEffect) {
@@ -42,8 +49,6 @@ export default class EffectManager {
         break;
       }
     }
-    if (!hasEffect) {
-      this.effects.push(new LightingEffect());
-    }
+    this.needApplyDefaultLighting = !hasEffect;
   }
 }


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
<!-- For other PRs without open issue -->
#### Background
The effects comparing is always fail in effects manager class because we added the default lighting.
<!-- For all the PRs -->
#### Change List
- use the right way to apply default lighting
