### PR TITLE
[React] Add the ability to use react-map-gl controls

### DIFF
--- a/docs/api-reference/react/deckgl.md
+++ b/docs/api-reference/react/deckgl.md
@@ -57,6 +57,18 @@ A [Context.Provider](https://reactjs.org/docs/context.html#contextprovider) comp
 - `container` (DOMElement) - the DOM element containing the deck canvas
 - `eventManager` ([EventManager](https://github.com/uber-web/mjolnir.js/blob/master/docs/api-reference/event-manager.md))
 
+```jsx
+/// Example using react-map-gl controls with deck.gl
+import DeckGL from '@deck.gl/react';
+import {_MapContext as MapContext, NavigationControl} from 'react-map-gl';
+
+<DeckGL ... ContextProvider={MapContext.Provider}>
+  <div style={NAVIGATION_CONTROL_STYLES}>
+    <NavigationControl onViewStateChange={...} />
+  </div>
+</DeckGL>
+```
+
 ### View State Properties
 
 For backwards compatibility, the `DeckGL` component can be used without the `viewState` prop. If a `viewState` prop is not supplied, `DeckGL` will attempt to autocreate a geospatial view state from the following props.

--- a/docs/api-reference/react/deckgl.md
+++ b/docs/api-reference/react/deckgl.md
@@ -47,6 +47,15 @@ const App = (data) => (
 
 `DeckGL` accepts all [Deck](/docs/api-reference/deck.md#properties) properties, with these additional semantics:
 
+### React Context
+
+##### `ContextProvider` (React.Component, optional)
+
+A [Context.Provider](https://reactjs.org/docs/context.html#contextprovider) component. If supplied, will be rendered as the ancester to all children. The passed through context contains the following values:
+
+- `viewport` ([Viewport](/docs/api-reference/viewport.md)) - the current viewport
+- `container` (DOMElement) - the DOM element containing the deck canvas
+- `eventManager` ([EventManager](https://github.com/uber-web/mjolnir.js/blob/master/docs/api-reference/event-manager.md))
 
 ### View State Properties
 

--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -17,7 +17,7 @@ import DeckGL from '@deck.gl/react';
 import React, {PureComponent} from 'react';
 import autobind from 'react-autobind';
 
-import {StaticMap} from 'react-map-gl';
+import {StaticMap, _MapContext as MapContext, NavigationControl} from 'react-map-gl';
 
 import {Matrix4} from 'math.gl';
 
@@ -40,6 +40,12 @@ const VIEW_LABEL_STYLES = {
   fontSize: 12,
   backgroundColor: '#282727',
   color: '#FFFFFF'
+};
+
+const NAVIGATION_CONTROL_STYLES = {
+  margin: 10,
+  position: 'absolute',
+  zIndex: 1
 };
 
 const ViewportLabel = props => (
@@ -302,6 +308,7 @@ export default class App extends PureComponent {
           useDevicePixels={useDevicePixels}
           debug={true}
           drawPickingColors={drawPickingColors}
+          ContextProvider={MapContext.Provider}
         >
           <View id="basemap">
             <StaticMap
@@ -319,6 +326,10 @@ export default class App extends PureComponent {
           <View id="infovis">
             <ViewportLabel>Orbit View (PlotLayer only, No Navigation)</ViewportLabel>
           </View>
+
+          <div style={NAVIGATION_CONTROL_STYLES}>
+            <NavigationControl onViewStateChange={this._onViewStateChange} />
+          </div>
         </DeckGL>
       </div>
     );

--- a/examples/layer-browser/src/index.js
+++ b/examples/layer-browser/src/index.js
@@ -18,7 +18,7 @@ class Root extends Component {
 
     return (
       <div>
-        <FPSStats isActive />
+        <FPSStats isActive left={100} />
         <AppComponent state={this._appState} onStateChange={this._onAppStateChange.bind(this)} />
       </div>
     );

--- a/modules/react/src/deckgl.js
+++ b/modules/react/src/deckgl.js
@@ -175,7 +175,8 @@ export default class DeckGL extends React.Component {
     const children = this._positionChildrenUnderViews({
       children: this.children,
       viewports: this.viewports,
-      deck: this.deck
+      deck: this.deck,
+      ContextProvider: this.props.ContextProvider
     });
 
     // TODO - this styling is enforced for correct positioning with children

--- a/modules/react/src/utils/position-children-under-views.js
+++ b/modules/react/src/utils/position-children-under-views.js
@@ -54,7 +54,9 @@ export default function positionChildrenUnderViews({children, viewports, deck, C
 
     const style = {
       position: 'absolute',
+      // Use child's z-index for ordering
       zIndex: childStyle && childStyle.zIndex,
+      // If this container is on top, it will block interaction with the deck canvas
       pointerEvents: 'none',
       left: x,
       top: y,

--- a/modules/react/src/utils/position-children-under-views.js
+++ b/modules/react/src/utils/position-children-under-views.js
@@ -5,7 +5,7 @@ import evaluateChildren from './evaluate-children';
 
 // Iterate over views and reposition children associated with views
 // TODO - Can we supply a similar function for the non-React case?
-export default function positionChildrenUnderViews({children, viewports, deck}) {
+export default function positionChildrenUnderViews({children, viewports, deck, ContextProvider}) {
   const {viewManager} = deck || {};
 
   if (!viewManager || !viewManager.views.length) {
@@ -25,6 +25,8 @@ export default function positionChildrenUnderViews({children, viewports, deck}) 
     // Unless child is a View, position / render as part of the default view
     let viewId = defaultViewId;
     let viewChildren = child;
+    const childStyle = child.props.style;
+
     if (inheritsFrom(child.type, View)) {
       viewId = child.props.id || defaultViewId;
       viewChildren = child.props.children;
@@ -50,8 +52,26 @@ export default function positionChildrenUnderViews({children, viewports, deck}) 
       viewState
     });
 
-    const style = {position: 'absolute', left: x, top: y, width, height};
+    const style = {
+      position: 'absolute',
+      zIndex: childStyle && childStyle.zIndex,
+      pointerEvents: 'none',
+      left: x,
+      top: y,
+      width,
+      height
+    };
     const key = `view-child-${viewId}-${i}`;
+
+    if (ContextProvider) {
+      const contextValue = {
+        viewport,
+        container: deck.canvas.offsetParent,
+        eventManager: deck.eventManager
+      };
+      viewChildren = createElement(ContextProvider, {value: contextValue}, viewChildren);
+    }
+
     return createElement('div', {key, id: key, style}, viewChildren);
   });
 }


### PR DESCRIPTION
#### Background

All react-map-gl control components require a React context provider rendered by the MapGL component. Currently, if we render these components outside of `StaticMap`, they crash; if we render them as children of `StaticMap`, they are not interactive, because they are stuck behind the deck.gl canvas.

This PR proposes a new prop `ContextProvider` for the `DeckGL` React component. If provided, deck will supply the React context to all child components.

#### Change List
- Add `ContextProvider` prop
- Add `NavigationControl` to layer-browser

<img width="861" alt="Screen Shot 2019-05-07 at 11 52 26 AM" src="https://user-images.githubusercontent.com/2059298/57326190-c739da80-70c0-11e9-8f50-7bccb9009a3d.png">

