### PR TITLE
Fix OrbitView and OrthographicView resize bug

### DIFF
--- a/modules/core/src/views/orbit-view.js
+++ b/modules/core/src/views/orbit-view.js
@@ -79,27 +79,19 @@ class OrbitViewport extends Viewport {
 }
 
 export default class OrbitView extends View {
+  constructor(props) {
+    super(
+      Object.assign({}, props, {
+        type: OrbitViewport
+      })
+    );
+  }
+
   get controller() {
     return this._getControllerProps({
       type: OrbitController,
       ViewportType: OrbitViewport
     });
-  }
-
-  _getViewport({x, y, width, height, viewState}) {
-    return new OrbitViewport(
-      Object.assign(
-        {
-          id: this.id,
-          x,
-          y,
-          width,
-          height
-        },
-        this.props,
-        viewState
-      )
-    );
   }
 }
 

--- a/modules/core/src/views/orthographic-view.js
+++ b/modules/core/src/views/orthographic-view.js
@@ -38,27 +38,19 @@ class OrthographicViewport extends Viewport {
 }
 
 export default class OrthographicView extends View {
+  constructor(props) {
+    super(
+      Object.assign({}, props, {
+        type: OrthographicViewport
+      })
+    );
+  }
+
   get controller() {
     return this._getControllerProps({
       type: OrthographicController,
       ViewportType: OrthographicViewport
     });
-  }
-
-  _getViewport({x, y, width, height, viewState}) {
-    return new OrthographicViewport(
-      Object.assign(
-        {
-          id: this.id,
-          x,
-          y,
-          width,
-          height
-        },
-        this.props,
-        viewState
-      )
-    );
   }
 }
 

--- a/test/modules/core/views/view.spec.js
+++ b/test/modules/core/views/view.spec.js
@@ -1,5 +1,5 @@
 import test from 'tape-catch';
-import {View, MapView} from 'deck.gl';
+import {View, Viewport, MapView, OrbitView, OrthographicView} from 'deck.gl';
 
 test('View#imports', t => {
   t.ok(View, 'View import ok');
@@ -39,6 +39,60 @@ test('View#equals', t => {
   t.ok(mapView1.equals(mapView2), 'Identical view props');
   t.notOk(mapView1.equals(mapView3), 'Different view props');
   t.notOk(mapView1.equals(mapView4), 'Different type');
+
+  t.end();
+});
+
+test('View#makeViewport', t => {
+  let viewport;
+
+  viewport = new MapView({id: 'map-view'}).makeViewport({
+    width: 100,
+    height: 100,
+    viewState: {
+      longitude: -122.4,
+      latitude: 37.8,
+      zoom: 12,
+      width: 200,
+      height: 200
+    }
+  });
+  t.ok(viewport instanceof Viewport, 'Mapview.makeViewport returns valid viewport');
+  t.is(viewport.id, 'map-view', 'Viewport has correct id');
+  t.ok(viewport.width === 100 && viewport.height === 100, 'Viewport has correct size');
+  t.is(viewport.zoom, 12, 'Viewport has correct parameters');
+
+  viewport = new OrbitView({id: '3d-view'}).makeViewport({
+    width: 100,
+    height: 100,
+    viewState: {
+      target: [0, 1, 0],
+      zoom: 1,
+      rotationOrbit: 45,
+      rotationX: -30,
+      width: 200,
+      height: 200
+    }
+  });
+  t.ok(viewport instanceof Viewport, 'OrbitView.makeViewport returns valid viewport');
+  t.is(viewport.id, '3d-view', 'Viewport has correct id');
+  t.ok(viewport.width === 100 && viewport.height === 100, 'Viewport has correct size');
+  t.is(viewport.zoom, 1, 'Viewport has correct parameters');
+
+  viewport = new OrthographicView({id: '2d-view'}).makeViewport({
+    width: 100,
+    height: 100,
+    viewState: {
+      target: [0, 1, 0],
+      zoom: 9,
+      width: 200,
+      height: 200
+    }
+  });
+  t.ok(viewport instanceof Viewport, 'OrthographicView.makeViewport returns valid viewport');
+  t.is(viewport.id, '2d-view', 'Viewport has correct id');
+  t.ok(viewport.width === 100 && viewport.height === 100, 'Viewport has correct size');
+  t.is(viewport.zoom, 9, 'Viewport has correct parameters');
 
   t.end();
 });


### PR DESCRIPTION
For #3042

When we merged viewport props the `width` and `height` in `viewState` ended up overriding the values provided by the `ViewManager`.

#### Change List
- Use base `View` class' `_getViewport` implementation instead
