### PR TITLE
Formal API for CompositeLayer data/accessor wrapping

### DIFF
--- a/docs/api-reference/composite-layer.md
+++ b/docs/api-reference/composite-layer.md
@@ -198,6 +198,33 @@ Returns:
 
 Constructor for this sublayer. The base class implementation checks if `type` is specified for the sublayer in `_subLayerProps`, otherwise returns the default.
 
+##### `getSubLayerDatum`
+
+Used by [adapter layers](/docs/developer-guide/custom-layers/composite-layers.md#transforming-data)) to decorate transformed data with a reference to the original object.
+
+Parameters:
+
+* `datum` (Object) - a custom data object to pass to a sublayer.
+* `sourceObject` (Object) - the original data object provided by the user
+* `sourceObjectIndex` (Object) - the index of the original data object provided by the user
+
+Returns:
+
+The `datum` object, decorated with a reference.
+
+
+##### `getSubLayerAccessor`
+
+Used by [adapter layers](/docs/developer-guide/custom-layers/composite-layers.md#transforming-data)) to allow user-provided accessors read the original objects from transformed data.
+
+Parameters:
+
+* `accessor` (Function|Any) - the accessor provided to the current layer.
+
+Returns:
+
+* If `accessor` is a function, returns a new accessor function.
+* If `accessor` is a constant value, returns it as is.
 
 ## Source
 

--- a/docs/api-reference/composite-layer.md
+++ b/docs/api-reference/composite-layer.md
@@ -198,19 +198,19 @@ Returns:
 
 Constructor for this sublayer. The base class implementation checks if `type` is specified for the sublayer in `_subLayerProps`, otherwise returns the default.
 
-##### `getSubLayerDatum`
+##### `getSubLayerRow`
 
 Used by [adapter layers](/docs/developer-guide/custom-layers/composite-layers.md#transforming-data)) to decorate transformed data with a reference to the original object.
 
 Parameters:
 
-* `datum` (Object) - a custom data object to pass to a sublayer.
+* `row` (Object) - a custom data object to pass to a sublayer.
 * `sourceObject` (Object) - the original data object provided by the user
 * `sourceObjectIndex` (Object) - the index of the original data object provided by the user
 
 Returns:
 
-The `datum` object, decorated with a reference.
+The `row` object, decorated with a reference.
 
 
 ##### `getSubLayerAccessor`

--- a/docs/developer-guide/custom-layers/composite-layers.md
+++ b/docs/developer-guide/custom-layers/composite-layers.md
@@ -256,7 +256,7 @@ For more details, read about [how picking works](/docs/developer-guide/custom-la
 
 Because deck.gl's primitive layers expect input to be a flat iteratorable data structure, some composite layers need to transform user data into a different format before passing to sublayers. This transformation may consist converting a tree to an array, filtering, sorting, etc. For example, the [GeoJsonLayer](/docs/layers/geojson-layer.md) splits features by type and passes each to `ScatterplotLayer`, `PathLayer` or `SolidPolygonLayer` respectively. The [TextLayer](/docs/layers/text-layer.md) breaks each text string down to multiple characters and render them with a variation of `IconLayer`.
 
-From the user's perspective, when they specify accessors such as `getColor`, or callbacks such as `onHover`, the functions should always interface with the original data that they give the top-level layer, instead of its internal implementations. For the sublayer to reference back to the original data, we can add a reference onto every transformed datum by calling `getSubLayerDatum`:
+From the user's perspective, when they specify accessors such as `getColor`, or callbacks such as `onHover`, the functions should always interface with the original data that they give the top-level layer, instead of its internal implementations. For the sublayer to reference back to the original data, we can add a reference onto every transformed datum by calling `getSubLayerRow`:
 
 ```js
 class MyCompositeLayer extends CompositeLayer {
@@ -282,8 +282,8 @@ class MyCompositeLayer extends CompositeLayer {
        */
       props.data.forEach((object, index) => {
         for (const timestamp of object.timestamps) {
-          // `getSubLayerDatum` decorates each datum with a reference to the original object and index
-          subLayerData.push(this.getSubLayerDatum({
+          // `getSubLayerRow` decorates each data row for the sub layer with a reference to the original object and index
+          subLayerData.push(this.getSubLayerRow({
             timestamp
           }, object, index));
         }
@@ -295,7 +295,7 @@ class MyCompositeLayer extends CompositeLayer {
 }
 ```
 
-When the sublayer receives data decorated by `getSubLayerDatum`, its accessors need to know how to read the data to access the original objects. In the above example, `getPosition: d => d.position` would fail if called with `{timestamp: 0}`, while the user expects it to be called with `{position: [-122.45, 37.78], timestamps: [0, 1, 4, 7, 8]}`. This can be solved by wrapping the user-provided accessor with `getSubLayerAccessor`:
+When the sublayer receives data decorated by `getSubLayerRow`, its accessors need to know how to read the data to access the original objects. In the above example, `getPosition: d => d.position` would fail if called with `{timestamp: 0}`, while the user expects it to be called with `{position: [-122.45, 37.78], timestamps: [0, 1, 4, 7, 8]}`. This can be solved by wrapping the user-provided accessor with `getSubLayerAccessor`:
 
 ```js
   renderLayers() {
@@ -316,4 +316,4 @@ When the sublayer receives data decorated by `getSubLayerDatum`, its accessors n
   }
 ```
 
-The default implementations of lifecycle methods such as `getPickingInfo` also understand how to retrieve the orignal objects from the sublayer data if they are created using `getSubLayerDatum`.
+The default implementations of lifecycle methods such as `getPickingInfo` also understand how to retrieve the orignal objects from the sublayer data if they are created using `getSubLayerRow`.

--- a/modules/core/src/lib/composite-layer.js
+++ b/modules/core/src/lib/composite-layer.js
@@ -45,7 +45,19 @@ export default class CompositeLayer extends Layer {
   // not apply to a composite layer.
   // @return null to cancel event
   getPickingInfo({info}) {
-    return info;
+    const {object} = info;
+    const isDataWrapped =
+      object && object.__source && object.__source.parent && object.__source.parent.id === this.id;
+
+    if (!isDataWrapped) {
+      return info;
+    }
+
+    return Object.assign(info, {
+      // override object with picked data
+      object: object.__source.object,
+      index: object.__source.index
+    });
   }
 
   // Implement to generate subLayers
@@ -67,6 +79,37 @@ export default class CompositeLayer extends Layer {
     return (
       (overridingProps && overridingProps[id] && overridingProps[id].type) || DefaultLayerClass
     );
+  }
+
+  // When casting user data into another format to pass to sublayers,
+  // add reference to the original object and object index
+  getSubLayerDatum(datum, object, index) {
+    datum.__source = {
+      parent: this,
+      object,
+      index
+    };
+    return datum;
+  }
+
+  // Some composite layers cast user data into another format before passing to sublayers
+  // We need to unwrap them before calling the accessor so that they see the original data
+  // objects
+  getSubLayerAccessor(accessor) {
+    if (typeof accessor === 'function') {
+      const objectInfo = {
+        data: this.props.data,
+        target: []
+      };
+      return (x, i) => {
+        if (x.__source) {
+          objectInfo.index = x.__source.index;
+          return accessor(x.__source.object, objectInfo);
+        }
+        return accessor(x, i);
+      };
+    }
+    return accessor;
   }
 
   // Returns sub layer props for a specific sublayer

--- a/modules/core/src/lib/composite-layer.js
+++ b/modules/core/src/lib/composite-layer.js
@@ -83,13 +83,13 @@ export default class CompositeLayer extends Layer {
 
   // When casting user data into another format to pass to sublayers,
   // add reference to the original object and object index
-  getSubLayerDatum(datum, sourceObject, sourceObjectIndex) {
-    datum.__source = {
+  getSubLayerRow(row, sourceObject, sourceObjectIndex) {
+    row.__source = {
       parent: this,
       object: sourceObject,
       index: sourceObjectIndex
     };
-    return datum;
+    return row;
   }
 
   // Some composite layers cast user data into another format before passing to sublayers

--- a/modules/core/src/lib/composite-layer.js
+++ b/modules/core/src/lib/composite-layer.js
@@ -83,11 +83,11 @@ export default class CompositeLayer extends Layer {
 
   // When casting user data into another format to pass to sublayers,
   // add reference to the original object and object index
-  getSubLayerDatum(datum, object, index) {
+  getSubLayerDatum(datum, sourceObject, sourceObjectIndex) {
     datum.__source = {
       parent: this,
-      object,
-      index
+      object: sourceObject,
+      index: sourceObjectIndex
     };
     return datum;
   }

--- a/modules/core/src/lib/layer-extension.js
+++ b/modules/core/src/lib/layer-extension.js
@@ -50,13 +50,8 @@ export class LayerExtension {
         newProps[key] = propValue;
         if (propDef && propDef.type === 'accessor') {
           newProps.updateTriggers[key] = this.props.updateTriggers[key];
-          // Some composite layers "wrap" user data into another format before passing to sublayers
-          // We need to unwrap them before calling the accessor so that they see the original data
-          // objects
-          // TODO - make this a formal API and document
-          if (this.unwrapObject && typeof propValue === 'function') {
-            newProps[key] = (object, objectInfo) =>
-              propValue(this.unwrapObject(object), objectInfo);
+          if (typeof propValue === 'function') {
+            newProps[key] = this.getSubLayerAccessor(propValue, true);
           }
         }
       }

--- a/modules/geo-layers/src/h3-layers/h3-cluster-layer.js
+++ b/modules/geo-layers/src/h3-layers/h3-cluster-layer.js
@@ -26,31 +26,12 @@ export default class H3ClusterLayer extends CompositeLayer {
         const multiPolygon = h3SetToMultiPolygon(hexagons, true);
 
         for (const polygon of multiPolygon) {
-          polygons.push({polygon, _obj: object, _idx: objectInfo.index});
+          polygons.push(this.getSubLayerDatum({polygon}, object, objectInfo.index));
         }
       }
 
       this.setState({polygons});
     }
-  }
-
-  getPickingInfo({info}) {
-    return Object.assign(info, {
-      object: info.object && info.object._obj,
-      index: info.object && info.object._idx
-    });
-  }
-
-  unwrapObject(object) {
-    return object._obj;
-  }
-
-  getSubLayerAccessor(accessor) {
-    if (typeof accessor !== 'function') return accessor;
-
-    return (object, objectInfo) => {
-      return accessor(object._obj, objectInfo);
-    };
   }
 
   renderLayers() {

--- a/modules/geo-layers/src/h3-layers/h3-cluster-layer.js
+++ b/modules/geo-layers/src/h3-layers/h3-cluster-layer.js
@@ -26,7 +26,7 @@ export default class H3ClusterLayer extends CompositeLayer {
         const multiPolygon = h3SetToMultiPolygon(hexagons, true);
 
         for (const polygon of multiPolygon) {
-          polygons.push(this.getSubLayerDatum({polygon}, object, objectInfo.index));
+          polygons.push(this.getSubLayerRow({polygon}, object, objectInfo.index));
         }
       }
 

--- a/modules/layers/src/geojson-layer/geojson-layer.js
+++ b/modules/layers/src/geojson-layer/geojson-layer.js
@@ -85,7 +85,7 @@ export default class GeoJsonLayer extends CompositeLayer {
       return;
     }
     const features = getGeojsonFeatures(props.data);
-    const wrapFeature = this.getSubLayerDatum.bind(this);
+    const wrapFeature = this.getSubLayerRow.bind(this);
 
     if (Array.isArray(changeFlags.dataChanged)) {
       const oldFeatures = this.state.features;

--- a/modules/layers/src/geojson-layer/geojson-layer.js
+++ b/modules/layers/src/geojson-layer/geojson-layer.js
@@ -26,12 +26,7 @@ import {PhongMaterial} from '@luma.gl/core';
 import SolidPolygonLayer from '../solid-polygon-layer/solid-polygon-layer';
 import {replaceInRange} from '../utils';
 
-import {
-  getGeojsonFeatures,
-  separateGeojsonFeatures,
-  unwrapSourceFeature,
-  unwrapSourceFeatureIndex
-} from './geojson';
+import {getGeojsonFeatures, separateGeojsonFeatures} from './geojson';
 
 const defaultLineColor = [0, 0, 0, 255];
 const defaultFillColor = [0, 0, 0, 255];
@@ -78,15 +73,6 @@ function getCoordinates(f) {
   return f.geometry.coordinates;
 }
 
-/**
- * Unwraps the real source feature passed into props and passes as the argument to `accessor`.
- */
-function unwrappingAccessor(accessor) {
-  if (typeof accessor !== 'function') return accessor;
-
-  return feature => accessor(unwrapSourceFeature(feature));
-}
-
 export default class GeoJsonLayer extends CompositeLayer {
   initializeState() {
     this.state = {
@@ -99,6 +85,7 @@ export default class GeoJsonLayer extends CompositeLayer {
       return;
     }
     const features = getGeojsonFeatures(props.data);
+    const wrapFeature = this.getSubLayerDatum.bind(this);
 
     if (Array.isArray(changeFlags.dataChanged)) {
       const oldFeatures = this.state.features;
@@ -110,12 +97,12 @@ export default class GeoJsonLayer extends CompositeLayer {
       }
 
       for (const dataRange of changeFlags.dataChanged) {
-        const partialFeatures = separateGeojsonFeatures(features, dataRange);
+        const partialFeatures = separateGeojsonFeatures(features, wrapFeature, dataRange);
         for (const key in oldFeatures) {
           featuresDiff[key].push(
             replaceInRange({
               data: newFeatures[key],
-              getIndex: unwrapSourceFeatureIndex,
+              getIndex: f => f.__source.index,
               dataRange,
               replace: partialFeatures[key]
             })
@@ -125,25 +112,10 @@ export default class GeoJsonLayer extends CompositeLayer {
       this.setState({features: newFeatures, featuresDiff});
     } else {
       this.setState({
-        features: separateGeojsonFeatures(features),
+        features: separateGeojsonFeatures(features, wrapFeature),
         featuresDiff: {}
       });
     }
-  }
-
-  getPickingInfo({info, sourceLayer}) {
-    // `info.index` is the index within the particular sub-layer
-    // We want to expose the index of the feature the user provided
-
-    return Object.assign(info, {
-      // override object with picked feature
-      object: info.object ? unwrapSourceFeature(info.object) : info.object,
-      index: info.object ? unwrapSourceFeatureIndex(info.object) : info.index
-    });
-  }
-
-  unwrapObject(object) {
-    return unwrapSourceFeature(object);
   }
 
   /* eslint-disable complexity */
@@ -197,9 +169,9 @@ export default class GeoJsonLayer extends CompositeLayer {
           filled,
           wireframe,
           material,
-          getElevation: unwrappingAccessor(getElevation),
-          getFillColor: unwrappingAccessor(getFillColor),
-          getLineColor: unwrappingAccessor(getLineColor),
+          getElevation: this.getSubLayerAccessor(getElevation),
+          getFillColor: this.getSubLayerAccessor(getFillColor),
+          getLineColor: this.getSubLayerAccessor(getLineColor),
 
           transitions: transitions && {
             getPolygon: transitions.geometry,
@@ -239,9 +211,9 @@ export default class GeoJsonLayer extends CompositeLayer {
           miterLimit: lineMiterLimit,
           dashJustified: lineDashJustified,
 
-          getColor: unwrappingAccessor(getLineColor),
-          getWidth: unwrappingAccessor(getLineWidth),
-          getDashArray: unwrappingAccessor(getLineDashArray),
+          getColor: this.getSubLayerAccessor(getLineColor),
+          getWidth: this.getSubLayerAccessor(getLineWidth),
+          getDashArray: this.getSubLayerAccessor(getLineDashArray),
 
           transitions: transitions && {
             getPath: transitions.geometry,
@@ -277,9 +249,9 @@ export default class GeoJsonLayer extends CompositeLayer {
           miterLimit: lineMiterLimit,
           dashJustified: lineDashJustified,
 
-          getColor: unwrappingAccessor(getLineColor),
-          getWidth: unwrappingAccessor(getLineWidth),
-          getDashArray: unwrappingAccessor(getLineDashArray),
+          getColor: this.getSubLayerAccessor(getLineColor),
+          getWidth: this.getSubLayerAccessor(getLineWidth),
+          getDashArray: this.getSubLayerAccessor(getLineDashArray),
 
           transitions: transitions && {
             getPath: transitions.geometry,
@@ -317,10 +289,10 @@ export default class GeoJsonLayer extends CompositeLayer {
           lineWidthMinPixels,
           lineWidthMaxPixels,
 
-          getFillColor: unwrappingAccessor(getFillColor),
-          getLineColor: unwrappingAccessor(getLineColor),
-          getRadius: unwrappingAccessor(getRadius),
-          getLineWidth: unwrappingAccessor(getLineWidth),
+          getFillColor: this.getSubLayerAccessor(getFillColor),
+          getLineColor: this.getSubLayerAccessor(getLineColor),
+          getRadius: this.getSubLayerAccessor(getRadius),
+          getLineWidth: this.getSubLayerAccessor(getLineWidth),
 
           transitions: transitions && {
             getPosition: transitions.geometry,

--- a/modules/layers/src/polygon-layer/polygon-layer.js
+++ b/modules/layers/src/polygon-layer/polygon-layer.js
@@ -115,10 +115,10 @@ export default class PolygonLayer extends CompositeLayer {
             holeIndices[i - 1] || 0,
             holeIndices[i] || positions.length
           );
-          paths.push(this.getSubLayerDatum({path}, object, objectInfo.index));
+          paths.push(this.getSubLayerRow({path}, object, objectInfo.index));
         }
       } else {
-        paths.push(this.getSubLayerDatum({path: positions}, object, objectInfo.index));
+        paths.push(this.getSubLayerRow({path: positions}, object, objectInfo.index));
       }
     }
     return paths;

--- a/modules/layers/src/polygon-layer/polygon-layer.js
+++ b/modules/layers/src/polygon-layer/polygon-layer.js
@@ -78,7 +78,7 @@ export default class PolygonLayer extends CompositeLayer {
       const pathsDiff = changeFlags.dataChanged.map(dataRange =>
         replaceInRange({
           data: paths,
-          getIndex: p => p._i,
+          getIndex: p => p.__source.index,
           dataRange,
           replace: this._getPaths(dataRange)
         })
@@ -90,17 +90,6 @@ export default class PolygonLayer extends CompositeLayer {
         pathsDiff: null
       });
     }
-  }
-
-  getPickingInfo({info}) {
-    return Object.assign(info, {
-      // override object with picked data
-      object: (info.object && info.object.object) || info.object
-    });
-  }
-
-  unwrapObject(object) {
-    return object.object || object;
   }
 
   _getPaths(dataRange = {}) {
@@ -126,20 +115,13 @@ export default class PolygonLayer extends CompositeLayer {
             holeIndices[i - 1] || 0,
             holeIndices[i] || positions.length
           );
-          paths.push({path, object, _i: objectInfo.index});
+          paths.push(this.getSubLayerDatum({path}, object, objectInfo.index));
         }
       } else {
-        paths.push({path: positions, object, _i: objectInfo.index});
+        paths.push(this.getSubLayerDatum({path: positions}, object, objectInfo.index));
       }
     }
     return paths;
-  }
-
-  _getAccessor(accessor) {
-    if (typeof accessor === 'function') {
-      return x => accessor(x.object);
-    }
-    return accessor;
   }
 
   /* eslint-disable complexity */
@@ -240,9 +222,9 @@ export default class PolygonLayer extends CompositeLayer {
             getPath: transitions.getPolygon
           },
 
-          getColor: this._getAccessor(getLineColor),
-          getWidth: this._getAccessor(getLineWidth),
-          getDashArray: this._getAccessor(getLineDashArray)
+          getColor: this.getSubLayerAccessor(getLineColor),
+          getWidth: this.getSubLayerAccessor(getLineWidth),
+          getDashArray: this.getSubLayerAccessor(getLineDashArray)
         },
         this.getSubLayerProps({
           id: 'stroke',

--- a/modules/layers/src/text-layer/text-layer.js
+++ b/modules/layers/src/text-layer/text-layer.js
@@ -192,7 +192,7 @@ export default class TextLayer extends CompositeLayer {
         let offsetLeft = 0;
 
         letters.forEach((letter, i) => {
-          const datum = this.getSubLayerDatum(
+          const datum = this.getSubLayerRow(
             {
               text: letter,
               index: i,

--- a/modules/layers/src/text-layer/text-layer.js
+++ b/modules/layers/src/text-layer/text-layer.js
@@ -102,7 +102,7 @@ export default class TextLayer extends CompositeLayer {
       const dataDiff = changeFlags.dataChanged.map(dataRange =>
         replaceInRange({
           data,
-          getIndex: p => p.objectIndex,
+          getIndex: p => p.__source.index,
           dataRange,
           replace: this.transformStringToLetters(dataRange)
         })
@@ -174,10 +174,6 @@ export default class TextLayer extends CompositeLayer {
     });
   }
 
-  unwrapObject(object) {
-    return object.object;
-  }
-
   /* eslint-disable no-loop-func */
   transformStringToLetters(dataRange = {}) {
     const {data, getText} = this.props;
@@ -196,15 +192,16 @@ export default class TextLayer extends CompositeLayer {
         let offsetLeft = 0;
 
         letters.forEach((letter, i) => {
-          const datum = {
-            text: letter,
-            index: i,
-            offsets,
-            len: text.length,
-            // reference of original object and object index
+          const datum = this.getSubLayerDatum(
+            {
+              text: letter,
+              index: i,
+              offsets,
+              len: text.length
+            },
             object,
-            objectIndex: objectInfo.index
-          };
+            objectInfo.index
+          );
 
           const frame = iconMapping[letter];
           if (frame) {
@@ -231,46 +228,18 @@ export default class TextLayer extends CompositeLayer {
     return datum.offsets[datum.offsets.length - 1];
   }
 
-  _getAccessor(accessor) {
-    if (typeof accessor === 'function') {
-      const objectInfo = {
-        data: this.props.data,
-        target: []
-      };
-      return x => {
-        objectInfo.index = x.objectIndex;
-        return accessor(x.object, objectInfo);
-      };
-    }
-    return accessor;
-  }
-
   getAnchorXFromTextAnchor(getTextAnchor) {
     if (typeof getTextAnchor === 'function') {
-      const objectInfo = {
-        data: this.props.data,
-        target: []
-      };
-      return x => {
-        objectInfo.index = x.objectIndex;
-        const textAnchor = getTextAnchor(x.object, objectInfo);
-        return TEXT_ANCHOR[textAnchor] || 0;
-      };
+      getTextAnchor = this.getSubLayerAccessor(getTextAnchor);
+      return x => TEXT_ANCHOR[getTextAnchor(x)] || 0;
     }
     return () => TEXT_ANCHOR[getTextAnchor] || 0;
   }
 
   getAnchorYFromAlignmentBaseline(getAlignmentBaseline) {
     if (typeof getAlignmentBaseline === 'function') {
-      const objectInfo = {
-        data: this.props.data,
-        target: []
-      };
-      return x => {
-        objectInfo.index = x.objectIndex;
-        const alignmentBaseline = getAlignmentBaseline(x.object, objectInfo);
-        return ALIGNMENT_BASELINE[alignmentBaseline] || 0;
-      };
+      getAlignmentBaseline = this.getSubLayerAccessor(getAlignmentBaseline);
+      return x => TEXT_ANCHOR[getAlignmentBaseline(x)] || 0;
     }
     return () => ALIGNMENT_BASELINE[getAlignmentBaseline] || 0;
   }
@@ -306,13 +275,14 @@ export default class TextLayer extends CompositeLayer {
 
         _dataDiff: dataDiff && (() => dataDiff),
 
-        getPosition: this._getAccessor(getPosition),
-        getColor: this._getAccessor(getColor),
-        getSize: this._getAccessor(getSize),
-        getAngle: this._getAccessor(getAngle),
+        getPosition: this.getSubLayerAccessor(getPosition),
+        getColor: this.getSubLayerAccessor(getColor),
+        getSize: this.getSubLayerAccessor(getSize),
+        getAngle: this.getSubLayerAccessor(getAngle),
         getAnchorX: this.getAnchorXFromTextAnchor(getTextAnchor),
         getAnchorY: this.getAnchorYFromAlignmentBaseline(getAlignmentBaseline),
-        getPixelOffset: this._getAccessor(getPixelOffset),
+        getPixelOffset: this.getSubLayerAccessor(getPixelOffset),
+        getPickingIndex: obj => obj.__source.index,
         billboard,
         sizeScale: sizeScale * scale,
         sizeUnits,

--- a/test/modules/core/utils/typed-array-manager.spec.js
+++ b/test/modules/core/utils/typed-array-manager.spec.js
@@ -1,0 +1,60 @@
+import test from 'tape-catch';
+import {TypedArrayManager} from '@deck.gl/core/utils/typed-array-manager';
+
+test('TypedArrayManager#allocate', t => {
+  const typedArrayManager = new TypedArrayManager({overAlloc: 2});
+
+  // Allocate an "empty" array
+  let array = typedArrayManager.allocate(null, 0, {size: 2, type: Float32Array});
+  t.ok(array instanceof Float32Array, 'Allocated array has correct type');
+  t.ok(array.length, 'Allocated array has length');
+
+  // Create a new array with over allocation
+  array = typedArrayManager.allocate(null, 1, {size: 2, type: Float32Array});
+  t.ok(array instanceof Float32Array, 'Allocated array has correct type');
+  t.is(array.length, 4, 'Allocated array has correct length');
+  array.fill(1);
+
+  // Existing array is large enough
+  let array2 = typedArrayManager.allocate(array, 2, {size: 2, type: Float32Array, copy: true});
+  t.is(array, array2, 'Did not allocate new array');
+
+  // Existing array is not large enough, release the old one and allocate new array
+  array2 = typedArrayManager.allocate(array, 3, {size: 2, type: Float32Array, copy: true});
+  t.is(array2.length, 12, 'Newly allocated array has correct length');
+  t.deepEqual(array2, [1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0], 'Copied existing array');
+
+  // Reuse a released array from pool
+  array2 = typedArrayManager.allocate(null, 1, {size: 2, type: Float32Array});
+  t.is(array, array2, 'Reused released array');
+
+  t.end();
+});
+
+test('TypedArrayManager#release', t => {
+  const typedArrayManager = new TypedArrayManager({overAlloc: 1, poolSize: 2});
+
+  t.doesNotThrow(() => typedArrayManager.release(null), 'Releasing null does not throw');
+
+  for (let i = 1; i <= 3; i++) {
+    const floatArr = typedArrayManager.allocate(null, i, {size: 3, type: Float32Array});
+    const byteArr = typedArrayManager.allocate(null, i, {size: 1, type: Uint8ClampedArray});
+
+    typedArrayManager.release(floatArr);
+    typedArrayManager.release(byteArr);
+  }
+
+  const floatArraysPool = typedArrayManager._pool.Float32Array;
+  const byteArraysPool = typedArrayManager._pool.Uint8ClampedArray;
+
+  t.is(floatArraysPool.length, 2, 'Has correct pool size');
+  t.deepEqual(floatArraysPool.map(arr => arr.length), [9, 6], 'Has correct arrays in pool');
+  t.is(byteArraysPool.length, 2, 'Has correct pool size');
+  t.deepEqual(byteArraysPool.map(arr => arr.length), [3, 2], 'Has correct arrays in pool');
+
+  typedArrayManager.allocate(null, 2, {size: 4, type: Float32Array});
+  t.is(floatArraysPool.length, 1, 'Reused released array');
+  t.deepEqual(floatArraysPool.map(arr => arr.length), [6], 'Has correct arrays in pool');
+
+  t.end();
+});

--- a/test/modules/layers/geojson.spec.js
+++ b/test/modules/layers/geojson.spec.js
@@ -19,12 +19,7 @@
 // THE SOFTWARE.
 
 import test from 'tape-catch';
-import {
-  getGeojsonFeatures,
-  separateGeojsonFeatures,
-  unwrapSourceFeature,
-  unwrapSourceFeatureIndex
-} from '@deck.gl/layers/geojson-layer/geojson';
+import {getGeojsonFeatures, separateGeojsonFeatures} from '@deck.gl/layers/geojson-layer/geojson';
 
 const TEST_DATA = {
   POINT: {
@@ -310,6 +305,20 @@ const TEST_CASES = [
   }
 ];
 
+function wrapSourceFeature(feature, object, index) {
+  feature._object = object;
+  feature._index = index;
+  return feature;
+}
+
+function unwrapSourceFeature(feature) {
+  return feature._object;
+}
+
+function unwrapSourceFeatureIndex(feature) {
+  return feature._index;
+}
+
 test('geojson#import', t => {
   t.ok(typeof getGeojsonFeatures === 'function', 'getGeojsonFeatures imported OK');
   t.ok(typeof separateGeojsonFeatures === 'function', 'separateGeojsonFeatures imported OK');
@@ -322,7 +331,7 @@ test('geojson#getGeojsonFeatures, separateGeojsonFeatures', t => {
       t.throws(
         () => {
           const featureArray = getGeojsonFeatures(tc.argument);
-          separateGeojsonFeatures(featureArray);
+          separateGeojsonFeatures(featureArray, wrapSourceFeature);
         },
         tc.error,
         `separateGeojsonFeatures ${tc.title} throws error`
@@ -331,7 +340,7 @@ test('geojson#getGeojsonFeatures, separateGeojsonFeatures', t => {
       const featureArray = getGeojsonFeatures(tc.argument);
       t.ok(Array.isArray(featureArray), `getGeojsonFeatures ${tc.title} returned array`);
 
-      const result = separateGeojsonFeatures(featureArray);
+      const result = separateGeojsonFeatures(featureArray, wrapSourceFeature);
       const actual = {
         pointFeaturesLength: result.pointFeatures.length,
         lineFeaturesLength: result.lineFeatures.length,


### PR DESCRIPTION
Follow up of comments in https://github.com/uber/deck.gl/pull/3307

#### Change List

- Add `getSubLayerDatum` and `getSubLayerAccessor` methods to `CompositeLayer`
- Update `GeoJsonLayer`, `PolygonLayer`, `TextLayer` and `H3ClusterLayer` to use the new API
- Documentation
