### PR TITLE
Fix react integration of mapbox layers

### DIFF
--- a/modules/mapbox/src/deck-utils.js
+++ b/modules/mapbox/src/deck-utils.js
@@ -6,13 +6,17 @@ export function getDeckInstance({map, gl, deck}) {
     return map.__deck;
   }
 
-  const customRender = (deck && deck.props._customRender) || (() => {});
+  const customRender = deck && deck.props._customRender;
 
   const deckProps = {
     useDevicePixels: true,
     _customRender: () => {
       map.triggerRepaint();
-      customRender();
+      if (customRender) {
+        // customRender may be subscribed by DeckGL React component to update child props
+        // make sure it is still called
+        customRender();
+      }
     },
     // TODO: import these defaults from a single source of truth
     parameters: {

--- a/modules/mapbox/src/deck-utils.js
+++ b/modules/mapbox/src/deck-utils.js
@@ -6,9 +6,14 @@ export function getDeckInstance({map, gl, deck}) {
     return map.__deck;
   }
 
+  const customRender = (deck && deck.props._customRender) || (() => {});
+
   const deckProps = {
     useDevicePixels: true,
-    _customRender: () => map.triggerRepaint(),
+    _customRender: () => {
+      map.triggerRepaint();
+      customRender();
+    },
     // TODO: import these defaults from a single source of truth
     parameters: {
       depthMask: true,


### PR DESCRIPTION
`MapboxLayer` was overwriting `<DeckGL>`'s `_customRender`, which handles viewport update for the child `<Map>` component.
