### PR TITLE
Attribute allocation bug fixes

### DIFF
--- a/modules/core/src/lib/attribute.js
+++ b/modules/core/src/lib/attribute.js
@@ -422,7 +422,7 @@ export default class Attribute extends BaseAttribute {
   _validateAttributeUpdaters() {
     const state = this.userData;
 
-    // Check that either 'accessor' or 'update' is a valid function
+    // Check that 'update' is a valid function
     const hasUpdater = state.noAlloc || typeof state.update === 'function';
     if (!hasUpdater) {
       throw new Error(`Attribute ${this.id} missing update or accessor`);

--- a/modules/layers/src/bitmap-layer/bitmap-layer.js
+++ b/modules/layers/src/bitmap-layer/bitmap-layer.js
@@ -74,7 +74,7 @@ export default class BitmapLayer extends Layer {
       }
     });
 
-    this.setState({numInstances: 4}); // 4 corners
+    this.setState({numInstances: 1});
   }
 
   updateState({props, oldProps, changeFlags}) {

--- a/modules/layers/src/bitmap-layer/bitmap-layer.js
+++ b/modules/layers/src/bitmap-layer/bitmap-layer.js
@@ -63,12 +63,14 @@ export default class BitmapLayer extends Layer {
       positions: {
         size: 3,
         update: this.calculatePositions,
-        value: new Float32Array(12)
+        value: new Float32Array(12),
+        noAlloc: true
       },
       positions64xyLow: {
         size: 3,
         update: this.calculatePositions64xyLow,
-        value: new Float32Array(12)
+        value: new Float32Array(12),
+        noAlloc: true
       }
     });
 


### PR DESCRIPTION
#### Change List
- Fix a bug where `Attribute.allocate` may skip allocation if previously set external buffer or constant value is large enough
- Make BitmapLayer attributes use pre-allocated typed arrays
- Unit tests
