### PR TITLE
Improve prop comparison perf

### DIFF
--- a/modules/core/src/lifecycle/component-state.js
+++ b/modules/core/src/lifecycle/component-state.js
@@ -50,11 +50,14 @@ export default class ComponentState {
       // Make sure oldProps is set
       this.oldProps = this.oldProps || this.component.props;
 
-      // Deep copy props (Object.assign only handles shallow props)
-      // TODO - Alternatively, just reconfigure the async prop descriptors to fixed values?
-      this.oldAsyncProps = {};
-      for (const propName in this.oldProps) {
-        this.oldAsyncProps[propName] = this.oldProps[propName];
+      // 1. inherit all synchronous props from oldProps
+      // 2. reconfigure the async prop descriptors to fixed values
+      this.oldAsyncProps = Object.create(this.oldProps);
+      for (const propName in this.asyncProps) {
+        Object.defineProperty(this.oldAsyncProps, propName, {
+          enumerable: true,
+          value: this.oldProps[propName]
+        });
       }
     }
   }

--- a/test/bench/compare-props.bench.js
+++ b/test/bench/compare-props.bench.js
@@ -74,6 +74,29 @@ const TEST_CASES = {
       instancePositions: new Float32Array(1e6).fill(Math.PI)
     }),
     propTypes
+  },
+  realWorld: {
+    oldProps: Object.assign(Object.create(defaultProps), {
+      getPosition: d => d.position,
+      getRadius: d => d.size,
+      getLineWidth: d => d.size / 10,
+      getFillColor: [0, 0, 0, 255],
+      getLineColor: [200, 0, 0, 255],
+      stroked: true,
+      filled: true,
+      lineWidthMinPixels: 1
+    }),
+    newProps: Object.assign(Object.create(defaultProps), {
+      getPosition: d => d.position,
+      getRadius: d => d.size,
+      getLineWidth: d => d.size / 10,
+      getFillColor: [0, 0, 0, 255],
+      getLineColor: [200, 0, 0, 255],
+      stroked: true,
+      filled: true,
+      lineWidthMinPixels: 1
+    }),
+    propTypes
   }
 };
 
@@ -84,7 +107,7 @@ export default function comparePropsBench(suite) {
     .add('compareProps#simple', () => {
       compareProps(TEST_CASES.simple);
     })
-    .add('compareProps#default', () => {
+    .add('compareProps#empty', () => {
       compareProps(TEST_CASES.default);
     })
     .add('compareProps#override function', () => {
@@ -95,5 +118,8 @@ export default function comparePropsBench(suite) {
     })
     .add('compareProps#override large array', () => {
       compareProps(TEST_CASES.overrideLargeArray);
+    })
+    .add('compareProps#real world sample', () => {
+      compareProps(TEST_CASES.realWorld);
     });
 }

--- a/test/modules/core/lifecycle/props.spec.js
+++ b/test/modules/core/lifecycle/props.spec.js
@@ -127,6 +127,42 @@ const TEST_CASES = [
     object1: {prop: x => x},
     object2: {prop: [1, 2, 3]},
     result: NOT_SAME
+  },
+  {
+    title: 'add key#1',
+    object1: Object.assign(Object.create(SHALLOW_OBJECT)),
+    object2: Object.assign(Object.create(SHALLOW_OBJECT), {c: 0}),
+    result: NOT_SAME
+  },
+  {
+    title: 'add key#2',
+    object1: Object.assign(Object.create(SHALLOW_OBJECT)),
+    object2: Object.assign(Object.create(SHALLOW_OBJECT), {b: 3}),
+    result: NOT_SAME
+  },
+  {
+    title: 'add key#3',
+    object1: Object.assign(Object.create(SHALLOW_OBJECT)),
+    object2: Object.assign(Object.create(SHALLOW_OBJECT), {b: 2}),
+    result: SAME
+  },
+  {
+    title: 'drop key#1',
+    object1: Object.assign(Object.create(SHALLOW_OBJECT), {c: 0}),
+    object2: Object.assign(Object.create(SHALLOW_OBJECT)),
+    result: NOT_SAME
+  },
+  {
+    title: 'drop key#2',
+    object1: Object.assign(Object.create(SHALLOW_OBJECT), {b: 3}),
+    object2: Object.assign(Object.create(SHALLOW_OBJECT)),
+    result: NOT_SAME
+  },
+  {
+    title: 'drop key#3',
+    object1: Object.assign(Object.create(SHALLOW_OBJECT), {b: 2}),
+    object2: Object.assign(Object.create(SHALLOW_OBJECT)),
+    result: SAME
   }
 ];
 


### PR DESCRIPTION
#### Background

Our `props` object is created by inheriting the `defaultProps` object (one per `Layer` class), and then assign user-specified values on top. Currently, we compare two props objects by iterating through all key-value pairs, including the default prop values even if they are not supplied by the user. This PR switches to only examining the props explicitly set by the user.

#### Benchmark

Before:
├─ compareProps#empty: 65.1K iterations/s ±7.02%
├─ compareProps#real world sample: 55.6K iterations/s ±7.31%

After:
├─ compareProps#empty: 15.2M iterations/s ±0.92%
├─ compareProps#real world sample: 1.08M iterations/s ±1.23%

#### Change List
- `compareProps` util
- Creation of `oldProps` object when an async prop is loaded
- Benchmark and unit tests
