### PR TITLE
Fix tree shaking in pre-bundled version

### DIFF
--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -25,7 +25,8 @@
     "dist.min.js"
   ],
   "sideEffects": [
-    "**/init.js"
+    "./dist/**/init.js",
+    "./src/lib/init.js"
   ],
   "scripts": {
     "build-bundle": "webpack --config ../../scripts/bundle.config.js",

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -25,9 +25,7 @@
     "dist.min.js"
   ],
   "sideEffects": [
-    "dist/es5/lib/init.js",
-    "dist/esm/lib/init.js",
-    "dist/es6/lib/init.js"
+    "**/init.js"
   ],
   "scripts": {
     "build-bundle": "webpack --config ../../scripts/bundle.config.js",


### PR DESCRIPTION
For #3213 

#### Background
In our bundle script, each module is resolved to source, and `src/lib/init.js` is not listed in `sideEffects`.

#### Change List
- Change `sideEffects` to use wildcard
