### PR TITLE
Update H3Hexagon Layer docs & props for ColumnLayer

### DIFF
--- a/docs/layers/column-layer.md
+++ b/docs/layers/column-layer.md
@@ -148,8 +148,6 @@ Whether to generate a line wireframe of the column. The outline will have
 "horizontal" lines closing the top and bottom polygons and a vertical line
 (a "strut") for each vertex on the polygon.
 
-Requires the `extruded` prop to be true.
-
 ##### `fp64` (Boolean, optional)
 
 * Default: `false`

--- a/docs/layers/h3-hexagon-layer.md
+++ b/docs/layers/h3-hexagon-layer.md
@@ -122,8 +122,8 @@ Whether to extrude hexagon. If set to false, all hexagons will be set to flat.
 * Default: `false`
 
 Whether to generate a line wireframe of the hexagon. The outline will have
-"horizontal" lines closing the top and bottom polygons and a vertical line
-(a "strut") for each vertex on the polygon.
+"horizontal" lines closing the top and bottom hexagons and a vertical line
+(a "strut") for each vertex on the hexagon.
 
 ##### `fp64` (Boolean, optional)
 
@@ -135,7 +135,7 @@ Whether the layer should be rendered in high-precision 64-bit mode. Note that si
 
 * Default: `new PhongMaterial()`
 
-This is an object that contains material props for [lighting effect](/docs/effects/lighting-effect.md) applied on extruded polygons.
+This is an object that contains material props for [lighting effect](/docs/effects/lighting-effect.md) applied on extruded hexagons.
 Check [PhongMaterial](https://github.com/uber/luma.gl/tree/7.0-release/docs/api-reference/core/materials/phong-material.md) for more details.
 
 ### Data Accessors
@@ -171,10 +171,10 @@ The rgba color of each object, in `r, g, b, [a]`. Each component is in the 0-255
 
 * Default: `[0, 0, 0, 255]`
 
-The rgba outline color of each polygon, in `r, g, b, [a]`. Each component is in the 0-255 range.
+The rgba outline color of each hexagon, in `r, g, b, [a]`. Each component is in the 0-255 range.
 
-* If an array is provided, it is used as the outline color for all polygons.
-* If a function is provided, it is called on each polygon to retrieve its outline color.
+* If an array is provided, it is used as the outline color for all hexagons.
+* If a function is provided, it is called on each hexagon to retrieve its outline color.
 * If not provided, it falls back to `getColor`.
 
 ##### `getElevation` ([Function](/docs/developer-guide/using-layers.md#accessors)|Number, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")

--- a/docs/layers/h3-hexagon-layer.md
+++ b/docs/layers/h3-hexagon-layer.md
@@ -117,6 +117,14 @@ to scale all hexagon elevations without updating the data.
 
 Whether to extrude hexagon. If set to false, all hexagons will be set to flat.
 
+##### `wireframe` (Boolean, optional)
+
+* Default: `false`
+
+Whether to generate a line wireframe of the hexagon. The outline will have
+"horizontal" lines closing the top and bottom polygons and a vertical line
+(a "strut") for each vertex on the polygon.
+
 ##### `fp64` (Boolean, optional)
 
 * Default: `false`
@@ -140,12 +148,34 @@ Method called to retrieve the [H3](https://uber.github.io/h3/) hexagon index of 
 
 ##### `getColor` ([Function](/docs/developer-guide/using-layers.md#accessors)|Array, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
-* Default: `[255, 0, 255, 255]`
+* Default: `[0, 0, 0, 255]`
 
 The rgba color of each object, in `r, g, b, [a]`. Each component is in the 0-255 range.
 
 * If an array is provided, it is used as the color for all objects.
 * If a function is provided, it is called on each object to retrieve its color.
+
+It will be overridden by `getLineColor` and `getFillColor` if these new accessors are specified.
+
+##### `getFillColor` ([Function](/docs/developer-guide/using-layers.md#accessors)|Array, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
+
+* Default: `[0, 0, 0, 255]`
+
+The rgba color of each object, in `r, g, b, [a]`. Each component is in the 0-255 range.
+
+* If an array is provided, it is used as the color for all objects.
+* If a function is provided, it is called on each object to retrieve its color.
+* If not provided, it falls back to `getColor`.
+
+##### `getLineColor` ([Function](/docs/developer-guide/using-layers.md#accessors)|Array, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
+
+* Default: `[0, 0, 0, 255]`
+
+The rgba outline color of each polygon, in `r, g, b, [a]`. Each component is in the 0-255 range.
+
+* If an array is provided, it is used as the outline color for all polygons.
+* If a function is provided, it is called on each polygon to retrieve its outline color.
+* If not provided, it falls back to `getColor`.
 
 ##### `getElevation` ([Function](/docs/developer-guide/using-layers.md#accessors)|Number, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
@@ -161,7 +191,8 @@ The elevation of each cell in meters.
 
 The `H3HexagonLayer` renders the following sublayers:
 
-* `hexagon-cell` - a [ColumnLayer](/docs/layers/column-layer.md) rendering all hexagons.
+* `hexagon-cell-hifi` - On `highPrecision` mode, rendered by [SolidPolygonLayer](/docs/layers/solid-polygon-layer.md)
+* `hexagon-cell` - On non `highPrecision` mode, rendered by [ColumnLayer](/docs/layers/column-layer.md)
 
 
 

--- a/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
+++ b/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
@@ -169,7 +169,10 @@ export default class H3HexagonLayer extends CompositeLayer {
       elevationScale,
       fp64,
       extruded,
+      wireframe,
       getColor,
+      getFillColor,
+      getLineColor,
       getElevation,
       material
     } = this.props;
@@ -181,8 +184,10 @@ export default class H3HexagonLayer extends CompositeLayer {
         coverage,
         elevationScale,
         extruded,
+        wireframe,
         fp64,
-        getColor,
+        getFillColor: getColor || getFillColor,
+        getLineColor,
         getElevation,
         material
       },


### PR DESCRIPTION
For #3015 

- Add `getFillColor`, `getLineColor` & `wireframe` props to ColumnLayer of H3Hexagon Layer.

- Add updated props to the docs.

- Fix ColumnLayer docs for `wireframe`.

