### PR TITLE
Support react-map-gl's new MapContext format

### DIFF
--- a/docs/api-reference/react/deckgl.md
+++ b/docs/api-reference/react/deckgl.md
@@ -64,7 +64,7 @@ import {_MapContext as MapContext, NavigationControl} from 'react-map-gl';
 
 <DeckGL ... ContextProvider={MapContext.Provider}>
   <div style={NAVIGATION_CONTROL_STYLES}>
-    <NavigationControl onViewStateChange={...} />
+    <NavigationControl />
   </div>
 </DeckGL>
 ```

--- a/examples/layer-browser/package.json
+++ b/examples/layer-browser/package.json
@@ -20,7 +20,7 @@
     "react": "^16.3.0",
     "react-autobind": "^1.0.6",
     "react-dom": "^16.3.0",
-    "react-map-gl": "^4.1.2",
+    "react-map-gl": "^4.1.4",
     "react-stats-zavatta": "^0.0.6"
   },
   "devDependencies": {

--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -347,7 +347,7 @@ export default class App extends PureComponent {
           </View>
 
           <div style={NAVIGATION_CONTROL_STYLES}>
-            <NavigationControl onViewStateChange={this._onViewStateChange} />
+            <NavigationControl />
           </div>
         </DeckGL>
       </div>

--- a/modules/react/src/utils/position-children-under-views.js
+++ b/modules/react/src/utils/position-children-under-views.js
@@ -69,7 +69,8 @@ export default function positionChildrenUnderViews({children, viewports, deck, C
       const contextValue = {
         viewport,
         container: deck.canvas.offsetParent,
-        eventManager: deck.eventManager
+        eventManager: deck.eventManager,
+        onViewStateChange: deck._onViewStateChange
       };
       viewChildren = createElement(ContextProvider, {value: contextValue}, viewChildren);
     }


### PR DESCRIPTION
#### Change List

- By passing `onViewStateChange` with the context, we make the viewport change callback on react-map-gl controls optional.
