### PR TITLE
Ensure UMD bundles are ES5

### DIFF
--- a/scripts/bundle.config.js
+++ b/scripts/bundle.config.js
@@ -68,7 +68,12 @@ const config = {
         // Compile ES2015 using babel
         test: /\.js$/,
         loader: 'babel-loader',
-        include: /src/
+        include: /src/,
+        options: {
+          presets: [
+            ['@babel/preset-env', {forceAllTransforms: true}]
+          ]
+        }
       }
     ]
   },


### PR DESCRIPTION
For #3076

I tried to verify this but wasn't able to. Running `npm run build` doesn't seem to create the dist bundle.