### PR TITLE
Fix coordinate origin z bug

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -1,5 +1,11 @@
 # Upgrade Guide
 
+## Upgrading from deck.gl v7.0 to v7.1
+
+Breaking Changes:
+
+- Fixed a bug where `coordinateOrigin`'s `z` is not applied in `METER_OFFSETS` and `LNGLAT_OFFSETS` coordinate systems.
+
 ## Upgrading from deck.gl v6.4 to v7.0
 
 #### Submodule Structure and Dependency Changes

--- a/modules/core/src/shaderlib/project/project.glsl.js
+++ b/modules/core/src/shaderlib/project/project.glsl.js
@@ -42,7 +42,7 @@ uniform vec2 project_uViewportSize;
 uniform float project_uDevicePixelRatio;
 uniform float project_uFocalDistance;
 uniform vec3 project_uCameraPosition;
-uniform vec2 project_uCoordinateOrigin;
+uniform vec3 project_uCoordinateOrigin;
 
 const float TILE_SIZE = 512.0;
 const float PI = 3.1415926536;
@@ -135,7 +135,7 @@ vec4 project_position(vec4 position, vec2 position64xyLow) {
   // Apply model matrix
   vec4 position_world = project_uModelMatrix * position;
   if (project_uCoordinateSystem == COORDINATE_SYSTEM_IDENTITY) {
-    position_world.xy -= project_uCoordinateOrigin;
+    position_world.xyz -= project_uCoordinateOrigin;
     // Translation is already added to the high parts
     position_world += project_uModelMatrix * vec4(position64xyLow, 0.0, 0.0);
   }

--- a/modules/core/src/shaderlib/project/viewport-uniforms.js
+++ b/modules/core/src/shaderlib/project/viewport-uniforms.js
@@ -24,7 +24,6 @@ import * as vec4 from 'gl-matrix/vec4';
 import {COORDINATE_SYSTEM} from '../../lib/constants';
 
 import memoize from '../../utils/memoize';
-import log from '../../utils/log';
 import assert from '../../utils/assert';
 
 import {PROJECT_COORDINATE_SYSTEM} from './constants';

--- a/modules/core/src/shaderlib/project/viewport-uniforms.js
+++ b/modules/core/src/shaderlib/project/viewport-uniforms.js
@@ -101,6 +101,8 @@ function calculateMatrixAndOffset({
     shaderCoordinateOrigin = [Math.fround(viewport.position[0]), Math.fround(viewport.position[1])];
   }
 
+  shaderCoordinateOrigin[2] = shaderCoordinateOrigin[2] || 0;
+
   switch (shaderCoordinateSystem) {
     case PROJECT_COORDINATE_SYSTEM.LNG_LAT:
       projectionCenter = ZERO_VECTOR;
@@ -122,10 +124,9 @@ function calculateMatrixAndOffset({
       cameraPosCommon = [
         cameraPosCommon[0] - positionCommonSpace[0],
         cameraPosCommon[1] - positionCommonSpace[1],
-        cameraPosCommon[2]
+        cameraPosCommon[2] - positionCommonSpace[2]
       ];
 
-      positionCommonSpace[2] = 0;
       positionCommonSpace[3] = 1;
 
       // projectionCenter = new Matrix4(viewProjectionMatrix)
@@ -178,13 +179,6 @@ export function getUniformsFromViewport({
   positionOrigin
 } = {}) {
   assert(viewport);
-
-  if (projectionMode !== undefined) {
-    log.removed('projectionMode', 'coordinateSystem')();
-  }
-  if (positionOrigin !== undefined) {
-    log.removed('positionOrigin', 'coordinateOrigin')();
-  }
 
   return Object.assign(
     {

--- a/test/modules/core/shaderlib/project/viewport-uniforms.spec.js
+++ b/test/modules/core/shaderlib/project/viewport-uniforms.spec.js
@@ -110,7 +110,7 @@ test('project#getUniforms', t => {
   t.notOk(getUniformsError(uniforms, UNIFORMS), 'Uniforms validated');
   t.deepEqual(
     uniforms.project_uCoordinateOrigin,
-    [-122.42694091796875, 37.75153732299805],
+    [-122.42694091796875, 37.75153732299805, 0],
     'Returned shader coordinate origin'
   );
   t.ok(uniforms.project_uCenter.some(x => x), 'Returned non-trivial projection center');
@@ -131,7 +131,7 @@ test('project#getUniforms', t => {
   t.notOk(getUniformsError(uniforms, UNIFORMS), 'Uniforms validated');
   t.deepEqual(
     uniforms.project_uCoordinateOrigin,
-    [10.285714149475098, -3.1415927410125732],
+    [10.285714149475098, -3.1415927410125732, 0],
     'Returned shader coordinate origin'
   );
   t.ok(uniforms.project_uCenter.some(x => x), 'Returned non-trivial projection center');


### PR DESCRIPTION
This is a breaking change if a vec3 is provided to `coordinateOrigin` while `coordinateSystem` is `COORDINATE_SYSTEM.METER_OFFSETS` or `COORDINATE_SYSTEM.LNGLAT_OFFSETS`.

`LNGLAT`, `LNGLAT_AUTO_OFFSET` and `IDENTITY` modes are not affected.