### PR TITLE
GPU GridLayer PART-4: Add support for picking

### DIFF
--- a/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-cell-layer-fragment.glsl.js
+++ b/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-cell-layer-fragment.glsl.js
@@ -30,5 +30,6 @@ out vec4 fragColor;
 
 void main(void) {
   fragColor = vColor;
+  fragColor = picking_filterColor(fragColor);
 }
 `;

--- a/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-cell-layer-vertex.glsl.js
+++ b/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-cell-layer-vertex.glsl.js
@@ -30,6 +30,7 @@ in vec3 normals;
 
 in vec4 colors;
 in vec4 elevations;
+in vec3 instancePickingColors;
 
 // Custom uniforms
 uniform vec2 offset;
@@ -111,6 +112,9 @@ void main(void) {
   vec3 centroidPosition = vec3(instancePositionXFP64[0], instancePositionYFP64[0], elevation);
   vec2 centroidPosition64xyLow = vec2(instancePositionXFP64[1], instancePositionYFP64[1]);
   vec3 pos = vec3(project_size(positions.xy + offset) * dotRadius, 0.);
+
+  // Set color to be rendered to picking fbo (also used to check for selection highlight).
+  picking_setPickingColor(instancePickingColors);
 
   vec4 position_commonspace;
   gl_Position = project_position_to_clipspace(centroidPosition, centroidPosition64xyLow, pos, position_commonspace);

--- a/modules/aggregation-layers/src/grid-layer/grid-aggregator.js
+++ b/modules/aggregation-layers/src/grid-layer/grid-aggregator.js
@@ -29,11 +29,12 @@ const R_EARTH = 6378000;
  * @param {function} getPosition - position accessor
  * @returns {object} - grid data, cell dimension
  */
-export function pointToDensityGridData(points, cellSize, getPosition) {
+export function pointToDensityGridDataCPU(points, cellSize, getPosition) {
   const {gridHash, gridOffset} = _pointsToGridHashing(points, cellSize, getPosition);
   const layerData = _getGridLayerDataFromGridHash(gridHash, gridOffset);
 
   return {
+    gridHash,
     gridOffset,
     layerData
   };

--- a/modules/aggregation-layers/src/grid-layer/grid-layer.js
+++ b/modules/aggregation-layers/src/grid-layer/grid-layer.js
@@ -26,7 +26,7 @@ import BinSorter from '../utils/bin-sorter';
 import {defaultColorRange} from '../utils/color-utils';
 import {getQuantizeScale, getLinearScale} from '../utils/scale-utils';
 
-import {pointToDensityGridData} from './grid-aggregator';
+import {pointToDensityGridDataCPU} from './grid-aggregator';
 
 function nop() {}
 
@@ -211,7 +211,7 @@ export default class GridLayer extends CompositeLayer {
 
   getLayerData() {
     const {data, cellSize, getPosition} = this.props;
-    const {layerData} = pointToDensityGridData(data, cellSize, getPosition);
+    const {layerData} = pointToDensityGridDataCPU(data, cellSize, getPosition);
 
     this.setState({layerData});
     this.getSortedBins();

--- a/modules/aggregation-layers/src/new-grid-layer/new-grid-layer.js
+++ b/modules/aggregation-layers/src/new-grid-layer/new-grid-layer.js
@@ -58,16 +58,11 @@ function getValueFunc(aggregation, accessor) {
   }
 }
 
-export default class NewGPULayer extends CompositeLayer {
+export default class NewGridLayer extends CompositeLayer {
   initializeState() {
     this.state = {
       useGPUAggregation: true
     };
-  }
-
-  getPickingInfo(opts) {
-    // TODO: implement picking.
-    return Object.assign({}, opts.info, {picked: false, object: null});
   }
 
   updateState({oldProps, props, changeFlags}) {
@@ -161,5 +156,5 @@ export default class NewGPULayer extends CompositeLayer {
   }
 }
 
-NewGPULayer.layerName = 'NewGPULayer';
-NewGPULayer.defaultProps = defaultProps;
+NewGridLayer.layerName = 'NewGridLayer';
+NewGridLayer.defaultProps = defaultProps;

--- a/modules/aggregation-layers/src/utils/gpu-grid-aggregation/gpu-grid-aggregator.js
+++ b/modules/aggregation-layers/src/utils/gpu-grid-aggregation/gpu-grid-aggregator.js
@@ -577,7 +577,7 @@ export default class GPUGridAggregator {
     const resourceName = `cpu-result-${id}-${bufferName}`;
     result[bufferName] = result[bufferName] || resources[resourceName];
     if (result[bufferName]) {
-      result[bufferName].subData({data});
+      result[bufferName].setData({data});
     } else {
       // save resource for garbage collection
       resources[resourceName] = new Buffer(gl, data);

--- a/modules/aggregation-layers/src/utils/gpu-grid-aggregation/grid-aggregation-utils.js
+++ b/modules/aggregation-layers/src/utils/gpu-grid-aggregation/grid-aggregation-utils.js
@@ -226,7 +226,6 @@ function getGPUAggregationParams({boundingBox, cellSize, worldOrigin}) {
   // Setup transformation matrix so that every point is in +ve range
   const gridTransformMatrix = new Matrix4().translate([-1 * originX, -1 * originY, 0]);
 
-  // const cellSize = [gridOffset.xOffset, gridOffset.yOffset];
   const gridOrigin = [originX, originY];
   const width = xMax - xMin + cellSize[0];
   const height = yMax - yMin + cellSize[1];

--- a/modules/main/src/index.js
+++ b/modules/main/src/index.js
@@ -124,7 +124,13 @@ export {
   TextLayer
 } from '@deck.gl/layers';
 
-export {ScreenGridLayer, GridLayer, HexagonLayer, ContourLayer} from '@deck.gl/aggregation-layers';
+export {
+  ScreenGridLayer,
+  GridLayer,
+  HexagonLayer,
+  ContourLayer,
+  _NewGridLayer
+} from '@deck.gl/aggregation-layers';
 
 export {
   GreatCircleLayer,

--- a/test/modules/aggregation-layers/grid-aggregator.spec.js
+++ b/test/modules/aggregation-layers/grid-aggregator.spec.js
@@ -22,15 +22,15 @@ import test from 'tape-catch';
 
 import * as FIXTURES from 'deck.gl-test/data';
 
-import {pointToDensityGridData} from '@deck.gl/aggregation-layers/grid-layer/grid-aggregator';
+import {pointToDensityGridDataCPU} from '@deck.gl/aggregation-layers/grid-layer/grid-aggregator';
 
 const getPosition = d => d.COORDINATES;
 const iterableData = new Set(FIXTURES.points);
 const cellSize = 500;
 
-test('pointToDensityGridData', t => {
+test('pointToDensityGridDataCPU', t => {
   t.ok(
-    typeof pointToDensityGridData(iterableData, cellSize, getPosition) === 'object',
+    typeof pointToDensityGridDataCPU(iterableData, cellSize, getPosition) === 'object',
     'should work with iterables'
   );
   t.end();


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #2084 
<!-- For other PRs without open issue -->
#### Background
- `GPUGridLayer` : Adding support for picking.
    - `onHover` will read data from aggregated textures, will only display, `colorValue`, `elevationValue` and `count` and `position` of selected grid cell.
    - For all other modes, data is aggregated on CPU (and saved in `state`). Based current selected cell `index`, corresponding `hash-key` is generated to access full aggregation results (including array of all aggregated `points`) from cpu Aggregation data.  CPU Aggregation is triggered only during picking and it is previously not calculated.
- `Picking Tests`
    - Add picking tests for `NewGridLayer`, for both cpu and gpu aggregaiton paths, and results are matched.
    - In addition to `pickInfo` count, update the tests to compare, number of aggregated points for each cell, results match in CPU and GPU paths. (this uses accessing CPU results from GPU layer).

OnHoover CPU result:
<img width="1792" alt="Screen Shot 2019-05-18 at 7 36 41 PM" src="https://user-images.githubusercontent.com/9502731/57989685-5d6fe800-7a53-11e9-9f02-2508544bcb2a.png">


OnHoover GPU result:
<img width="1792" alt="Screen Shot 2019-05-18 at 7 36 33 PM" src="https://user-images.githubusercontent.com/9502731/57989687-619c0580-7a53-11e9-8e21-01de24dbdd14.png">



<!-- For all the PRs -->
#### Change List
- GPU GridLayer PART-4: Add supporting for picking
