### PR TITLE
Support loaders.gl data attributes

### DIFF
--- a/modules/core/src/lib/attribute-manager.js
+++ b/modules/core/src/lib/attribute-manager.js
@@ -232,7 +232,11 @@ export default class AttributeManager {
     for (const attributeName in this.attributes) {
       const attribute = this.attributes[attributeName];
 
-      if (attribute.setExternalBuffer(buffers[attributeName], this.numInstances)) {
+      if (
+        attribute.setExternalBuffer(
+          buffers[attributeName] || (data.attributes && data.attributes[attributeName])
+        )
+      ) {
         // Attribute is using external buffer from the props
       } else if (attribute.setGenericValue(props[attribute.getAccessor()])) {
         // Attribute is using generic value from the props

--- a/modules/layers/src/point-cloud-layer/point-cloud-layer.js
+++ b/modules/layers/src/point-cloud-layer/point-cloud-layer.js
@@ -50,14 +50,11 @@ function normalizeData(data) {
     return;
   }
 
-  data.length = data.header.vertexCount;
+  data.length = header.vertexCount;
 
-  if (attributes.POSITION instanceof Float32Array) {
+  if (attributes.POSITION) {
     attributes.instancePositions = attributes.POSITION;
     attributes.instancePositions64xyLow = {constant: true, value: new Float32Array(2)};
-  } else if (attributes.POSITION) {
-    attributes.instancePositions = new Float32Array(attributes.POSITION);
-    attributes.instancePositions64xyLow = new Float32Array(attributes.POSITION.map(fp64LowPart));
   }
   if (attributes.NORMAL) {
     attributes.instanceNormals = attributes.NORMAL;

--- a/modules/layers/src/point-cloud-layer/point-cloud-layer.js
+++ b/modules/layers/src/point-cloud-layer/point-cloud-layer.js
@@ -43,6 +43,30 @@ const defaultProps = {
   radiusPixels: {deprecatedFor: 'pointSize'}
 };
 
+// support loaders.gl point cloud format
+function normalizeData(data) {
+  const {header, attributes} = data;
+  if (!header || !attributes) {
+    return;
+  }
+
+  data.length = data.header.vertexCount;
+
+  if (attributes.POSITION instanceof Float32Array) {
+    attributes.instancePositions = attributes.POSITION;
+    attributes.instancePositions64xyLow = {constant: true, value: new Float32Array(2)};
+  } else if (attributes.POSITION) {
+    attributes.instancePositions = new Float32Array(attributes.POSITION);
+    attributes.instancePositions64xyLow = new Float32Array(attributes.POSITION.map(fp64LowPart));
+  }
+  if (attributes.NORMAL) {
+    attributes.instanceNormals = attributes.NORMAL;
+  }
+  if (attributes.COLOR_0) {
+    attributes.instanceColors = attributes.COLOR_0;
+  }
+}
+
 export default class PointCloudLayer extends Layer {
   getShaders(id) {
     return super.getShaders({vs, fs, modules: ['project32', 'gouraud-lighting', 'picking']});
@@ -87,6 +111,9 @@ export default class PointCloudLayer extends Layer {
       }
       this.setState({model: this._getModel(gl)});
       this.getAttributeManager().invalidateAll();
+    }
+    if (changeFlags.dataChanged) {
+      normalizeData(props.data);
     }
   }
 

--- a/test/modules/layers/index.js
+++ b/test/modules/layers/index.js
@@ -25,6 +25,7 @@ import './core-layers.spec';
 import './polygon-layer.spec';
 import './geojson.spec';
 import './geojson-layer.spec';
+import './point-cloud-layer.spec';
 import './simple-mesh-layer.spec';
 import './scenegraph-layer.spec';
 import './path-layer/path-layer-vertex.spec';

--- a/test/modules/layers/point-cloud-layer.spec.js
+++ b/test/modules/layers/point-cloud-layer.spec.js
@@ -1,0 +1,41 @@
+import test from 'tape-catch';
+import {testLayer} from '@deck.gl/test-utils';
+
+import {PointCloudLayer} from '@deck.gl/layers';
+
+test('PointCloudLayer#loaders.gl support', t => {
+  const testCases = [
+    {
+      props: {
+        data: null
+      },
+      onAfterUpdate: ({layer}) => {
+        t.is(layer.getNumInstances(), 0, 'returns correct instance count');
+      }
+    },
+    {
+      props: {
+        data: {
+          header: {vertexCount: 10},
+          attributes: {
+            POSITION: {size: 3, value: new Float32Array(30)},
+            NORMAL: {size: 3, value: new Float32Array(30)},
+            COLOR_0: {size: 4, value: new Uint8ClampedArray(40)}
+          }
+        }
+      },
+      onAfterUpdate: ({layer}) => {
+        t.is(layer.getNumInstances(), 10, 'returns correct instance count');
+        t.is(
+          layer.getAttributeManager().getAttributes().instancePositions.value,
+          layer.props.data.attributes.POSITION.value,
+          'used external attribute'
+        );
+      }
+    }
+  ];
+
+  testLayer({Layer: PointCloudLayer, testCases, onError: t.notOk});
+
+  t.end();
+});


### PR DESCRIPTION
For [RFC](https://github.com/uber/deck.gl/blob/c21a75a428d5126dab7d4f89af21b5f67916203e/dev-docs/RFCs/v7.x/data-loading-rfc.md)

#### Change List
- Add `onDataLoad` callback (needs audit)
- In addition to `Buffer` and typed array, `Attribute` class supports externally provided attribute descriptors (`{value, size, stride, ...}`)
- `AttributeManager` supports external buffers provided via `data.attributes`.

