### PR TITLE
add NON_INSTANCED_MODEL define

### DIFF
--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -67,6 +67,7 @@ export default class SolidPolygonLayer extends Layer {
     return {
       vs,
       fs,
+      defines: {},
       modules: [projectModule, 'gouraud-lighting', 'picking']
     };
   }
@@ -283,9 +284,12 @@ export default class SolidPolygonLayer extends Layer {
     let sideModel;
 
     if (filled) {
+      const shaders = this.getShaders(vsTop);
+      shaders.defines.NON_INSTANCED_MODEL = 1;
+
       topModel = new Model(
         gl,
-        Object.assign({}, this.getShaders(vsTop), {
+        Object.assign({}, shaders, {
           id: `${id}-top`,
           drawMode: GL.TRIANGLES,
           attributes: {


### PR DESCRIPTION
Pull `SolidPolygonLayer` change from https://github.com/uber/deck.gl/pull/3306 into 7.1-release.

For kepler.gl's data filter implementation.

#### Change List
- Add `NON_INSTANCED_MODEL` define to `SolidPolygonLayer` shader
