### PR TITLE
Fix TileLayer flashing

### DIFF
--- a/docs/layers/tile-layer.md
+++ b/docs/layers/tile-layer.md
@@ -124,7 +124,7 @@ The maximum cache size for a tile layer. If not defined, it is calculated using 
 
 ##### `getTileData` (Function,  optional)
 
-`getTileData` given x, y, z indices of the tile, returns a Promise that resolves to the decoded tile data.
+`getTileData` given x, y, z indices of the tile, returns the tile data or a Promise that resolves to the tile data.
 
 - Default: `getTileData: ({x, y, z}) => Promise.resolve(null)`
 

--- a/examples/website/map-tile/package.json
+++ b/examples/website/map-tile/package.json
@@ -7,7 +7,7 @@
     "start": "webpack-dev-server --progress --hot --open"
   },
   "dependencies": {
-    "deck.gl": "^7.1.0",
+    "deck.gl": "^7.2.0-alpha",
     "react": "^16.3.0",
     "react-dom": "^16.3.0"
   },

--- a/modules/geo-layers/src/tile-layer/utils/tile.js
+++ b/modules/geo-layers/src/tile-layer/utils/tile.js
@@ -27,10 +27,7 @@ export default class Tile {
   }
 
   get data() {
-    if (this._data) {
-      return Promise.resolve(this._data);
-    }
-    return this._loader;
+    return this._data || this._loader;
   }
 
   get isLoaded() {

--- a/modules/geo-layers/src/tile-layer/utils/tile.js
+++ b/modules/geo-layers/src/tile-layer/utils/tile.js
@@ -39,8 +39,8 @@ export default class Tile {
     if (!this.getTileData) {
       return null;
     }
-    const getTileDataPromise = this.getTileData({x, y, z, bbox});
-    return getTileDataPromise
+
+    return Promise.resolve(this.getTileData({x, y, z, bbox}))
       .then(buffers => {
         this._data = buffers;
         this._isLoaded = true;


### PR DESCRIPTION
For #2987 

`Tile.data` wraps resolved data in a new promise which prevents it from being rendered immediately.

#### Change List
- Fix tile flashing
- Support synchronous `getTileData`
