### PR TITLE
Fix TileLayer bug at low zoom levels

### DIFF
--- a/docs/layers/tile-layer.md
+++ b/docs/layers/tile-layer.md
@@ -129,6 +129,13 @@ The maximum cache size for a tile layer. If not defined, it is calculated using 
 
 - Default: `getTileData: ({x, y, z}) => Promise.resolve(null)`
 
+Receives arguments:
+
+- `x` (Number) - X of [the OSM tile index](https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames)
+- `y` (Number) - Y of [the OSM tile index](https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames)
+- `z` (Number) - Z of [the OSM tile index](https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames)
+- `bbox` (Object) - bounding box of the tile, in the shape of `{west, north, east, south}`.
+
 ##### `onTileError` (Function, optional)
 
 `onTileError` called when a tile failed to load.

--- a/modules/geo-layers/src/tile-layer/utils/tile.js
+++ b/modules/geo-layers/src/tile-layer/utils/tile.js
@@ -38,11 +38,10 @@ export default class Tile {
   }
 
   _loadData() {
-    const {x, y, z} = this;
     if (!this.getTileData) {
       return null;
     }
-    const getTileDataPromise = this.getTileData({x, y, z});
+    const getTileDataPromise = this.getTileData(this);
     return getTileDataPromise
       .then(buffers => {
         this._data = buffers;

--- a/modules/geo-layers/src/tile-layer/utils/tile.js
+++ b/modules/geo-layers/src/tile-layer/utils/tile.js
@@ -38,10 +38,11 @@ export default class Tile {
   }
 
   _loadData() {
+    const {x, y, z, bbox} = this;
     if (!this.getTileData) {
       return null;
     }
-    const getTileDataPromise = this.getTileData(this);
+    const getTileDataPromise = this.getTileData({x, y, z, bbox});
     return getTileDataPromise
       .then(buffers => {
         this._data = buffers;

--- a/modules/geo-layers/src/tile-layer/utils/viewport-util.js
+++ b/modules/geo-layers/src/tile-layer/utils/viewport-util.js
@@ -19,7 +19,7 @@ function getBoundingBox(viewport) {
 }
 
 function pixelsToTileIndex(a) {
-  return Math.floor(a / TILE_SIZE);
+  return a / TILE_SIZE;
 }
 
 /**
@@ -41,13 +41,23 @@ export function getTileIndices(viewport, maxZoom, minZoom) {
 
   const bbox = getBoundingBox(viewport);
 
-  const [minX, minY] = lngLatToWorld([bbox[0], bbox[3]], viewport.scale).map(pixelsToTileIndex);
-  const [maxX, maxY] = lngLatToWorld([bbox[2], bbox[1]], viewport.scale).map(pixelsToTileIndex);
+  let [minX, minY] = lngLatToWorld([bbox[0], bbox[3]], viewport.scale).map(pixelsToTileIndex);
+  let [maxX, maxY] = lngLatToWorld([bbox[2], bbox[1]], viewport.scale).map(pixelsToTileIndex);
+
+  /*
+      |  TILE  |  TILE  |  TILE  |
+        |(minPixel)           |(maxPixel)
+      |(minIndex)                |(maxIndex)  
+   */
+  minX = Math.max(0, Math.floor(minX));
+  maxX = Math.min(viewport.scale, Math.ceil(maxX));
+  minY = Math.max(0, Math.floor(minY));
+  maxY = Math.min(viewport.scale, Math.ceil(maxY));
 
   const indices = [];
 
-  for (let x = minX; x <= maxX; x++) {
-    for (let y = minY; y <= maxY; y++) {
+  for (let x = minX; x < maxX; x++) {
+    for (let y = minY; y < maxY; y++) {
       if (maxZoom && z > maxZoom) {
         indices.push(getAdjustedTileIndex({x, y, z}, maxZoom));
       } else {

--- a/test/modules/geo-layers/tile-layer/index.js
+++ b/test/modules/geo-layers/tile-layer/index.js
@@ -1,3 +1,4 @@
 import './tile-cache.spec';
 import './tile.spec';
 import './tile-layer.spec';
+import './viewport-util.spec';

--- a/test/modules/geo-layers/tile-layer/viewport-util.spec.js
+++ b/test/modules/geo-layers/tile-layer/viewport-util.spec.js
@@ -1,0 +1,97 @@
+import test from 'tape-catch';
+import {getTileIndices} from '@deck.gl/geo-layers/tile-layer/utils/viewport-util';
+import {WebMercatorViewport} from '@deck.gl/core';
+
+const TEST_CASES = [
+  {
+    title: 'flat viewport (fractional)',
+    viewport: new WebMercatorViewport({
+      width: 800,
+      height: 400,
+      longitude: -90,
+      latitude: 45,
+      zoom: 3.5
+    }),
+    minZoom: undefined,
+    maxZoom: undefined,
+    output: ['1,2,3', '1,3,3', '2,2,3', '2,3,3']
+  },
+  {
+    title: 'tilted viewport',
+    viewport: new WebMercatorViewport({
+      width: 800,
+      height: 400,
+      pitch: 30,
+      bearing: -25,
+      longitude: -90,
+      latitude: 45,
+      zoom: 3.5
+    }),
+    minZoom: undefined,
+    maxZoom: undefined,
+    output: ['0,1,3', '0,2,3', '0,3,3', '1,1,3', '1,2,3', '1,3,3', '2,1,3', '2,2,3', '2,3,3']
+  },
+  {
+    title: 'flat viewport (exact)',
+    viewport: new WebMercatorViewport({
+      width: 1024,
+      height: 1024,
+      longitude: 0,
+      latitude: 0,
+      zoom: 4
+    }),
+    minZoom: undefined,
+    maxZoom: undefined,
+    output: ['6,6,4', '6,7,4', '6,8,4', '7,6,4', '7,7,4', '7,8,4', '8,6,4', '8,7,4', '8,8,4']
+  },
+  {
+    title: 'under zoom',
+    viewport: new WebMercatorViewport({longitude: -90, latitude: 45, zoom: 3}),
+    minZoom: 4,
+    maxZoom: undefined,
+    output: []
+  },
+  {
+    title: 'over zoom',
+    viewport: new WebMercatorViewport({
+      width: 800,
+      height: 400,
+      longitude: -90,
+      latitude: 45,
+      zoom: 5
+    }),
+    minZoom: 0,
+    maxZoom: 3,
+    output: ['1,2,3', '2,2,3']
+  },
+  {
+    title: 'z0 repeat',
+    viewport: new WebMercatorViewport({
+      width: 800,
+      height: 400,
+      longitude: -90,
+      latitude: 0,
+      zoom: 0
+    }),
+    minZoom: undefined,
+    maxZoom: undefined,
+    output: ['0,0,0']
+  }
+];
+
+function getTileIds(tiles) {
+  const set = new Set();
+  for (const tile of tiles) {
+    set.add(`${tile.x},${tile.y},${tile.z}`);
+  }
+  return Array.from(set).sort();
+}
+
+test('getTileIndices', t => {
+  for (const testCase of TEST_CASES) {
+    const result = getTileIndices(testCase.viewport, testCase.maxZoom, testCase.minZoom);
+    t.deepEqual(getTileIds(result), testCase.output, testCase.title);
+  }
+
+  t.end();
+});


### PR DESCRIPTION
#### Background

TileLayer generates invalid tile indices (e.g. `x: -1, y: -1, z: 0`) at low zoom levels.

#### Change List
- Fix tile index generation from viewport, add tests
- Add `bbox` to arguments when calling `getTileData` (needed by H3 hexagon lookup)
