### PR TITLE
CompositeLayer: add ability to override sublayer updateTriggers

### DIFF
--- a/docs/api-reference/composite-layer.md
+++ b/docs/api-reference/composite-layer.md
@@ -78,6 +78,30 @@ new GeoJsonLayer({
 });
 ```
 
+Example: use customized `ColumnLayer` with a additional updateTrigger (required for the added customization)
+
+```js
+import {ColumnLayer} from '@deck.gl/layers';
+import {H3HexagonLayer} from '@deck.gl/geo-layers';
+
+class CustomizedColumnLayer extends ColumnLayer {
+  // customization that adds new accessor prop `getCoverage` and hence requires new updateTrigger
+  // following code show how to provide this update trigger
+  // ...
+}
+
+new H3HexagonLayer({
+  // ...other props
+  _subLayerProps: {
+    'hexagon-cell': {
+      type: CustomizedColumnLayer,
+      getCoverage: data.getCoverage,
+      updateTriggers: {getCoverage: getCoverageTrigger}
+    }
+  }
+});
+```
+
 
 ## Methods
 

--- a/docs/api-reference/composite-layer.md
+++ b/docs/api-reference/composite-layer.md
@@ -72,43 +72,10 @@ new GeoJsonLayer({
       iconMapping: './icon-mapping.json',
       getIcon: d => d.sourceFeature.feature.properties.marker,
       getColor: [255, 200, 0],
-      getSize: 32
-    }
-  }
-});
-```
-
-Example: Use customized `IconLayer` instead of `ScatterplotLayer` to render the point features in a `GeoJsonLayer`.
-
-`IconLayer` is customized by subclassing it, adding a new attribute `instanceElevation` and corresponding accessor prop `getElevation`. For this customization we also need to add an updateTrigger for `getElevation` prop.
-
-```js
-import {IconLayer, GeoJsonLayer} from '@deck.gl/layers';
-
-class CustomizedIconLayer extends IconLayer {
-  getShaders() {
-    // provide updated shaders that use new attribute `instanceElevation`
-  }
-
-  // Add new attribute
-  initializeState() {
-    super.initializeState();
-
-    this.getAttributeManager().addInstanced({
-      instanceElevation: {size: 1, accessor: 'getElevation'}
-    });
-  }
-
-  // ... any other customization code
-}
-
-new GeoJsonLayer({
-  // ...other props
-  _subLayerProps: {
-    points: {
-      type: CustomizedIconLayer,
-      getElevation: getElevationValue, // newly added prop
-      updateTriggers: {getElevation: getElevationTrigger} // update trigger for new attribute
+      getSize: 32,
+      updateTriggers: {
+        getIcon: triggerValue
+      }
     }
   }
 });

--- a/docs/api-reference/composite-layer.md
+++ b/docs/api-reference/composite-layer.md
@@ -78,25 +78,37 @@ new GeoJsonLayer({
 });
 ```
 
-Example: use customized `ColumnLayer` with a additional updateTrigger (required for the added customization)
+Example: Use customized `IconLayer` instead of `ScatterplotLayer` to render the point features in a `GeoJsonLayer`.
+
+`IconLayer` is customized by subclassing it, adding a new attribute `instanceElevation` and corresponding accessor prop `getElevation`. For this customization we also need to add an updateTrigger for `getElevation` prop.
 
 ```js
-import {ColumnLayer} from '@deck.gl/layers';
-import {H3HexagonLayer} from '@deck.gl/geo-layers';
+import {IconLayer, GeoJsonLayer} from '@deck.gl/layers';
 
-class CustomizedColumnLayer extends ColumnLayer {
-  // customization that adds new accessor prop `getCoverage` and hence requires new updateTrigger
-  // following code show how to provide this update trigger
-  // ...
+class CustomizedIconLayer extends IconLayer {
+  getShaders() {
+    // provide updated shaders that use new attribute `instanceElevation`
+  }
+
+  // Add new attribute
+  initializeState() {
+    super.initializeState();
+
+    this.getAttributeManager().addInstanced({
+      instanceElevation: {size: 1, accessor: 'getElevation'}
+    });
+  }
+
+  // ... any other customization code
 }
 
-new H3HexagonLayer({
+new GeoJsonLayer({
   // ...other props
   _subLayerProps: {
-    'hexagon-cell': {
-      type: CustomizedColumnLayer,
-      getCoverage: data.getCoverage,
-      updateTriggers: {getCoverage: getCoverageTrigger}
+    points: {
+      type: CustomizedIconLayer,
+      getElevation: getElevationValue, // newly added prop
+      updateTriggers: {getElevation: getElevationTrigger} // update trigger for new attribute
     }
   }
 });

--- a/modules/core/src/lib/composite-layer.js
+++ b/modules/core/src/lib/composite-layer.js
@@ -104,18 +104,22 @@ export default class CompositeLayer extends Layer {
     };
 
     if (sublayerProps) {
+      const overridingSublayerProps = overridingProps && overridingProps[sublayerProps.id];
+      const overridingSublayerTriggers =
+        overridingSublayerProps && overridingSublayerProps.updateTriggers;
       Object.assign(
         newProps,
         sublayerProps,
         // experimental feature that allows users to override sublayer props via parent layer prop
-        overridingProps && overridingProps[sublayerProps.id],
+        overridingSublayerProps,
         {
           id: `${this.props.id}-${sublayerProps.id}`,
           updateTriggers: Object.assign(
             {
               all: this.props.updateTriggers.all
             },
-            sublayerProps.updateTriggers
+            sublayerProps.updateTriggers,
+            overridingSublayerTriggers
           )
         }
       );

--- a/test/modules/core/lib/composite-layer.spec.js
+++ b/test/modules/core/lib/composite-layer.spec.js
@@ -105,7 +105,7 @@ test('CompositeLayer#getSubLayerProps', t => {
   t.end();
 });
 
-test.only('CompositeLayer#getSubLayerProps(override)', t => {
+test('CompositeLayer#getSubLayerProps(override)', t => {
   const TEST_CASES = [
     {
       name: 'No sublayer props',
@@ -154,8 +154,6 @@ test.only('CompositeLayer#getSubLayerProps(override)', t => {
 
   for (const tc of TEST_CASES) {
     const {name, sublayerProps, baseLayerProps, overrideProps, expected} = tc;
-
-    //
     const layer = new TestCompositeLayer(
       Object.assign(
         {id: BASE_LAYER_ID},
@@ -167,11 +165,6 @@ test.only('CompositeLayer#getSubLayerProps(override)', t => {
     const combinedSublayerProps = layer.getSubLayerProps(
       sublayerProps && Object.assign({id: SUB_LAYER_ID}, sublayerProps)
     );
-    // t.deepEqual(
-    //   Object.keys(combinedSublayerProps).sort(),
-    //   Object.keys(expected).sort(),
-    //   `${name}: should receive expected props`
-    // );
     for (const propName in expected) {
       t.deepEqual(
         combinedSublayerProps[propName],

--- a/test/modules/core/lib/composite-layer.spec.js
+++ b/test/modules/core/lib/composite-layer.spec.js
@@ -21,6 +21,9 @@
 import test from 'tape-catch';
 import {CompositeLayer, Layer, COORDINATE_SYSTEM} from 'deck.gl';
 
+const SUB_LAYER_ID = 'sub-layer-id';
+const BASE_LAYER_ID = 'composite-layer-id';
+
 const BASE_LAYER_PROPS = {
   opacity: 0.2,
   pickable: true,
@@ -32,7 +35,27 @@ const BASE_LAYER_PROPS = {
   highlightColor: [1, 1, 1],
   coordinateSystem: COORDINATE_SYSTEM.METER_OFFSETS,
   coordinateOrigin: [1, 1, 1],
+  wrapLongitude: false,
   modelMatrix: [1]
+};
+
+const SUB_LAYER_PROPS = {
+  opacity: 0.3,
+  newForwardProp: 'NFP',
+  updateTriggers: {
+    getColor: 'c',
+    getPosition: 10
+  }
+};
+
+// used for _subLayerProps to override sublayer props
+const OVERRIDE_PROPS = {
+  opacity: 0.5,
+  newProp: 'abc',
+  updateTriggers: {
+    getColor: 'b',
+    getCoverage: 100
+  }
 };
 
 class TestLayer extends Layer {}
@@ -48,15 +71,15 @@ class TestCompositeLayer extends CompositeLayer {
 TestCompositeLayer.layerName = 'TestCompositeLayer';
 
 test('CompositeLayer#constructor', t => {
-  const layer = new TestCompositeLayer(Object.assign({id: 'composite-layer'}, BASE_LAYER_PROPS));
+  const layer = new TestCompositeLayer(Object.assign({id: BASE_LAYER_ID}, BASE_LAYER_PROPS));
   t.ok(layer, 'CompositeLayer created');
-  t.equal(layer.id, 'composite-layer', 'CompositeLayer id set correctly');
+  t.equal(layer.id, BASE_LAYER_ID, 'CompositeLayer id set correctly');
   t.ok(layer.props, 'CompositeLayer props not null');
   t.end();
 });
 
 test('CompositeLayer#getSubLayerProps', t => {
-  const layer = new TestCompositeLayer(Object.assign({id: 'composite-layer'}, BASE_LAYER_PROPS));
+  const layer = new TestCompositeLayer(Object.assign({id: BASE_LAYER_ID}, BASE_LAYER_PROPS));
 
   // TODO - add table driven test cases for all forwarded sublayer props
   const baseProps = layer.getSubLayerProps();
@@ -77,6 +100,85 @@ test('CompositeLayer#getSubLayerProps', t => {
       BASE_LAYER_PROPS[propName],
       `CompositeLayer subLayerProp ${propName} ok`
     );
+  }
+
+  t.end();
+});
+
+test.only('CompositeLayer#getSubLayerProps(override)', t => {
+  const TEST_CASES = [
+    {
+      name: 'No sublayer props',
+      baseLayerProps: BASE_LAYER_PROPS,
+      // sublayerProps not defined
+      overrideProps: OVERRIDE_PROPS,
+      // result just contains base layer props
+      expected: BASE_LAYER_PROPS
+    },
+    {
+      name: 'With sub layer props and no override props',
+      baseLayerProps: BASE_LAYER_PROPS,
+      sublayerProps: SUB_LAYER_PROPS,
+      // overrideProps not defined
+      // sub layer props take precendence
+      expected: Object.assign(
+        {id: `${BASE_LAYER_ID}-${SUB_LAYER_ID}`},
+        BASE_LAYER_PROPS,
+        SUB_LAYER_PROPS,
+        {
+          updateTriggers: Object.assign({all: undefined}, SUB_LAYER_PROPS.updateTriggers)
+        }
+      )
+    },
+    {
+      name: 'With overriding sub layer props',
+      baseLayerProps: BASE_LAYER_PROPS,
+      sublayerProps: SUB_LAYER_PROPS,
+      overrideProps: OVERRIDE_PROPS,
+      // overriding sub layer props take precendence
+      expected: Object.assign(
+        {id: `${BASE_LAYER_ID}-${SUB_LAYER_ID}`},
+        BASE_LAYER_PROPS,
+        SUB_LAYER_PROPS,
+        OVERRIDE_PROPS,
+        {
+          updateTriggers: Object.assign(
+            {all: undefined},
+            SUB_LAYER_PROPS.updateTriggers,
+            OVERRIDE_PROPS.updateTriggers
+          )
+        }
+      )
+    }
+  ];
+
+  for (const tc of TEST_CASES) {
+    const {name, sublayerProps, baseLayerProps, overrideProps, expected} = tc;
+
+    //
+    const layer = new TestCompositeLayer(
+      Object.assign(
+        {id: BASE_LAYER_ID},
+        Object.assign({}, baseLayerProps, {
+          _subLayerProps: {[SUB_LAYER_ID]: overrideProps}
+        })
+      )
+    );
+    const combinedSublayerProps = layer.getSubLayerProps(
+      sublayerProps && Object.assign({id: SUB_LAYER_ID}, sublayerProps)
+    );
+    // t.deepEqual(
+    //   Object.keys(combinedSublayerProps).sort(),
+    //   Object.keys(expected).sort(),
+    //   `${name}: should receive expected props`
+    // );
+    for (const propName in expected) {
+      t.deepEqual(
+        combinedSublayerProps[propName],
+        expected[propName],
+        `${name} : ${propName} sub layer prop should get set correctly`
+      );
+    }
   }
 
   t.end();


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #3233 
<!-- For other PRs without open issue -->
#### Background
Allow to override `updateTriggers` using `_subLayerProps`.
Add unit tests and update docs.
<!-- For all the PRs -->
#### Change List
- CompositeLayer: add ability to override sublayer updateTriggers
