### PR TITLE
Fix GoogleMapsOverlay remove and finalize

### DIFF
--- a/modules/google-maps/src/google-maps-overlay.js
+++ b/modules/google-maps/src/google-maps-overlay.js
@@ -11,6 +11,7 @@ export default class GoogleMapsOverlay {
 
     const overlay = new google.maps.OverlayView();
     overlay.onAdd = this._onAdd.bind(this);
+    overlay.onRemove = this._onRemove.bind(this);
     overlay.draw = this._draw.bind(this);
     this._overlay = overlay;
 
@@ -53,16 +54,22 @@ export default class GoogleMapsOverlay {
   }
 
   finalize() {
+    this.setMap(null);
     if (this._deck) {
       destroyDeckInstance(this._deck);
+      this._deck = null;
     }
-    this.setMap(null);
   }
 
   /* Private API */
   _onAdd() {
     this._deck = createDeckInstance(this._map, this._overlay, this._deck);
     this._deck.setProps(this.props);
+  }
+
+  _onRemove() {
+    // Clear deck canvas
+    this._deck.setProps({layerFilter: HIDE_ALL_LAYERS});
   }
 
   _draw() {

--- a/modules/google-maps/src/utils.js
+++ b/modules/google-maps/src/utils.js
@@ -63,14 +63,17 @@ function createDeckCanvas(overlay) {
  * @param deck (Deck) - a previously created instances
  */
 export function destroyDeckInstance(deck) {
-  const {_googleMap: map, _eventListeners: eventListeners} = deck.props.userData;
+  const {_eventListeners: eventListeners} = deck.props.userData;
 
   // Unregister event listeners
   for (const eventType in eventListeners) {
-    map.removeListener(eventListeners[eventType]);
+    eventListeners[eventType].remove();
   }
 
   deck.finalize();
+
+  // Remove canvas
+  deck.canvas.parentNode.removeChild(deck.canvas);
 }
 
 /**


### PR DESCRIPTION
For #2981 

#### Change List
- Implement `overlay.onRemove`
- Remove listeners correctly
- Remove canvas when finalized