### PR TITLE
Fix ArcLayer bug when using non-iterable data with pre-allocated target array

### DIFF
--- a/docs/api-reference/test-utils/test-layer.md
+++ b/docs/api-reference/test-utils/test-layer.md
@@ -22,7 +22,7 @@ test('GeoJsonLayer#tests', t => {
       props: {
         data: SAMPLE_GEOJSON
       },
-      assert({layer, oldState}) {
+      onAfterUpdate({layer, oldState}) {
         t.ok(layer.state.features !== oldState.features, 'should update features');
         t.is(subLayers.length, 2, 'should render 2 subLayers');
       }
@@ -33,7 +33,7 @@ test('GeoJsonLayer#tests', t => {
         // will be merged with the previous props
         lineWidthScale: 3
       },
-      assert({subLayers}) {
+      onAfterUpdate({subLayers}) {
         const pathLayer = subLayers.find(layer => layer.id.endsWith('linestrings'));
         t.is(pathLayer.props.widthScale, 3, 'widthScale is passed to sub layer');
       }

--- a/modules/layers/src/arc-layer/arc-layer.js
+++ b/modules/layers/src/arc-layer/arc-layer.js
@@ -181,9 +181,9 @@ export default class ArcLayer extends Layer {
     for (const object of iterable) {
       objectInfo.index++;
       const sourcePosition = getSourcePosition(object, objectInfo);
-      const targetPosition = getTargetPosition(object, objectInfo);
       value[i++] = sourcePosition[0];
       value[i++] = sourcePosition[1];
+      const targetPosition = getTargetPosition(object, objectInfo);
       value[i++] = targetPosition[0];
       value[i++] = targetPosition[1];
     }
@@ -205,9 +205,9 @@ export default class ArcLayer extends Layer {
     for (const object of iterable) {
       objectInfo.index++;
       const sourcePosition = getSourcePosition(object, objectInfo);
-      const targetPosition = getTargetPosition(object, objectInfo);
       value[i++] = fp64LowPart(sourcePosition[0]);
       value[i++] = fp64LowPart(sourcePosition[1]);
+      const targetPosition = getTargetPosition(object, objectInfo);
       value[i++] = fp64LowPart(targetPosition[0]);
       value[i++] = fp64LowPart(targetPosition[1]);
     }

--- a/modules/layers/src/arc-layer/arc-layer.js
+++ b/modules/layers/src/arc-layer/arc-layer.js
@@ -183,6 +183,8 @@ export default class ArcLayer extends Layer {
       const sourcePosition = getSourcePosition(object, objectInfo);
       value[i++] = sourcePosition[0];
       value[i++] = sourcePosition[1];
+      // Call `getTargetPosition` after `sourcePosition` is used in case both accessors write into
+      // the same temp array
       const targetPosition = getTargetPosition(object, objectInfo);
       value[i++] = targetPosition[0];
       value[i++] = targetPosition[1];
@@ -207,6 +209,8 @@ export default class ArcLayer extends Layer {
       const sourcePosition = getSourcePosition(object, objectInfo);
       value[i++] = fp64LowPart(sourcePosition[0]);
       value[i++] = fp64LowPart(sourcePosition[1]);
+      // Call `getTargetPosition` after `sourcePosition` is used in case both accessors write into
+      // the same temp array
       const targetPosition = getTargetPosition(object, objectInfo);
       value[i++] = fp64LowPart(targetPosition[0]);
       value[i++] = fp64LowPart(targetPosition[1]);

--- a/test/modules/layers/core-layers.spec.js
+++ b/test/modules/layers/core-layers.spec.js
@@ -108,6 +108,49 @@ test('ArcLayer', t => {
   t.end();
 });
 
+test('ArcLayer#non-iterable', t => {
+  const data = FIXTURES.routes;
+
+  testLayer({
+    Layer: ArcLayer,
+    testCases: [
+      {
+        props: {
+          data: {
+            length: data.length
+          },
+          getSourcePosition: (_, {index, target}) => {
+            target[0] = data[index].START[0];
+            target[1] = data[index].START[1];
+            return target;
+          },
+          getTargetPosition: (_, {index, target}) => {
+            target[0] = data[index].END[0];
+            target[1] = data[index].END[1];
+            return target;
+          }
+        },
+        onAfterUpdate: ({layer}) => {
+          const instancePositions = layer.getAttributeManager().attributes.instancePositions.value;
+          t.is(
+            instancePositions.length,
+            FIXTURES.routes.length * 4,
+            'instancePositions has correct length'
+          );
+          t.deepEquals(
+            instancePositions.slice(0, 4),
+            [data[0].START[0], data[0].START[1], data[0].END[0], data[0].END[1]].map(Math.fround),
+            'instancePositions has correct content'
+          );
+        }
+      }
+    ],
+    onError: t.notOk
+  });
+
+  t.end();
+});
+
 test('PointCloudLayer', t => {
   const testCases = generateLayerTests({
     Layer: PointCloudLayer,


### PR DESCRIPTION
If `getSourcePosition` and `getTargetPosition` write into the same target array, the layer fails to render. (see test case)

#### Change List
- Fix attribute updater bug
