### PR TITLE
Fix bug in click event handling

### DIFF
--- a/modules/core/src/lib/deck-picker.js
+++ b/modules/core/src/lib/deck-picker.js
@@ -102,8 +102,7 @@ export default class DeckPicker {
   }
 
   // Returns a new picking info object by assuming the last picked object is still picked
-  getLastPickedObject({x, y, layers, viewports}) {
-    const lastPickedInfo = this.lastPickedInfo.info;
+  getLastPickedObject({x, y, layers, viewports}, lastPickedInfo = this.lastPickedInfo.info) {
     const lastPickedLayerId = lastPickedInfo && lastPickedInfo.layer && lastPickedInfo.layer.id;
     const layer = lastPickedLayerId ? layers.find(l => l.id === lastPickedLayerId) : null;
     const coordinate = viewports[0] && viewports[0].unproject([x, y]);

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -128,7 +128,9 @@ export default class Deck {
 
     this._needsRedraw = true;
     this._pickRequest = {};
-    this._pickedInfo = null;
+    // Pick and store the object under the pointer on `pointerdown`.
+    // This object is reused for subsequent `onClick` and `onDrag*` callbacks.
+    this._lastPointerDownInfo = null;
 
     this.viewState = props.initialViewState || null; // Internal view state if no callback is supplied
     this.interactiveState = {
@@ -164,7 +166,7 @@ export default class Deck {
   finalize() {
     this.animationLoop.stop();
     this.animationLoop = null;
-    this._pickedInfo = null;
+    this._lastPointerDownInfo = null;
 
     if (this.layerManager) {
       this.layerManager.finalize();
@@ -710,7 +712,7 @@ export default class Deck {
         layers,
         viewports: this.getViewports(pos)
       },
-      this._pickedInfo
+      this._lastPointerDownInfo
     );
 
     const {layer} = info;
@@ -729,7 +731,7 @@ export default class Deck {
 
   _onPointerDown(event) {
     const pos = event.offsetCenter;
-    this._pickedInfo = this.pickObject({
+    this._lastPointerDownInfo = this.pickObject({
       x: pos.x,
       y: pos.y
     });


### PR DESCRIPTION
For #https://github.com/uber/deck.gl/issues/2986

#### Background
This bug is caused by overloading the `lastPickedInfo` object in DeckPicker. We used this object for two purposes:

1. Store the last hovered object for use during the next `hover` event. The `onHover` callback is only fired when the hovered object is changed.
2. Store the picked object on `pointerdown`. This object is reused for subsequent `onClick` and `onDrag*` callbacks.

This design was based on the assumption that when the pointer remains down, `pointermove` does not trigger a `hover` event, therefore the object from (2) cannot be overwritten by (1).

This becomes an issue when the user clicks and quickly moves the pointer away. The `click` event fires with a small delay to rule out double clicking. During this delay, if the pointer is moved, the `lastPickedInfo` object does get overwritten by the `hover` event.

#### Change List
- Store picking result from `pointerdown` separately from the last picked object from `hover`.
