### PR TITLE
Add Jupyter widget - JS Module

### DIFF
--- a/modules/jupyter-widget/README.md
+++ b/modules/jupyter-widget/README.md
@@ -1,0 +1,5 @@
+# @deck.gl/jupyter-widget
+
+Jupyter widget for rendering deck.gl in a Jupyter notebook
+
+See [deck.gl](http://deck.gl) for documentation.

--- a/modules/jupyter-widget/package.json
+++ b/modules/jupyter-widget/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@deck.gl/jupyter-widget",
+  "description": "Jupyter widget for rendering deck.gl in a Jupyter notebook",
+  "license": "MIT",
+  "version": "7.0.0-alpha.3",
+  "keywords": [
+    "jupyter",
+    "jupyterlab",
+    "jupyterlab-extension",
+    "widgets"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/uber/deck.gl.git"
+  },
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
+  "esnext": "dist/es6/index.js",
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "clean": "rm -fr dist dist-es6 && mkdir -p dist/es5 dist/esm dist/es6",
+    "build-es6": "BABEL_ENV=es6 babel src --out-dir dist/es6 --source-maps --ignore 'node_modules/'",
+    "build-esm": "BABEL_ENV=esm babel src --out-dir dist/esm --source-maps --ignore 'node_modules/'",
+    "build-es5": "BABEL_ENV=es5 babel src --out-dir dist/es5 --source-maps --ignore 'node_modules/'",
+    "build": "npm run clean && npm run build-es6 && npm run build-esm && npm run build-es5"
+  },
+  "dependencies": {
+    "@deck.gl/json": "7.0.0-beta.2",
+    "@deck.gl/aggregation-layers": "7.0.0-beta.2",
+    "@deck.gl/layers": "7.0.0-beta.2",
+    "@jupyter-widgets/base": "^1.1.10",
+    "@types/mapbox-gl": "^0.51.4",
+    "@deck.gl/core": "7.0.0-beta.2",
+    "mapbox-gl": "^0.53.1"
+  }
+}

--- a/modules/jupyter-widget/src/embed.js
+++ b/modules/jupyter-widget/src/embed.js
@@ -1,0 +1,1 @@
+module.exports = require('./index.js');

--- a/modules/jupyter-widget/src/index.js
+++ b/modules/jupyter-widget/src/index.js
@@ -1,0 +1,4 @@
+// Copyright (c) Uber Technologies Inc.
+// Distributed under the terms of the Modified BSD License.
+export {MODULE_VERSION, MODULE_NAME} from './version';
+export {DeckGLModel, DeckGLView} from './widget';

--- a/modules/jupyter-widget/src/plugin.js
+++ b/modules/jupyter-widget/src/plugin.js
@@ -1,0 +1,30 @@
+import {IJupyterWidgetRegistry} from '@jupyter-widgets/base';
+
+import {DeckGLModel, DeckGLView} from './widget';
+
+import {MODULE_NAME, MODULE_VERSION} from './version';
+
+const EXTENSION_ID = 'deckgl-widget:plugin';
+
+const DeckGLPlugin = {
+  id: EXTENSION_ID,
+  requires: [IJupyterWidgetRegistry],
+  activate: activateWidgetExtension,
+  autoStart: true
+};
+
+export default DeckGLPlugin;
+
+/**
+ * Registers the widget with the Jupyter notebook
+ */
+function activateWidgetExtension(app, registry) {
+  registry.registerWidget({
+    name: MODULE_NAME,
+    version: MODULE_VERSION,
+    exports: {
+      DeckGLModel,
+      DeckGLView
+    }
+  });
+}

--- a/modules/jupyter-widget/src/utils.js
+++ b/modules/jupyter-widget/src/utils.js
@@ -1,0 +1,114 @@
+/* global document */
+/**
+ * Gets CSS from a given URL and appends it to the document head
+ * @param url URL of CSS page
+ */
+function loadCss(url) {
+  const link = document.createElement('link');
+  link.type = 'text/css';
+  link.rel = 'stylesheet';
+  link.href = url;
+  document.getElementsByTagName('head')[0].appendChild(link);
+}
+
+/**
+ * Creates a div of a default 500px by 500px for the Jupyter widget
+ * @param idName ID attribute of div
+ * @param width Width of div in pixels (defaults to 500)
+ * @param height Height of div in pixels (defaults to 500)
+ * @return div object for appending to the document
+ */
+function createWidgetDiv(idName, width = 500, height = 500) {
+  const div = document.createElement('div');
+  div.style.width = `${width}px`;
+  div.style.height = `${height}px`;
+  div.id = idName;
+  return div;
+}
+
+/**
+ * Creates a canvas for the Jupyter widget
+ * @param idName ID attribute of canvas
+ * @return canvas canvas for appending
+ */
+function createCanvas(idName) {
+  const canvas = document.createElement('canvas');
+  Object.assign(canvas.style, {
+    width: '100%',
+    height: '100%',
+    position: 'absolute',
+    'z-index': 2
+  });
+  canvas.id = idName;
+  return canvas;
+}
+
+/**
+ * Creates a div for the Jupyter widget's basemap
+ * @param idName ID attribute of div
+ * @return div object for appending to the document
+ */
+function createMapDiv(idName) {
+  const div = document.createElement('div');
+  Object.assign(div.style, {
+    'pointer-events': 'none',
+    height: '100%',
+    width: '100%',
+    position: 'absolute',
+    'z-index': 1
+  });
+  div.id = idName;
+  return div;
+}
+
+/**
+ * Hides a warning in the mapbox-gl.js library from surfacing in the notebook as text.
+ */
+function hideMapboxCSSWarning() {
+  const missingCssWarning = document.getElementsByClassName('mapboxgl-missing-css')[0];
+  if (missingCssWarning) {
+    missingCssWarning.style.display = 'none';
+  }
+}
+
+/**
+ * Creates and appends all DOM elements for the deck.gl widget at the specified root node
+ * @param rootElement ID attribute of div
+ */
+function createDeckScaffold(rootElement, width = 500, height = 500) {
+  const mapNode = createMapDiv('map');
+  const canvasNode = createCanvas('deck-map-container');
+  const mapWrapperNode = createWidgetDiv('deck-map-wrapper', width, height);
+  mapWrapperNode.appendChild(canvasNode);
+  mapWrapperNode.appendChild(mapNode);
+  rootElement
+    .appendChild(createWidgetDiv('deck-container', width, height))
+    .appendChild(mapWrapperNode);
+}
+
+/**
+ * Sets common properties for basemap
+ * @param map ID attribute of div
+ * @param props ID attribute of div
+ * @return div object for appending to the document
+ */
+function setMapProps(map, props) {
+  if ('viewState' in props && props.viewState.longitude && props.viewState.latitude) {
+    const {viewState} = props;
+    map.jumpTo({
+      center: [viewState.longitude, viewState.latitude],
+      zoom: Number.isFinite(viewState.zoom) ? viewState.zoom : 10,
+      bearing: viewState.bearing || 0,
+      pitch: viewState.pitch || 0
+    });
+  }
+
+  if (props.map && 'style' in props.map) {
+    if (props.map.style !== map.deckStyle) {
+      map.setStyle(props.map.style);
+      map.deckStyle = props.map.style;
+    }
+  }
+}
+
+export {createDeckScaffold, loadCss, hideMapboxCSSWarning, setMapProps};

--- a/modules/jupyter-widget/src/version.js
+++ b/modules/jupyter-widget/src/version.js
@@ -1,0 +1,14 @@
+const data = require('../package.json');
+
+/**
+ * The _model_module_version/_view_module_version this package implements.
+ *
+ * The html widget manager assumes that this is the same as the npm package
+ * version number.
+ */
+export const MODULE_VERSION = data.version;
+
+/*
+ * The current package name.
+ */
+export const MODULE_NAME = data.name;

--- a/modules/jupyter-widget/src/widget.js
+++ b/modules/jupyter-widget/src/widget.js
@@ -1,0 +1,106 @@
+import {DOMWidgetModel, DOMWidgetView} from '@jupyter-widgets/base';
+
+import {MODULE_NAME, MODULE_VERSION} from './version';
+
+import {createDeckScaffold, loadCss, hideMapboxCSSWarning, setMapProps} from './utils';
+
+const mapboxgl = require('mapbox-gl');
+const deckgl = require('@deck.gl/core');
+const deckglLayers = require('@deck.gl/layers');
+const deckAggregationLayers = require('@deck.gl/aggregation-layers');
+const deckJson = require('@deck.gl/json');
+
+const MAPBOX_CSS_URL = 'https://api.tiles.mapbox.com/mapbox-gl-js/v0.53.1/mapbox-gl.css';
+const MAPBOX_TILE_URL = 'mapbox://styles/mapbox/light-v9';
+
+export class DeckGLModel extends DOMWidgetModel {
+  defaults() {
+    return {
+      ...super.defaults(),
+      _model_name: DeckGLModel.model_name,
+      _model_module: DeckGLModel.model_module,
+      _model_module_version: DeckGLModel.model_module_version,
+      _view_name: DeckGLModel.view_name,
+      _view_module: DeckGLModel.view_module,
+      _view_module_version: DeckGLModel.view_module_version,
+      json_input: null
+    };
+  }
+
+  static get serializers() {
+    return {...DOMWidgetModel.serializers};
+    // Add any extra serializers here
+  }
+
+  static get model_name() {
+    return 'DeckGLModel';
+  }
+  static get model_module() {
+    return MODULE_NAME;
+  }
+  static get model_module_version() {
+    return MODULE_VERSION;
+  }
+  static get view_name() {
+    return 'DeckGLView';
+  }
+  static get view_module() {
+    return MODULE_NAME;
+  }
+  static get view_module_version() {
+    return MODULE_VERSION;
+  }
+}
+
+export class DeckGLView extends DOMWidgetView {
+  render() {
+    super.render();
+    this.listenTo(this.model, 'change:json_input', this.value_changed);
+    loadCss(MAPBOX_CSS_URL);
+    const [width, height] = [this.model.get('width'), this.model.get('height')];
+    createDeckScaffold(this.el, width, height);
+  }
+
+  _onViewStateChange({viewState}) {
+    this.deck.setProps({viewState});
+    setMapProps(this.mapLayer, {viewState});
+  }
+
+  initJSElements() {
+    if (!this.deck) {
+      mapboxgl.accessToken = this.model.get('mapbox_key');
+      this.deck = new deckgl.Deck({
+        canvas: 'deck-map-container',
+        height: '100%',
+        width: '100%',
+        mapboxApiAccessToken: mapboxgl.accessToken,
+        views: [new deckgl.MapView()],
+        onViewStateChange: this._onViewStateChange.bind(this)
+      });
+    }
+
+    if (!this.mapLayer) {
+      this.mapLayer = new mapboxgl.Map({
+        container: 'map',
+        interactive: false,
+        style: MAPBOX_TILE_URL
+      });
+    }
+  }
+
+  value_changed() {
+    this.json_input = this.model.get('json_input');
+    this.initJSElements();
+
+    const jsonConverter = new deckJson._JSONConverter({
+      configuration: {
+        layers: [...deckglLayers, ...deckAggregationLayers]
+      }
+    });
+
+    const results = jsonConverter.convertJsonToDeckProps(JSON.parse(this.json_input));
+    this.deck.setProps(results);
+    hideMapboxCSSWarning();
+    setMapProps(this.mapLayer, this.deck.props);
+  }
+}

--- a/test/modules/jupyter-widget/index.js
+++ b/test/modules/jupyter-widget/index.js
@@ -1,0 +1,1 @@
+import './index.spec';

--- a/test/modules/jupyter-widget/index.spec.js
+++ b/test/modules/jupyter-widget/index.spec.js
@@ -1,0 +1,10 @@
+import '@jupyter-widgets/base';
+
+import {DeckGLView} from '@deck.gl/jupyter-widget';
+import test from 'tape-catch';
+
+test('DeckGLView should initialize', t => {
+  const obj = new DeckGLView();
+  t.ok(obj, 'DeckGLView initalized');
+  t.end();
+});

--- a/test/modules/jupyter-widget/utils.spec.js
+++ b/test/modules/jupyter-widget/utils.spec.js
@@ -1,0 +1,93 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+/* eslint-disable no-console, no-undef */
+
+import * as widgets from '@jupyter-widgets/base';
+
+let numComms = 0;
+
+/**
+ * Creates a mock connection to a Jupyter notebook
+ */
+export class MockComm {
+  constructor() {
+    this.comm_id = `mock-comm-id-${numComms}`;
+    numComms += 1;
+  }
+  on_close(fn) {
+    this._on_close = fn;
+  }
+  on_msg(fn) {
+    this._on_msg = fn;
+  }
+  _process_msg(msg) {
+    if (this._on_msg) {
+      return this._on_msg(msg);
+    }
+    return Promise.resolve();
+  }
+  close() {
+    if (this._on_close) {
+      this._on_close();
+    }
+    return 'dummy';
+  }
+  send() {
+    return 'dummy';
+  }
+
+  open() {
+    return 'dummy';
+  }
+}
+
+export class DummyManager extends widgets.ManagerBase {
+  constructor() {
+    super();
+    this.el = window.document.createElement('div');
+  }
+
+  display_view(msg, view, options) {
+    // TODO: make this a spy
+    // TODO: return an html element
+    return Promise.resolve(view).then(v => {
+      this.el.appendChild(v.el);
+      v.on('remove', () => console.log('view removed', v));
+      return v.el;
+    });
+  }
+
+  loadClass(className, moduleName, moduleVersion) {
+    if (moduleName === '@jupyter-widgets/base') {
+      if (widgets[className]) {
+        return Promise.resolve(widgets[className]);
+      }
+      return Promise.reject(`Cannot find class ${className}`);
+    } else if (moduleName === 'jupyter-datawidgets') {
+      if (this.testClasses[className]) {
+        return Promise.resolve(this.testClasses[className]);
+      }
+      return Promise.reject(`Cannot find class ${className}`);
+    }
+    return Promise.reject(`Cannot find module ${moduleName}`);
+  }
+
+  _get_comm_info() {
+    return Promise.resolve({});
+  }
+
+  _create_comm() {
+    return Promise.resolve(new MockComm());
+  }
+}
+
+export function createTestModel(constructor, attributes) {
+  const id = widgets.uuid();
+  const widget_manager = new DummyManager();
+  const modelOptions = {
+    widget_manager,
+    model_id: id
+  };
+
+  return new constructor(attributes, modelOptions);
+}


### PR DESCRIPTION
Adding a Jupyter widget for rendering deck.gl in a Python environment, building on #3013. 

#### Background

See #2929.

#### Change List
- Adds JS module to support a Jupyter notebook extension
- Modifies `pydeck` Python library to support a Jupyter notebook extension