### PR TITLE
Minor changes to the IconLayer AutoPacking Docs Example

### DIFF
--- a/docs/layers/icon-layer.md
+++ b/docs/layers/icon-layer.md
@@ -91,7 +91,7 @@ const App = ({data, viewport}) => {
    */
   const layer = new IconLayer({
     id: 'icon-layer',
-    data: octokit.repos.listContributors({
+    data: octokit.repos.getContributors({
       owner: 'uber',
       repo: 'deck.gl' 
     }).then(result => result.data),
@@ -102,7 +102,6 @@ const App = ({data, viewport}) => {
       width: 128,
       height: 128,
       anchorY: 128,
-      mask: true
     }),
     // icon size is based on data point's contributions, between 2 - 25 
     getSize: d => Math.max(2, Math.min(d.contributions / 1000 * 25, 25)),
@@ -110,9 +109,8 @@ const App = ({data, viewport}) => {
     pickable: true,
     sizeScale: 15,
     getPosition: d => d.coordinates,
-    getColor: d => [Math.sqrt(d.exits), 140, 0],
     onHover: ({object, x, y}) => {
-      const tooltip = `${object.name}\n${object.address}`;
+      const tooltip = `${object.login}\n${object.contributions}`;
       /* Update tooltip
          http://deck.gl/#/documentation/developer-guide/adding-interactivity?section=example-display-a-tooltip-for-hovered-object
       */

--- a/docs/layers/icon-layer.md
+++ b/docs/layers/icon-layer.md
@@ -101,11 +101,10 @@ const App = ({data, viewport}) => {
       url: d.avatar_url,
       width: 128,
       height: 128,
-      anchorY: 128,
+      anchorY: 128
     }),
     // icon size is based on data point's contributions, between 2 - 25 
     getSize: d => Math.max(2, Math.min(d.contributions / 1000 * 25, 25)),
-
     pickable: true,
     sizeScale: 15,
     getPosition: d => d.coordinates,


### PR DESCRIPTION
**IconLayer AutoPacking Example**

- Change Octokit request format from `octokit.repos.listContributors` to `octokit.repos.getContributors`

- Change the tooltip parameters according to example dataset.

- For the autopacking example, I don't think Icons need to be treated as a transparency mask. Keep the default value for mask which is false and the user-defined `getColor` accessor is not required.