### PR TITLE
Add partial update support to AttributeManager

### DIFF
--- a/docs/api-reference/attribute-manager.md
+++ b/docs/api-reference/attribute-manager.md
@@ -61,7 +61,7 @@ Takes a single parameter as a map of attribute descriptor objects:
 * keys are attribute names
 * values are objects with attribute definitions:
   + `size` (Number) - number of elements per object
-  + `accessor` (String | Array of strings) - accessor name(s) that will
+  + `accessor` (String | Array of strings | Function) - accessor name(s) that will
     trigger an update of this attribute when changed. Used with
     [`updateTriggers`](/docs/api-reference/layer.md#-updatetriggers-object-optional-).
   + `update` (Function) - the function to be called when data changes
@@ -118,6 +118,8 @@ attributeManager.update({
     data,
     numInstances,
     transitions,
+    startIndex,
+    endIndex,
     props = {},
     buffers = {},
     context = {},
@@ -132,6 +134,8 @@ Parameters:
 * `buffers` (Object) - pre-allocated buffers
 * `props` (Object) - passed to updaters
 * `context` (Object) - Used as "this" context for updaters
+* `startIndex` (Number) - start index in the data object, if only a subset of data needs to be considered in the update
+* `endIndex` (Number) - end index in the data object, if only a subset of data needs to be considered in the update
 
 Notes:
 

--- a/docs/api-reference/attribute-manager.md
+++ b/docs/api-reference/attribute-manager.md
@@ -134,8 +134,6 @@ Parameters:
 * `buffers` (Object) - pre-allocated buffers
 * `props` (Object) - passed to updaters
 * `context` (Object) - Used as "this" context for updaters
-* `startIndex` (Number) - start index in the data object, if only a subset of data needs to be considered in the update
-* `endIndex` (Number) - end index in the data object, if only a subset of data needs to be considered in the update
 
 Notes:
 

--- a/modules/core/src/lib/attribute-manager.js
+++ b/modules/core/src/lib/attribute-manager.js
@@ -217,8 +217,6 @@ export default class AttributeManager {
     numInstances,
     bufferLayout,
     transitions,
-    startIndex,
-    endIndex,
     props = {},
     buffers = {},
     context = {}
@@ -245,8 +243,6 @@ export default class AttributeManager {
           numInstances,
           bufferLayout,
           data,
-          startIndex,
-          endIndex,
           props,
           context
         });

--- a/modules/core/src/lib/attribute-manager.js
+++ b/modules/core/src/lib/attribute-manager.js
@@ -392,7 +392,9 @@ export default class AttributeManager {
     return invalidatedAttributes;
   }
 
-  _updateAttribute({attribute, numInstances, bufferLayout, data, props, context}) {
+  _updateAttribute(opts) {
+    const {attribute, numInstances} = opts;
+
     if (attribute.allocate(numInstances)) {
       logFunctions.onUpdate({
         level: LOG_DETAIL_PRIORITY,
@@ -404,7 +406,7 @@ export default class AttributeManager {
     // Calls update on any buffers that need update
     const timeStart = Date.now();
 
-    const updated = attribute.updateBuffer({numInstances, bufferLayout, data, props, context});
+    const updated = attribute.updateBuffer(opts);
     if (updated) {
       this.needsRedraw = true;
 

--- a/modules/core/src/lib/attribute-manager.js
+++ b/modules/core/src/lib/attribute-manager.js
@@ -217,6 +217,8 @@ export default class AttributeManager {
     numInstances,
     bufferLayout,
     transitions,
+    startIndex,
+    endIndex,
     props = {},
     buffers = {},
     context = {}
@@ -238,7 +240,16 @@ export default class AttributeManager {
         // Attribute is using generic value from the props
       } else if (attribute.needsUpdate()) {
         updated = true;
-        this._updateAttribute({attribute, numInstances, bufferLayout, data, props, context});
+        this._updateAttribute({
+          attribute,
+          numInstances,
+          bufferLayout,
+          data,
+          startIndex,
+          endIndex,
+          props,
+          context
+        });
       }
 
       this.needsRedraw |= attribute.needsRedraw();

--- a/modules/core/src/lib/attribute.js
+++ b/modules/core/src/lib/attribute.js
@@ -341,10 +341,7 @@ export default class Attribute extends BaseAttribute {
     return true;
   }
 
-  _standardAccessor(
-    attribute,
-    {data, startIndex = 0, endIndex = Infinity, props, numInstances, bufferLayout}
-  ) {
+  _standardAccessor(attribute, {data, startIndex, endIndex, props, numInstances, bufferLayout}) {
     const state = attribute.userData;
 
     const {accessor} = state;
@@ -353,24 +350,16 @@ export default class Attribute extends BaseAttribute {
 
     assert(typeof accessorFunc === 'function', `accessor "${accessor}" is not a function`);
 
-    let i = 0;
-    const {iterable, objectInfo} = createIterable(data);
+    let i = attribute._getVertexOffset(startIndex || 0, bufferLayout);
+    const {iterable, objectInfo} = createIterable(data, startIndex, endIndex);
     for (const object of iterable) {
-      const objectIndex = ++objectInfo.index;
-
-      if (objectIndex < startIndex) {
-        i += (bufferLayout ? bufferLayout[objectIndex] : 1) * size;
-        continue; // eslint-disable-line
-      }
-      if (objectIndex >= endIndex) {
-        break;
-      }
+      objectInfo.index++;
 
       const objectValue = accessorFunc(object, objectInfo);
 
       if (bufferLayout) {
         attribute._normalizeValue(objectValue, objectInfo.target);
-        const numVertices = bufferLayout[objectIndex];
+        const numVertices = bufferLayout[objectInfo.index];
         fillArray({
           target: attribute.value,
           source: objectInfo.target,

--- a/modules/core/src/utils/iterable-utils.js
+++ b/modules/core/src/utils/iterable-utils.js
@@ -26,7 +26,7 @@ const placeholderArray = [];
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols
  * and a "context" tracker from the given data
  */
-export function createIterable(data, startIndex = 0, endIndex) {
+export function createIterable(data, startRow = 0, endRow = Infinity) {
   let iterable = EMPTY_ARRAY;
 
   const objectInfo = {
@@ -46,12 +46,9 @@ export function createIterable(data, startIndex = 0, endIndex) {
     iterable = placeholderArray;
   }
 
-  if (startIndex > 0 || Number.isFinite(endIndex)) {
-    iterable = (Array.isArray(iterable) ? iterable : Array.from(iterable)).slice(
-      startIndex,
-      endIndex
-    );
-    objectInfo.index = startIndex - 1;
+  if (startRow > 0 || Number.isFinite(endRow)) {
+    iterable = (Array.isArray(iterable) ? iterable : Array.from(iterable)).slice(startRow, endRow);
+    objectInfo.index = startRow - 1;
   }
 
   return {iterable, objectInfo};

--- a/modules/core/src/utils/iterable-utils.js
+++ b/modules/core/src/utils/iterable-utils.js
@@ -26,7 +26,7 @@ const placeholderArray = [];
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols
  * and a "context" tracker from the given data
  */
-export function createIterable(data) {
+export function createIterable(data, startIndex = 0, endIndex) {
   let iterable = EMPTY_ARRAY;
 
   const objectInfo = {
@@ -44,6 +44,14 @@ export function createIterable(data) {
   } else if (data.length > 0) {
     placeholderArray.length = data.length;
     iterable = placeholderArray;
+  }
+
+  if (startIndex > 0 || Number.isFinite(endIndex)) {
+    iterable = (Array.isArray(iterable) ? iterable : Array.from(iterable)).slice(
+      startIndex,
+      endIndex
+    );
+    objectInfo.index = startIndex - 1;
   }
 
   return {iterable, objectInfo};

--- a/test/modules/core/lib/attribute.spec.js
+++ b/test/modules/core/lib/attribute.spec.js
@@ -251,6 +251,108 @@ test('Attribute#updateBuffer', t => {
   t.end();
 });
 
+test('Attribute#updateBuffer - partial', t => {
+  let accessorCalled = 0;
+
+  const TEST_PROPS = {
+    data: [{id: 'A'}, {id: 'B'}, {id: 'C'}, {id: 'D'}],
+    getValue: d => accessorCalled++
+  };
+
+  const ATTRIBUTE_1 = new Attribute(gl, {
+    id: 'values-1',
+    type: GL.FLOAT,
+    size: 1,
+    accessor: 'getValue'
+  });
+
+  const ATTRIBUTE_2 = new Attribute(gl, {
+    id: 'values-2',
+    type: GL.FLOAT,
+    size: 1,
+    accessor: 'getValue'
+  });
+
+  const TEST_CASES = [
+    {
+      title: 'full update',
+      attribute: ATTRIBUTE_1,
+      params: {
+        numInstances: 4
+      },
+      value: [0, 1, 2, 3]
+    },
+    {
+      title: 'update with startIndex only',
+      attribute: ATTRIBUTE_1,
+      params: {
+        numInstances: 4,
+        startIndex: 3
+      },
+      value: [0, 1, 2, 0]
+    },
+    {
+      title: 'update with index range',
+      attribute: ATTRIBUTE_1,
+      params: {
+        numInstances: 4,
+        startIndex: 1,
+        endIndex: 3
+      },
+      value: [0, 0, 1, 0]
+    },
+    {
+      title: 'full update - variable size',
+      attribute: ATTRIBUTE_2,
+      params: {
+        numInstances: 10,
+        bufferLayout: [2, 1, 4, 3]
+      },
+      value: [0, 0, 1, 2, 2, 2, 2, 3, 3, 3]
+    },
+    {
+      title: 'update with startIndex only - variable size',
+      attribute: ATTRIBUTE_2,
+      params: {
+        numInstances: 10,
+        bufferLayout: [2, 1, 4, 3],
+        startIndex: 3
+      },
+      value: [0, 0, 1, 2, 2, 2, 2, 0, 0, 0]
+    },
+    {
+      title: 'update with index range - variable size',
+      attribute: ATTRIBUTE_2,
+      params: {
+        numInstances: 10,
+        bufferLayout: [2, 1, 4, 3],
+        startIndex: 1,
+        endIndex: 3
+      },
+      value: [0, 0, 0, 1, 1, 1, 1, 0, 0, 0]
+    }
+  ];
+
+  for (const testCase of TEST_CASES) {
+    const {attribute} = testCase;
+    attribute.setNeedsUpdate(true);
+
+    // reset stats
+    accessorCalled = 0;
+
+    attribute.allocate(testCase.params.numInstances);
+    attribute.updateBuffer({
+      ...testCase.params,
+      data: TEST_PROPS.data,
+      props: TEST_PROPS
+    });
+
+    t.deepEqual(attribute.value, testCase.value, `${testCase.title} yields correct result`);
+  }
+
+  t.end();
+});
+
 // t.ok(attribute.allocate(attributeName, allocCount), 'Attribute.allocate function available');
 // t.ok(attribute._setExternalBuffer(attributeName, buffer, numInstances), 'Attribute._setExternalBuffer function available');
 // t.ok(attribute._analyzeBuffer(attributeName, numInstances), 'Attribute._analyzeBuffer function available');

--- a/test/modules/core/lib/attribute.spec.js
+++ b/test/modules/core/lib/attribute.spec.js
@@ -256,7 +256,9 @@ test('Attribute#updateBuffer - partial', t => {
 
   const TEST_PROPS = {
     data: [{id: 'A'}, {id: 'B'}, {id: 'C'}, {id: 'D'}],
-    getValue: d => accessorCalled++
+    // This accessor checks two things: how many times an accessor is called,
+    // and whether `index` is consistently populated for each object
+    getValue: (d, {index}) => accessorCalled++ + index * 10
   };
 
   const ATTRIBUTE_1 = new Attribute(gl, {
@@ -280,7 +282,7 @@ test('Attribute#updateBuffer - partial', t => {
       params: {
         numInstances: 4
       },
-      value: [0, 1, 2, 3]
+      value: [0, 11, 22, 33]
     },
     {
       title: 'update with startIndex only',
@@ -289,7 +291,7 @@ test('Attribute#updateBuffer - partial', t => {
         numInstances: 4,
         startIndex: 3
       },
-      value: [0, 1, 2, 0]
+      value: [0, 11, 22, 30]
     },
     {
       title: 'update with index range',
@@ -299,7 +301,7 @@ test('Attribute#updateBuffer - partial', t => {
         startIndex: 1,
         endIndex: 3
       },
-      value: [0, 0, 1, 0]
+      value: [0, 10, 21, 30]
     },
     {
       title: 'full update - variable size',
@@ -308,7 +310,7 @@ test('Attribute#updateBuffer - partial', t => {
         numInstances: 10,
         bufferLayout: [2, 1, 4, 3]
       },
-      value: [0, 0, 1, 2, 2, 2, 2, 3, 3, 3]
+      value: [0, 0, 11, 22, 22, 22, 22, 33, 33, 33]
     },
     {
       title: 'update with startIndex only - variable size',
@@ -318,7 +320,7 @@ test('Attribute#updateBuffer - partial', t => {
         bufferLayout: [2, 1, 4, 3],
         startIndex: 3
       },
-      value: [0, 0, 1, 2, 2, 2, 2, 0, 0, 0]
+      value: [0, 0, 11, 22, 22, 22, 22, 30, 30, 30]
     },
     {
       title: 'update with index range - variable size',
@@ -329,7 +331,7 @@ test('Attribute#updateBuffer - partial', t => {
         startIndex: 1,
         endIndex: 3
       },
-      value: [0, 0, 0, 1, 1, 1, 1, 0, 0, 0]
+      value: [0, 0, 10, 21, 21, 21, 21, 30, 30, 30]
     }
   ];
 

--- a/test/modules/core/lib/attribute.spec.js
+++ b/test/modules/core/lib/attribute.spec.js
@@ -285,21 +285,21 @@ test('Attribute#updateBuffer - partial', t => {
       value: [0, 11, 22, 33]
     },
     {
-      title: 'update with startIndex only',
+      title: 'update with startRow only',
       attribute: ATTRIBUTE_1,
       params: {
         numInstances: 4,
-        startIndex: 3
+        startRow: 3
       },
       value: [0, 11, 22, 30]
     },
     {
-      title: 'update with index range',
+      title: 'update with partial range',
       attribute: ATTRIBUTE_1,
       params: {
         numInstances: 4,
-        startIndex: 1,
-        endIndex: 3
+        startRow: 1,
+        endRow: 3
       },
       value: [0, 10, 21, 30]
     },
@@ -313,23 +313,23 @@ test('Attribute#updateBuffer - partial', t => {
       value: [0, 0, 11, 22, 22, 22, 22, 33, 33, 33]
     },
     {
-      title: 'update with startIndex only - variable size',
+      title: 'update with startRow only - variable size',
       attribute: ATTRIBUTE_2,
       params: {
         numInstances: 10,
         bufferLayout: [2, 1, 4, 3],
-        startIndex: 3
+        startRow: 3
       },
       value: [0, 0, 11, 22, 22, 22, 22, 30, 30, 30]
     },
     {
-      title: 'update with index range - variable size',
+      title: 'update with partial range - variable size',
       attribute: ATTRIBUTE_2,
       params: {
         numInstances: 10,
         bufferLayout: [2, 1, 4, 3],
-        startIndex: 1,
-        endIndex: 3
+        startRow: 1,
+        endRow: 3
       },
       value: [0, 0, 10, 21, 21, 21, 21, 30, 30, 30]
     }

--- a/test/modules/core/utils/index.js
+++ b/test/modules/core/utils/index.js
@@ -25,4 +25,5 @@ import './flatten.spec';
 import './positions.spec';
 import './memoize.spec';
 import './array-utils.spec';
+import './iterable-utils.spec';
 // import './compare-objects.spec';

--- a/test/modules/core/utils/iterable-utils.spec.js
+++ b/test/modules/core/utils/iterable-utils.spec.js
@@ -1,0 +1,109 @@
+import test from 'tape-catch';
+import {createIterable} from '@deck.gl/core/utils/iterable-utils';
+
+const TEST_CASES = [
+  {
+    title: 'empty data',
+    input: {
+      data: null
+    },
+    count: 0
+  },
+  {
+    title: 'array data',
+    input: {
+      data: [1, 2, 3]
+    },
+    count: 3,
+    firstObject: 1,
+    firstIndex: 0
+  },
+  {
+    title: 'iterable data',
+    input: {
+      data: new Map([['x', 1], ['y', 2], ['z', 3]])
+    },
+    count: 3,
+    firstObject: ['x', 1],
+    firstIndex: 0
+  },
+  {
+    title: 'non-iterable data',
+    input: {
+      data: {length: 3}
+    },
+    count: 3,
+    firstObject: undefined,
+    firstIndex: 0
+  },
+  {
+    title: 'array data with range',
+    input: {
+      data: [1, 2, 3],
+      startIndex: 0,
+      endIndex: 1
+    },
+    count: 1,
+    firstObject: 1,
+    firstIndex: 0
+  },
+  {
+    title: 'array data with range',
+    input: {
+      data: [1, 2, 3],
+      startIndex: 1
+    },
+    count: 2,
+    firstObject: 2,
+    firstIndex: 1
+  },
+  {
+    title: 'iterable data with range',
+    input: {
+      data: new Map([['x', 1], ['y', 2], ['z', 3]]),
+      startIndex: 1,
+      endIndex: 4
+    },
+    count: 2,
+    firstObject: ['y', 2],
+    firstIndex: 1
+  },
+  {
+    title: 'non-iterable data with range',
+    input: {
+      data: {length: 3},
+      startIndex: 2
+    },
+    count: 1,
+    firstObject: undefined,
+    firstIndex: 2
+  }
+];
+
+test('createIterable', t => {
+  for (const testCase of TEST_CASES) {
+    const {iterable, objectInfo} = createIterable(
+      testCase.input.data,
+      testCase.input.startIndex,
+      testCase.input.endIndex
+    );
+    let count = 0;
+    let firstObject;
+    let firstIndex;
+
+    for (const object of iterable) {
+      count++;
+      objectInfo.index++;
+      if (firstIndex === undefined) {
+        firstIndex = objectInfo.index;
+        firstObject = object;
+      }
+    }
+
+    t.is(count, testCase.count, `${testCase.title} yields correct object count`);
+    t.deepEqual(firstObject, testCase.firstObject, `${testCase.title} yields correct first object`);
+    t.is(firstIndex, testCase.firstIndex, `${testCase.title} yields correct first index`);
+  }
+
+  t.end();
+});


### PR DESCRIPTION
For #1576 [RFC](https://github.com/uber/deck.gl/blob/master/dev-docs/RFCs/vNext/partial-updates-rfc.md)

This is a non-breaking change -- any custom attribute updater now receive `startIndex` `endIndex` parameters. If it doesn't handle them, it would perform a full update on the attribute array just like before.

#### Change List
- Add optional `startIndex` `endIndex` parameters to `AttributeManager.update`
- Docs
- Unit test

#### TODO
- Add a test app for this feature
- Handle partial updates in core layers (e.g. `PathTesselator` and `PolygonTesselator`)
- Validate the provided range -- in path and polygon use cases, if the old and new vertex counts in the partial range do not match, partial update would corrupt the attribute array. This is less of a concern if we limit the usage to internal scenarios.
