### PR TITLE
GPU GridLayer PART 5: Add new color/elevation props to Grid and Hexagon layers

### DIFF
--- a/docs/layers/grid-layer.md
+++ b/docs/layers/grid-layer.md
@@ -218,6 +218,26 @@ You should pass in the function defined outside the render function so it doesn'
  }
 ```
 
+
+##### `getColorWeight` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
+
+* Default: `point => 1`
+
+`getColorWeight` is the accessor function to get the weight of a point used to calcuate the color value for a cell.
+It takes the data prop array element and returns the weight, for example, to use `SPACE` field, `getColorWeight` should be set to `point => point.SPACES`.
+By default `getColorWeight` returns `1`.
+
+Note: similar to `getColorValue`, grid layer compares whether `getColorWeight` has changed to recalculate the value for each bin that its color based on.
+
+
+##### `colorAggregation` (String, optional)
+
+* Default: 'SUM'
+
+`colorAggregation` defines, operation used to aggregate all data point weights to calculate a cell's color value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
+
+Note: `getColorWeight` and `colorAggregation` together define how color value of cell is determined, same can be done by setting `getColorValue` prop. But to enable gpu aggregation, former props must be provided instead of later.
+
 ##### `getElevationValue` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `points => points.length`
@@ -228,6 +248,27 @@ By default `getElevationValue` returns the length of the points array.
 
 Note: grid layer compares whether `getElevationValue` has changed to recalculate the value for each cell for its elevation.
 You should pass in the function defined outside the render function so it doesn't create a new function on every rendering pass.
+
+
+##### `getElevationWeight` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
+
+* Default: `point => 1`
+
+`getElevationWeight` is the accessor function to get the weight of a point used to calcuate the elevation value for a cell.
+It takes the data prop array element and returns the weight, for example, to use `SPACE` field, `getElevationWeight` should be set to `point => point.SPACES`.
+By default `getElevationWeight` returns `1`.
+
+Note: similar to `getElevationValue`, grid layer compares whether `getElevationWeight` has changed to recalculate the value for each bin that its color based on.
+
+
+##### `elevationAggregation` (String, optional)
+
+* Default: 'SUM'
+
+`elevationAggregation` defines, operation used to aggregate all data point weights to calculate a cell's elevation value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
+
+Note: `getElevationWeight` and `elevationAggregation` together define how elevation value of cell is determined, same can be done by setting `getColorValue` prop. But to enable gpu aggregation, former props must be provided instead of later.
+
 
 ##### `onSetColorDomain` (Function, optional)
 

--- a/docs/layers/grid-layer.md
+++ b/docs/layers/grid-layer.md
@@ -224,8 +224,6 @@ You should pass in the function defined outside the render function so it doesn'
 * Default: `point => 1`
 
 `getColorWeight` is the accessor function to get the weight of a point used to calcuate the color value for a cell.
-It takes the data prop array element and returns the weight, for example, to use `SPACE` field, `getColorWeight` should be set to `point => point.SPACES`.
-By default `getColorWeight` returns `1`.
 
 Note: similar to `getColorValue`, grid layer compares whether `getColorWeight` has changed to recalculate the value for each bin that its color based on.
 
@@ -236,7 +234,69 @@ Note: similar to `getColorValue`, grid layer compares whether `getColorWeight` h
 
 `colorAggregation` defines, operation used to aggregate all data point weights to calculate a cell's color value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
 
-Note: `getColorWeight` and `colorAggregation` together define how color value of cell is determined, same can be done by setting `getColorValue` prop. But to enable gpu aggregation, former props must be provided instead of later.
+Note: `getColorWeight` and `colorAggregation` together define how color value of cell is determined, same can be done by setting `getColorValue` prop. But to enable GPU aggregation, former props must be provided instead of later.
+
+###### Example1 : Using count of data elements that fall into a cell to encode the its color
+```js
+function getCount(points) {
+  return points.length;
+}
+...
+const layer = new GridLayer({
+  id: 'my-grid-layer',
+  ...
+  getColorValue: getCount,
+  ...
+});
+```
+
+####### Using `getColorWeight` and `colorAggregation`
+```js
+function getWeight(point) {
+  return 1;
+}
+...
+const layer = new GridLayer({
+  id: 'my-grid-layer',
+  ...
+  getColorWeight: getWeight,
+  colorAggregation: 'SUM'
+  ...
+});
+```
+
+###### Example2 : Using mean value of 'SPACES' field of data elements to encode the color of the cell
+
+####### Using `getColorValue`
+```js
+function getMean(points) {
+  return points.reduce((sum, p) => sum += p.SPACES, 0) / points.length;
+}
+...
+const layer = new GridLayer({
+  id: 'my-grid-layer',
+  ...
+  getColorValue: getMean,
+  ...
+});
+```
+
+####### Using `getColorWeight` and `colorAggregation`
+```js
+function getWeight(point) {
+  return point.SPACES;
+}
+...
+const layer = new GridLayer({
+  id: 'my-grid-layer',
+  ...
+  getColorWeight: getWeight,
+  colorAggregation: 'SUM'
+  ...
+});
+```
+
+If your use case requires aggregating using an operation that is not one of 'SUM', 'MEAN', 'MAX' and 'MIN', `getColorValue` should be used to define such custom aggregation function. In those cases GPU aggregation is not supported.
 
 ##### `getElevationValue` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
@@ -255,8 +315,6 @@ You should pass in the function defined outside the render function so it doesn'
 * Default: `point => 1`
 
 `getElevationWeight` is the accessor function to get the weight of a point used to calcuate the elevation value for a cell.
-It takes the data prop array element and returns the weight, for example, to use `SPACE` field, `getElevationWeight` should be set to `point => point.SPACES`.
-By default `getElevationWeight` returns `1`.
 
 Note: similar to `getElevationValue`, grid layer compares whether `getElevationWeight` has changed to recalculate the value for each bin that its color based on.
 
@@ -267,8 +325,73 @@ Note: similar to `getElevationValue`, grid layer compares whether `getElevationW
 
 `elevationAggregation` defines, operation used to aggregate all data point weights to calculate a cell's elevation value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
 
-Note: `getElevationWeight` and `elevationAggregation` together define how elevation value of cell is determined, same can be done by setting `getColorValue` prop. But to enable gpu aggregation, former props must be provided instead of later.
+Note: `getElevationWeight` and `elevationAggregation` together define how elevation value of cell is determined, same can be done by setting `getColorValue` prop. But to enable GPU aggregation, former props must be provided instead of later.
 
+
+###### Example1 : Using count of data elements that fall into a cell to encode the its elevation
+
+####### Using `getElevationValue`
+
+```js
+function getCount(points) {
+  return points.length;
+}
+...
+const layer = new GridLayer({
+  id: 'my-grid-layer',
+  ...
+  getElevationValue: getCount,
+  ...
+});
+```
+
+####### Using `getElevationWeight` and `elevationAggregation`
+```js
+function getWeight(point) {
+  return 1;
+}
+...
+const layer = new GridLayer({
+  id: 'my-grid-layer',
+  ...
+  getElevationWeight: getWeight,
+  elevationAggregation: 'SUM'
+  ...
+});
+```
+
+###### Example2 : Using maximum value of 'SPACES' field of data elements to encode the elevation of the cell
+
+####### Using `getElevationValue`
+```js
+function getMax(points) {
+  return points.reduce((max, p) => p.SPACES > max ? p.SPACES : max, -Infinity);
+}
+...
+const layer = new GridLayer({
+  id: 'my-grid-layer',
+  ...
+  getElevationValue: getMax,
+  ...
+});
+```
+
+####### Using `getElevationWeight` and `elevationAggregation`
+```js
+function getWeight(point) {
+  return point.SPACES;
+}
+...
+const layer = new GridLayer({
+  id: 'my-grid-layer',
+  ...
+  getElevationWeight: getWeight,
+  elevationAggregation: 'MAX'
+  ...
+});
+```
+
+If your use case requires aggregating using an operation that is not one of 'SUM', 'MEAN', 'MAX' and 'MIN', `getElevationValue` should be used to define such custom aggregation function. In those cases GPU aggregation is not supported.
 
 ##### `onSetColorDomain` (Function, optional)
 

--- a/docs/layers/grid-layer.md
+++ b/docs/layers/grid-layer.md
@@ -225,8 +225,6 @@ You should pass in the function defined outside the render function so it doesn'
 
 `getColorWeight` is the accessor function to get the weight of a point used to calcuate the color value for a cell.
 
-Note: similar to `getColorValue`, grid layer compares whether `getColorWeight` has changed to recalculate the value for each bin that its color based on.
-
 
 ##### `colorAggregation` (String, optional)
 
@@ -237,6 +235,8 @@ Note: similar to `getColorValue`, grid layer compares whether `getColorWeight` h
 Note: `getColorWeight` and `colorAggregation` together define how color value of cell is determined, same can be done by setting `getColorValue` prop. But to enable GPU aggregation, former props must be provided instead of later.
 
 ###### Example1 : Using count of data elements that fall into a cell to encode the its color
+
+####### Using `getColorValue`
 ```js
 function getCount(points) {
   return points.length;
@@ -315,8 +315,6 @@ You should pass in the function defined outside the render function so it doesn'
 * Default: `point => 1`
 
 `getElevationWeight` is the accessor function to get the weight of a point used to calcuate the elevation value for a cell.
-
-Note: similar to `getElevationValue`, grid layer compares whether `getElevationWeight` has changed to recalculate the value for each bin that its color based on.
 
 
 ##### `elevationAggregation` (String, optional)

--- a/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-layer.js
+++ b/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-layer.js
@@ -22,6 +22,7 @@ import {PhongMaterial} from '@luma.gl/core';
 import {CompositeLayer} from '@deck.gl/core';
 
 import GPUGridAggregator from '../utils/gpu-grid-aggregation/gpu-grid-aggregator';
+import {AGGREGATION_OPERATION} from '../utils/gpu-grid-aggregation/gpu-grid-aggregator-constants';
 import {pointToDensityGridData} from '../utils/gpu-grid-aggregation/grid-aggregation-utils';
 import {defaultColorRange, colorRangeToFlatArray} from '../utils/color-utils';
 import GPUGridCellLayer from './gpu-grid-cell-layer';
@@ -33,13 +34,13 @@ const defaultProps = {
   colorDomain: null,
   colorRange: defaultColorRange,
   getColorWeight: {type: 'accessor', value: x => 1},
-  colorAggregation: {type: 'number', value: 1, min: 1, max: 4}, // AGGREGATION_OPERATION, SUM is default
+  colorAggregation: 'SUM',
 
   // elevation
   elevationDomain: null,
   elevationRange: [0, 1000],
   getElevationWeight: {type: 'accessor', value: x => 1},
-  elevationAggregation: {type: 'number', value: 1, min: 1, max: 4}, // AGGREGATION_OPERATION, SUM is default
+  elevationAggregation: 'SUM',
   elevationScale: {type: 'number', min: 0, value: 1},
 
   // grid
@@ -200,14 +201,14 @@ export default class GPUGridLayer extends CompositeLayer {
     const weightParams = {
       color: {
         getWeight: getColorWeight,
-        operation: colorAggregation,
+        operation: AGGREGATION_OPERATION[colorAggregation] || AGGREGATION_OPERATION[defaultProps.colorAggregation],
         needMin: true,
         needMax: true,
         combineMaxMin: true
       },
       elevation: {
         getWeight: getElevationWeight,
-        operation: elevationAggregation,
+        operation: AGGREGATION_OPERATION[elevationAggregation] || AGGREGATION_OPERATION[defaultProps.elevationAggregation],
         needMin: true,
         needMax: true,
         combineMaxMin: true

--- a/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-layer.js
+++ b/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-layer.js
@@ -201,14 +201,18 @@ export default class GPUGridLayer extends CompositeLayer {
     const weightParams = {
       color: {
         getWeight: getColorWeight,
-        operation: AGGREGATION_OPERATION[colorAggregation] || AGGREGATION_OPERATION[defaultProps.colorAggregation],
+        operation:
+          AGGREGATION_OPERATION[colorAggregation] ||
+          AGGREGATION_OPERATION[defaultProps.colorAggregation],
         needMin: true,
         needMax: true,
         combineMaxMin: true
       },
       elevation: {
         getWeight: getElevationWeight,
-        operation: AGGREGATION_OPERATION[elevationAggregation] || AGGREGATION_OPERATION[defaultProps.elevationAggregation],
+        operation:
+          AGGREGATION_OPERATION[elevationAggregation] ||
+          AGGREGATION_OPERATION[defaultProps.elevationAggregation],
         needMin: true,
         needMax: true,
         combineMaxMin: true

--- a/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-layer.js
+++ b/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-layer.js
@@ -22,7 +22,7 @@ import {PhongMaterial} from '@luma.gl/core';
 import {CompositeLayer} from '@deck.gl/core';
 
 import GPUGridAggregator from '../utils/gpu-grid-aggregation/gpu-grid-aggregator';
-import {AGGREGATION_OPERATION} from '../utils/gpu-grid-aggregation/gpu-grid-aggregator-constants';
+import {AGGREGATION_OPERATION} from '../utils/aggregation-operation-utils';
 import {pointToDensityGridData} from '../utils/gpu-grid-aggregation/grid-aggregation-utils';
 import {defaultColorRange, colorRangeToFlatArray} from '../utils/color-utils';
 import GPUGridCellLayer from './gpu-grid-cell-layer';

--- a/modules/aggregation-layers/src/grid-layer/grid-layer.js
+++ b/modules/aggregation-layers/src/grid-layer/grid-layer.js
@@ -26,8 +26,13 @@ import BinSorter from '../utils/bin-sorter';
 import {defaultColorRange} from '../utils/color-utils';
 import {getQuantizeScale, getLinearScale} from '../utils/scale-utils';
 import {pointToDensityGridDataCPU} from './grid-aggregator';
-import {AGGREGATION_OPERATION} from '../utils/gpu-grid-aggregation/gpu-grid-aggregator-constants';
-import {getMean, getSum, getMax, getMin} from '../utils/aggregation-operation-utils';
+import {
+  getMean,
+  getSum,
+  getMax,
+  getMin,
+  AGGREGATION_OPERATION
+} from '../utils/aggregation-operation-utils';
 function nop() {}
 
 const defaultMaterial = new PhongMaterial();

--- a/modules/aggregation-layers/src/hexagon-layer/hexagon-layer.js
+++ b/modules/aggregation-layers/src/hexagon-layer/hexagon-layer.js
@@ -32,14 +32,12 @@ import {pointToHexbin} from './hexagon-aggregator';
 function nop() {}
 
 const defaultMaterial = new PhongMaterial();
-// To detect a default value vs custom value, used in new-grid-layer
-const DEFAULT_GETVALUE = points => points.length;
 
 const defaultProps = {
   // color
   colorDomain: null,
   colorRange: defaultColorRange,
-  getColorValue: {type: 'accessor', value: DEFAULT_GETVALUE},
+  getColorValue: {type: 'accessor', value: null}, // default value is calcuated from `getColorWeight` and `colorAggregation`
   getColorWeight: {type: 'accessor', value: x => 1},
   colorAggregation: 'SUM',
   lowerPercentile: {type: 'number', value: 0, min: 0, max: 100},
@@ -49,7 +47,7 @@ const defaultProps = {
   // elevation
   elevationDomain: null,
   elevationRange: [0, 1000],
-  getElevationValue: {type: 'accessor', value: DEFAULT_GETVALUE},
+  getElevationValue: {type: 'accessor', value: null}, // default value is calcuated from `getElevationWeight` and `elevationAggregation`
   getElevationWeight: {type: 'accessor', value: x => 1},
   elevationAggregation: 'SUM',
   elevationLowerPercentile: {type: 'number', value: 0, min: 0, max: 100},
@@ -67,6 +65,9 @@ const defaultProps = {
   material: defaultMaterial
 };
 
+const COLOR_PROPS = ['getColorValue', 'colorAggregation', 'getColorWeight'];
+const ELEVATION_PROPS = ['getElevationValue', 'elevationAggregation', 'getElevationWeight'];
+
 export default class HexagonLayer extends CompositeLayer {
   initializeState() {
     this.state = {
@@ -82,7 +83,7 @@ export default class HexagonLayer extends CompositeLayer {
   }
 
   updateState({oldProps, props, changeFlags}) {
-    this.updateGetValueFuncs(props);
+    this.updateGetValueFuncs(oldProps, props);
     const dimensionChanges = this.getDimensionChanges(oldProps, props);
 
     if (changeFlags.dataChanged || this.needsReProjectPoints(oldProps, props)) {
@@ -93,19 +94,41 @@ export default class HexagonLayer extends CompositeLayer {
     }
   }
 
-  updateGetValueFuncs(props) {
+  colorElevationPropsChanged(oldProps, props) {
+    let colorChanged = false;
+    let elevationChanged = false;
+    for (const p of COLOR_PROPS) {
+      if (oldProps[p] !== props[p]) {
+        colorChanged = true;
+      }
+    }
+    for (const p of ELEVATION_PROPS) {
+      if (oldProps[p] !== props[p]) {
+        elevationChanged = true;
+      }
+    }
+    return {colorChanged, elevationChanged};
+  }
+
+  updateGetValueFuncs(oldProps, props) {
     let {getColorValue, getElevationValue} = props;
     const {colorAggregation, getColorWeight, elevationAggregation, getElevationWeight} = this.props;
+    const {colorChanged, elevationChanged} = this.colorElevationPropsChanged(oldProps, props);
 
-    // If a custom `getColorValue` is provided (other than default) use it
-    if (getColorValue === defaultProps.getColorValue.value) {
+    if (colorChanged && getColorValue === null) {
+      // If `getColorValue` is not provided, build it.
       getColorValue = getValueFunc(colorAggregation, getColorWeight);
     }
-    // If a custom `getElevationValue` is provided (other than default) use it
-    if (getElevationValue === defaultProps.getColorValue.value) {
+    if (elevationChanged && getElevationValue === null) {
+      // If `getElevationValue` is not provided, build it.
       getElevationValue = getValueFunc(elevationAggregation, getElevationWeight);
     }
-    this.setState({getColorValue, getElevationValue});
+    if (getColorValue) {
+      this.setState({getColorValue});
+    }
+    if (getElevationValue) {
+      this.setState({getElevationValue});
+    }
   }
 
   needsReProjectPoints(oldProps, props) {

--- a/modules/aggregation-layers/src/index.js
+++ b/modules/aggregation-layers/src/index.js
@@ -29,7 +29,7 @@ export {default as _GPUGridLayer} from './gpu-grid-layer/gpu-grid-layer';
 export {default as _NewGridLayer} from './new-grid-layer/new-grid-layer';
 
 export {default as _GPUGridAggregator} from './utils/gpu-grid-aggregation/gpu-grid-aggregator';
-export {AGGREGATION_OPERATION} from './utils/gpu-grid-aggregation/gpu-grid-aggregator-constants';
+export {AGGREGATION_OPERATION} from './utils/aggregation-operation-utils';
 
 import {default as BinSorter} from './utils/bin-sorter';
 import {linearScale, getLinearScale, quantizeScale, getQuantizeScale} from './utils/scale-utils';

--- a/modules/aggregation-layers/src/new-grid-layer/new-grid-layer.js
+++ b/modules/aggregation-layers/src/new-grid-layer/new-grid-layer.js
@@ -44,7 +44,8 @@ function getMin(pts, accessor) {
 
 // Function to convert from getWeight/aggregation props to getValue prop for Color and Elevation
 function getValueFunc(aggregation, accessor) {
-  switch (aggregation) {
+  const op = AGGREGATION_OPERATION[aggregation.toUpperCase()] || AGGREGATION_OPERATION.SUM;
+  switch (op) {
     case AGGREGATION_OPERATION.MIN:
       return pts => getMin(pts, accessor);
     case AGGREGATION_OPERATION.SUM:

--- a/modules/aggregation-layers/src/new-grid-layer/new-grid-layer.js
+++ b/modules/aggregation-layers/src/new-grid-layer/new-grid-layer.js
@@ -1,63 +1,9 @@
 import {CompositeLayer} from '@deck.gl/core';
-import {AGGREGATION_OPERATION} from '../utils/gpu-grid-aggregation/gpu-grid-aggregator-constants';
 import GPUGridAggregator from '../utils/gpu-grid-aggregation/gpu-grid-aggregator';
 import GPUGridLayer from '../gpu-grid-layer/gpu-grid-layer';
 import GridLayer from '../grid-layer/grid-layer';
 
 const defaultProps = Object.assign({}, GPUGridLayer.defaultProps, GridLayer.defaultProps);
-
-function sumReducer(accu, cur) {
-  return accu + cur;
-}
-
-function maxReducer(accu, cur) {
-  return cur > accu ? cur : accu;
-}
-
-function minReducer(accu, cur) {
-  return cur < accu ? cur : accu;
-}
-
-function getMean(pts, accessor) {
-  const filtered = pts.map(accessor).filter(Number.isFinite);
-
-  return filtered.length ? filtered.reduce(sumReducer, 0) / filtered.length : null;
-}
-
-function getSum(pts, accessor) {
-  const filtered = pts.map(accessor).filter(Number.isFinite);
-
-  return filtered.length ? filtered.reduce(sumReducer, 0) : null;
-}
-
-function getMax(pts, accessor) {
-  const filtered = pts.map(accessor).filter(Number.isFinite);
-
-  return filtered.length ? filtered.reduce(maxReducer, -Infinity) : null;
-}
-
-function getMin(pts, accessor) {
-  const filtered = pts.map(accessor).filter(Number.isFinite);
-
-  return filtered.length ? filtered.reduce(minReducer, Infinity) : null;
-}
-
-// Function to convert from getWeight/aggregation props to getValue prop for Color and Elevation
-function getValueFunc(aggregation, accessor) {
-  const op = AGGREGATION_OPERATION[aggregation.toUpperCase()] || AGGREGATION_OPERATION.SUM;
-  switch (op) {
-    case AGGREGATION_OPERATION.MIN:
-      return pts => getMin(pts, accessor);
-    case AGGREGATION_OPERATION.SUM:
-      return pts => getSum(pts, accessor);
-    case AGGREGATION_OPERATION.MEAN:
-      return pts => getMean(pts, accessor);
-    case AGGREGATION_OPERATION.MAX:
-      return pts => getMax(pts, accessor);
-    default:
-      return null;
-  }
-}
 
 export default class NewGridLayer extends CompositeLayer {
   initializeState() {
@@ -73,59 +19,22 @@ export default class NewGridLayer extends CompositeLayer {
   }
 
   renderLayers() {
-    let gridLayer = null;
     const {data, updateTriggers} = this.props;
-    if (this.state.useGPUAggregation) {
-      gridLayer = new GPUGridLayer(
-        this.props,
-        this.getSubLayerProps({
-          id: 'GPU',
-          updateTriggers
-        }),
-        {
-          data
-        }
-      );
-    } else {
-      const buildColorElevationProps = this.buildColorElevationProps(this.props);
-      gridLayer = new GridLayer(
-        this.props,
-        buildColorElevationProps,
-        this.getSubLayerProps({
-          id: 'CPU',
-          updateTriggers
-        }),
-        {
-          data
-        }
-      );
-    }
-    return gridLayer;
+    const id = this.state.useGPUAggregation ? 'GPU' : 'CPU';
+    const LayerType = this.state.useGPUAggregation ? GPUGridLayer : GridLayer;
+    return new LayerType(
+      this.props,
+      this.getSubLayerProps({
+        id,
+        updateTriggers
+      }),
+      {
+        data
+      }
+    );
   }
 
   // Private methods
-
-  // this method converts getColorWeight and colorAggregation props to getColorValue prop.
-  // similarly for Elevation, for backward compitability.
-  buildColorElevationProps(props) {
-    const getValueProps = {};
-    const {
-      colorAggregation,
-      getColorWeight,
-      getColorValue,
-      elevationAggregation,
-      getElevationWeight,
-      getElevationValue
-    } = props;
-
-    if (getColorValue === GridLayer.defaultProps.getColorValue.value) {
-      getValueProps.getColorValue = getValueFunc(colorAggregation, getColorWeight);
-    }
-    if (getElevationValue === GridLayer.defaultProps.getElevationValue.value) {
-      getValueProps.getElevationValue = getValueFunc(elevationAggregation, getElevationWeight);
-    }
-    return getValueProps;
-  }
 
   canUseGPUAggregation(props) {
     const {

--- a/modules/aggregation-layers/src/screen-grid-layer/screen-grid-layer.js
+++ b/modules/aggregation-layers/src/screen-grid-layer/screen-grid-layer.js
@@ -22,7 +22,7 @@ import {Layer, WebMercatorViewport, createIterable, log, experimental} from '@de
 const {count} = experimental;
 import {defaultColorRange, colorRangeToFlatArray} from '../utils/color-utils';
 import GPUGridAggregator from '../utils/gpu-grid-aggregation/gpu-grid-aggregator';
-import {AGGREGATION_OPERATION} from '../utils/gpu-grid-aggregation/gpu-grid-aggregator-constants';
+import {AGGREGATION_OPERATION} from '../utils/aggregation-operation-utils';
 
 import GL from '@luma.gl/constants';
 import {Model, Geometry, Buffer, isWebGL2} from '@luma.gl/core';

--- a/modules/aggregation-layers/src/utils/aggregation-operation-utils.js
+++ b/modules/aggregation-layers/src/utils/aggregation-operation-utils.js
@@ -1,0 +1,55 @@
+// Copyright (c) 2015 - 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+function sumReducer(accu, cur) {
+  return accu + cur;
+}
+
+function maxReducer(accu, cur) {
+  return cur > accu ? cur : accu;
+}
+
+function minReducer(accu, cur) {
+  return cur < accu ? cur : accu;
+}
+
+export function getMean(pts, accessor) {
+  const filtered = pts.map(accessor).filter(Number.isFinite);
+
+  return filtered.length ? filtered.reduce(sumReducer, 0) / filtered.length : null;
+}
+
+export function getSum(pts, accessor) {
+  const filtered = pts.map(accessor).filter(Number.isFinite);
+
+  return filtered.length ? filtered.reduce(sumReducer, 0) : null;
+}
+
+export function getMax(pts, accessor) {
+  const filtered = pts.map(accessor).filter(Number.isFinite);
+
+  return filtered.length ? filtered.reduce(maxReducer, -Infinity) : null;
+}
+
+export function getMin(pts, accessor) {
+  const filtered = pts.map(accessor).filter(Number.isFinite);
+
+  return filtered.length ? filtered.reduce(minReducer, Infinity) : null;
+}

--- a/modules/aggregation-layers/src/utils/aggregation-operation-utils.js
+++ b/modules/aggregation-layers/src/utils/aggregation-operation-utils.js
@@ -60,3 +60,20 @@ export function getMin(pts, accessor) {
 
   return filtered.length ? filtered.reduce(minReducer, Infinity) : null;
 }
+
+// Function to convert from aggregation/accessor props (like colorAggregation and getColorWeight) to getValue prop (like getColorValue)
+export function getValueFunc(aggregation, accessor) {
+  const op = AGGREGATION_OPERATION[aggregation.toUpperCase()] || AGGREGATION_OPERATION.SUM;
+  switch (op) {
+    case AGGREGATION_OPERATION.MIN:
+      return pts => getMin(pts, accessor);
+    case AGGREGATION_OPERATION.SUM:
+      return pts => getSum(pts, accessor);
+    case AGGREGATION_OPERATION.MEAN:
+      return pts => getMean(pts, accessor);
+    case AGGREGATION_OPERATION.MAX:
+      return pts => getMax(pts, accessor);
+    default:
+      return null;
+  }
+}

--- a/modules/aggregation-layers/src/utils/aggregation-operation-utils.js
+++ b/modules/aggregation-layers/src/utils/aggregation-operation-utils.js
@@ -18,6 +18,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+export const AGGREGATION_OPERATION = {
+  SUM: 1,
+  MEAN: 2,
+  MIN: 3,
+  MAX: 4
+};
+
 function sumReducer(accu, cur) {
   return accu + cur;
 }

--- a/modules/aggregation-layers/src/utils/gpu-grid-aggregation/gpu-grid-aggregator-constants.js
+++ b/modules/aggregation-layers/src/utils/gpu-grid-aggregation/gpu-grid-aggregator-constants.js
@@ -1,16 +1,5 @@
 import GL from '@luma.gl/constants';
-
-// public
-
-export const AGGREGATION_OPERATION = {
-  SUM: 1,
-  MEAN: 2,
-  MIN: 3,
-  MAX: 4
-};
-
-// private
-
+import {AGGREGATION_OPERATION} from '../aggregation-operation-utils';
 export const DEFAULT_CHANGE_FLAGS = {
   dataChanged: true,
   viewportChanged: true,

--- a/modules/aggregation-layers/src/utils/gpu-grid-aggregation/gpu-grid-aggregator.js
+++ b/modules/aggregation-layers/src/utils/gpu-grid-aggregation/gpu-grid-aggregator.js
@@ -15,7 +15,6 @@ import {worldToPixels} from 'viewport-mercator-project';
 const {fp64ifyMatrix4} = fp64Utils;
 
 import {
-  AGGREGATION_OPERATION,
   DEFAULT_CHANGE_FLAGS,
   DEFAULT_RUN_PARAMS,
   MAX_32_BIT_FLOAT,
@@ -29,6 +28,7 @@ import {
   PIXEL_SIZE,
   WEIGHT_SIZE
 } from './gpu-grid-aggregator-constants';
+import {AGGREGATION_OPERATION} from '../aggregation-operation-utils';
 
 import AGGREGATE_TO_GRID_VS from './aggregate-to-grid-vs.glsl';
 import AGGREGATE_TO_GRID_VS_FP64 from './aggregate-to-grid-vs-64.glsl';

--- a/test/modules/aggregation-layers/grid-layer/grid-layer.spec.js
+++ b/test/modules/aggregation-layers/grid-layer/grid-layer.spec.js
@@ -276,6 +276,85 @@ test('GridLayer#updates', t => {
       },
       {
         updateProps: {
+          getColorWeight: x => 2,
+          updateTriggers: {
+            getColorWeight: 1
+          }
+        },
+        onAfterUpdate({layer, oldState}) {
+          t.ok(oldState.layerData === layer.state.layerData, 'should not update layer data');
+
+          t.ok(
+            oldState.sortedColorBins !== layer.state.sortedColorBins,
+            'should update sortedColorBins'
+          );
+
+          t.ok(
+            oldState.sortedElevationBins === layer.state.sortedElevationBins,
+            'should not update sortedElevationBins'
+          );
+
+          t.ok(
+            oldState.colorValueDomain !== layer.state.colorValueDomain,
+            'should re calculate colorValueDomain'
+          );
+
+          t.ok(
+            oldState.elevationValueDomain === layer.state.elevationValueDomain,
+            'should not update elevationValueDomain'
+          );
+
+          t.ok(
+            oldState.colorScaleFunc !== layer.state.colorScaleFunc,
+            'should update colorScaleFunc'
+          );
+
+          t.ok(
+            oldState.elevationScaleFunc === layer.state.elevationScaleFunc,
+            'should not update colorScaleFunc'
+          );
+        }
+      },
+      {
+        updateProps: {
+          elevationAggregation: 'Mean'
+        },
+        onAfterUpdate({layer, oldState}) {
+          t.ok(oldState.layerData === layer.state.layerData, 'should not update layer data');
+
+          t.ok(
+            oldState.sortedColorBins === layer.state.sortedColorBins,
+            'should not update sortedColorBins'
+          );
+
+          t.ok(
+            oldState.sortedElevationBins !== layer.state.sortedElevationBins,
+            'should update sortedElevationBins'
+          );
+
+          t.ok(
+            oldState.colorValueDomain === layer.state.colorValueDomain,
+            'should not re calculate colorValueDomain'
+          );
+
+          t.ok(
+            oldState.elevationValueDomain !== layer.state.elevationValueDomain,
+            'should update elevationValueDomain'
+          );
+
+          t.ok(
+            oldState.colorScaleFunc === layer.state.colorScaleFunc,
+            'should not update colorScaleFunc'
+          );
+
+          t.ok(
+            oldState.elevationScaleFunc !== layer.state.elevationScaleFunc,
+            'should update colorScaleFunc'
+          );
+        }
+      },
+      {
+        updateProps: {
           upperPercentile: 90
         },
         onAfterUpdate({layer, oldState}) {

--- a/test/modules/aggregation-layers/grid-layer/grid-layer.spec.js
+++ b/test/modules/aggregation-layers/grid-layer/grid-layer.spec.js
@@ -27,8 +27,8 @@ import {testLayer, testInitializeLayer, generateLayerTests} from '@deck.gl/test-
 import {GridCellLayer} from '@deck.gl/layers';
 import {GridLayer} from '@deck.gl/aggregation-layers';
 
-const getColorValue = points => points.length;
-const getElevationValue = points => points.length;
+const GET_COLOR_VALUE = points => points.length;
+const GET_ELEVATION_VALUE = points => points.length;
 const getPosition = d => d.COORDINATES;
 
 test('GridLayer', t => {
@@ -106,6 +106,18 @@ test('GridLayer#updates', t => {
       oldState.elevationScaleFunc === layer.state.elevationScaleFunc,
       'should not update colorScaleFunc'
     );
+
+    // color porps changed
+    t.ok(
+      layer.state.getColorValue !== oldState.getColorValue,
+      'getColorValue should get re-calculated'
+    );
+
+    // elevation porps didn't change
+    t.ok(
+      layer.state.getElevationValue === oldState.getElevationValue,
+      'getElevationValue should not get re-calculated'
+    );
   }
   testLayer({
     Layer: GridLayer,
@@ -124,7 +136,9 @@ test('GridLayer#updates', t => {
             sortedColorBins,
             sortedElevationBins,
             colorValueDomain,
-            elevationValueDomain
+            elevationValueDomain,
+            getColorValue,
+            getElevationValue
           } = layer.state;
 
           t.ok(layerData.length > 0, 'GridLayer.state.layerDate calculated');
@@ -132,6 +146,11 @@ test('GridLayer#updates', t => {
           t.ok(sortedElevationBins, 'GridLayer.state.sortedColorBins calculated');
           t.ok(Array.isArray(colorValueDomain), 'GridLayer.state.valueDomain calculated');
           t.ok(Array.isArray(elevationValueDomain), 'GridLayer.state.valueDomain calculated');
+          t.ok(typeof getColorValue === 'function', 'GridLayer.state.getColorValue calculated');
+          t.ok(
+            typeof getElevationValue === 'function',
+            'GridLayer.state.getElevationValue calculated'
+          );
 
           t.ok(
             Array.isArray(sortedColorBins.sortedBins),
@@ -167,9 +186,18 @@ test('GridLayer#updates', t => {
           pickable: true
         },
         spies: ['_onGetSublayerColor', '_onGetSublayerElevation'],
-        onAfterUpdate({layer, subLayer, spies}) {
+        onAfterUpdate({layer, subLayer, spies, oldState}) {
           t.ok(subLayer instanceof GridCellLayer, 'GridCellLayer rendered');
 
+          // color or elevation porps didn't change
+          t.ok(
+            layer.state.getColorValue === oldState.getColorValue,
+            'getColorValue should not get re-calculated'
+          );
+          t.ok(
+            layer.state.getElevationValue === oldState.getElevationValue,
+            'getElevationValue should not get re-calculated'
+          );
           // should call attribute updater twice
           // because test util calls both initialize and update layer
           t.ok(spies._onGetSublayerColor.called, 'should call _onGetSublayerColor');
@@ -262,18 +290,18 @@ test('GridLayer#updates', t => {
       },
       {
         updateProps: {
-          getColorValue,
+          getColorWeight: x => 2,
           updateTriggers: {
-            getColorValue: 1
+            getColorWeight: 1
           }
         },
         onAfterUpdate: onAfterUpdateColor
       },
       {
         updateProps: {
-          getColorWeight: x => 2,
+          getColorValue: GET_COLOR_VALUE,
           updateTriggers: {
-            getColorWeight: 1
+            getColorValue: 1
           }
         },
         onAfterUpdate: onAfterUpdateColor
@@ -313,6 +341,18 @@ test('GridLayer#updates', t => {
           t.ok(
             oldState.elevationScaleFunc !== layer.state.elevationScaleFunc,
             'should update colorScaleFunc'
+          );
+
+          // color porps didn't changed
+          t.ok(
+            layer.state.getColorValue === oldState.getColorValue,
+            'getColorValue should not get re-calculated'
+          );
+
+          // elevation porps changed
+          t.ok(
+            layer.state.getElevationValue !== oldState.getElevationValue,
+            'getElevationValue should get re-calculated'
           );
         }
       },
@@ -394,7 +434,7 @@ test('GridLayer#updates', t => {
       },
       {
         updateProps: {
-          getElevationValue,
+          getElevationValue: GET_ELEVATION_VALUE,
           updateTriggers: {
             getElevationValue: 1
           }
@@ -560,7 +600,7 @@ test('GridLayer#updateTriggers', t => {
       },
       {
         updateProps: {
-          getColorValue,
+          getColorValue: GET_COLOR_VALUE,
           updateTriggers: {
             getColorValue: 1
           }
@@ -593,7 +633,7 @@ test('GridLayer#updateTriggers', t => {
       },
       {
         updateProps: {
-          getElevationValue,
+          getElevationValue: GET_ELEVATION_VALUE,
           updateTriggers: {
             getElevationValue: 1
           }

--- a/test/modules/aggregation-layers/grid-layer/grid-layer.spec.js
+++ b/test/modules/aggregation-layers/grid-layer/grid-layer.spec.js
@@ -80,6 +80,33 @@ test('GridLayer#renderSubLayer', t => {
 });
 
 test('GridLayer#updates', t => {
+  function onAfterUpdateColor({layer, oldState}) {
+    t.ok(oldState.layerData === layer.state.layerData, 'should not update layer data');
+
+    t.ok(oldState.sortedColorBins !== layer.state.sortedColorBins, 'should update sortedColorBins');
+
+    t.ok(
+      oldState.sortedElevationBins === layer.state.sortedElevationBins,
+      'should not update sortedElevationBins'
+    );
+
+    t.ok(
+      oldState.colorValueDomain !== layer.state.colorValueDomain,
+      'should re calculate colorValueDomain'
+    );
+
+    t.ok(
+      oldState.elevationValueDomain === layer.state.elevationValueDomain,
+      'should not update elevationValueDomain'
+    );
+
+    t.ok(oldState.colorScaleFunc !== layer.state.colorScaleFunc, 'should update colorScaleFunc');
+
+    t.ok(
+      oldState.elevationScaleFunc === layer.state.elevationScaleFunc,
+      'should not update colorScaleFunc'
+    );
+  }
   testLayer({
     Layer: GridLayer,
     onError: t.notOk,
@@ -240,39 +267,7 @@ test('GridLayer#updates', t => {
             getColorValue: 1
           }
         },
-        onAfterUpdate({layer, oldState}) {
-          t.ok(oldState.layerData === layer.state.layerData, 'should not update layer data');
-
-          t.ok(
-            oldState.sortedColorBins !== layer.state.sortedColorBins,
-            'should update sortedColorBins'
-          );
-
-          t.ok(
-            oldState.sortedElevationBins === layer.state.sortedElevationBins,
-            'should not update sortedElevationBins'
-          );
-
-          t.ok(
-            oldState.colorValueDomain !== layer.state.colorValueDomain,
-            'should re calculate colorValueDomain'
-          );
-
-          t.ok(
-            oldState.elevationValueDomain === layer.state.elevationValueDomain,
-            'should not update elevationValueDomain'
-          );
-
-          t.ok(
-            oldState.colorScaleFunc !== layer.state.colorScaleFunc,
-            'should update colorScaleFunc'
-          );
-
-          t.ok(
-            oldState.elevationScaleFunc === layer.state.elevationScaleFunc,
-            'should not update colorScaleFunc'
-          );
-        }
+        onAfterUpdate: onAfterUpdateColor
       },
       {
         updateProps: {
@@ -281,39 +276,7 @@ test('GridLayer#updates', t => {
             getColorWeight: 1
           }
         },
-        onAfterUpdate({layer, oldState}) {
-          t.ok(oldState.layerData === layer.state.layerData, 'should not update layer data');
-
-          t.ok(
-            oldState.sortedColorBins !== layer.state.sortedColorBins,
-            'should update sortedColorBins'
-          );
-
-          t.ok(
-            oldState.sortedElevationBins === layer.state.sortedElevationBins,
-            'should not update sortedElevationBins'
-          );
-
-          t.ok(
-            oldState.colorValueDomain !== layer.state.colorValueDomain,
-            'should re calculate colorValueDomain'
-          );
-
-          t.ok(
-            oldState.elevationValueDomain === layer.state.elevationValueDomain,
-            'should not update elevationValueDomain'
-          );
-
-          t.ok(
-            oldState.colorScaleFunc !== layer.state.colorScaleFunc,
-            'should update colorScaleFunc'
-          );
-
-          t.ok(
-            oldState.elevationScaleFunc === layer.state.elevationScaleFunc,
-            'should not update colorScaleFunc'
-          );
-        }
+        onAfterUpdate: onAfterUpdateColor
       },
       {
         updateProps: {

--- a/test/modules/aggregation-layers/hexagon-layer.spec.js
+++ b/test/modules/aggregation-layers/hexagon-layer.spec.js
@@ -88,6 +88,18 @@ test('HexagonLayer#updateLayer', t => {
       oldState.colorScaleFunc === layer.state.colorScaleFunc,
       'should not update colorScaleFunc'
     );
+
+    // color porps didn't change
+    t.ok(
+      layer.state.getColorValue === oldState.getColorValue,
+      'getColorValue should not get re-calculated'
+    );
+
+    // elevation porps changed
+    t.ok(
+      layer.state.getElevationValue !== oldState.getElevationValue,
+      'getElevationValue should get re-calculated'
+    );
   }
   function onAfterUpdateColor({layer, oldState}) {
     t.ok(oldState.hexagons === layer.state.hexagons, 'should not update layer data');
@@ -118,6 +130,18 @@ test('HexagonLayer#updateLayer', t => {
       oldState.elevationScaleFunc === layer.state.elevationScaleFunc,
       'should not update colorScaleFunc'
     );
+
+    // color porps changed
+    t.ok(
+      layer.state.getColorValue !== oldState.getColorValue,
+      'getColorValue should get re-calculated'
+    );
+
+    // elevation porps didn't change
+    t.ok(
+      layer.state.getElevationValue === oldState.getElevationValue,
+      'getElevationValue should not get re-calculated'
+    );
   }
 
   testLayer({
@@ -130,6 +154,16 @@ test('HexagonLayer#updateLayer', t => {
           data: data.points,
           radius: 400,
           getPosition
+        },
+        onAfterUpdate({layer}) {
+          t.ok(
+            typeof layer.state.getColorValue === 'function',
+            'GridLayer.state.getColorValue calculated'
+          );
+          t.ok(
+            typeof layer.state.getElevationValue === 'function',
+            'GridLayer.state.getElevationValue calculated'
+          );
         }
       },
       {
@@ -172,19 +206,19 @@ test('HexagonLayer#updateLayer', t => {
         }
       },
       {
+        title: 'Update colorAggregation',
+        updateProps: {
+          colorAggregation: 'MAX'
+        },
+        onAfterUpdate: onAfterUpdateColor
+      },
+      {
         title: 'Update getColorValue accessor',
         updateProps: {
           getColorValue,
           updateTriggers: {
             getColorValue: 1
           }
-        },
-        onAfterUpdate: onAfterUpdateColor
-      },
-      {
-        title: 'Update colorAggregation',
-        updateProps: {
-          colorAggregation: 'MAX'
         },
         onAfterUpdate: onAfterUpdateColor
       },

--- a/test/modules/aggregation-layers/hexagon-layer.spec.js
+++ b/test/modules/aggregation-layers/hexagon-layer.spec.js
@@ -56,6 +56,70 @@ test('HexagonLayer', t => {
 // update props
 // asserts on the resulting layer
 test('HexagonLayer#updateLayer', t => {
+  function onAfterUpdateElevation({layer, oldState}) {
+    t.ok(oldState.hexagons === layer.state.hexagons, 'should not update layer data');
+
+    t.ok(
+      oldState.sortedElevationBins !== layer.state.sortedElevationBins,
+      'should update sortedElevationBins'
+    );
+
+    t.ok(
+      oldState.elevationValueDomain !== layer.state.elevationValueDomain,
+      'should re calculate elevationValueDomain'
+    );
+
+    t.ok(
+      oldState.elevationScaleFunc !== layer.state.elevationScaleFunc,
+      'should update elevationScaleFunc'
+    );
+
+    t.ok(
+      oldState.sortedColorBins === layer.state.sortedColorBins,
+      'should not update sortedColorBins'
+    );
+
+    t.ok(
+      oldState.colorValueDomain === layer.state.colorValueDomain,
+      'should not re calculate colorValueDomain'
+    );
+
+    t.ok(
+      oldState.colorScaleFunc === layer.state.colorScaleFunc,
+      'should not update colorScaleFunc'
+    );
+  }
+  function onAfterUpdateColor({layer, oldState}) {
+    t.ok(oldState.hexagons === layer.state.hexagons, 'should not update layer data');
+
+    t.ok(
+      oldState.sortedColorBins !== layer.state.sortedColorBins,
+      'should not update sortedColorBins'
+    );
+
+    t.ok(
+      oldState.sortedElevationBins === layer.state.sortedElevationBins,
+      'should update sortedElevationBins'
+    );
+
+    t.ok(
+      oldState.colorValueDomain !== layer.state.colorValueDomain,
+      'should re calculate colorValueDomain'
+    );
+
+    t.ok(
+      oldState.elevationValueDomain === layer.state.elevationValueDomain,
+      'should not update elevationValueDomain'
+    );
+
+    t.ok(oldState.colorScaleFunc !== layer.state.colorScaleFunc, 'should update colorScaleFunc');
+
+    t.ok(
+      oldState.elevationScaleFunc === layer.state.elevationScaleFunc,
+      'should not update colorScaleFunc'
+    );
+  }
+
   testLayer({
     Layer: HexagonLayer,
     onError: t.notOk,
@@ -115,42 +179,17 @@ test('HexagonLayer#updateLayer', t => {
             getColorValue: 1
           }
         },
-        onAfterUpdate({layer, oldState}) {
-          t.ok(oldState.hexagons === layer.state.hexagons, 'should not update layer data');
-
-          t.ok(
-            oldState.sortedColorBins !== layer.state.sortedColorBins,
-            'should not update sortedColorBins'
-          );
-
-          t.ok(
-            oldState.sortedElevationBins === layer.state.sortedElevationBins,
-            'should update sortedElevationBins'
-          );
-
-          t.ok(
-            oldState.colorValueDomain !== layer.state.colorValueDomain,
-            'should re calculate colorValueDomain'
-          );
-
-          t.ok(
-            oldState.elevationValueDomain === layer.state.elevationValueDomain,
-            'should not update elevationValueDomain'
-          );
-
-          t.ok(
-            oldState.colorScaleFunc !== layer.state.colorScaleFunc,
-            'should update colorScaleFunc'
-          );
-
-          t.ok(
-            oldState.elevationScaleFunc === layer.state.elevationScaleFunc,
-            'should not update colorScaleFunc'
-          );
-        }
+        onAfterUpdate: onAfterUpdateColor
       },
       {
-        title: 'Update getColorValue accessor',
+        title: 'Update colorAggregation',
+        updateProps: {
+          colorAggregation: 'MAX'
+        },
+        onAfterUpdate: onAfterUpdateColor
+      },
+      {
+        title: 'Update upperPercentile',
         updateProps: {
           upperPercentile: 90
         },
@@ -228,46 +267,24 @@ test('HexagonLayer#updateLayer', t => {
         }
       },
       {
-        title: 'Update getElevationValue accessor',
+        title: 'Update getElevationWeight accessor',
+        updateProps: {
+          getElevationWeight: x => 2,
+          updateTriggers: {
+            getElevationWeight: 1
+          }
+        },
+        onAfterUpdate: onAfterUpdateElevation
+      },
+      {
+        title: 'Update getElevationWeight accessor',
         updateProps: {
           getElevationValue,
           updateTriggers: {
             getElevationValue: 1
           }
         },
-        onAfterUpdate({layer, oldState}) {
-          t.ok(oldState.hexagons === layer.state.hexagons, 'should not update layer data');
-
-          t.ok(
-            oldState.sortedElevationBins !== layer.state.sortedElevationBins,
-            'should update sortedElevationBins'
-          );
-
-          t.ok(
-            oldState.elevationValueDomain !== layer.state.elevationValueDomain,
-            'should re calculate elevationValueDomain'
-          );
-
-          t.ok(
-            oldState.elevationScaleFunc !== layer.state.elevationScaleFunc,
-            'should update elevationScaleFunc'
-          );
-
-          t.ok(
-            oldState.sortedColorBins === layer.state.sortedColorBins,
-            'should not update sortedColorBins'
-          );
-
-          t.ok(
-            oldState.colorValueDomain === layer.state.colorValueDomain,
-            'should not re calculate colorValueDomain'
-          );
-
-          t.ok(
-            oldState.colorScaleFunc === layer.state.colorScaleFunc,
-            'should not update colorScaleFunc'
-          );
-        }
+        onAfterUpdate: onAfterUpdateElevation
       },
       {
         title: 'Update elevation lower percentile',

--- a/test/modules/aggregation-layers/new-grid-layer.spec.js
+++ b/test/modules/aggregation-layers/new-grid-layer.spec.js
@@ -49,7 +49,7 @@ test('NewGridLayer', t => {
   t.end();
 });
 
-test('NewGridLayer#updates', t => {
+test.only('NewGridLayer#updates', t => {
   if (!GPUGridAggregator.isSupported(gl)) {
     t.comment('GPUGridLayer not supported, skipping');
     t.end();
@@ -101,6 +101,17 @@ test('NewGridLayer#updates', t => {
       {
         updateProps: {
           gpuAggregation: true
+        },
+        onAfterUpdate({layer, subLayers, spies}) {
+          t.ok(
+            layer.state.useGPUAggregation === true,
+            'Should use GPU Aggregation (gpuAggregation: true)'
+          );
+        }
+      },
+      {
+        updateProps: {
+          colorAggregation: 'Mean'
         },
         onAfterUpdate({layer, subLayers, spies}) {
           t.ok(

--- a/test/modules/aggregation-layers/new-grid-layer.spec.js
+++ b/test/modules/aggregation-layers/new-grid-layer.spec.js
@@ -49,7 +49,7 @@ test('NewGridLayer', t => {
   t.end();
 });
 
-test.only('NewGridLayer#updates', t => {
+test('NewGridLayer#updates', t => {
   if (!GPUGridAggregator.isSupported(gl)) {
     t.comment('GPUGridLayer not supported, skipping');
     t.end();

--- a/test/modules/aggregation-layers/utils/gpu-grid-aggregator.spec.js
+++ b/test/modules/aggregation-layers/utils/gpu-grid-aggregator.spec.js
@@ -1,6 +1,6 @@
 import test from 'tape-catch';
 import GPUGridAggregator from '@deck.gl/aggregation-layers/utils/gpu-grid-aggregation/gpu-grid-aggregator';
-import {AGGREGATION_OPERATION} from '@deck.gl/aggregation-layers/utils/gpu-grid-aggregation/gpu-grid-aggregator-constants';
+import {AGGREGATION_OPERATION} from '@deck.gl/aggregation-layers/utils/aggregation-operation-utils';
 import {gl} from '@deck.gl/test-utils';
 import {GridAggregationData} from 'deck.gl-test/data';
 import {equals, config} from 'math.gl';

--- a/test/render/test-cases.js
+++ b/test/render/test-cases.js
@@ -4,8 +4,8 @@ import * as dataSamples from '../../examples/layer-browser/src/data-samples';
 import {parseColor, setOpacity} from '../../examples/layer-browser/src/utils/color';
 import {
   _GPUGridLayer as GPUGridLayer,
-  _NewGridLayer as NewGridLayer,
-  AGGREGATION_OPERATION
+  _NewGridLayer as NewGridLayer
+  // AGGREGATION_OPERATION
 } from '@deck.gl/aggregation-layers';
 import {COORDINATE_SYSTEM, OrbitView, OrthographicView, FirstPersonView} from '@deck.gl/core';
 
@@ -75,10 +75,18 @@ function getMax(pts, key) {
 function getColorValue(points) {
   return getMean(points, 'SPACES');
 }
+function getColorWeight(point) {
+  return point.SPACES;
+}
+const colorAggregation = 'mean';
 
 function getElevationValue(points) {
   return getMax(points, 'SPACES');
 }
+function getElevationWeight(point) {
+  return point.SPACES;
+}
+const elevationAggregation = 'max';
 
 export const WIDTH = 800;
 export const HEIGHT = 450;
@@ -834,6 +842,22 @@ export const TEST_CASES = [
     goldenImage: GRID_LAYER_INFO.goldenImage
   },
   {
+    name: 'grid-lnglat-2',
+    viewState: GRID_LAYER_INFO.viewState,
+    layers: [
+      new GridLayer(
+        Object.assign({}, GRID_LAYER_INFO.props, {
+          id: 'grid-lnglat',
+          getColorWeight,
+          colorAggregation,
+          getElevationWeight,
+          elevationAggregation
+        })
+      )
+    ],
+    goldenImage: GRID_LAYER_INFO.goldenImage
+  },
+  {
     name: 'new-grid-lnglat-cpu',
     viewState: GRID_LAYER_INFO.viewState,
     layers: [
@@ -841,9 +865,9 @@ export const TEST_CASES = [
         Object.assign({}, GRID_LAYER_INFO.props, {
           id: 'new-grid-lnglat-cpu',
           getColorWeight: x => x.SPACES,
-          colorAggregation: AGGREGATION_OPERATION.MEAN,
+          colorAggregation: 'MEAN',
           getElevationWeight: x => x.SPACES,
-          elevationAggregation: AGGREGATION_OPERATION.MAX,
+          elevationAggregation: 'MAX',
           gpuAggregation: false
         })
       )
@@ -858,9 +882,9 @@ export const TEST_CASES = [
         Object.assign({}, GRID_LAYER_INFO.props, {
           id: 'new-grid-lnglat-gpu',
           getColorWeight: x => x.SPACES,
-          colorAggregation: AGGREGATION_OPERATION.MEAN,
+          colorAggregation: 'MEAN',
           getElevationWeight: x => x.SPACES,
-          elevationAggregation: AGGREGATION_OPERATION.MAX,
+          elevationAggregation: 'MAX',
           gpuAggregation: true
         })
       )

--- a/test/render/test-cases.js
+++ b/test/render/test-cases.js
@@ -56,6 +56,27 @@ const GRID_LAYER_INFO = {
   goldenImage: './test/render/golden-images/grid-lnglat.png'
 };
 
+const HEXAGON_LAYER_INFO = {
+  viewState: {
+    latitude: 37.751537058389985,
+    longitude: -122.42694203247012,
+    zoom: 11.5,
+    pitch: 20,
+    bearing: 0
+  },
+  props: {
+    data: dataSamples.points,
+    extruded: true,
+    pickable: true,
+    radius: 1000,
+    opacity: 1,
+    elevationScale: 1,
+    elevationRange: [0, 3000],
+    coverage: 1,
+    getPosition: d => d.COORDINATES
+  }
+};
+
 function getMean(pts, key) {
   const filtered = pts.filter(pt => Number.isFinite(pt[key]));
 
@@ -991,28 +1012,31 @@ export const TEST_CASES = [
   },
   {
     name: 'hexagon-lnglat',
-    viewState: {
-      latitude: 37.751537058389985,
-      longitude: -122.42694203247012,
-      zoom: 11.5,
-      pitch: 20,
-      bearing: 0
-    },
+    viewState: HEXAGON_LAYER_INFO.viewState,
     layers: [
-      new HexagonLayer({
-        id: 'hexagon-lnglat',
-        data: dataSamples.points,
-        extruded: true,
-        pickable: true,
-        radius: 1000,
-        opacity: 1,
-        elevationScale: 1,
-        elevationRange: [0, 3000],
-        coverage: 1,
-        getPosition: d => d.COORDINATES,
-        getColorValue,
-        getElevationValue
-      })
+      new HexagonLayer(
+        Object.assign({}, HEXAGON_LAYER_INFO.props, {
+          id: 'hexagon-lnglat',
+          getColorValue,
+          getElevationValue
+        })
+      )
+    ],
+    goldenImage: './test/render/golden-images/hexagon-lnglat.png'
+  },
+  {
+    name: 'hexagon-lnglat-2',
+    viewState: HEXAGON_LAYER_INFO.viewState,
+    layers: [
+      new HexagonLayer(
+        Object.assign({}, HEXAGON_LAYER_INFO.props, {
+          id: 'hexagon-lnglat',
+          getColorWeight,
+          colorAggregation,
+          getElevationWeight,
+          elevationAggregation
+        })
+      )
     ],
     goldenImage: './test/render/golden-images/hexagon-lnglat.png'
   },


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #2084
<!-- For other PRs without open issue -->
#### Background
Following props are needed to perform GPU Aggregation. For parity add these props to `GridLayer` and `HexagonLayer`
- `getColorWeight`, `colorAggregation`, `getElevationWeight` and `elevationAggregation`
<!-- For all the PRs -->
#### Change List
- Add new color/elevation props to Grid and Hexagon layers
