### PR TITLE
GPUGridLayer: make it exclusive for WebGL2

### DIFF
--- a/docs/layers/cpu-grid-layer.md
+++ b/docs/layers/cpu-grid-layer.md
@@ -8,11 +8,13 @@
 
 # CPUGridLayer
 
-The Grid Layer renders a grid heatmap based on an array of points.
+The `CPUGridLayer` renders a grid heatmap based on an array of points.
 It takes the constant cell size, aggregates input points into cells. Aggregation is performed on CPU. The color
 and height of the cell is scaled by number of points it contains.
 
-CPUGridLayer is a [CompositeLayer](/docs/api-reference/composite-layer.md).
+`CPUGridLayer` is one of the sublayers for [GridLayer](/docs/layers/grid-layer.md), and is provided to customize CPU Aggregation for advanced use cases. For any regular use case, [GridLayer](/docs/layers/grid-layer.md) is recommended.
+
+`CPUGridLayer` is a [CompositeLayer](/docs/api-reference/composite-layer.md).
 
 ```js
 import DeckGL from '@deck.gl/react';

--- a/docs/layers/gpu-grid-layer.md
+++ b/docs/layers/gpu-grid-layer.md
@@ -12,7 +12,9 @@ The `GPUGridLayer` renders a grid heatmap based on an array of points.
 It takes the constant cell size, aggregates input points into cells. When possible aggregation is performed on GPU. The color
 and height of the cell is scaled by number of points it contains.
 
-GPUGridLayer is a [CompositeLayer](/docs/api-reference/composite-layer.md) and is only supported when using `WebGL2` enabled browsers, for browsers that don't support `WebGL2`, use [GridLayer](/docs/layers/grid-layer.md).
+`GPUGridLayer` is one of the sublayers for [GridLayer](/docs/layers/grid-layer.md) and is only supported when using `WebGL2` enabled browsers. It is provided to customize GPU Aggregation for advanced use cases. For any regular use case, [GridLayer](/docs/layers/grid-layer.md) is recommended.
+
+`GPUGridLayer` is a [CompositeLayer](/docs/api-reference/composite-layer.md).
 
 ```js
 import DeckGL from '@deck.gl/react';

--- a/docs/layers/gpu-grid-layer.md
+++ b/docs/layers/gpu-grid-layer.md
@@ -6,13 +6,13 @@
   <img src="https://img.shields.io/badge/lighting-yes-blue.svg?style=flat-square" alt="lighting" />
 </p>
 
-# GPUGridLayer
+# GPUGridLayer (WebGL2)
 
 The `GPUGridLayer` renders a grid heatmap based on an array of points.
 It takes the constant cell size, aggregates input points into cells. When possible aggregation is performed on GPU. The color
 and height of the cell is scaled by number of points it contains.
 
-GPUGridLayer is a [CompositeLayer](/docs/api-reference/composite-layer.md).
+GPUGridLayer is a [CompositeLayer](/docs/api-reference/composite-layer.md) and is only supported when using `WebGL2` enabled browsers, for browsers that don't support `WebGL2`, use [GridLayer](/docs/layers/grid-layer.md).
 
 ```js
 import DeckGL from '@deck.gl/react';

--- a/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-layer.js
+++ b/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-layer.js
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 import {PhongMaterial} from '@luma.gl/core';
-import {CompositeLayer} from '@deck.gl/core';
+import {CompositeLayer, log} from '@deck.gl/core';
 
 import GPUGridAggregator from '../utils/gpu-grid-aggregation/gpu-grid-aggregator';
 import {AGGREGATION_OPERATION} from '../utils/aggregation-operation-utils';
@@ -60,6 +60,9 @@ const defaultProps = {
 export default class GPUGridLayer extends CompositeLayer {
   initializeState() {
     const {gl} = this.context;
+    if (!GPUGridAggregator.isSupported(gl)) {
+      log.error('GPUGridLayer is not supported on this browser, use GridLayer instead')();
+    }
     const options = {
       id: `${this.id}-gpu-aggregator`,
       shaderCache: this.context.shaderCache
@@ -86,6 +89,10 @@ export default class GPUGridLayer extends CompositeLayer {
 
   getAggregationFlags({oldProps, props, changeFlags}) {
     let aggregationFlags = null;
+    if (!GPUGridAggregator.isSupported(this.context.gl)) {
+      // Skip update, layer not supported
+      return false;
+    }
     if (this.isDataChanged({oldProps, props, changeFlags})) {
       aggregationFlags = Object.assign({}, aggregationFlags, {dataChanged: true});
     }
@@ -233,6 +240,9 @@ export default class GPUGridLayer extends CompositeLayer {
   }
 
   renderLayers() {
+    if (!GPUGridAggregator.isSupported(this.context.gl)) {
+      return null;
+    }
     const {
       elevationScale,
       fp64,

--- a/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-layer.js
+++ b/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-layer.js
@@ -60,15 +60,18 @@ const defaultProps = {
 export default class GPUGridLayer extends CompositeLayer {
   initializeState() {
     const {gl} = this.context;
+    let isSupported = true;
     if (!GPUGridAggregator.isSupported(gl)) {
       log.error('GPUGridLayer is not supported on this browser, use GridLayer instead')();
+      isSupported = false;
     }
     const options = {
       id: `${this.id}-gpu-aggregator`,
       shaderCache: this.context.shaderCache
     };
     this.state = {
-      gpuGridAggregator: new GPUGridAggregator(gl, options)
+      gpuGridAggregator: new GPUGridAggregator(gl, options),
+      isSupported
     };
   }
 
@@ -89,7 +92,7 @@ export default class GPUGridLayer extends CompositeLayer {
 
   getAggregationFlags({oldProps, props, changeFlags}) {
     let aggregationFlags = null;
-    if (!GPUGridAggregator.isSupported(this.context.gl)) {
+    if (!this.state.isSupported) {
       // Skip update, layer not supported
       return false;
     }
@@ -240,7 +243,7 @@ export default class GPUGridLayer extends CompositeLayer {
   }
 
   renderLayers() {
-    if (!GPUGridAggregator.isSupported(this.context.gl)) {
+    if (!this.state.isSupported) {
       return null;
     }
     const {

--- a/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-layer.js
+++ b/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-layer.js
@@ -60,10 +60,9 @@ const defaultProps = {
 export default class GPUGridLayer extends CompositeLayer {
   initializeState() {
     const {gl} = this.context;
-    let isSupported = true;
-    if (!GPUGridAggregator.isSupported(gl)) {
+    const isSupported = GPUGridAggregator.isSupported(gl);
+    if (!isSupported) {
       log.error('GPUGridLayer is not supported on this browser, use GridLayer instead')();
-      isSupported = false;
     }
     const options = {
       id: `${this.id}-gpu-aggregator`,

--- a/modules/aggregation-layers/src/utils/gpu-grid-aggregation/gpu-grid-aggregator.js
+++ b/modules/aggregation-layers/src/utils/gpu-grid-aggregation/gpu-grid-aggregator.js
@@ -214,7 +214,7 @@ export default class GPUGridAggregator {
       return this.runAggregationOnGPU(aggregationParams);
     }
     if (useGPU) {
-      log.warn('ScreenGridAggregator: GPU Aggregation not supported, falling back to CPU')();
+      log.info('GPUGridAggregator: GPU Aggregation not supported, falling back to CPU')();
     }
     return this.runAggregationOnCPU(aggregationParams);
   }

--- a/website/contents/pages.js
+++ b/website/contents/pages.js
@@ -430,6 +430,7 @@ export const docPages = generatePath([
           },
           {
             name: 'GPUGridLayer',
+            tag: 'advanced',
             content: getDocUrl('layers/gpu-grid-layer.md')
           },
           {
@@ -438,6 +439,7 @@ export const docPages = generatePath([
           },
           {
             name: 'CPUGridLayer',
+            tag: 'advanced',
             content: getDocUrl('layers/cpu-grid-layer.md')
           },
           {


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #3173 
<!-- For other PRs without open issue -->
#### Background
GPUGridLayer is only supported when using `WebGL2`, add a warning to use `GridLayer` when not supported.
<!-- For all the PRs -->
#### Change List
- GPUGridLayer: make it exclusive for WebGL2
