### PR TITLE
Force gl context loss, Fixes #3039

### DIFF
--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -125,6 +125,7 @@ export default class Deck {
     this.effectManager = null;
     this.deckRenderer = null;
     this.deckPicker = null;
+    this.gl = null;
 
     this._needsRedraw = true;
     this._pickRequest = {};
@@ -180,6 +181,12 @@ export default class Deck {
 
     if (this.eventManager) {
       this.eventManager.destroy();
+    }
+
+    if (this.gl) {
+      // force context loss
+      const extension = this.gl.getExtension('WEBGL_lose_context').loseContext();
+      if (extension) extension.loseContext();
     }
 
     if (!this.props.canvas && !this.props.gl && this.canvas) {
@@ -586,6 +593,8 @@ export default class Deck {
     this.deckRenderer = new DeckRenderer(gl);
 
     this.deckPicker = new DeckPicker(gl);
+
+    this.gl = gl;
 
     this.setProps(this.props);
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #3039
<!-- For other PRs without open issue -->
#### Background

A partial fix was published in 7.0.4, however garbage collector is still not able to release all the memory used.

![2](https://user-images.githubusercontent.com/40487685/57233613-81243e80-700e-11e9-8c41-061fa4ce3883.png)
![3](https://user-images.githubusercontent.com/40487685/57233614-81243e80-700e-11e9-934c-8028d0616797.png)
![4](https://user-images.githubusercontent.com/40487685/57233616-81bcd500-700e-11e9-9bb1-ed6c8b812c51.png)
![5](https://user-images.githubusercontent.com/40487685/57233617-81bcd500-700e-11e9-8918-80131986d095.png)

Since being able of mounting and unmounting Deckgl components without any memory leakage was a must, I just implemented a simple context lose at the time of finalization achieving the following results:

![1](https://user-images.githubusercontent.com/40487685/57234232-baa97980-700f-11e9-8628-ea20ed6a8581.png)
![2](https://user-images.githubusercontent.com/40487685/57234234-baa97980-700f-11e9-8a91-fd30790bbd63.png)
![3](https://user-images.githubusercontent.com/40487685/57234235-baa97980-700f-11e9-926e-0c4e675b748c.png)
![4](https://user-images.githubusercontent.com/40487685/57234236-baa97980-700f-11e9-9d28-201b098be6ce.png)
![5](https://user-images.githubusercontent.com/40487685/57234238-baa97980-700f-11e9-9461-d8b8ae99df82.png)
  
This may seem unnecesary for a simple app like the example web but it was critical for my App, where I'm rendering huge amounts of data while mounting/unmounting different instances

I'd like to know what do you think about this approach.

#### Change List
- Reference the gl context at component level
- Make sure we force the loss of such context




Thanks 
