### PR TITLE
Use a single model for stroke and fill in ColumnLayer

### DIFF
--- a/modules/layers/src/column-layer/column-geometry.js
+++ b/modules/layers/src/column-layer/column-geometry.js
@@ -18,7 +18,7 @@ export class ColumnGeometry extends Geometry {
 
 /* eslint-disable max-statements, complexity */
 function tesselateCylinder(props) {
-  const {radius, height = 1, nradial = 10, mode} = props;
+  const {radius, height = 1, nradial = 10, mode, vertices} = props;
 
   const vertsAroundEdge = nradial + 1; // loop
   const numVertices = vertsAroundEdge * 3; // top, side top edge, side bottom edge
@@ -32,7 +32,7 @@ function tesselateCylinder(props) {
   const normals = new Float32Array(numVertices * 3);
 
   let i = 0;
-  let a = 0;
+  let v = 0;
 
   // top tesselation: 0, -1, 1, -2, 2, -3, 3, ...
   //
@@ -45,13 +45,14 @@ function tesselateCylinder(props) {
   //   -3 -- 4
   //
   for (let j = 0; j < vertsAroundEdge; j++) {
-    const v = Math.floor(j / 2) * Math.sign((j % 2) - 0.5);
-    a = v * stepAngle;
+    v = Math.floor(j / 2) * Math.sign((j % 2) - 0.5);
+    const a = v * stepAngle;
+    const vertex = vertices && vertices[(v + nradial) % nradial];
     const sin = Math.sin(a);
     const cos = Math.cos(a);
 
-    positions[i + 0] = cos * radius;
-    positions[i + 1] = sin * radius;
+    positions[i + 0] = vertex ? vertex[0] : cos * radius;
+    positions[i + 1] = vertex ? vertex[1] : sin * radius;
     positions[i + 2] = height / 2;
 
     normals[i + 2] = 1;
@@ -66,12 +67,14 @@ function tesselateCylinder(props) {
   // 1 - 3 - 5  ... bottom
   //
   for (let j = 0; j < vertsAroundEdge; j++) {
+    const a = v * stepAngle;
+    const vertex = vertices && vertices[(v + nradial) % nradial];
     const sin = Math.sin(a);
     const cos = Math.cos(a);
 
     for (let k = 0; k < 2; k++) {
-      positions[i + 0] = cos * radius;
-      positions[i + 1] = sin * radius;
+      positions[i + 0] = vertex ? vertex[0] : cos * radius;
+      positions[i + 1] = vertex ? vertex[1] : sin * radius;
       positions[i + 2] = (1 / 2 - k) * height;
 
       normals[i + 0] = cos;
@@ -79,7 +82,7 @@ function tesselateCylinder(props) {
 
       i += 3;
     }
-    a += stepAngle;
+    v++;
   }
 
   if (mode === WIREFRAME_MODE) {

--- a/modules/layers/src/column-layer/column-geometry.js
+++ b/modules/layers/src/column-layer/column-geometry.js
@@ -1,9 +1,7 @@
+import {log} from '@deck.gl/core';
 import {Geometry, uid} from '@luma.gl/core';
 
-export const FILL_MODE = 'fill';
-export const WIREFRAME_MODE = 'wireframe';
-
-export class ColumnGeometry extends Geometry {
+export default class ColumnGeometry extends Geometry {
   constructor(props = {}) {
     const {id = uid('column-geometry')} = props;
     const {indices, attributes} = tesselateColumn(props);
@@ -18,7 +16,8 @@ export class ColumnGeometry extends Geometry {
 
 /* eslint-disable max-statements, complexity */
 function tesselateColumn(props) {
-  const {radius, height = 1, nradial = 10, mode, vertices} = props;
+  const {radius, height = 1, nradial = 10, vertices} = props;
+  log.assert(!vertices || vertices.length >= nradial);
 
   const vertsAroundEdge = nradial + 1; // loop
   const numVertices = vertsAroundEdge * 3; // top, side top edge, side bottom edge
@@ -26,7 +25,7 @@ function tesselateColumn(props) {
   const stepAngle = (Math.PI * 2) / nradial;
 
   // Used for wireframe
-  let indices = new Uint16Array(nradial * 3 * 2); // top loop, side vertical, bottom loop
+  const indices = new Uint16Array(nradial * 3 * 2); // top loop, side vertical, bottom loop
 
   const positions = new Float32Array(numVertices * 3);
   const normals = new Float32Array(numVertices * 3);
@@ -83,21 +82,17 @@ function tesselateColumn(props) {
     i += 3;
   }
 
-  if (mode === WIREFRAME_MODE) {
-    let index = 0;
-    for (let j = 0; j < nradial; j++) {
-      // top loop
-      indices[index++] = j * 2 + 0;
-      indices[index++] = j * 2 + 2;
-      // side vertical
-      indices[index++] = j * 2 + 0;
-      indices[index++] = j * 2 + 1;
-      // bottom loop
-      indices[index++] = j * 2 + 1;
-      indices[index++] = j * 2 + 3;
-    }
-  } else if (mode === FILL_MODE) {
-    indices = null;
+  let index = 0;
+  for (let j = 0; j < nradial; j++) {
+    // top loop
+    indices[index++] = j * 2 + 0;
+    indices[index++] = j * 2 + 2;
+    // side vertical
+    indices[index++] = j * 2 + 0;
+    indices[index++] = j * 2 + 1;
+    // bottom loop
+    indices[index++] = j * 2 + 1;
+    indices[index++] = j * 2 + 3;
   }
 
   return {

--- a/modules/layers/src/column-layer/column-layer.js
+++ b/modules/layers/src/column-layer/column-layer.js
@@ -18,10 +18,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {Layer, log, createIterable} from '@deck.gl/core';
+import {Layer, createIterable} from '@deck.gl/core';
 import GL from '@luma.gl/constants';
 import {Model, fp64, PhongMaterial} from '@luma.gl/core';
-import {ColumnGeometry, FILL_MODE, WIREFRAME_MODE} from './column-geometry';
+import ColumnGeometry from './column-geometry';
 const {fp64LowPart} = fp64;
 const defaultMaterial = new PhongMaterial();
 
@@ -100,110 +100,94 @@ export default class ColumnLayer extends Layer {
   updateState({props, oldProps, changeFlags}) {
     super.updateState({props, oldProps, changeFlags});
 
-    const regenerateModels =
-      props.fp64 !== oldProps.fp64 ||
-      props.diskResolution !== oldProps.diskResolution ||
-      props.filled !== oldProps.filled ||
-      props.wireframe !== oldProps.wireframe;
+    const regenerateModels = props.fp64 !== oldProps.fp64;
 
     if (regenerateModels) {
       const {gl} = this.context;
-      if (this.state.models) {
-        this.state.models.forEach(model => model.delete());
+      if (this.state.model) {
+        this.state.model.delete();
       }
-      this.setState(this._getModels(gl));
+      this.setState({model: this._getModel(gl)});
       this.getAttributeManager().invalidateAll();
     }
 
-    if (regenerateModels || props.vertices !== oldProps.vertices) {
-      this._updateVertices(props.vertices);
+    if (
+      regenerateModels ||
+      props.diskResolution !== oldProps.diskResolution ||
+      props.vertices !== oldProps.vertices
+    ) {
+      this._updateGeometry(props);
     }
   }
 
-  getGeometry(diskResolution, mode = FILL_MODE, vertices) {
-    return new ColumnGeometry({
+  getGeometry(diskResolution, vertices) {
+    const geometry = new ColumnGeometry({
       radius: 1,
-      mode,
-      drawMode: mode === FILL_MODE ? GL.TRIANGLE_STRIP : GL.LINES,
       height: 2,
       vertices,
       nradial: diskResolution
     });
+
+    return geometry;
   }
 
-  _getModels(gl) {
-    const {id, filled, wireframe, diskResolution} = this.props;
-    let fillModel;
-    let wireframeModel;
-
-    if (filled) {
-      fillModel = new Model(
-        gl,
-        Object.assign({}, this.getShaders(), {
-          id: `${id}-${FILL_MODE}`,
-          uniforms: {isWireframe: false},
-          geometry: this.getGeometry(diskResolution, FILL_MODE),
-          isInstanced: true,
-          shaderCache: this.context.shaderCache
-        })
-      );
-    }
-    if (wireframe) {
-      wireframeModel = new Model(
-        gl,
-        Object.assign({}, this.getShaders(), {
-          id: `${id}-${WIREFRAME_MODE}`,
-          uniforms: {isWireframe: true},
-          geometry: this.getGeometry(diskResolution, WIREFRAME_MODE),
-          isInstanced: true,
-          shaderCache: this.context.shaderCache
-        })
-      );
-    }
-
-    return {
-      models: [fillModel, wireframeModel].filter(Boolean),
-      fillModel,
-      wireframeModel
-    };
+  _getModel(gl) {
+    return new Model(
+      gl,
+      Object.assign({}, this.getShaders(), {
+        id: this.props.id,
+        isInstanced: true,
+        shaderCache: this.context.shaderCache
+      })
+    );
   }
 
-  _updateVertices(vertices) {
-    if (!vertices) {
-      return;
-    }
-    const {diskResolution} = this.props;
-    log.assert(vertices.length >= diskResolution);
-    const {fillModel, wireframeModel} = this.state;
+  _updateGeometry({diskResolution, vertices}) {
+    const geometry = this.getGeometry(diskResolution, vertices);
 
-    if (fillModel) {
-      const fillGeometry = this.getGeometry(diskResolution, FILL_MODE, vertices);
-      fillModel.setProps({geometry: fillGeometry});
-    }
+    this.setState({
+      fillVertexCount: geometry.attributes.POSITION.value.length / 3,
+      wireframeVertexCount: geometry.indices.value.length
+    });
 
-    if (wireframeModel) {
-      const wireframeGeometry = this.getGeometry(diskResolution, WIREFRAME_MODE, vertices);
-      wireframeModel.setProps({geometry: wireframeGeometry});
-    }
+    this.state.model.setProps({geometry});
   }
 
   draw({uniforms}) {
-    const {elevationScale, extruded, offset, coverage, radius, angle} = this.props;
-    const {models} = this.state;
-    const renderUniforms = Object.assign({}, uniforms, {
-      radius,
-      angle: (angle / 180) * Math.PI,
-      offset,
+    const {
+      elevationScale,
       extruded,
+      filled,
+      wireframe,
+      offset,
       coverage,
-      elevationScale
-    });
-    const numInstances = this.getNumInstances();
+      radius,
+      angle
+    } = this.props;
+    const {model, fillVertexCount, wireframeVertexCount} = this.state;
 
-    for (const model of models) {
-      model.setInstanceCount(numInstances);
-      model.setUniforms(renderUniforms);
-      model.draw();
+    model.setUniforms(
+      Object.assign({}, uniforms, {
+        radius,
+        angle: (angle / 180) * Math.PI,
+        offset,
+        extruded,
+        coverage,
+        elevationScale
+      })
+    );
+
+    if (wireframe) {
+      model.setProps({isIndexed: true});
+      model.setVertexCount(wireframeVertexCount);
+      model.setDrawMode(GL.LINES);
+      model.setUniforms({isWireframe: true}).draw();
+    }
+    if (filled) {
+      model.setProps({isIndexed: false});
+      model.setVertexCount(fillVertexCount);
+      model.setDrawMode(GL.TRIANGLE_STRIP);
+      model.setUniforms({isWireframe: false}).draw();
     }
   }
 

--- a/modules/layers/src/column-layer/column-layer.js
+++ b/modules/layers/src/column-layer/column-layer.js
@@ -120,12 +120,13 @@ export default class ColumnLayer extends Layer {
     }
   }
 
-  getGeometry(diskResolution, mode = FILL_MODE) {
+  getGeometry(diskResolution, mode = FILL_MODE, vertices) {
     return new ColumnGeometry({
       radius: 1,
       mode,
       drawMode: mode === FILL_MODE ? GL.TRIANGLE_STRIP : GL.LINES,
       height: 2,
+      vertices,
       nradial: diskResolution
     });
   }
@@ -176,29 +177,13 @@ export default class ColumnLayer extends Layer {
     const {fillModel, wireframeModel} = this.state;
 
     if (fillModel) {
-      const fillGeometry = this.getGeometry(diskResolution, FILL_MODE);
-      this.updateGeometry(fillGeometry, vertices, diskResolution);
+      const fillGeometry = this.getGeometry(diskResolution, FILL_MODE, vertices);
       fillModel.setProps({geometry: fillGeometry});
     }
 
     if (wireframeModel) {
-      const wireframeGeometry = this.getGeometry(diskResolution, WIREFRAME_MODE);
-      this.updateGeometry(wireframeGeometry, vertices, diskResolution);
+      const wireframeGeometry = this.getGeometry(diskResolution, WIREFRAME_MODE, vertices);
       wireframeModel.setProps({geometry: wireframeGeometry});
-    }
-  }
-
-  updateGeometry(geometry, vertices, diskResolution) {
-    const positions = geometry.attributes.POSITION;
-    let i = 0;
-    for (let loopIndex = 0; loopIndex < 3; loopIndex++) {
-      for (let j = 0; j <= diskResolution; j++) {
-        const p = vertices[j] || vertices[0]; // auto close loop
-        // replace x and y in geometry
-        positions.value[i++] = p[0];
-        positions.value[i++] = p[1];
-        i++;
-      }
     }
   }
 

--- a/modules/layers/src/column-layer/column-layer.js
+++ b/modules/layers/src/column-layer/column-layer.js
@@ -123,14 +123,10 @@ export default class ColumnLayer extends Layer {
   getGeometry(diskResolution, mode = FILL_MODE) {
     return new ColumnGeometry({
       radius: 1,
-      topCap: false,
-      bottomCap: mode === FILL_MODE,
       mode,
-      drawMode: mode === FILL_MODE ? GL.TRIANGLES : GL.LINES,
+      drawMode: mode === FILL_MODE ? GL.TRIANGLE_STRIP : GL.LINES,
       height: 2,
-      verticalAxis: 'z',
-      nradial: diskResolution,
-      nvertical: 1
+      nradial: diskResolution
     });
   }
 

--- a/modules/layers/src/column-layer/grid-cell-layer.js
+++ b/modules/layers/src/column-layer/grid-cell-layer.js
@@ -19,7 +19,6 @@
 // THE SOFTWARE.
 
 import {CubeGeometry} from '@luma.gl/core';
-import GL from '@luma.gl/constants';
 import ColumnLayer from './column-layer';
 
 const defaultProps = {
@@ -34,19 +33,19 @@ export default class GridCellLayer extends ColumnLayer {
 
   draw({uniforms}) {
     const {elevationScale, extruded, offset, coverage, cellSize, angle} = this.props;
-    const {fillModel} = this.state;
-    const numInstances = this.getNumInstances();
-    const renderUniforms = Object.assign({}, uniforms, {
-      radius: cellSize / 2,
-      angle,
-      offset,
-      extruded,
-      coverage,
-      elevationScale
-    });
-    fillModel.setInstanceCount(numInstances);
-    fillModel.setDrawMode(GL.TRIANGLES);
-    fillModel.setUniforms(renderUniforms).draw();
+    this.state.model
+      .setUniforms(
+        Object.assign({}, uniforms, {
+          radius: cellSize / 2,
+          angle,
+          offset,
+          extruded,
+          coverage,
+          elevationScale,
+          isWireframe: false
+        })
+      )
+      .draw();
   }
 }
 


### PR DESCRIPTION
For #3015 

#### Change List
- Remove unused options, reduce attribute size (1/3 vertex count)
- Move custom vertices handling into `ColumnGeometry` constructor
