### PR TITLE
fix missing viewport id

### DIFF
--- a/modules/core/src/views/view.js
+++ b/modules/core/src/views/view.js
@@ -36,6 +36,7 @@ export default class View {
     this.type = type;
 
     this.props = Object.assign({}, props, {
+      id: this.id,
       projectionMatrix,
       fovy,
       near,

--- a/test/modules/core/views/view.spec.js
+++ b/test/modules/core/views/view.spec.js
@@ -1,5 +1,5 @@
 import test from 'tape-catch';
-import {View, Viewport, MapView, OrbitView, OrthographicView} from 'deck.gl';
+import {View, Viewport, MapView, OrbitView, OrthographicView, FirstPersonView} from 'deck.gl';
 
 test('View#imports', t => {
   t.ok(View, 'View import ok');
@@ -43,10 +43,9 @@ test('View#equals', t => {
   t.end();
 });
 
-test('View#makeViewport', t => {
-  let viewport;
-
-  viewport = new MapView({id: 'map-view'}).makeViewport({
+test('MapView', t => {
+  const view = new MapView();
+  const viewport = view.makeViewport({
     width: 100,
     height: 100,
     viewState: {
@@ -58,11 +57,37 @@ test('View#makeViewport', t => {
     }
   });
   t.ok(viewport instanceof Viewport, 'Mapview.makeViewport returns valid viewport');
-  t.is(viewport.id, 'map-view', 'Viewport has correct id');
+  t.is(viewport.id, view.id, 'Viewport has correct id');
   t.ok(viewport.width === 100 && viewport.height === 100, 'Viewport has correct size');
   t.is(viewport.zoom, 12, 'Viewport has correct parameters');
 
-  viewport = new OrbitView({id: '3d-view'}).makeViewport({
+  t.end();
+});
+
+test('FirstPersonView', t => {
+  const view = new FirstPersonView();
+  const viewport = view.makeViewport({
+    width: 100,
+    height: 100,
+    viewState: {
+      longitude: -122.4,
+      latitude: 37.8,
+      bearing: 90,
+      width: 200,
+      height: 200
+    }
+  });
+  t.ok(viewport instanceof Viewport, 'Mapview.makeViewport returns valid viewport');
+  t.is(viewport.id, view.id, 'Viewport has correct id');
+  t.ok(viewport.width === 100 && viewport.height === 100, 'Viewport has correct size');
+  t.ok(viewport.zoom, 'Viewport zoom is populated');
+
+  t.end();
+});
+
+test('OrbitView', t => {
+  const view = new OrbitView({id: '3d-view'});
+  const viewport = view.makeViewport({
     width: 100,
     height: 100,
     viewState: {
@@ -75,11 +100,16 @@ test('View#makeViewport', t => {
     }
   });
   t.ok(viewport instanceof Viewport, 'OrbitView.makeViewport returns valid viewport');
-  t.is(viewport.id, '3d-view', 'Viewport has correct id');
+  t.is(viewport.id, view.id, 'Viewport has correct id');
   t.ok(viewport.width === 100 && viewport.height === 100, 'Viewport has correct size');
   t.is(viewport.zoom, 1, 'Viewport has correct parameters');
 
-  viewport = new OrthographicView({id: '2d-view'}).makeViewport({
+  t.end();
+});
+
+test('OrthographicView', t => {
+  const view = new OrthographicView({id: '2d-view'});
+  const viewport = view.makeViewport({
     width: 100,
     height: 100,
     viewState: {
@@ -90,7 +120,7 @@ test('View#makeViewport', t => {
     }
   });
   t.ok(viewport instanceof Viewport, 'OrthographicView.makeViewport returns valid viewport');
-  t.is(viewport.id, '2d-view', 'Viewport has correct id');
+  t.is(viewport.id, view.id, 'Viewport has correct id');
   t.ok(viewport.width === 100 && viewport.height === 100, 'Viewport has correct size');
   t.is(viewport.zoom, 9, 'Viewport has correct parameters');
 


### PR DESCRIPTION
For #3259

#### Background

If the user does not specify an id for the view, the viewport created by `makeViewport` end up with a different default id from its view.

#### Change List
- Force viewports to have the same id as the parent view
