### PR TITLE
More React synchronization fix

### DIFF
--- a/modules/react/src/deckgl.js
+++ b/modules/react/src/deckgl.js
@@ -82,7 +82,7 @@ export default class DeckGL extends React.Component {
 
     // If the child components have changed, React needs to rerender (case 2 or 3)
     const childrenChanged = this.children !== this._parseJSX(nextProps).children;
-    // If the views have changed, WebGL context needs to redraw (case 1 or 3)
+    // If the views have changed, both React and WebGL context need update (case 3)
     const viewsChanged = this.deck.viewManager && this.deck.viewManager.needsRedraw();
 
     // Only call `render` right away in case 2

--- a/modules/react/src/deckgl.js
+++ b/modules/react/src/deckgl.js
@@ -70,8 +70,8 @@ export default class DeckGL extends React.Component {
 
   // This method checks if React needs to call `render`.
   // Props changes may lead to 3 types of updates:
-  // 1. Only the WebGL context - updated in to Deck's render cycle (next animation frame)
-  // 2. Only the DOM - updated by calling React's lifecycle method `render` (now)
+  // 1. Only the WebGL context - updated in Deck's render cycle (next animation frame)
+  // 2. Only the DOM - updated in React's lifecycle (now)
   // 3. Both the WebGL context and the DOM - defer React rerender to next animation frame just
   //    before Deck redraw to ensure perfect synchronization & avoid excessive redraw
   //    This is because multiple changes may happen to Deck between two frames e.g. transition


### PR DESCRIPTION
#### Background

In streetscape.gl, viewState and React children (DOM labels) are changed at the same time. In the current implementation, child components are updated before the Deck viewports, resulting in flashing of label positions.

#### Change List
- When both children and views are changed, defer React rerender to the next animation frame.
