### PR TITLE
Implement layer extensions RFC

### DIFF
--- a/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-cell-layer.js
+++ b/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-cell-layer.js
@@ -56,7 +56,11 @@ const defaultProps = {
 
 export default class GPUGridCellLayer extends Layer {
   getShaders() {
-    return {vs, fs, modules: ['project32', 'gouraud-lighting', 'picking', 'fp64']};
+    return super.getShaders({
+      vs,
+      fs,
+      modules: ['project32', 'gouraud-lighting', 'picking', 'fp64']
+    });
   }
 
   initializeState() {

--- a/modules/aggregation-layers/src/screen-grid-layer/screen-grid-layer.js
+++ b/modules/aggregation-layers/src/screen-grid-layer/screen-grid-layer.js
@@ -55,7 +55,7 @@ export default class ScreenGridLayer extends Layer {
   getShaders() {
     const shaders = isWebGL2(this.context.gl) ? {vs, fs} : {vs: vs_WebGL1, fs: fs_WebGL1};
     shaders.modules = ['picking'];
-    return shaders;
+    return super.getShaders(shaders);
   }
 
   initializeState() {

--- a/modules/core/src/index.js
+++ b/modules/core/src/index.js
@@ -94,6 +94,8 @@ import memoize from './utils/memoize';
 // lighting
 export {AmbientLight} from '@luma.gl/core';
 
+export {LayerExtension} from './lib/layer-extension';
+
 // Exports for layers
 // Experimental Features may change in minor version bumps, use at your own risk)
 export const experimental = {

--- a/modules/core/src/lib/layer-extension.js
+++ b/modules/core/src/lib/layer-extension.js
@@ -17,17 +17,26 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+import {deepEqual} from '../utils/deep-equal';
 
 export class LayerExtension {
-  constructor(opts) {
+  constructor(opts = {}) {
     this.opts = opts;
   }
 
-  getShaders(layer) {
+  equals(extension) {
+    if (this === extension) {
+      return true;
+    }
+
+    return this.constructor === extension.constructor && deepEqual(this.opts, extension.opts);
+  }
+
+  getShaders(opts) {
     return null;
   }
 
-  initializeState(layer, context) {}
+  initializeState(context, opts) {}
 
-  updateState(layer, params) {}
+  updateState(params, opts) {}
 }

--- a/modules/core/src/lib/layer-extension.js
+++ b/modules/core/src/lib/layer-extension.js
@@ -39,4 +39,6 @@ export class LayerExtension {
   initializeState(context, opts) {}
 
   updateState(params, opts) {}
+
+  finalizeState(opts) {}
 }

--- a/modules/core/src/lib/layer-extension.js
+++ b/modules/core/src/lib/layer-extension.js
@@ -18,14 +18,16 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import './color.spec';
-import './deep-equal.spec';
-import './flatten.spec';
-import './positions.spec';
-import './memoize.spec';
-import './array-utils.spec';
-import './iterable-utils.spec';
-import './range.spec';
-import './math-utils.spec';
-import './shader.spec';
-// import './compare-objects.spec';
+export class LayerExtension {
+  constructor(opts) {
+    this.opts = opts;
+  }
+
+  getShaders(layer) {
+    return null;
+  }
+
+  initializeState(layer, context) {}
+
+  updateState(layer, params) {}
+}

--- a/modules/core/src/lifecycle/props.js
+++ b/modules/core/src/lifecycle/props.js
@@ -19,7 +19,7 @@ export function diffProps(props, oldProps) {
     newProps: props,
     oldProps,
     propTypes: getPropTypes(props),
-    ignoreProps: {data: null, updateTriggers: null}
+    ignoreProps: {data: null, updateTriggers: null, extensions: null}
   });
 
   // Now check if any data related props have changed
@@ -35,7 +35,8 @@ export function diffProps(props, oldProps) {
   return {
     dataChanged: dataChangedReason,
     propsChanged: propsChangedReason,
-    updateTriggersChanged: updateTriggersChangedReason
+    updateTriggersChanged: updateTriggersChangedReason,
+    extensionsChanged: diffExtensions(props, oldProps)
   };
 }
 
@@ -171,6 +172,29 @@ function diffUpdateTriggers(props, oldProps) {
   }
 
   return reason;
+}
+
+// Returns true if any extensions have changed
+function diffExtensions(props, oldProps) {
+  if (oldProps === null) {
+    return 'oldProps is null, initial diff';
+  }
+
+  const oldExtensions = oldProps.extensions;
+  const {extensions} = props;
+
+  if (extensions === oldExtensions) {
+    return false;
+  }
+  if (extensions.length !== oldExtensions.length) {
+    return true;
+  }
+  for (let i = 0; i < extensions.length; i++) {
+    if (!extensions[i].equals(oldExtensions[i])) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function diffUpdateTrigger(props, oldProps, triggerName) {

--- a/modules/core/src/utils/shader.js
+++ b/modules/core/src/utils/shader.js
@@ -18,14 +18,21 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import './color.spec';
-import './deep-equal.spec';
-import './flatten.spec';
-import './positions.spec';
-import './memoize.spec';
-import './array-utils.spec';
-import './iterable-utils.spec';
-import './range.spec';
-import './math-utils.spec';
-import './shader.spec';
-// import './compare-objects.spec';
+// Merge two luma.gl shader descriptors
+export function mergeShaders(target, source) {
+  if (!source) {
+    return target;
+  }
+  const result = Object.assign({}, target, source);
+
+  if ('defines' in source) {
+    result.defines = Object.assign({}, target.defines, source.defines);
+  }
+  if ('modules' in source) {
+    result.modules = (target.modules || []).concat(source.modules);
+  }
+  if ('inject' in source) {
+    result.inject = Object.assign({}, target.inject, source.inject);
+  }
+  return result;
+}

--- a/modules/layers/src/arc-layer/arc-layer.js
+++ b/modules/layers/src/arc-layer/arc-layer.js
@@ -52,9 +52,11 @@ const defaultProps = {
 
 export default class ArcLayer extends Layer {
   getShaders() {
-    return this.use64bitProjection()
-      ? {vs: vs64, fs, modules: ['project64', 'picking']}
-      : {vs, fs, modules: ['picking']}; // 'project' module added by default.
+    return super.getShaders(
+      this.use64bitProjection()
+        ? {vs: vs64, fs, modules: ['project64', 'picking']}
+        : {vs, fs, modules: ['picking']}
+    ); // 'project' module added by default.
   }
 
   initializeState() {

--- a/modules/layers/src/bitmap-layer/bitmap-layer.js
+++ b/modules/layers/src/bitmap-layer/bitmap-layer.js
@@ -57,7 +57,7 @@ const defaultProps = {
 export default class BitmapLayer extends Layer {
   getShaders() {
     const projectModule = this.use64bitProjection() ? 'project64' : 'project32';
-    return {vs, fs, modules: [projectModule, 'picking']};
+    return super.getShaders({vs, fs, modules: [projectModule, 'picking']});
   }
 
   initializeState() {

--- a/modules/layers/src/column-layer/column-layer.js
+++ b/modules/layers/src/column-layer/column-layer.js
@@ -62,7 +62,7 @@ const defaultProps = {
 export default class ColumnLayer extends Layer {
   getShaders() {
     const projectModule = this.use64bitProjection() ? 'project64' : 'project32';
-    return {vs, fs, modules: [projectModule, 'gouraud-lighting', 'picking']};
+    return super.getShaders({vs, fs, modules: [projectModule, 'gouraud-lighting', 'picking']});
   }
 
   /**

--- a/modules/layers/src/icon-layer/icon-layer.js
+++ b/modules/layers/src/icon-layer/icon-layer.js
@@ -71,7 +71,7 @@ const defaultProps = {
 export default class IconLayer extends Layer {
   getShaders() {
     const projectModule = this.use64bitProjection() ? 'project64' : 'project32';
-    return {vs, fs, modules: [projectModule, 'picking']};
+    return super.getShaders({vs, fs, modules: [projectModule, 'picking']});
   }
 
   initializeState() {

--- a/modules/layers/src/line-layer/line-layer.js
+++ b/modules/layers/src/line-layer/line-layer.js
@@ -48,7 +48,7 @@ const defaultProps = {
 export default class LineLayer extends Layer {
   getShaders() {
     const projectModule = this.use64bitProjection() ? 'project64' : 'project32';
-    return {vs, fs, modules: [projectModule, 'picking']};
+    return super.getShaders({vs, fs, modules: [projectModule, 'picking']});
   }
 
   initializeState() {

--- a/modules/layers/src/path-layer/path-layer.js
+++ b/modules/layers/src/path-layer/path-layer.js
@@ -55,9 +55,11 @@ const ATTRIBUTE_TRANSITION = {
 
 export default class PathLayer extends Layer {
   getShaders() {
-    return this.use64bitProjection()
-      ? {vs: vs64, fs, modules: ['project64', 'picking']}
-      : {vs, fs, modules: ['project32', 'picking']}; // 'project' module added by default.
+    return super.getShaders(
+      this.use64bitProjection()
+        ? {vs: vs64, fs, modules: ['project64', 'picking']}
+        : {vs, fs, modules: ['project32', 'picking']}
+    ); // 'project' module added by default.
   }
 
   initializeState() {

--- a/modules/layers/src/point-cloud-layer/point-cloud-layer.js
+++ b/modules/layers/src/point-cloud-layer/point-cloud-layer.js
@@ -48,7 +48,7 @@ const defaultProps = {
 export default class PointCloudLayer extends Layer {
   getShaders(id) {
     const projectModule = this.use64bitProjection() ? 'project64' : 'project32';
-    return {vs, fs, modules: [projectModule, 'gouraud-lighting', 'picking']};
+    return super.getShaders({vs, fs, modules: [projectModule, 'gouraud-lighting', 'picking']});
   }
 
   initializeState() {

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer.js
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer.js
@@ -57,7 +57,7 @@ const defaultProps = {
 export default class ScatterplotLayer extends Layer {
   getShaders(id) {
     const projectModule = this.use64bitProjection() ? 'project64' : 'project32';
-    return {vs, fs, modules: [projectModule, 'picking']};
+    return super.getShaders({vs, fs, modules: [projectModule, 'picking']});
   }
 
   initializeState() {

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -64,11 +64,11 @@ const ATTRIBUTE_TRANSITION = {
 export default class SolidPolygonLayer extends Layer {
   getShaders(vs) {
     const projectModule = this.use64bitProjection() ? 'project64' : 'project32';
-    return {
+    return super.getShaders({
       vs,
       fs,
       modules: [projectModule, 'gouraud-lighting', 'picking']
-    };
+    });
   }
 
   initializeState() {

--- a/modules/main/src/index.js
+++ b/modules/main/src/index.js
@@ -71,7 +71,9 @@ export {
   // Lights
   AmbientLight,
   PointLight,
-  DirectionalLight
+  DirectionalLight,
+  // Extension
+  LayerExtension
 } from '@deck.gl/core';
 
 // EXPERIMENTAL CORE LIB CLASSES (May change in minor version bumps, use at your own risk)

--- a/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.js
+++ b/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.js
@@ -120,7 +120,7 @@ export default class SimpleMeshLayer extends Layer {
     const vs = gl2 ? vs3 : vs1;
     const fs = gl2 ? fs3 : fs1;
 
-    return {vs, fs, modules: [projectModule, 'phong-lighting', 'picking']};
+    return super.getShaders({vs, fs, modules: [projectModule, 'phong-lighting', 'picking']});
   }
 
   initializeState() {

--- a/test/modules/core/lib/index.js
+++ b/test/modules/core/lib/index.js
@@ -27,6 +27,7 @@ import './deck.spec';
 import './deck-picker.spec';
 import './layer.spec';
 import './composite-layer.spec';
+import './layer-extension.spec';
 import './layer-manager.spec';
 import './transition-manager.spec';
 import './seer-integration.spec';

--- a/test/modules/core/lib/layer-extension.spec.js
+++ b/test/modules/core/lib/layer-extension.spec.js
@@ -1,0 +1,84 @@
+import test from 'tape-catch';
+import {LayerExtension} from '@deck.gl/core';
+import {ScatterplotLayer} from '@deck.gl/layers';
+import {testLayer} from '@deck.gl/test-utils';
+
+class MockExtension extends LayerExtension {
+  getShaders() {
+    return {modules: [{name: 'empty-module', vs: ''}]};
+  }
+  initializeState(context, opts) {
+    opts.assert(this.id === 'test-layer', 'initializeState: Self is layer instance');
+    opts.assert(context.gl, 'initializeState: context received');
+
+    MockExtension.initializeCalled++;
+  }
+  updateState(updateParams, opts) {
+    opts.assert(this.id === 'test-layer', 'updateState: Self is layer instance');
+    opts.assert(updateParams.changeFlags, 'updateState: changeFlags received');
+
+    MockExtension.updateCalled++;
+  }
+  finalizeState(opts) {
+    opts.assert(this.id === 'test-layer', 'finalizeState: Self is layer instance');
+
+    MockExtension.finalizeCalled++;
+  }
+}
+
+MockExtension.resetStats = () => {
+  MockExtension.initializeCalled = 0;
+  MockExtension.updateCalled = 0;
+  MockExtension.finalizeCalled = 0;
+};
+
+test('LayerExtension', t => {
+  const extension0 = new MockExtension({fp64: true, assert: t.ok});
+  const extension1 = new MockExtension({fp64: true, assert: t.ok});
+  const extension2 = new MockExtension({fp64: false, assert: t.ok});
+
+  MockExtension.resetStats();
+
+  testLayer({
+    Layer: ScatterplotLayer,
+    testCases: [
+      {
+        props: {
+          id: 'test-layer',
+          data: [],
+          extensions: [extension0]
+        },
+        onAfterUpdate: () => {
+          t.is(MockExtension.initializeCalled, 1, 'initializeState called');
+          t.is(MockExtension.updateCalled, 1, 'updateState called');
+          t.is(MockExtension.finalizeCalled, 0, 'finalizeState called');
+        }
+      },
+      {
+        updateProps: {
+          extensions: [extension1]
+        },
+        onAfterUpdate: () => {
+          t.is(MockExtension.initializeCalled, 1, 'initializeState not called');
+          t.is(MockExtension.updateCalled, 1, 'updateState not called');
+          t.is(MockExtension.finalizeCalled, 0, 'finalizeState not called');
+        }
+      },
+      {
+        updateProps: {
+          extensions: [extension2]
+        },
+        onAfterUpdate: () => {
+          t.is(MockExtension.initializeCalled, 1, 'initializeState not called');
+          t.is(MockExtension.updateCalled, 2, 'updateState called');
+          t.is(MockExtension.finalizeCalled, 0, 'finalizeState not called');
+        }
+      }
+    ],
+    onError: t.notOk
+  });
+
+  t.is(MockExtension.finalizeCalled, 1, 'finalizeState called');
+
+  t.end();
+});

--- a/test/modules/core/utils/shader.spec.js
+++ b/test/modules/core/utils/shader.spec.js
@@ -1,0 +1,54 @@
+import test from 'tape-catch';
+import {mergeShaders} from '@deck.gl/core/utils/shader';
+
+const TEST_SHADERS = {vs: 'vs', fs: 'fs'};
+
+const TEST_CASES = [
+  {
+    title: 'empty',
+    input: null,
+    output: {vs: 'vs', fs: 'fs'}
+  },
+  {
+    title: 'missing target fields',
+    input: {
+      defines: {DRAW: 1},
+      modules: ['project'],
+      inject: {'fs#main-start': 'discard;'}
+    },
+    output: {
+      vs: 'vs',
+      fs: 'fs',
+      defines: {DRAW: 1},
+      modules: ['project'],
+      inject: {'fs#main-start': 'discard;'}
+    }
+  },
+  {
+    title: 'deep merge source and target fields',
+    input: {
+      vs: 'vs-v2',
+      defines: {DRAW: 0, EXTRUDE: 1},
+      modules: ['phong-lighting'],
+      inject: {'fs#main-end': 'filter_pickingColor(gl_FragColor);'}
+    },
+    output: {
+      vs: 'vs-v2',
+      fs: 'fs',
+      defines: {DRAW: 0, EXTRUDE: 1},
+      modules: ['project', 'phong-lighting'],
+      inject: {'fs#main-start': 'discard;', 'fs#main-end': 'filter_pickingColor(gl_FragColor);'}
+    }
+  }
+];
+
+test('mergeShaders', t => {
+  let shaders = TEST_SHADERS;
+
+  for (const testCase of TEST_CASES) {
+    shaders = mergeShaders(shaders, testCase.input);
+    t.deepEqual(shaders, testCase.output, `${testCase.title} returned correct result`);
+  }
+
+  t.end();
+});

--- a/test/modules/extensions/data-filter.spec.js
+++ b/test/modules/extensions/data-filter.spec.js
@@ -1,0 +1,27 @@
+import test from 'tape-catch';
+import {DataFilterExtension} from '@deck.gl/extensions';
+import {ScatterplotLayer} from '@deck.gl/layers';
+import {testLayer} from '@deck.gl/test-utils';
+
+test.only('DataFilterExtension', t => {
+  const testCases = [
+    {
+      props: {
+        data: [
+          {position: [-122.453, 37.782], timestamp: 120, entry: 13567, exit: 4802},
+          {position: [-122.454, 37.781], timestamp: 140, entry: 144, exit: 5493}
+        ],
+        getPosition: d => d.position,
+        getFilterValue: d => d.timestamp,
+        extensions: [new DataFilterExtension()]
+      },
+      onAfterRender: ({layer}) => {
+        // layer.state.model
+      }
+    }
+  ];
+
+  testLayer({Layer: ScatterplotLayer, testCases, onError: t.notOk});
+
+  t.end();
+});

--- a/test/modules/extensions/index.js
+++ b/test/modules/extensions/index.js
@@ -1,0 +1,1 @@
+import './data-filter.spec';


### PR DESCRIPTION
[RFC](https://github.com/uber/deck.gl/blob/fe927512b171618746e566744a7b173039ee883f/dev-docs/RFCs/vNext/layer-extension-rfc.md)

#### Change List
- Add `LayerExtensions` interface
- Handle `extensions` prop in base Layer class: lifecycle callbacks, `extensionsChanged` flag
- Update all layers to use new `getShaders` API
- Tests