### PR TITLE
Fix missing brace on link in viewport doc

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ dist.js
 *.min.js
 **/mapbox-gl-dev.js
 **/mapbox-gl.js
+*.md

--- a/docs/api-reference/viewport.md
+++ b/docs/api-reference/viewport.md
@@ -4,9 +4,9 @@
 
 A deck.gl `Viewport` is essentially a geospatially enabled camera, and combines a number of responsibilities, which can project and unproject 3D coordinates to the screen.
 
-`Viewport` classes are focused on mathematical operations such as coordinate projection/unprojection, and calculation of `view` and `projection` matrices and other uniforms needed by the WebGL vertex shaders. The basic `Viewport` class is a generic geospatially enabled version of the typical 3D "camera" class you would find in most 3D/WebGL/OpenGL library. 
+`Viewport` classes are focused on mathematical operations such as coordinate projection/unprojection, and calculation of `view` and `projection` matrices and other uniforms needed by the WebGL vertex shaders. The basic `Viewport` class is a generic geospatially enabled version of the typical 3D "camera" class you would find in most 3D/WebGL/OpenGL library.
 
-While the `Viewport` class can certainly be used directly if you need and are able to calculate your own projection matrices, you typically do not directly create `Viewport` instances. Instead, `Viewport` classes are created using the View](/docs/api-reference/view.md) class descriptors and the current `viewState`.
+While the `Viewport` class can certainly be used directly if you need and are able to calculate your own projection matrices, you typically do not directly create `Viewport` instances. Instead, `Viewport` classes are created using the [View](/docs/api-reference/view.md) class descriptors and the current `viewState`.
 
 ## Overview of Viewport Classes
 


### PR DESCRIPTION
#### Background
There is a typo in the `viewport` api doc page which is causing a link to render as text. 
<img width="986" alt="Screen Shot 2019-06-15 at 12 02 53 PM" src="https://user-images.githubusercontent.com/11323991/59555424-d422d700-8f66-11e9-8b96-325c169965e1.png">


#### Change List
- Fix the link bracket to render the link correctly.
- add `*.md` to the `.prettierignore` to prevent prettier from ruining the docs formatting.
