### PR TITLE
Improve H3HexagonLayer perf

### DIFF
--- a/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
+++ b/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
@@ -14,7 +14,7 @@ import {ColumnLayer, PolygonLayer} from '@deck.gl/layers';
 // There is a cost to updating the instanced geometries when using highPrecision: false
 // This constant defines the distance between two hexagons that leads to "significant
 // distortion." Smaller value makes the column layer more sensitive to viewport change.
-const UPDATE_THRESHOLD = 10000; // 10km
+const UPDATE_THRESHOLD_KM = 10;
 
 function getHexagonCentroid(getHexagon, object, objectInfo) {
   const hexagonId = getHexagon(object, objectInfo);
@@ -68,7 +68,7 @@ export default class H3HexagonLayer extends CompositeLayer {
       }
       this.setState({
         resolution,
-        meanEdgeLength: resolution >= 0 ? edgeLength(resolution, UNITS.m) : 0,
+        edgeLengthKM: resolution >= 0 ? edgeLength(resolution, UNITS.km) : 0,
         hasPentagon,
         vertices: null
       });
@@ -86,14 +86,14 @@ export default class H3HexagonLayer extends CompositeLayer {
     if (this._shouldUseHighPrecision()) {
       return;
     }
-    const {resolution, meanEdgeLength, centerHex} = this.state;
+    const {resolution, edgeLengthKM, centerHex} = this.state;
     if (resolution < 0) {
       return;
     }
     const hex = geoToH3(viewport.latitude, viewport.longitude, resolution);
     if (
       centerHex === hex ||
-      (centerHex && h3Distance(centerHex, hex) * meanEdgeLength < UPDATE_THRESHOLD)
+      (centerHex && h3Distance(centerHex, hex) * edgeLengthKM < UPDATE_THRESHOLD_KM)
     ) {
       return;
     }


### PR DESCRIPTION
#### Background

The current implementation of `H3HexagonLayer` updates the instanced geometry (regenerating attributes and creating new WebGL buffers) whenever the hexagon at the center of the viewport changes. This is excessive especially at fine resolutions.

This PR introduces a distance threshold within which we consider all hexagons having the same shape. This significantly reduces the number of attribute updates needed when interacting with the viewport.

#### Change List
- Use the distance between the current center hex and the last center hex to determine whether geometry update is needed
