### PR TITLE
H3Hexagon: add support for coverage.

### DIFF
--- a/docs/layers/h3-hexagon-layer.md
+++ b/docs/layers/h3-hexagon-layer.md
@@ -102,6 +102,13 @@ However, there are 12 pentagons world wide at each resolution. The hexagons at a
 * if `false`, the layer chooses the mode automatically. High-precision rendering is only used if resolution is at or below `5`, or if a pentagon is found in the data.
 * if `true`, always use high-precision rendering.
 
+##### `coverage` (Number, optional)
+
+* Default: `1`
+
+Hexagon radius multiplier, between 0 - 1. When `coverage` = 1, hexagon is rendered with actual size, by specifying a different value (between 0 and 1) hexagon can be scaled down.
+
+
 ### Data Accessors
 
 ##### `getHexagon` ([Function](/docs/developer-guide/using-layers.md#accessors), optional)
@@ -123,4 +130,3 @@ The `H3HexagonLayer` renders the following sublayers:
 ## Source
 
 [modules/geo-layers/src/h3-layers/h3-hexagon-layer](https://github.com/uber/deck.gl/tree/master/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js)
-

--- a/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
+++ b/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
@@ -18,8 +18,8 @@ import {ColumnLayer, PolygonLayer} from '@deck.gl/layers';
 const UPDATE_THRESHOLD_KM = 10;
 
 // normalize longitudes w.r.t center `refLng`, when not provided first vertex
-export function normalizeLongitudes(vertices, refLng = null) {
-  refLng = refLng || vertices[0][0];
+export function normalizeLongitudes(vertices, refLng) {
+  refLng = refLng === undefined ? vertices[0][0] : refLng;
   for (const pt of vertices) {
     const deltaLng = pt[0] - refLng;
     if (deltaLng > 180) {
@@ -57,12 +57,12 @@ function h3ToPolygon(hexId, coverage = 1) {
   const vertices = h3ToGeoBoundary(hexId, true);
 
   if (coverage !== 1) {
-    // updates array object elements of vertices array.
+    // scale and normalize vertices w.r.t to center
     scalePolygon(hexId, vertices, coverage);
+  } else {
+    // normalize w.r.t to start vertex
+    normalizeLongitudes(vertices);
   }
-
-  // normalize with respect start vertex
-  normalizeLongitudes(vertices);
 
   return vertices;
 }

--- a/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
+++ b/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
@@ -17,7 +17,7 @@ import {ColumnLayer, PolygonLayer} from '@deck.gl/layers';
 // distortion." Smaller value makes the column layer more sensitive to viewport change.
 const UPDATE_THRESHOLD_KM = 10;
 
-// normalize longitudes w.r.t center `refLng`, when not provided first vertex
+// normalize longitudes w.r.t center (refLng), when not provided first vertex
 export function normalizeLongitudes(vertices, refLng) {
   refLng = refLng === undefined ? vertices[0][0] : refLng;
   for (const pt of vertices) {

--- a/test/modules/geo-layers/h3-layers.spec.js
+++ b/test/modules/geo-layers/h3-layers.spec.js
@@ -173,44 +173,34 @@ test('H3HexagonLayer#normalizeLongitudes', t => {
   const TEST_CASES = [
     {
       vertices: [[-180, 30], [90, 76], [180, -90], [-110, -21]],
-      expected: [[-180, 30], [-270, 76], [-180, -90], [-110, -21]],
-      info: 'Vertices should get normalized with first vertex longitude',
-      refLng: null
+      expected: [[-180, 30], [-270, 76], [-180, -90], [-110, -21]]
     },
     {
       vertices: [[-180, 30], [90, 76], [180, -90], [-110, -21]],
       expected: [[180, 30], [90, 76], [180, -90], [250, -21]],
-      refLng: 180,
-      info: 'Vertices should get normalized with reference longitude'
+      refLng: 180
+    },
+    {
+      hexId: '88283082e1fffff'
     },
     {
       hexId: '88283082e1fffff',
-      info: 'Vertices should get normalized with first vertex longitude',
-      refLng: null
-    },
-    {
-      hexId: '88283082e1fffff',
-      info: 'Vertices should get normalized for longitude 1',
       refLng: 1
     },
     {
       hexId: '88283082e1fffff',
-      info: 'Vertices should get normalized for longitude 98',
       refLng: 98
     },
     {
       hexId: '88283082e1fffff',
-      info: 'Vertices should get normalized for longitude 170',
       refLng: 170
     },
     {
       hexId: '88283082e1fffff',
-      info: 'Vertices should get normalized with first vertex longitude',
       refLng: -70
     },
     {
       hexId: '88283082e1fffff',
-      info: 'Vertices should get normalized with first vertex longitude',
       refLng: -150
     }
   ];

--- a/test/modules/geo-layers/h3-layers.spec.js
+++ b/test/modules/geo-layers/h3-layers.spec.js
@@ -19,10 +19,12 @@
 // THE SOFTWARE.
 
 import test from 'tape-catch';
+import {h3ToGeoBoundary, h3ToGeo} from 'h3-js';
 import {experimental} from '@deck.gl/core';
 const {count} = experimental;
 import {testLayer, generateLayerTests} from '@deck.gl/test-utils';
 import {H3HexagonLayer, H3ClusterLayer} from '@deck.gl/geo-layers';
+import {scalePolygon} from '@deck.gl/geo-layers/h3-layers/h3-hexagon-layer';
 import data from 'deck.gl-test/data/h3-sf.json';
 
 const SAMPLE_PROPS = {
@@ -52,7 +54,7 @@ test('H3HexagonLayer', t => {
   t.end();
 });
 
-test('H3HexagonLayer#mergeTriggers', t => {
+test.only('H3HexagonLayer#mergeTriggers', t => {
   testLayer({
     Layer: H3HexagonLayer,
     onError: t.notOk,
@@ -86,7 +88,7 @@ test('H3HexagonLayer#mergeTriggers', t => {
         onAfterUpdate({layer}) {
           t.deepEqual(
             layer.internalState.subLayers[0].props.updateTriggers.getPolygon,
-            [0, 0],
+            {getHexagon: 0, coverage: 0},
             'SubLayer update trigger should be merged correctly'
           );
         }
@@ -98,7 +100,7 @@ test('H3HexagonLayer#mergeTriggers', t => {
         onAfterUpdate({layer}) {
           t.deepEqual(
             layer.internalState.subLayers[0].props.updateTriggers.getPolygon,
-            ['A', 1, 0],
+            {0: 'A', 1: 1, coverage: 0},
             'SubLayer update trigger should be merged correctly with Array'
           );
         }
@@ -118,6 +120,52 @@ test('H3HexagonLayer#mergeTriggers', t => {
       }
     ]
   });
+  t.end();
+});
+
+test('H3HexagonLayer#scalePolygon', t => {
+  const TEST_CASES = [
+    {
+      coverage: 0,
+      verify: (vertices, hexId) => {
+        const [lat, lng] = h3ToGeo(hexId);
+        return vertices.every(vertex => vertex[0] === lng || vertex[1] === lat);
+      }
+    },
+    {
+      coverage: 1,
+      verify: (vertices, hexId) => {
+        const expectedVertices = h3ToGeoBoundary(hexId, true);
+        return vertices.every(
+          (vertex, i) =>
+            vertex[0] === expectedVertices[i][0] || vertex[1] === expectedVertices[i][1]
+        );
+      }
+    },
+    {
+      coverage: 0.5,
+      verify: (vertices, hexId) => {
+        const [lat, lng] = h3ToGeo(hexId);
+        const end = h3ToGeoBoundary(hexId, true);
+
+        return vertices.every(
+          (vertex, i) =>
+            vertex[0] === 0.5 * (lng + end[i][0]) || vertex[1] === 0.5 * (lat + end[i][1])
+        );
+      }
+    }
+  ];
+  const HEXID = '88283082e1fffff';
+
+  for (const testCase of TEST_CASES) {
+    const vertices = h3ToGeoBoundary(HEXID, true);
+    scalePolygon(HEXID, vertices, testCase.coverage);
+    t.deepEqual(vertices[0], vertices[vertices.length - 1], 'first and last vertices should match');
+    t.ok(
+      testCase.verify(vertices, HEXID),
+      `vertices should match for coverage: ${testCase.coverage}`
+    );
+  }
   t.end();
 });
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #3209 

<!-- For other PRs without open issue -->
#### Background
- Forward `coverage` prop to `ColumnLayer`
- Scale polygon vertices when using `PolygonLayer`.

<!-- For all the PRs -->
#### Change List
- H3Hexagon: add support for coverage.


![H3Coverage](https://user-images.githubusercontent.com/9502731/59066629-57a44000-8864-11e9-889a-982c5be4b78b.gif)
