### PR TITLE
GPU GridLyer Part 6: GPUGridLayer fixes and docs.

### DIFF
--- a/docs/layers/hexagon-layer.md
+++ b/docs/layers/hexagon-layer.md
@@ -240,6 +240,26 @@ new function on every rendering pass.
  }
 ```
 
+##### `getColorWeight` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
+
+* Default: `point => 1`
+
+`getColorWeight` is the accessor function to get the weight of a point used to calcuate the color value for a cell.
+It takes the data prop array element and returns the weight, for example, to use `SPACE` field, `getColorWeight` should be set to `point => point.SPACES`.
+By default `getColorWeight` returns `1`.
+
+Note: similar to `getColorValue`, grid layer compares whether `getColorWeight` has changed to recalculate the value for each bin that its color based on.
+
+
+##### `colorAggregation` (String, optional)
+
+* Default: 'SUM'
+
+`colorAggregation` defines, operation used to aggregate all data point weights to calculate a cell's color value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
+
+Note: `getColorWeight` and `colorAggregation` together define how color value of cell is determined, same can be done by setting `getColorValue` prop. But to enable gpu aggregation, former props must be provided instead of later.
+
+
 ##### `getElevationValue` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `points => points.length`
@@ -252,6 +272,25 @@ Note: hexagon layer compares whether `getElevationValue` has changed to
 recalculate the value for each bin for elevation. You should
 pass in the function defined outside the render function so it doesn't create a
 new function on every rendering pass.
+
+
+##### `getElevationWeight` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
+
+* Default: `point => 1`
+
+`getElevationWeight` is the accessor function to get the weight of a point used to calcuate the elevation value for a cell.
+It takes the data prop array element and returns the weight, for example, to use `SPACE` field, `getElevationWeight` should be set to `point => point.SPACES`.
+By default `getElevationWeight` returns `1`.
+
+Note: similar to `getElevationValue`, grid layer compares whether `getElevationWeight` has changed to recalculate the value for each bin that its color based on.
+
+##### `elevationAggregation` (String, optional)
+
+* Default: 'SUM'
+
+`elevationAggregation` defines, operation used to aggregate all data point weights to calculate a cell's elevation value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
+
+Note: `getElevationWeight` and `elevationAggregation` together define how elevation value of cell is determined, same can be done by setting `getColorValue` prop. But to enable gpu aggregation, former props must be provided instead of later.
 
 
 ##### `onSetColorDomain` (Function, optional)

--- a/docs/layers/hexagon-layer.md
+++ b/docs/layers/hexagon-layer.md
@@ -245,8 +245,6 @@ new function on every rendering pass.
 * Default: `point => 1`
 
 `getColorWeight` is the accessor function to get the weight of a point used to calcuate the color value for a cell.
-It takes the data prop array element and returns the weight, for example, to use `SPACE` field, `getColorWeight` should be set to `point => point.SPACES`.
-By default `getColorWeight` returns `1`.
 
 Note: similar to `getColorValue`, grid layer compares whether `getColorWeight` has changed to recalculate the value for each bin that its color based on.
 
@@ -258,6 +256,68 @@ Note: similar to `getColorValue`, grid layer compares whether `getColorWeight` h
 `colorAggregation` defines, operation used to aggregate all data point weights to calculate a cell's color value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
 
 Note: `getColorWeight` and `colorAggregation` together define how color value of cell is determined, same can be done by setting `getColorValue` prop. But to enable gpu aggregation, former props must be provided instead of later.
+
+###### Example1 : Using count of data elements that fall into a cell to encode the its color
+```js
+function getCount(points) {
+  return points.length;
+}
+...
+const layer = new HexagonLayer({
+  id: 'my-hexagon-layer',
+  ...
+  getColorValue: getCount,
+  ...
+});
+```
+
+####### Using `getColorWeight` and `colorAggregation`
+```js
+function getWeight(point) {
+  return 1;
+}
+...
+const layer = new HexagonLayer({
+  id: 'my-hexagon-layer',
+  ...
+  getColorWeight: getWeight,
+  colorAggregation: 'SUM'
+  ...
+});
+```
+
+###### Example2 : Using mean value of 'SPACES' field of data elements to encode the color of the cell
+
+####### Using `getColorValue`
+```js
+function getMean(points) {
+  return points.reduce((sum, p) => sum += p.SPACES, 0) / points.length;
+}
+...
+const layer = new HexagonLayer({
+  id: 'my-hexagon-layer',
+  ...
+  getColorValue: getMean,
+  ...
+});
+```
+
+####### Using `getColorWeight` and `colorAggregation`
+```js
+function getWeight(point) {
+  return point.SPACES;
+}
+...
+const layer = new HexagonLayer({
+  id: 'my-hexagon-layer',
+  ...
+  getColorWeight: getWeight,
+  colorAggregation: 'SUM'
+  ...
+});
+```
+
+If your use case requires aggregating using an operation that is not one of 'SUM', 'MEAN', 'MAX' and 'MIN', `getColorValue` should be used to define such custom aggregation function. In those cases GPU aggregation is not supported.
 
 
 ##### `getElevationValue` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
@@ -279,8 +339,6 @@ new function on every rendering pass.
 * Default: `point => 1`
 
 `getElevationWeight` is the accessor function to get the weight of a point used to calcuate the elevation value for a cell.
-It takes the data prop array element and returns the weight, for example, to use `SPACE` field, `getElevationWeight` should be set to `point => point.SPACES`.
-By default `getElevationWeight` returns `1`.
 
 Note: similar to `getElevationValue`, grid layer compares whether `getElevationWeight` has changed to recalculate the value for each bin that its color based on.
 
@@ -292,6 +350,71 @@ Note: similar to `getElevationValue`, grid layer compares whether `getElevationW
 
 Note: `getElevationWeight` and `elevationAggregation` together define how elevation value of cell is determined, same can be done by setting `getColorValue` prop. But to enable gpu aggregation, former props must be provided instead of later.
 
+
+###### Example1 : Using count of data elements that fall into a cell to encode the its elevation
+
+####### Using `getElevationValue`
+
+```js
+function getCount(points) {
+  return points.length;
+}
+...
+const layer = new HexagonLayer({
+  id: 'my-hexagon-layer',
+  ...
+  getElevationValue: getCount,
+  ...
+});
+```
+
+####### Using `getElevationWeight` and `elevationAggregation`
+```js
+function getWeight(point) {
+  return 1;
+}
+...
+const layer = new HexagonLayer({
+  id: 'my-hexagon-layer',
+  ...
+  getElevationWeight: getWeight,
+  elevationAggregation: 'SUM'
+  ...
+});
+```
+
+###### Example2 : Using maximum value of 'SPACES' field of data elements to encode the elevation of the cell
+
+####### Using `getElevationValue`
+```js
+function getMax(points) {
+  return points.reduce((max, p) => p.SPACES > max ? p.SPACES : max, -Infinity);
+}
+...
+const layer = new HexagonLayer({
+  id: 'my-hexagon-layer',
+  ...
+  getElevationValue: getMax,
+  ...
+});
+```
+
+####### Using `getElevationWeight` and `elevationAggregation`
+```js
+function getWeight(point) {
+  return point.SPACES;
+}
+...
+const layer = new HexagonLayer({
+  id: 'my-hexagon-layer',
+  ...
+  getElevationWeight: getWeight,
+  elevationAggregation: 'MAX'
+  ...
+});
+```
+
+If your use case requires aggregating using an operation that is not one of 'SUM', 'MEAN', 'MAX' and 'MIN', `getElevationValue` should be used to define such custom aggregation function. In those cases GPU aggregation is not supported.
 
 ##### `onSetColorDomain` (Function, optional)
 

--- a/docs/layers/new-grid-layer.md
+++ b/docs/layers/new-grid-layer.md
@@ -1,4 +1,4 @@
-<!-- INJECT:"GridLayerDemo" -->
+<!-- INJECT:"NewGridLayerDemo" -->
 
 <p class="badges">
   <img src="https://img.shields.io/badge/@deck.gl/aggregation--layers-lightgrey.svg?style=flat-square" alt="@deck.gl/aggregation-layers" />
@@ -6,13 +6,15 @@
   <img src="https://img.shields.io/badge/lighting-yes-blue.svg?style=flat-square" alt="lighting" />
 </p>
 
-# GridLayer
+# NewGridLayer
 
-The Grid Layer renders a grid heatmap based on an array of points.
+The NewGrid Layer renders a grid heatmap based on an array of points.
 It takes the constant size all each cell, projects points into cells. The color
 and height of the cell is scaled by number of points it contains.
 
-GridLayer is a [CompositeLayer](/docs/api-reference/composite-layer.md).
+It functions similar to `GridLayer` and supports aggregation on GPU. This layer supports all of the `GridLayer` props, in addition, it has `gpuAggregation` prop that can be used to control whether aggregation to happen on CPU or GPU. For more details check `GPU Aggregation` section below.
+
+NewGridLayer is a [CompositeLayer](/docs/api-reference/composite-layer.md).
 
 ```js
 import DeckGL from '@deck.gl/react';
@@ -27,8 +29,8 @@ const App = ({data, viewport}) => {
    *   ...
    * ]
    */
-  const layer = new GridLayer({
-    id: 'grid-layer',
+  const layer = new NewGridLayer({
+    id: 'new-grid-layer',
     data,
     pickable: true,
     extruded: true,
@@ -47,7 +49,7 @@ const App = ({data, viewport}) => {
 };
 ```
 
-**Note:** The `GridLayer` at the moment only works with `COORDINATE_SYSTEM.LNGLAT`.
+**Note:** The `NewGridLayer` at the moment only works with `COORDINATE_SYSTEM.LNGLAT`.
 
 
 ## Installation
@@ -61,8 +63,8 @@ npm install @deck.gl/core @deck.gl/layers @deck.gl/aggregation-layers
 ```
 
 ```js
-import {GridLayer} from '@deck.gl/aggregation-layers';
-new GridLayer({});
+import {_NewGridLayer as NewGridLayer} from '@deck.gl/aggregation-layers';
+new NewGridLayer({});
 ```
 
 To use pre-bundled scripts:
@@ -76,7 +78,7 @@ To use pre-bundled scripts:
 ```
 
 ```js
-new deck.GridLayer({});
+new deck._NewGridLayer({});
 ```
 
 
@@ -174,12 +176,21 @@ smaller than the elevationLowerPercentile will be hidden.
 
 Whether the layer should be rendered in high-precision 64-bit mode. Note that since deck.gl v6.1, the default 32-bit projection uses a hybrid mode that matches 64-bit precision with significantly better performance.
 
+##### `gpuAggregation` (bool, optional)
+
+* Default: false
+
+When set to true, aggregation is performed on GPU, provided other conditions are met, for more details check `GPU Aggregation` section below. GPU aggregation can be 2 to 3 times faster depending upon number of points and number of cells.
+
+**Note:** GPU Aggregation is faster only when using large data sets (point count is more than 500K), for smaller data sets GPU Aggregation could be potentially slower than CPU Aggregation.
+
 ##### `material` (Object, optional)
 
 * Default: `new PhongMaterial()`
 
 This is an object that contains material props for [lighting effect](/docs/effects/lighting-effect.md) applied on extruded polygons.
 Check [PhongMaterial](https://github.com/uber/luma.gl/tree/7.0-release/docs/api-reference/core/materials/phong-material.md) for more details.
+
 
 ### Data Accessors
 
@@ -224,6 +235,10 @@ You should pass in the function defined outside the render function so it doesn'
 * Default: `point => 1`
 
 `getColorWeight` is the accessor function to get the weight of a point used to calcuate the color value for a cell.
+It takes the data prop array element and returns the weight, for example, to use `SPACE` field, `getColorWeight` should be set to `point => point.SPACES`.
+By default `getColorWeight` returns `1`.
+
+Note: similar to `getColorValue`, grid layer compares whether `getColorWeight` has changed to recalculate the value for each bin that its color based on.
 
 
 ##### `colorAggregation` (String, optional)
@@ -232,71 +247,7 @@ You should pass in the function defined outside the render function so it doesn'
 
 `colorAggregation` defines, operation used to aggregate all data point weights to calculate a cell's color value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
 
-Note: `getColorWeight` and `colorAggregation` together define how color value of cell is determined, same can be done by setting `getColorValue` prop. But to enable GPU aggregation, former props must be provided instead of later.
-
-###### Example1 : Using count of data elements that fall into a cell to encode the its color
-
-####### Using `getColorValue`
-```js
-function getCount(points) {
-  return points.length;
-}
-...
-const layer = new GridLayer({
-  id: 'my-grid-layer',
-  ...
-  getColorValue: getCount,
-  ...
-});
-```
-
-####### Using `getColorWeight` and `colorAggregation`
-```js
-function getWeight(point) {
-  return 1;
-}
-...
-const layer = new GridLayer({
-  id: 'my-grid-layer',
-  ...
-  getColorWeight: getWeight,
-  colorAggregation: 'SUM'
-  ...
-});
-```
-
-###### Example2 : Using mean value of 'SPACES' field of data elements to encode the color of the cell
-
-####### Using `getColorValue`
-```js
-function getMean(points) {
-  return points.reduce((sum, p) => sum += p.SPACES, 0) / points.length;
-}
-...
-const layer = new GridLayer({
-  id: 'my-grid-layer',
-  ...
-  getColorValue: getMean,
-  ...
-});
-```
-
-####### Using `getColorWeight` and `colorAggregation`
-```js
-function getWeight(point) {
-  return point.SPACES;
-}
-...
-const layer = new GridLayer({
-  id: 'my-grid-layer',
-  ...
-  getColorWeight: getWeight,
-  colorAggregation: 'SUM'
-  ...
-});
-```
-
-If your use case requires aggregating using an operation that is not one of 'SUM', 'MEAN', 'MAX' and 'MIN', `getColorValue` should be used to define such custom aggregation function. In those cases GPU aggregation is not supported.
+Note: `getColorWeight` and `colorAggregation` together define how color value of cell is determined, same can be done by setting `getColorValue` prop. But to enable gpu aggregation, former props must be provided instead of later.
 
 
 ##### `getElevationValue` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
@@ -316,6 +267,10 @@ You should pass in the function defined outside the render function so it doesn'
 * Default: `point => 1`
 
 `getElevationWeight` is the accessor function to get the weight of a point used to calcuate the elevation value for a cell.
+It takes the data prop array element and returns the weight, for example, to use `SPACE` field, `getElevationWeight` should be set to `point => point.SPACES`.
+By default `getElevationWeight` returns `1`.
+
+Note: similar to `getElevationValue`, grid layer compares whether `getElevationWeight` has changed to recalculate the value for each bin that its color based on.
 
 
 ##### `elevationAggregation` (String, optional)
@@ -324,73 +279,8 @@ You should pass in the function defined outside the render function so it doesn'
 
 `elevationAggregation` defines, operation used to aggregate all data point weights to calculate a cell's elevation value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
 
-Note: `getElevationWeight` and `elevationAggregation` together define how elevation value of cell is determined, same can be done by setting `getColorValue` prop. But to enable GPU aggregation, former props must be provided instead of later.
+Note: `getElevationWeight` and `elevationAggregation` together define how elevation value of cell is determined, same can be done by setting `getColorValue` prop. But to enable gpu aggregation, former props must be provided instead of later.
 
-
-###### Example1 : Using count of data elements that fall into a cell to encode the its elevation
-
-####### Using `getElevationValue`
-
-```js
-function getCount(points) {
-  return points.length;
-}
-...
-const layer = new GridLayer({
-  id: 'my-grid-layer',
-  ...
-  getElevationValue: getCount,
-  ...
-});
-```
-
-####### Using `getElevationWeight` and `elevationAggregation`
-```js
-function getWeight(point) {
-  return 1;
-}
-...
-const layer = new GridLayer({
-  id: 'my-grid-layer',
-  ...
-  getElevationWeight: getWeight,
-  elevationAggregation: 'SUM'
-  ...
-});
-```
-
-###### Example2 : Using maximum value of 'SPACES' field of data elements to encode the elevation of the cell
-
-####### Using `getElevationValue`
-```js
-function getMax(points) {
-  return points.reduce((max, p) => p.SPACES > max ? p.SPACES : max, -Infinity);
-}
-...
-const layer = new GridLayer({
-  id: 'my-grid-layer',
-  ...
-  getElevationValue: getMax,
-  ...
-});
-```
-
-####### Using `getElevationWeight` and `elevationAggregation`
-```js
-function getWeight(point) {
-  return point.SPACES;
-}
-...
-const layer = new GridLayer({
-  id: 'my-grid-layer',
-  ...
-  getElevationWeight: getWeight,
-  elevationAggregation: 'MAX'
-  ...
-});
-```
-
-If your use case requires aggregating using an operation that is not one of 'SUM', 'MEAN', 'MAX' and 'MIN', `getElevationValue` should be used to define such custom aggregation function. In those cases GPU aggregation is not supported.
 
 ##### `onSetColorDomain` (Function, optional)
 
@@ -405,12 +295,37 @@ This callback will be called when bin color domain has been calculated.
 This callback will be called when bin elevation domain has been calculated.
 
 
+## GPU Aggregation
+
+This layer performs aggregation on GPU when browser is using `WebGL2` and `gpuAggregation` prop is set to true, but with following exceptions.
+
+### Fallback cases:
+
+Aggregation will fallback to CPU in following cases :
+
+#### Percentile Props
+
+When following percentile props are set, it requires sorting of aggregated values, which cannot be supported when aggregating on GPU.
+
+* `lowerPercentile`, `upperPercentile`, `elevationLowerPercentile` and `elevationUpperPercentile`.
+
+#### Color and Elevation Props
+
+When `getColorValue` and `getElevationValue` are set to a custom value other than their default values, aggregation will fallback to CPU. For GPU Aggregation, use `getColorWeight`, `colorAggregation`, `getElevationWeight` and `elevationAggregation`.
+
+### Domain callbacks
+
+When using GPU Aggregation, `onSetColorDomain` and `onSetElevationDomain` are not fired.
+
+
 ## Sub Layers
 
-The GridLayer renders the following sublayers:
+The NewGridLayer renders the following sublayers:
 
-* `grid-cell` - a [GridCellLayer](/docs/layers/grid-cell-layer.md) rendering the aggregated columns.
+* `CPU` - a [GridLayer](/docs/layers/grid-layer.md) when using CPU aggregatoin.
+
+* `GPU` - a [GPUGridLayer](/docs/layers/grid-layer.md) when using GPU aggregatoin.
 
 ## Source
 
-[modules/aggregation-layers/src/grid-layer](https://github.com/uber/deck.gl/tree/master/modules/aggregation-layers/src/grid-layer)
+[modules/aggregation-layers/src/new-grid-layer](https://github.com/uber/deck.gl/tree/master/modules/aggregation-layers/src/new-grid-layer)

--- a/docs/layers/new-grid-layer.md
+++ b/docs/layers/new-grid-layer.md
@@ -178,7 +178,7 @@ Whether the layer should be rendered in high-precision 64-bit mode. Note that si
 
 ##### `gpuAggregation` (bool, optional)
 
-* Default: false
+* Default: `false`
 
 When set to true, aggregation is performed on GPU, provided other conditions are met, for more details check `GPU Aggregation` section below. GPU aggregation can be 2 to 3 times faster depending upon number of points and number of cells.
 

--- a/docs/layers/new-grid-layer.md
+++ b/docs/layers/new-grid-layer.md
@@ -249,6 +249,68 @@ Note: similar to `getColorValue`, grid layer compares whether `getColorWeight` h
 
 Note: `getColorWeight` and `colorAggregation` together define how color value of cell is determined, same can be done by setting `getColorValue` prop. But to enable gpu aggregation, former props must be provided instead of later.
 
+###### Example1 : Using count of data elements that fall into a cell to encode the its color
+```js
+function getCount(points) {
+  return points.length;
+}
+...
+const layer = new GridLayer({
+  id: 'my-grid-layer',
+  ...
+  getColorValue: getCount,
+  ...
+});
+```
+
+####### Using `getColorWeight` and `colorAggregation`
+```js
+function getWeight(point) {
+  return 1;
+}
+...
+const layer = new GridLayer({
+  id: 'my-grid-layer',
+  ...
+  getColorWeight: getWeight,
+  colorAggregation: 'SUM'
+  ...
+});
+```
+
+###### Example2 : Using mean value of 'SPACES' field of data elements to encode the color of the cell
+
+####### Using `getColorValue`
+```js
+function getMean(points) {
+  return points.reduce((sum, p) => sum += p.SPACES, 0) / points.length;
+}
+...
+const layer = new GridLayer({
+  id: 'my-grid-layer',
+  ...
+  getColorValue: getMean,
+  ...
+});
+```
+
+####### Using `getColorWeight` and `colorAggregation`
+```js
+function getWeight(point) {
+  return point.SPACES;
+}
+...
+const layer = new GridLayer({
+  id: 'my-grid-layer',
+  ...
+  getColorWeight: getWeight,
+  colorAggregation: 'SUM'
+  ...
+});
+```
+
+If your use case requires aggregating using an operation that is not one of 'SUM', 'MEAN', 'MAX' and 'MIN', `getColorValue` should be used to define such custom aggregation function. In those cases GPU aggregation is not supported.
+
 
 ##### `getElevationValue` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
@@ -282,6 +344,71 @@ Note: similar to `getElevationValue`, grid layer compares whether `getElevationW
 Note: `getElevationWeight` and `elevationAggregation` together define how elevation value of cell is determined, same can be done by setting `getColorValue` prop. But to enable gpu aggregation, former props must be provided instead of later.
 
 
+###### Example1 : Using count of data elements that fall into a cell to encode the its elevation
+
+####### Using `getElevationValue`
+
+```js
+function getCount(points) {
+  return points.length;
+}
+...
+const layer = new GridLayer({
+  id: 'my-grid-layer',
+  ...
+  getElevationValue: getCount,
+  ...
+});
+```
+
+####### Using `getElevationWeight` and `elevationAggregation`
+```js
+function getWeight(point) {
+  return 1;
+}
+...
+const layer = new GridLayer({
+  id: 'my-grid-layer',
+  ...
+  getElevationWeight: getWeight,
+  elevationAggregation: 'SUM'
+  ...
+});
+```
+
+###### Example2 : Using maximum value of 'SPACES' field of data elements to encode the elevation of the cell
+
+####### Using `getElevationValue`
+```js
+function getMax(points) {
+  return points.reduce((max, p) => p.SPACES > max ? p.SPACES : max, -Infinity);
+}
+...
+const layer = new GridLayer({
+  id: 'my-grid-layer',
+  ...
+  getElevationValue: getMax,
+  ...
+});
+```
+
+####### Using `getElevationWeight` and `elevationAggregation`
+```js
+function getWeight(point) {
+  return point.SPACES;
+}
+...
+const layer = new GridLayer({
+  id: 'my-grid-layer',
+  ...
+  getElevationWeight: getWeight,
+  elevationAggregation: 'MAX'
+  ...
+});
+```
+
+If your use case requires aggregating using an operation that is not one of 'SUM', 'MEAN', 'MAX' and 'MIN', `getElevationValue` should be used to define such custom aggregation function. In those cases GPU aggregation is not supported.
+
 ##### `onSetColorDomain` (Function, optional)
 
 * Default: `() => {}`
@@ -313,7 +440,7 @@ When following percentile props are set, it requires sorting of aggregated value
 
 When `getColorValue` and `getElevationValue` are set to a custom value other than their default values, aggregation will fallback to CPU. For GPU Aggregation, use `getColorWeight`, `colorAggregation`, `getElevationWeight` and `elevationAggregation`.
 
-### Domain callbacks
+### Domain setting callbacks
 
 When using GPU Aggregation, `onSetColorDomain` and `onSetElevationDomain` are not fired.
 

--- a/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-cell-layer-vertex.glsl.js
+++ b/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-cell-layer-vertex.glsl.js
@@ -128,7 +128,7 @@ void main(void) {
     vec3 lightColor = lighting_getLightColor(color.rgb, project_uCameraPosition, position_commonspace.xyz, normals_commonspace);
     vColor = vec4(lightColor, color.a * opacity) / 255.;
   } else {
-    vColor = vec4(color.rgb, color.a * opacity);
+    vColor = vec4(color.rgb, color.a * opacity) / 255.;
   }
 }
 `;

--- a/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-cell-layer-vertex.glsl.js
+++ b/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-cell-layer-vertex.glsl.js
@@ -47,6 +47,13 @@ uniform vec2 gridOffset;
 uniform vec2 gridOffsetLow;
 uniform vec4 colorRange[RANGE_COUNT];
 uniform vec2 elevationRange;
+
+// Domain uniforms
+uniform vec2 colorDomain;
+uniform bool colorDomainValid;
+uniform vec2 elevationDomain;
+uniform bool elevationDomainValid;
+
 layout(std140) uniform;
 uniform ColorData
 {
@@ -81,19 +88,22 @@ vec4 quantizeScale(vec2 domain, vec4 range[RANGE_COUNT], float value) {
 }
 
 float linearScale(vec2 domain, vec2 range, float value) {
-  return ((value - domain.x) / (domain.y - domain.x)) * (range.y - range.x) + range.x;
+  if (value >= (domain.x - EPSILON) && value <= (domain.y + EPSILON)) {
+    return ((value - domain.x) / (domain.y - domain.x)) * (range.y - range.x) + range.x;
+  }
+  return -1.;
 }
 
 void main(void) {
 
-  vec2 colorDomain = vec2(colorData.maxMinCount.a, colorData.maxMinCount.r);
-  vec4 color = quantizeScale(colorDomain, colorRange, colors.r);
+  vec2 clrDomain = colorDomainValid ? colorDomain : vec2(colorData.maxMinCount.a, colorData.maxMinCount.r);
+  vec4 color = quantizeScale(clrDomain, colorRange, colors.r);
 
   float elevation = 0.0;
 
   if (extruded) {
-    vec2 elevationDomain = vec2(elevationData.maxMinCount.a, elevationData.maxMinCount.r);
-    elevation = linearScale(elevationDomain, elevationRange, elevations.r);
+    vec2 elvDomain = elevationDomainValid ? elevationDomain : vec2(elevationData.maxMinCount.a, elevationData.maxMinCount.r);
+    elevation = linearScale(elvDomain, elevationRange, elevations.r);
     elevation = elevation  * (positions.z + 1.0) / 2.0 * elevationScale;
   }
 

--- a/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-layer.js
+++ b/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-layer.js
@@ -240,7 +240,9 @@ export default class GPUGridLayer extends CompositeLayer {
       cellSize: cellSizeMeters,
       coverage,
       material,
-      elevationRange
+      elevationRange,
+      colorDomain,
+      elevationDomain
     } = this.props;
 
     const {weights, gridSize, gridOrigin, cellSize} = this.state;
@@ -256,6 +258,8 @@ export default class GPUGridLayer extends CompositeLayer {
         gridOffset: cellSize,
         colorRange,
         elevationRange,
+        colorDomain,
+        elevationDomain,
 
         fp64,
         cellSize: cellSizeMeters,

--- a/modules/aggregation-layers/src/new-grid-layer/new-grid-layer.js
+++ b/modules/aggregation-layers/src/new-grid-layer/new-grid-layer.js
@@ -3,7 +3,9 @@ import GPUGridAggregator from '../utils/gpu-grid-aggregation/gpu-grid-aggregator
 import GPUGridLayer from '../gpu-grid-layer/gpu-grid-layer';
 import GridLayer from '../grid-layer/grid-layer';
 
-const defaultProps = Object.assign({}, GPUGridLayer.defaultProps, GridLayer.defaultProps);
+const defaultProps = Object.assign({}, GPUGridLayer.defaultProps, GridLayer.defaultProps, {
+  gpuAggregation: false
+});
 
 export default class NewGridLayer extends CompositeLayer {
   initializeState() {
@@ -21,7 +23,9 @@ export default class NewGridLayer extends CompositeLayer {
   renderLayers() {
     const {data, updateTriggers} = this.props;
     const id = this.state.useGPUAggregation ? 'GPU' : 'CPU';
-    const LayerType = this.state.useGPUAggregation ? GPUGridLayer : GridLayer;
+    const LayerType = this.state.useGPUAggregation
+      ? this.getSubLayerClass('GPU', GPUGridLayer)
+      : this.getSubLayerClass('CPU', GridLayer);
     return new LayerType(
       this.props,
       this.getSubLayerProps({

--- a/modules/main/src/index.js
+++ b/modules/main/src/index.js
@@ -129,7 +129,8 @@ export {
   GridLayer,
   HexagonLayer,
   ContourLayer,
-  _NewGridLayer
+  _NewGridLayer,
+  _GPUGridLayer
 } from '@deck.gl/aggregation-layers';
 
 export {

--- a/test/modules/aggregation-layers/new-grid-layer.spec.js
+++ b/test/modules/aggregation-layers/new-grid-layer.spec.js
@@ -62,7 +62,18 @@ test('NewGridLayer#updates', t => {
       {
         props: SAMPLE_PROPS,
         onAfterUpdate({layer}) {
-          t.ok(layer.state.useGPUAggregation === true, 'Should use GPU Aggregation');
+          t.ok(layer.state.useGPUAggregation === false, 'By default should use CPU Aggregation');
+        }
+      },
+      {
+        updateProps: {
+          gpuAggregation: true
+        },
+        onAfterUpdate({layer}) {
+          t.ok(
+            layer.state.useGPUAggregation === true,
+            'Should use GPU Aggregation (gpuAggregation: true)'
+          );
         }
       },
       {

--- a/website/contents/pages.js
+++ b/website/contents/pages.js
@@ -452,6 +452,10 @@ export const docPages = generatePath([
             content: getDocUrl('layers/h3-hexagon-layer.md')
           },
           {
+            name: 'NewGridLayer',
+            content: getDocUrl('layers/new-grid-layer.md')
+          },
+          {
             name: 'S2Layer',
             content: getDocUrl('layers/s2-layer.md')
           },

--- a/website/src/components/demos/aggregation-layer-demos.js
+++ b/website/src/components/demos/aggregation-layer-demos.js
@@ -1,7 +1,16 @@
+/* eslint-disable import/namespace, import/default, import/no-extraneous-dependencies */
 import createLayerDemoClass from './layer-demo-base';
 import {DATA_URI} from '../../constants/defaults';
 
-import {ContourLayer, GridLayer, GridCellLayer, HexagonLayer, ScreenGridLayer} from 'deck.gl';
+import {
+  ContourLayer,
+  GridLayer,
+  GridCellLayer,
+  HexagonLayer,
+  ScreenGridLayer,
+  _GPUGridLayer as GPUGridLayer,
+  _NewGridLayer as NewGridLayer
+} from '@deck.gl/aggregation-layers';
 
 export const ContourLayerDemo = createLayerDemoClass({
   Layer: ContourLayer,
@@ -36,8 +45,7 @@ export const GridCellLayerDemo = createLayerDemoClass({
   }
 });
 
-export const GridLayerDemo = createLayerDemoClass({
-  Layer: GridLayer,
+const GRID_LAYER_INFO = {
   dataUrl: `${DATA_URI}/sf-bike-parking.json`,
   formatTooltip: d => `${d.position.join(', ')}\nCount: ${d.count}`,
   props: {
@@ -47,6 +55,21 @@ export const GridLayerDemo = createLayerDemoClass({
     elevationScale: 4,
     getPosition: d => d.COORDINATES
   }
+};
+
+export const GPUGridLayerDemo = createLayerDemoClass({
+  Layer: GPUGridLayer,
+  ...GRID_LAYER_INFO
+});
+
+export const NewGridLayerDemo = createLayerDemoClass({
+  Layer: NewGridLayer,
+  ...GRID_LAYER_INFO
+});
+
+export const GridLayerDemo = createLayerDemoClass({
+  Layer: GridLayer,
+  ...GRID_LAYER_INFO
 });
 
 export const HexagonLayerDemo = createLayerDemoClass({


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #2084
<!-- For other PRs without open issue -->
#### Background
- Docs:
   - Update doc page for `GPUGridLayer`
   - Add doc page for `NewGridLayer`
   - Add sections in above docs describing differences with `GridLayer` and list all fallback cases.
   - Add demos for `GPUGridLayer` and `NewGridLayer`
- GPUGridLayer
   - Fix color calculation when not extruded.
   - Fix color and elevation domain processing.
- NewGridLayer
  - disable GPU Aggregation by default.
  - Use `getSubLayerClass` method to allow customization.

<!-- For all the PRs -->
#### Change List
- GPU GridLyer Part 6: GPUGridLayer fixes and docs.
