### PR TITLE
Fix broken mapbox layer example

### DIFF
--- a/examples/gallery/src/mapbox-layer.html
+++ b/examples/gallery/src/mapbox-layer.html
@@ -2,7 +2,7 @@
   <head>
     <title>Interleaving deck.gl with Mapbox Layers</title>
     <script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
-    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v0.50.0/mapbox-gl.js"></script>
+    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   </head>
 
   <body style="margin:0"></body>

--- a/test/apps/mapbox-layers/package.json
+++ b/test/apps/mapbox-layers/package.json
@@ -8,10 +8,10 @@
     "build": "NODE_ENV=production webpack --env.prod=true"
   },
   "dependencies": {
-    "deck.gl": "^6.2.0",
+    "deck.gl": "^7.1.0",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
-    "react-map-gl": "^4.1.2"
+    "react-map-gl": "^5.0.0"
   },
   "devDependencies": {
     "buble": "^0.19.3",


### PR DESCRIPTION
For some reason the older versions of mapbox-gl stopped working.

#### Change List
- Upgrade mapbox in examples
