### PR TITLE
[For Discussion] Add compilation mode flag

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,7 +26,7 @@ module.exports = {
     'import/no-extraneous-dependencies': ['error', {devDependencies: false, peerDependencies: true}]
   },
   globals: {
-    VISGL_PROD: 'readonly'
+    DEBUG: 'readonly'
   },
   parserOptions: {
     ecmaVersion: 2018

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,9 @@ module.exports = {
     'import/no-unresolved': ['error', {ignore: ['test']}],
     'import/no-extraneous-dependencies': ['error', {devDependencies: false, peerDependencies: true}]
   },
+  globals: {
+    VISGL_PROD: 'readonly'
+  },
   parserOptions: {
     ecmaVersion: 2018
   }

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -165,22 +165,24 @@ export default class Deck {
     this.animationLoop = this._createAnimationLoop(props);
 
     this.stats = new Stats({id: 'deck.gl'});
-    this.metrics = {
-      fps: 0,
-      setPropsTime: 0,
-      updateAttributesTime: 0,
-      framesRedrawn: 0,
-      pickTime: 0,
-      pickCount: 0,
-      gpuTime: 0,
-      gpuTimePerFrame: 0,
-      cpuTime: 0,
-      cpuTimePerFrame: 0,
-      bufferMemory: 0,
-      textureMemory: 0,
-      renderbufferMemory: 0,
-      gpuMemory: 0
-    };
+    this.metrics = VISGL_PROD
+      ? {}
+      : {
+          fps: 0,
+          setPropsTime: 0,
+          updateAttributesTime: 0,
+          framesRedrawn: 0,
+          pickTime: 0,
+          pickCount: 0,
+          gpuTime: 0,
+          gpuTimePerFrame: 0,
+          cpuTime: 0,
+          cpuTimePerFrame: 0,
+          bufferMemory: 0,
+          textureMemory: 0,
+          renderbufferMemory: 0,
+          gpuMemory: 0
+        };
     this._metricsCounter = 0;
 
     this.setProps(props);
@@ -798,6 +800,9 @@ export default class Deck {
   }
 
   _getMetrics() {
+    if (VISGL_PROD) {
+      return;
+    }
     this.metrics.fps = this.stats.get('frameRate').getHz();
     this.metrics.setPropsTime = this.stats.get('setProps Time').time;
     this.metrics.updateAttributesTime = this.stats.get('Update Attributes').time;

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -165,9 +165,8 @@ export default class Deck {
     this.animationLoop = this._createAnimationLoop(props);
 
     this.stats = new Stats({id: 'deck.gl'});
-    this.metrics = VISGL_PROD
-      ? {}
-      : {
+    this.metrics = DEBUG
+      ? {
           fps: 0,
           setPropsTime: 0,
           updateAttributesTime: 0,
@@ -182,7 +181,8 @@ export default class Deck {
           textureMemory: 0,
           renderbufferMemory: 0,
           gpuMemory: 0
-        };
+        }
+      : {};
     this._metricsCounter = 0;
 
     this.setProps(props);
@@ -800,7 +800,7 @@ export default class Deck {
   }
 
   _getMetrics() {
-    if (VISGL_PROD) {
+    if (!DEBUG) {
       return;
     }
     this.metrics.fps = this.stats.get('frameRate').getHz();

--- a/modules/core/src/lib/layer-manager.js
+++ b/modules/core/src/lib/layer-manager.js
@@ -20,7 +20,6 @@
 
 import assert from '../utils/assert';
 import {_ShaderCache as ShaderCache} from '@luma.gl/core';
-import seer from 'seer';
 import Layer from './layer';
 import {LIFECYCLE} from '../lifecycle/constants';
 import log from '../utils/log';
@@ -31,8 +30,8 @@ import Viewport from '../viewports/viewport';
 
 import {
   setPropOverrides,
-  layerEditListener,
-  seerInitListener,
+  addSeerListeners,
+  removeSeerListeners,
   initLayerInSeer,
   updateLayerInSeer
 } from './seer-integration';
@@ -102,8 +101,7 @@ export default class LayerManager {
 
     Object.seal(this);
 
-    seerInitListener(this._initSeer);
-    layerEditListener(this._editSeer);
+    addSeerListeners({onInit: this._initSeer, onEdit: this._editSeer});
   }
 
   // Method to call when the layer manager is not needed anymore.
@@ -114,8 +112,7 @@ export default class LayerManager {
       this._finalizeLayer(layer);
     }
 
-    seer.removeListener(this._initSeer);
-    seer.removeListener(this._editSeer);
+    removeSeerListeners({onInit: this._initSeer, onEdit: this._editSeer});
   }
 
   // Check if a redraw is needed

--- a/modules/core/src/lib/seer-integration.js
+++ b/modules/core/src/lib/seer-integration.js
@@ -22,7 +22,7 @@ const overrides = new Map();
  * Do nothing in case Seer as not been initialized to prevent any preformance drawback.
  */
 export const setPropOverrides = (id, valuePath, value) => {
-  if (!seer.isReady()) {
+  if (VISGL_PROD || !seer.isReady()) {
     return;
   }
 
@@ -39,7 +39,7 @@ export const setPropOverrides = (id, valuePath, value) => {
  * Invalidates the data to be sure new ones are always picked up.
  */
 export const applyPropOverrides = props => {
-  if (!seer.isReady() || !props.id) {
+  if (VISGL_PROD || !seer.isReady() || !props.id) {
     return;
   }
 
@@ -57,30 +57,26 @@ export const applyPropOverrides = props => {
   });
 };
 
-/**
- * Listen for deck.gl edit events
- */
-export const layerEditListener = cb => {
-  if (!seer.isReady()) {
+export const addSeerListeners = ({onInit, onEdit}) => {
+  if (VISGL_PROD || !seer.isReady()) {
     return;
   }
-
-  seer.listenFor('deck.gl', cb);
+  // Listen for seer events to resend data
+  seer.listenFor('init', onInit);
+  // Listen for deck.gl edit events
+  seer.listenFor('deck.gl', onEdit);
 };
 
-/**
- * Listen for seer init events to resend data
- */
-export const seerInitListener = cb => {
-  if (!seer.isReady()) {
+export const removeSeerListeners = ({onInit, onEdit}) => {
+  if (VISGL_PROD || !seer.isReady()) {
     return;
   }
-
-  seer.listenFor('init', cb);
+  seer.removeListener(onInit);
+  seer.removeListener(onEdit);
 };
 
 export const initLayerInSeer = layer => {
-  if (!seer.isReady() || !layer) {
+  if (VISGL_PROD || !seer.isReady() || !layer) {
     return;
   }
 
@@ -98,7 +94,7 @@ export const initLayerInSeer = layer => {
  * Log layer's properties to Seer
  */
 export const updateLayerInSeer = layer => {
-  if (!seer.isReady() || seer.throttle(`deck.gl:${layer.id}`, 1e3)) {
+  if (VISGL_PROD || !seer.isReady() || seer.throttle(`deck.gl:${layer.id}`, 1e3)) {
     return;
   }
 
@@ -110,7 +106,7 @@ export const updateLayerInSeer = layer => {
  * On finalize of a specify layer, remove it from seer
  */
 export const removeLayerInSeer = id => {
-  if (!seer.isReady() || !id) {
+  if (VISGL_PROD || !seer.isReady() || !id) {
     return;
   }
 

--- a/modules/core/src/lib/seer-integration.js
+++ b/modules/core/src/lib/seer-integration.js
@@ -22,7 +22,7 @@ const overrides = new Map();
  * Do nothing in case Seer as not been initialized to prevent any preformance drawback.
  */
 export const setPropOverrides = (id, valuePath, value) => {
-  if (VISGL_PROD || !seer.isReady()) {
+  if (!DEBUG || !seer.isReady()) {
     return;
   }
 
@@ -39,7 +39,7 @@ export const setPropOverrides = (id, valuePath, value) => {
  * Invalidates the data to be sure new ones are always picked up.
  */
 export const applyPropOverrides = props => {
-  if (VISGL_PROD || !seer.isReady() || !props.id) {
+  if (!DEBUG || !seer.isReady() || !props.id) {
     return;
   }
 
@@ -58,7 +58,7 @@ export const applyPropOverrides = props => {
 };
 
 export const addSeerListeners = ({onInit, onEdit}) => {
-  if (VISGL_PROD || !seer.isReady()) {
+  if (!DEBUG || !seer.isReady()) {
     return;
   }
   // Listen for seer events to resend data
@@ -68,7 +68,7 @@ export const addSeerListeners = ({onInit, onEdit}) => {
 };
 
 export const removeSeerListeners = ({onInit, onEdit}) => {
-  if (VISGL_PROD || !seer.isReady()) {
+  if (!DEBUG || !seer.isReady()) {
     return;
   }
   seer.removeListener(onInit);
@@ -76,7 +76,7 @@ export const removeSeerListeners = ({onInit, onEdit}) => {
 };
 
 export const initLayerInSeer = layer => {
-  if (VISGL_PROD || !seer.isReady() || !layer) {
+  if (!DEBUG || !seer.isReady() || !layer) {
     return;
   }
 
@@ -94,7 +94,7 @@ export const initLayerInSeer = layer => {
  * Log layer's properties to Seer
  */
 export const updateLayerInSeer = layer => {
-  if (VISGL_PROD || !seer.isReady() || seer.throttle(`deck.gl:${layer.id}`, 1e3)) {
+  if (!DEBUG || !seer.isReady() || seer.throttle(`deck.gl:${layer.id}`, 1e3)) {
     return;
   }
 
@@ -106,7 +106,7 @@ export const updateLayerInSeer = layer => {
  * On finalize of a specify layer, remove it from seer
  */
 export const removeLayerInSeer = id => {
-  if (VISGL_PROD || !seer.isReady() || !id) {
+  if (!DEBUG || !seer.isReady() || !id) {
     return;
   }
 

--- a/modules/core/src/utils/globals.js
+++ b/modules/core/src/utils/globals.js
@@ -29,4 +29,7 @@ const window_ = typeof window !== 'undefined' ? window : global;
 const global_ = typeof global !== 'undefined' ? global : window;
 const document_ = typeof document !== 'undefined' ? document : {};
 
+// Avoid breaking `VISGL_PROD` if conditional compilation is not setup
+global_.VISGL_PROD = false;
+
 export {window_ as window, global_ as global, document_ as document};

--- a/modules/core/src/utils/globals.js
+++ b/modules/core/src/utils/globals.js
@@ -29,7 +29,7 @@ const window_ = typeof window !== 'undefined' ? window : global;
 const global_ = typeof global !== 'undefined' ? global : window;
 const document_ = typeof document !== 'undefined' ? document : {};
 
-// Avoid breaking `VISGL_PROD` if conditional compilation is not setup
-global_.VISGL_PROD = false;
+// Avoid breaking `VISGL_DEBUG` if conditional compilation is not setup
+global_.DEBUG = true;
 
 export {window_ as window, global_ as global, document_ as document};

--- a/scripts/bundle.config.js
+++ b/scripts/bundle.config.js
@@ -88,7 +88,7 @@ const config = {
     // This is called in prepublishOnly, after lerna bumps the package versions
     new webpack.DefinePlugin({
       __VERSION__: JSON.stringify(PACKAGE_INFO.version),
-      VISGL_PROD: true
+      DEBUG: false
     })
     // Uncomment for bundle size debug
     // ,new (require('webpack-bundle-analyzer').BundleAnalyzerPlugin)()

--- a/scripts/bundle.config.js
+++ b/scripts/bundle.config.js
@@ -87,7 +87,8 @@ const config = {
     // Therefore we need to manually import the correct version from the core
     // This is called in prepublishOnly, after lerna bumps the package versions
     new webpack.DefinePlugin({
-      __VERSION__: JSON.stringify(PACKAGE_INFO.version)
+      __VERSION__: JSON.stringify(PACKAGE_INFO.version),
+      VISGL_PROD: true
     })
     // Uncomment for bundle size debug
     // ,new (require('webpack-bundle-analyzer').BundleAnalyzerPlugin)()


### PR DESCRIPTION
For #2386

#### Background

Add a global `DEBUG` flag for [conditional compilation](https://github.com/terser-js/terser#conditional-compilation). This allows us to drop certain functionalities in production to save on bundle size / runtime performance.

The intention is to eventually tie the `DEBUG` flag to `process.env.NODE_ENV` in the same way that [React does](https://unpkg.com/react@16.8.6/index.js). For backward compatibility, it is for now default to `true` and require explicit definition in the bundler config.

#### Change List

- POC: Disable metrics reporting in debug mode
- POC Disable seer integration in debug mode
