### PR TITLE
Fix compareProps perf

### DIFF
--- a/modules/core/src/lifecycle/props.js
+++ b/modules/core/src/lifecycle/props.js
@@ -76,7 +76,7 @@ export function compareProps({
   for (const key in oldProps) {
     if (!(key in ignoreProps)) {
       if (!(key in newProps)) {
-        return `${triggerName}.${key} dropped: ${oldProps[key]} -> undefined`;
+        return `${triggerName}.${key} dropped`;
       }
       const newProp = newProps[key];
       const oldProp = oldProps[key];
@@ -85,19 +85,19 @@ export function compareProps({
       // If prop type has an equal function, invoke it
       let equal = propType && propType.equal;
       if (equal && !equal(newProp, oldProp, propType)) {
-        return `${triggerName}.${key} changed deeply: ${oldProp} -> ${newProp}`;
+        return `${triggerName}.${key} changed deeply`;
       }
 
       if (!equal) {
         // If object has an equals function, invoke it
         equal = newProp && oldProp && newProp.equals;
         if (equal && !equal.call(newProp, oldProp)) {
-          return `${triggerName}.${key} changed deeply: ${oldProp} -> ${newProp}`;
+          return `${triggerName}.${key} changed deeply`;
         }
       }
 
       if (!equal && oldProp !== newProp) {
-        return `${triggerName}.${key} changed shallowly: ${oldProp} -> ${newProp}`;
+        return `${triggerName}.${key} changed shallowly`;
       }
     }
   }

--- a/test/bench/compare-props.bench.js
+++ b/test/bench/compare-props.bench.js
@@ -1,0 +1,99 @@
+// Copyright (c) 2015 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+/* eslint-disable no-console, no-invalid-this */
+
+import {Layer, ScatterplotLayer} from 'deck.gl';
+import {parsePropTypes} from '@deck.gl/core/lifecycle/prop-types';
+import {compareProps} from '@deck.gl/core/lifecycle/props';
+
+// sample prop types
+const propTypes = Object.assign(
+  {},
+  parsePropTypes(Layer.defaultProps).propTypes,
+  parsePropTypes(ScatterplotLayer.defaultProps).propTypes
+);
+
+const defaultProps = Object.assign(
+  {},
+  parsePropTypes(Layer.defaultProps).defaultProps,
+  parsePropTypes(ScatterplotLayer.defaultProps).defaultProps
+);
+
+// test cases
+const TEST_CASES = {
+  simple: {
+    oldProps: {size: 0, color: '#f00', data: []},
+    newProps: {size: 0, color: '#f00', data: []}
+  },
+  default: {
+    oldProps: Object.create(defaultProps),
+    newProps: Object.create(defaultProps),
+    propTypes
+  },
+  overrideFunc: {
+    oldProps: Object.assign(Object.create(defaultProps), {
+      getRadius: d => d.radius
+    }),
+    newProps: Object.assign(Object.create(defaultProps), {
+      getRadius: d => d.radius
+    }),
+    propTypes
+  },
+  overrideArray: {
+    oldProps: Object.assign(Object.create(defaultProps), {
+      modelMatrix: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
+    }),
+    newProps: Object.assign(Object.create(defaultProps), {
+      modelMatrix: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
+    }),
+    propTypes
+  },
+  overrideLargeArray: {
+    oldProps: Object.assign(Object.create(defaultProps), {
+      instancePositions: new Float32Array(1e6).fill(Math.PI)
+    }),
+    newProps: Object.assign(Object.create(defaultProps), {
+      instancePositions: new Float32Array(1e6).fill(Math.PI)
+    }),
+    propTypes
+  }
+};
+
+export default function comparePropsBench(suite) {
+  return suite
+    .group('COMPARE PROPS')
+
+    .add('compareProps#simple', () => {
+      compareProps(TEST_CASES.simple);
+    })
+    .add('compareProps#default', () => {
+      compareProps(TEST_CASES.default);
+    })
+    .add('compareProps#override function', () => {
+      compareProps(TEST_CASES.overrideFunc);
+    })
+    .add('compareProps#override array', () => {
+      compareProps(TEST_CASES.overrideArray);
+    })
+    .add('compareProps#override large array', () => {
+      compareProps(TEST_CASES.overrideLargeArray);
+    });
+}

--- a/test/bench/index.js
+++ b/test/bench/index.js
@@ -31,6 +31,7 @@ import gridAggregatorBench from './gpu-grid-aggregator.bench';
 import utilsBench from './utils.bench';
 import arrayCopyBench from './array-copy.bench';
 import attributeUpdateBench from './attribute-update.bench';
+import comparePropsBench from './compare-props.bench';
 
 const suite = new Bench({});
 
@@ -45,6 +46,7 @@ tesselationBench(suite);
 gridAggregatorBench(suite);
 arrayCopyBench(suite);
 attributeUpdateBench(suite);
+comparePropsBench(suite);
 
 // Run the suite
 suite.run();


### PR DESCRIPTION
For https://github.com/uber/streetscape.gl/issues/298

If shallow comparison fails, `compareProps` stringifies the changed prop values. This imposes a large cost when the value is a large array.

Benchmark with a `instancePositions` prop for 33.3k points:

Before: 7.30 iterations/s ±0.43%
After: 389K iterations/s ±4.19%

#### Change List
- Remove values from `compreProps`'s props changed reason string.
