### PR TITLE
improve shadow/sun example depth value encoding

### DIFF
--- a/examples/experimental/sun/src/shadow-effect/shadow-module.js
+++ b/examples/experimental/sun/src/shadow-effect/shadow-module.js
@@ -27,9 +27,9 @@ uniform vec4 shadow_color;
 
 varying vec3 shadow_vPosition;
 
-const vec4 bitPackShift = vec4(1.0, 256.0, 256.0 * 256.0, 256.0 * 256.0 * 256.0);
+const vec4 bitPackShift = vec4(1.0, 255.0, 65025.0, 16581375.0);
 const vec4 bitUnpackShift = 1.0 / bitPackShift;
-const vec4 bitMask = vec4(1.0 / 256.0, 1.0 / 256.0, 1.0 / 256.0,  0.0);
+const vec4 bitMask = vec4(1.0 / 255.0, 1.0 / 255.0, 1.0 / 255.0,  0.0);
 
 float shadow_getShadowWeight(vec2 texCoords) {
   vec4 rgbaDepth = texture2D(shadow_shadowMap, texCoords);


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
<!-- For other PRs without open issue -->
#### Background
Depth value encoding is wrong which made the shadow is not rendered correctly.
![image](https://user-images.githubusercontent.com/15093546/59132276-9b14b200-8929-11e9-8e4f-cad1b050a809.png)
![image](https://user-images.githubusercontent.com/15093546/59132303-b2539f80-8929-11e9-8d4a-afa18b3ab111.png)

<!-- For all the PRs -->
#### Change List
- improve depth encoding
