### PR TITLE
Add support for RGB color format

### DIFF
--- a/docs/api-reference/layer.md
+++ b/docs/api-reference/layer.md
@@ -300,7 +300,8 @@ Default `'XYZ'`.
 
 One of `'RGBA'`, `'RGB'`.
 
-Setting it to `'RGB'` will make the layer ignore the alpha channel and assume `a: 255`.
+Setting it to `'RGB'` will make the layer ignore the alpha channel of the colors returned by accessors, and instead assume all objects to be opaque.
+The layer's overall transparency controlled by `opacity` is still applied.
 
 Default `'RGBA'`.
 

--- a/docs/api-reference/layer.md
+++ b/docs/api-reference/layer.md
@@ -288,6 +288,21 @@ And is expected to return an array of "ranges", in the form of `{startRow, endRo
 
 **This feature is experimental and intended for advanced use cases.** Note that it only rewrites part of a buffer, not remove or insert, therefore the user of this prop is responsible of making sure that all the unchanged objects remain at the same indices between `oldData` and `newData`. This becomes trickier when dealing with data of dynamic lengths, for example `PathLayer`, `PolygonLayer` and `GeoJsonLayer`. Generally speaking, it is not recommended to use this feature when the count of vertices in the paths/polygons may change.
 
+##### `positionFormat` (String, optional)
+
+One of `'XYZ'`, `'XY'`.
+
+This prop is currently only effective in `PathLayer`, `SolidPolygonLayer` and `PolygonLayer`.
+
+Default `'XYZ'`.
+
+##### `colorFormat` (String, optional)
+
+One of `'RGBA'`, `'RGB'`.
+
+Setting it to `'RGB'` will make the layer ignore the alpha channel and assume `a: 255`.
+
+Default `'RGBA'`.
 
 ##### `numInstances` (Number, optional)
 

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -74,6 +74,8 @@ const defaultProps = {
   coordinateOrigin: {type: 'array', value: [0, 0, 0], compare: true},
   modelMatrix: {type: 'array', value: null, compare: true, optional: true},
   wrapLongitude: false,
+  positionFormat: 'XYZ',
+  colorFormat: 'RGBA',
 
   parameters: {},
   uniforms: {},
@@ -298,6 +300,11 @@ export default class Layer extends Component {
   getShaders(shaders) {
     for (const extension of this.props.extensions) {
       shaders = mergeShaders(shaders, extension.getShaders.call(this, extension));
+    }
+    if (this.props.colorFormat === 'RGB') {
+      shaders = mergeShaders(shaders, {
+        defines: {COLOR_FORMAT_RGB: 1}
+      });
     }
     return shaders;
   }

--- a/modules/core/src/shaderlib/index.js
+++ b/modules/core/src/shaderlib/index.js
@@ -40,6 +40,16 @@ export function initializeShaderModules() {
   createShaderHook('vs:DECKGL_FILTER_COLOR(inout vec4 color, VertexGeometry geometry)');
   createShaderHook('fs:DECKGL_FILTER_COLOR(inout vec4 color, FragmentGeometry geometry)');
 
+  createModuleInjection('geometry', {
+    hook: 'vs:DECKGL_FILTER_COLOR',
+    order: 99,
+    injection: `
+  #ifdef COLOR_FORMAT_RGB
+  color.a = opacity;
+  #endif
+`
+  });
+
   createModuleInjection('picking', {
     hook: 'fs:DECKGL_FILTER_COLOR',
     order: 99,

--- a/modules/core/src/shaderlib/index.js
+++ b/modules/core/src/shaderlib/index.js
@@ -40,6 +40,10 @@ export function initializeShaderModules() {
   createShaderHook('vs:DECKGL_FILTER_COLOR(inout vec4 color, VertexGeometry geometry)');
   createShaderHook('fs:DECKGL_FILTER_COLOR(inout vec4 color, FragmentGeometry geometry)');
 
+  // https://www.khronos.org/opengl/wiki/Vertex_Specification
+  // If the vertex shader has more components than the array provides, the extras are given values
+  // from the vector (0, 0, 0, 1) for the missing XYZW components.
+  // In RGB mode (color attributes missing the 4th component), a is default to 1.0. We want 255.0
   createModuleInjection('geometry', {
     hook: 'vs:DECKGL_FILTER_COLOR',
     order: 99,

--- a/modules/core/src/shaderlib/index.js
+++ b/modules/core/src/shaderlib/index.js
@@ -45,7 +45,7 @@ export function initializeShaderModules() {
     order: 99,
     injection: `
   #ifdef COLOR_FORMAT_RGB
-  color.a = opacity;
+  color.a *= 255.;
   #endif
 `
   });

--- a/modules/layers/src/arc-layer/arc-layer.js
+++ b/modules/layers/src/arc-layer/arc-layer.js
@@ -68,14 +68,14 @@ export default class ArcLayer extends Layer {
         update: this.calculateInstancePositions64Low
       },
       instanceSourceColors: {
-        size: this.props.colorFormat === 'RGB' ? 3 : 4,
+        size: this.props.colorFormat.length,
         type: GL.UNSIGNED_BYTE,
         transition: true,
         accessor: 'getSourceColor',
         defaultValue: DEFAULT_COLOR
       },
       instanceTargetColors: {
-        size: this.props.colorFormat === 'RGB' ? 3 : 4,
+        size: this.props.colorFormat.length,
         type: GL.UNSIGNED_BYTE,
         transition: true,
         accessor: 'getTargetColor',

--- a/modules/layers/src/arc-layer/arc-layer.js
+++ b/modules/layers/src/arc-layer/arc-layer.js
@@ -68,14 +68,14 @@ export default class ArcLayer extends Layer {
         update: this.calculateInstancePositions64Low
       },
       instanceSourceColors: {
-        size: 4,
+        size: this.props.colorFormat === 'RGB' ? 3 : 4,
         type: GL.UNSIGNED_BYTE,
         transition: true,
         accessor: 'getSourceColor',
         defaultValue: DEFAULT_COLOR
       },
       instanceTargetColors: {
-        size: 4,
+        size: this.props.colorFormat === 'RGB' ? 3 : 4,
         type: GL.UNSIGNED_BYTE,
         transition: true,
         accessor: 'getTargetColor',

--- a/modules/layers/src/column-layer/column-layer.js
+++ b/modules/layers/src/column-layer/column-layer.js
@@ -86,14 +86,14 @@ export default class ColumnLayer extends Layer {
         update: this.calculateInstancePositions64xyLow
       },
       instanceFillColors: {
-        size: 4,
+        size: this.props.colorFormat === 'RGB' ? 3 : 4,
         type: GL.UNSIGNED_BYTE,
         transition: true,
         accessor: 'getFillColor',
         defaultValue: DEFAULT_COLOR
       },
       instanceLineColors: {
-        size: 4,
+        size: this.props.colorFormat === 'RGB' ? 3 : 4,
         type: GL.UNSIGNED_BYTE,
         transition: true,
         accessor: 'getLineColor',

--- a/modules/layers/src/column-layer/column-layer.js
+++ b/modules/layers/src/column-layer/column-layer.js
@@ -86,14 +86,14 @@ export default class ColumnLayer extends Layer {
         update: this.calculateInstancePositions64xyLow
       },
       instanceFillColors: {
-        size: this.props.colorFormat === 'RGB' ? 3 : 4,
+        size: this.props.colorFormat.length,
         type: GL.UNSIGNED_BYTE,
         transition: true,
         accessor: 'getFillColor',
         defaultValue: DEFAULT_COLOR
       },
       instanceLineColors: {
-        size: this.props.colorFormat === 'RGB' ? 3 : 4,
+        size: this.props.colorFormat.length,
         type: GL.UNSIGNED_BYTE,
         transition: true,
         accessor: 'getLineColor',

--- a/modules/layers/src/icon-layer/icon-layer.js
+++ b/modules/layers/src/icon-layer/icon-layer.js
@@ -103,7 +103,7 @@ export default class IconLayer extends Layer {
         update: this.calculateInstanceColorMode
       },
       instanceColors: {
-        size: this.props.colorFormat === 'RGB' ? 3 : 4,
+        size: this.props.colorFormat.length,
         type: GL.UNSIGNED_BYTE,
         transition: true,
         accessor: 'getColor',

--- a/modules/layers/src/icon-layer/icon-layer.js
+++ b/modules/layers/src/icon-layer/icon-layer.js
@@ -103,7 +103,7 @@ export default class IconLayer extends Layer {
         update: this.calculateInstanceColorMode
       },
       instanceColors: {
-        size: 4,
+        size: this.props.colorFormat === 'RGB' ? 3 : 4,
         type: GL.UNSIGNED_BYTE,
         transition: true,
         accessor: 'getColor',

--- a/modules/layers/src/line-layer/line-layer.js
+++ b/modules/layers/src/line-layer/line-layer.js
@@ -68,7 +68,7 @@ export default class LineLayer extends Layer {
         update: this.calculateInstanceSourceTargetPositions64xyLow
       },
       instanceColors: {
-        size: this.props.colorFormat === 'RGB' ? 3 : 4,
+        size: this.props.colorFormat.length,
         type: GL.UNSIGNED_BYTE,
         transition: true,
         accessor: 'getColor',

--- a/modules/layers/src/line-layer/line-layer.js
+++ b/modules/layers/src/line-layer/line-layer.js
@@ -68,7 +68,7 @@ export default class LineLayer extends Layer {
         update: this.calculateInstanceSourceTargetPositions64xyLow
       },
       instanceColors: {
-        size: 4,
+        size: this.props.colorFormat === 'RGB' ? 3 : 4,
         type: GL.UNSIGNED_BYTE,
         transition: true,
         accessor: 'getColor',

--- a/modules/layers/src/path-layer/path-layer.js
+++ b/modules/layers/src/path-layer/path-layer.js
@@ -120,7 +120,7 @@ export default class PathLayer extends Layer {
       },
       instanceDashArrays: {size: 2, accessor: 'getDashArray'},
       instanceColors: {
-        size: this.props.colorFormat === 'RGB' ? 3 : 4,
+        size: this.props.colorFormat.length,
         type: GL.UNSIGNED_BYTE,
         accessor: 'getColor',
         transition: ATTRIBUTE_TRANSITION,

--- a/modules/layers/src/path-layer/path-layer.js
+++ b/modules/layers/src/path-layer/path-layer.js
@@ -120,7 +120,7 @@ export default class PathLayer extends Layer {
       },
       instanceDashArrays: {size: 2, accessor: 'getDashArray'},
       instanceColors: {
-        size: 4,
+        size: this.props.colorFormat === 'RGB' ? 3 : 4,
         type: GL.UNSIGNED_BYTE,
         accessor: 'getColor',
         transition: ATTRIBUTE_TRANSITION,

--- a/modules/layers/src/point-cloud-layer/point-cloud-layer.js
+++ b/modules/layers/src/point-cloud-layer/point-cloud-layer.js
@@ -68,7 +68,7 @@ export default class PointCloudLayer extends Layer {
         defaultValue: DEFAULT_NORMAL
       },
       instanceColors: {
-        size: this.props.colorFormat === 'RGB' ? 3 : 4,
+        size: this.props.colorFormat.length,
         type: GL.UNSIGNED_BYTE,
         transition: true,
         accessor: 'getColor',

--- a/modules/layers/src/point-cloud-layer/point-cloud-layer.js
+++ b/modules/layers/src/point-cloud-layer/point-cloud-layer.js
@@ -68,7 +68,7 @@ export default class PointCloudLayer extends Layer {
         defaultValue: DEFAULT_NORMAL
       },
       instanceColors: {
-        size: 4,
+        size: this.props.colorFormat === 'RGB' ? 3 : 4,
         type: GL.UNSIGNED_BYTE,
         transition: true,
         accessor: 'getColor',

--- a/modules/layers/src/polygon-layer/polygon-layer.js
+++ b/modules/layers/src/polygon-layer/polygon-layer.js
@@ -135,7 +135,8 @@ export default class PolygonLayer extends CompositeLayer {
       extruded,
       wireframe,
       elevationScale,
-      transitions
+      transitions,
+      positionFormat
     } = this.props;
 
     // Rendering props underlying layer
@@ -196,6 +197,7 @@ export default class PolygonLayer extends CompositeLayer {
         }),
         {
           data,
+          positionFormat,
           getPolygon
         }
       );
@@ -236,6 +238,7 @@ export default class PolygonLayer extends CompositeLayer {
         }),
         {
           data: paths,
+          positionFormat,
           getPath: x => x.path
         }
       );

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer.js
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer.js
@@ -76,14 +76,14 @@ export default class ScatterplotLayer extends Layer {
         defaultValue: 1
       },
       instanceFillColors: {
-        size: 4,
+        size: this.props.colorFormat === 'RGB' ? 3 : 4,
         transition: true,
         type: GL.UNSIGNED_BYTE,
         accessor: 'getFillColor',
         defaultValue: [0, 0, 0, 255]
       },
       instanceLineColors: {
-        size: 4,
+        size: this.props.colorFormat === 'RGB' ? 3 : 4,
         transition: true,
         type: GL.UNSIGNED_BYTE,
         accessor: 'getLineColor',

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer.js
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer.js
@@ -76,14 +76,14 @@ export default class ScatterplotLayer extends Layer {
         defaultValue: 1
       },
       instanceFillColors: {
-        size: this.props.colorFormat === 'RGB' ? 3 : 4,
+        size: this.props.colorFormat.length,
         transition: true,
         type: GL.UNSIGNED_BYTE,
         accessor: 'getFillColor',
         defaultValue: [0, 0, 0, 255]
       },
       instanceLineColors: {
-        size: this.props.colorFormat === 'RGB' ? 3 : 4,
+        size: this.props.colorFormat.length,
         transition: true,
         type: GL.UNSIGNED_BYTE,
         accessor: 'getLineColor',

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -149,7 +149,7 @@ export default class SolidPolygonLayer extends Layer {
       },
       fillColors: {
         alias: 'colors',
-        size: 4,
+        size: this.props.colorFormat === 'RGB' ? 3 : 4,
         type: GL.UNSIGNED_BYTE,
         transition: ATTRIBUTE_TRANSITION,
         accessor: 'getFillColor',
@@ -165,7 +165,7 @@ export default class SolidPolygonLayer extends Layer {
       },
       lineColors: {
         alias: 'colors',
-        size: 4,
+        size: this.props.colorFormat === 'RGB' ? 3 : 4,
         type: GL.UNSIGNED_BYTE,
         transition: ATTRIBUTE_TRANSITION,
         accessor: 'getLineColor',

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -149,7 +149,7 @@ export default class SolidPolygonLayer extends Layer {
       },
       fillColors: {
         alias: 'colors',
-        size: this.props.colorFormat === 'RGB' ? 3 : 4,
+        size: this.props.colorFormat.length,
         type: GL.UNSIGNED_BYTE,
         transition: ATTRIBUTE_TRANSITION,
         accessor: 'getFillColor',
@@ -165,7 +165,7 @@ export default class SolidPolygonLayer extends Layer {
       },
       lineColors: {
         alias: 'colors',
-        size: this.props.colorFormat === 'RGB' ? 3 : 4,
+        size: this.props.colorFormat.length,
         type: GL.UNSIGNED_BYTE,
         transition: ATTRIBUTE_TRANSITION,
         accessor: 'getLineColor',

--- a/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.js
+++ b/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.js
@@ -76,7 +76,7 @@ export default class ScenegraphLayer extends Layer {
         update: this.calculateInstancePositions64xyLow
       },
       instanceColors: {
-        size: 4,
+        size: this.props.colorFormat === 'RGB' ? 3 : 4,
         accessor: 'getColor',
         defaultValue: DEFAULT_COLOR,
         transition: true

--- a/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.js
+++ b/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.js
@@ -76,7 +76,7 @@ export default class ScenegraphLayer extends Layer {
         update: this.calculateInstancePositions64xyLow
       },
       instanceColors: {
-        size: this.props.colorFormat === 'RGB' ? 3 : 4,
+        size: this.props.colorFormat.length,
         accessor: 'getColor',
         defaultValue: DEFAULT_COLOR,
         transition: true

--- a/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.js
+++ b/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.js
@@ -137,7 +137,7 @@ export default class SimpleMeshLayer extends Layer {
       },
       instanceColors: {
         transition: true,
-        size: 4,
+        size: this.props.colorFormat === 'RGB' ? 3 : 4,
         accessor: 'getColor',
         defaultValue: [0, 0, 0, 255]
       },

--- a/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.js
+++ b/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.js
@@ -137,7 +137,7 @@ export default class SimpleMeshLayer extends Layer {
       },
       instanceColors: {
         transition: true,
-        size: this.props.colorFormat === 'RGB' ? 3 : 4,
+        size: this.props.colorFormat.length,
         accessor: 'getColor',
         defaultValue: [0, 0, 0, 255]
       },


### PR DESCRIPTION
For #3197 

There is a small save on resources, but this is most useful when using external buffers.

#### Change List
- Add `colorFormat` prop
- Fix `positionFormat` support in `PolygonLayer`
- Documentation
