### PR TITLE
Add stroke functionality for the H3Hexagon Layer

### DIFF
--- a/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
+++ b/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
@@ -120,7 +120,6 @@ export default class H3HexagonLayer extends CompositeLayer {
       getHexagon,
       wireframe,
       elevationScale,
-      extruded,
       fp64,
       material,
       stroked,
@@ -144,7 +143,7 @@ export default class H3HexagonLayer extends CompositeLayer {
       {
         filled: true,
         elevationScale,
-        extruded,
+        extruded: true,
         fp64,
         wireframe,
         stroked,
@@ -183,7 +182,6 @@ export default class H3HexagonLayer extends CompositeLayer {
 
       coverage,
       elevationScale,
-      extruded,
       fp64,
 
       getColor,
@@ -197,7 +195,7 @@ export default class H3HexagonLayer extends CompositeLayer {
       {
         coverage,
         elevationScale,
-        extruded,
+        extruded: true,
         fp64,
         getColor,
         getElevation,

--- a/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
+++ b/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
@@ -8,19 +8,19 @@ function getHexagonCentroid(getHexagon, object, objectInfo) {
   return [lng, lat];
 }
 
+const polygonProps = Object.assign({}, PolygonLayer.defaultProps, {
+  extruded: true,
+  getColor: null
+});
+
 const defaultProps = Object.assign(
   {
     highPrecision: false,
     coverage: {type: 'number', min: 0, max: 1, value: 1},
     elevationScale: {type: 'number', min: 0, value: 1},
-
-    getHexagon: {type: 'accessor', value: x => x.hexagon},
-    getColor: {type: 'accessor', value: [255, 0, 255, 255]}
+    getHexagon: {type: 'accessor', value: x => x.hexagon}
   },
-  {
-    ...PolygonLayer.defaultProps,
-    extruded: true
-  }
+  polygonProps
 );
 
 /**
@@ -120,7 +120,8 @@ export default class H3HexagonLayer extends CompositeLayer {
       lineWidthScale,
       lineWidthMinPixels,
       lineWidthMaxPixels,
-      getColor,
+      getColor, // Deprecate getColor Prop in the next major release
+      getFillColor,
       getElevation,
       getLineColor,
       getLineWidth,
@@ -142,13 +143,16 @@ export default class H3HexagonLayer extends CompositeLayer {
         lineWidthMaxPixels,
         material,
         getElevation,
-        getFillColor: getColor,
+        getFillColor: getColor || getFillColor,
         getLineColor,
         getLineWidth
       },
       this.getSubLayerProps({
         id: 'hexagon-cell-hifi',
-        updateTriggers
+        updateTriggers: {
+          getFillColor: updateTriggers.getColor,
+          getPolygon: updateTriggers.getHexagon
+        }
       }),
       {
         data,

--- a/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
+++ b/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
@@ -1,6 +1,5 @@
 import {h3ToGeoBoundary, h3GetResolution, h3ToGeo, geoToH3, h3IsPentagon} from 'h3-js';
 import {CompositeLayer, createIterable} from '@deck.gl/core';
-import {PhongMaterial} from '@luma.gl/core';
 import {ColumnLayer, PolygonLayer} from '@deck.gl/layers';
 
 function getHexagonCentroid(getHexagon, object, objectInfo) {
@@ -16,10 +15,12 @@ const defaultProps = Object.assign(
     elevationScale: {type: 'number', min: 0, value: 1},
 
     getHexagon: {type: 'accessor', value: x => x.hexagon},
-    getColor: {type: 'accessor', value: [255, 0, 255, 255]},
-    material: new PhongMaterial()
+    getColor: {type: 'accessor', value: [255, 0, 255, 255]}
   },
-  PolygonLayer.defaultProps
+  {
+    ...PolygonLayer.defaultProps,
+    extruded: true
+  }
 );
 
 /**
@@ -102,14 +103,6 @@ export default class H3HexagonLayer extends CompositeLayer {
     this.setState({centerHex: hex, vertices});
   }
 
-  getSubLayerAccessor(accessor) {
-    if (typeof accessor !== 'function') return accessor;
-
-    return (object, objectInfo) => {
-      return accessor(object, objectInfo);
-    };
-  }
-
   renderLayers() {
     return this._shouldUseHighPrecision() ? this._renderPolygonLayer() : this._renderColumnLayer();
   }
@@ -122,18 +115,15 @@ export default class H3HexagonLayer extends CompositeLayer {
       elevationScale,
       fp64,
       material,
+      extruded,
       stroked,
       lineWidthScale,
       lineWidthMinPixels,
       lineWidthMaxPixels,
-      lineJointRounded,
-      lineMiterLimit,
-      lineDashJustified,
       getColor,
       getElevation,
       getLineColor,
       getLineWidth,
-      getLineDashArray,
       updateTriggers
     } = this.props;
 
@@ -143,22 +133,18 @@ export default class H3HexagonLayer extends CompositeLayer {
       {
         filled: true,
         elevationScale,
-        extruded: true,
+        extruded,
         fp64,
         wireframe,
         stroked,
         lineWidthScale,
         lineWidthMinPixels,
         lineWidthMaxPixels,
-        lineJointRounded,
-        lineMiterLimit,
-        lineDashJustified,
         material,
-        getElevation: this.getSubLayerAccessor(getElevation),
-        getFillColor: this.getSubLayerAccessor(getColor),
-        getLineColor: this.getSubLayerAccessor(getLineColor),
-        getLineWidth: this.getSubLayerAccessor(getLineWidth),
-        getLineDashArray: this.getSubLayerAccessor(getLineDashArray)
+        getElevation,
+        getFillColor: getColor,
+        getLineColor,
+        getLineWidth
       },
       this.getSubLayerProps({
         id: 'hexagon-cell-hifi',
@@ -179,11 +165,10 @@ export default class H3HexagonLayer extends CompositeLayer {
       data,
       getHexagon,
       updateTriggers,
-
       coverage,
       elevationScale,
       fp64,
-
+      extruded,
       getColor,
       getElevation,
       material
@@ -195,7 +180,7 @@ export default class H3HexagonLayer extends CompositeLayer {
       {
         coverage,
         elevationScale,
-        extruded: true,
+        extruded,
         fp64,
         getColor,
         getElevation,

--- a/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
+++ b/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
@@ -8,18 +8,13 @@ function getHexagonCentroid(getHexagon, object, objectInfo) {
   return [lng, lat];
 }
 
-const defaultProps = Object.assign(
-  {
-    highPrecision: false,
-    coverage: {type: 'number', min: 0, max: 1, value: 1},
-    elevationScale: {type: 'number', min: 0, value: 1},
-    getHexagon: {type: 'accessor', value: x => x.hexagon}
-  },
-  Object.assign({}, PolygonLayer.defaultProps, {
-    extruded: true,
-    getColor: null
-  })
-);
+const defaultProps = Object.assign({}, PolygonLayer.defaultProps, {
+  highPrecision: false,
+  coverage: {type: 'number', min: 0, max: 1, value: 1},
+  getHexagon: {type: 'accessor', value: x => x.hexagon},
+  extruded: true,
+  getColor: null
+});
 
 /**
  * A subclass of HexagonLayer that uses H3 hexagonIds in data objects

--- a/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
+++ b/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
@@ -8,11 +8,6 @@ function getHexagonCentroid(getHexagon, object, objectInfo) {
   return [lng, lat];
 }
 
-const polygonProps = Object.assign({}, PolygonLayer.defaultProps, {
-  extruded: true,
-  getColor: null
-});
-
 const defaultProps = Object.assign(
   {
     highPrecision: false,
@@ -20,7 +15,10 @@ const defaultProps = Object.assign(
     elevationScale: {type: 'number', min: 0, value: 1},
     getHexagon: {type: 'accessor', value: x => x.hexagon}
   },
-  polygonProps
+  Object.assign({}, PolygonLayer.defaultProps, {
+    extruded: true,
+    getColor: null
+  })
 );
 
 /**
@@ -150,7 +148,10 @@ export default class H3HexagonLayer extends CompositeLayer {
       this.getSubLayerProps({
         id: 'hexagon-cell-hifi',
         updateTriggers: {
-          getFillColor: updateTriggers.getColor,
+          getFillColor: updateTriggers.getColor || updateTriggers.getFillColor,
+          getElevation: updateTriggers.getElevation,
+          getLineColor: updateTriggers.getLineColor,
+          getLineWidth: updateTriggers.getLineWidth,
           getPolygon: updateTriggers.getHexagon
         }
       }),

--- a/test/modules/geo-layers/h3-layers.spec.js
+++ b/test/modules/geo-layers/h3-layers.spec.js
@@ -37,7 +37,7 @@ test('H3HexagonLayer', t => {
     onAfterUpdate: ({layer, subLayers}) => {
       if (layer._shouldUseHighPrecision()) {
         t.ok(
-          subLayers.find(l => l.constructor.layerName === 'SolidPolygonLayer'),
+          subLayers.find(l => l.constructor.layerName === 'PolygonLayer'),
           'renders polygon layer'
         );
       } else {


### PR DESCRIPTION
For #3015 

- Enable `stroke` feature for H3Hexagon Layer by changing the subLayer `SolidPolygonLayer` to `PolygonLayer`.

- Required changes for the support of the new SubLayer.

![Peek 2019-04-24 02-53](https://user-images.githubusercontent.com/45285388/56628561-eae43600-6667-11e9-85b2-4050cac99006.gif)