### PR TITLE
Update peer dependency versions

### DIFF
--- a/modules/aggregation-layers/package.json
+++ b/modules/aggregation-layers/package.json
@@ -33,7 +33,7 @@
     "d3-hexbin": "^0.2.1"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^7.0.0-beta.1",
-    "@deck.gl/layers": "^7.0.0-beta.1"
+    "@deck.gl/core": "^7.0.0",
+    "@deck.gl/layers": "^7.0.0"
   }
 }

--- a/modules/geo-layers/package.json
+++ b/modules/geo-layers/package.json
@@ -34,7 +34,7 @@
     "s2-geometry": "^1.2.10"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^7.0.0-beta.1",
-    "@deck.gl/layers": "^7.0.0-beta.1"
+    "@deck.gl/core": "^7.0.0",
+    "@deck.gl/layers": "^7.0.0"
   }
 }

--- a/modules/google-maps/package.json
+++ b/modules/google-maps/package.json
@@ -30,6 +30,6 @@
     "prepublishOnly": "npm run build-bundle && npm run build-bundle -- --env.dev"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^7.0.0-beta.1"
+    "@deck.gl/core": "^7.0.0"
   }
 }

--- a/modules/json/package.json
+++ b/modules/json/package.json
@@ -33,6 +33,6 @@
     "d3-dsv": "^1.0.8"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^7.0.0-beta.1"
+    "@deck.gl/core": "^7.0.0"
   }
 }

--- a/modules/layers/package.json
+++ b/modules/layers/package.json
@@ -35,6 +35,6 @@
     "earcut": "^2.0.6"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^7.0.0-beta.1"
+    "@deck.gl/core": "^7.0.0"
   }
 }

--- a/modules/mapbox/package.json
+++ b/modules/mapbox/package.json
@@ -30,6 +30,6 @@
     "prepublishOnly": "npm run build-bundle && npm run build-bundle -- --env.dev"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^7.0.0-beta.1"
+    "@deck.gl/core": "^7.0.0"
   }
 }

--- a/modules/mesh-layers/package.json
+++ b/modules/mesh-layers/package.json
@@ -30,7 +30,7 @@
     "prepublishOnly": "npm run build-bundle && npm run build-bundle -- --env.dev"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^7.0.0-beta.1"
+    "@deck.gl/core": "^7.0.0"
   },
   "dependencies": {
     "@loaders.gl/core": "^1.0.3",

--- a/modules/react/package.json
+++ b/modules/react/package.json
@@ -29,7 +29,7 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^7.0.0-beta.1",
+    "@deck.gl/core": "^7.0.0",
     "react": "0.14.x - 16.x",
     "react-dom": "0.14.x - 16.x"
   }

--- a/modules/test-utils/package.json
+++ b/modules/test-utils/package.json
@@ -24,7 +24,7 @@
     "src"
   ],
   "peerDependencies": {
-    "@deck.gl/core": "^7.0.0-beta.1",
+    "@deck.gl/core": "^7.0.0",
     "@probe.gl/test-utils": "^3.0.1"
   },
   "scripts": {}


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/3118

Lerna does not manage peer dependency versions.