### PR TITLE
fix post-processing effect framebuffer binding bug

### DIFF
--- a/modules/core/src/passes/screen-pass.js
+++ b/modules/core/src/passes/screen-pass.js
@@ -4,7 +4,7 @@
 // Attribution: This class and the multipass system were inspired by
 // the THREE.js EffectComposer and *Pass classes
 
-import {ClipSpace, withParameters} from '@luma.gl/core';
+import {ClipSpace, withParameters, clear} from '@luma.gl/core';
 import Pass from './pass';
 
 export default class ScreenPass extends Pass {
@@ -45,7 +45,7 @@ export default class ScreenPass extends Pass {
    * @param {Framebuffer} outputBuffer - Frame buffer that serves as the output render target
    */
   _renderPass(gl, {inputBuffer, outputBuffer}) {
-    outputBuffer.clear();
+    clear(gl, {color: true});
     this.model.draw({
       uniforms: {
         texture: inputBuffer,


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #2962
<!-- For other PRs without open issue -->
#### Background
Edgework effect doesn't work well because the target framebuffer is not bound correctly. Replace framebuffer.clear() with clear() function to resolve the issue
<!-- For all the PRs -->
#### Change List
- Replace framebuffer.clear() with clear()
