### PR TITLE
Fix update vertices when regenerate models

### DIFF
--- a/modules/layers/src/column-layer/column-layer.js
+++ b/modules/layers/src/column-layer/column-layer.js
@@ -89,7 +89,9 @@ export default class ColumnLayer extends Layer {
 
   updateState({props, oldProps, changeFlags}) {
     super.updateState({props, oldProps, changeFlags});
-    if (props.fp64 !== oldProps.fp64 || props.diskResolution !== oldProps.diskResolution) {
+    const regenerateModels =
+      props.fp64 !== oldProps.fp64 || props.diskResolution !== oldProps.diskResolution;
+    if (regenerateModels) {
       const {gl} = this.context;
       if (this.state.model) {
         this.state.model.delete();
@@ -98,7 +100,7 @@ export default class ColumnLayer extends Layer {
       this.getAttributeManager().invalidateAll();
     }
 
-    if (props.vertices !== oldProps.vertices) {
+    if (regenerateModels || props.vertices !== oldProps.vertices) {
       this._updateVertices(props.vertices);
     }
   }


### PR DESCRIPTION
If models are regenerated but vertices are not updated, model geometry are not correctly positioned.

![h3hexgon-bug](https://user-images.githubusercontent.com/2927808/57394991-c74ae080-717b-11e9-8f4e-b642b1fdcb31.gif)

