### PR TITLE
Simplify `layer.updateAttributes` override

### DIFF
--- a/examples/website/plot/plot-layer/axes-layer.js
+++ b/examples/website/plot/plot-layer/axes-layer.js
@@ -156,20 +156,8 @@ export default class AxesLayer extends Layer {
     }
   }
 
-  updateAttributes(props) {
-    super.updateAttributes(props);
-    const {attributeManager, modelsByName, numInstances} = this.state;
-    const changedAttributes = attributeManager.getChangedAttributes({clearChangedFlags: true});
-
-    modelsByName.grids.setInstanceCount(numInstances);
-    modelsByName.grids.setAttributes(changedAttributes);
-
-    modelsByName.labels.setInstanceCount(numInstances);
-    modelsByName.labels.setAttributes(changedAttributes);
-  }
-
-  draw({uniforms, moduleParameters}) {
-    const {gridDims, gridCenter, modelsByName, labelTexture} = this.state;
+  draw({uniforms}) {
+    const {gridDims, gridCenter, modelsByName, labelTexture, numInstances} = this.state;
     const {fontSize, color, padding} = this.props;
 
     if (labelTexture) {
@@ -181,10 +169,8 @@ export default class AxesLayer extends Layer {
         strokeColor: color
       };
 
-      if (moduleParameters) {
-        modelsByName.grids.updateModuleSettings(moduleParameters);
-        modelsByName.labels.updateModuleSettings(moduleParameters);
-      }
+      modelsByName.grids.setInstanceCount(numInstances);
+      modelsByName.labels.setInstanceCount(numInstances);
 
       modelsByName.grids.setUniforms(Object.assign({}, uniforms, baseUniforms)).draw();
       modelsByName.labels

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
@@ -271,7 +271,7 @@ export default class HeatmapLayer extends CompositeLayer {
 
   _updateWeightmapAttributes() {
     // base Layer class doesn't update attributes for composite layers, hence manually trigger it.
-    this.updateAttributes(this.props);
+    this._updateAttributes(this.props);
     // Attribute manager sets data array count as instaceCount on model
     // we need to set that as elementCount on 'weightsTransform'
     this.state.weightsTransform.update({

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -384,8 +384,14 @@ export default class Layer extends Component {
     }
   }
 
+  updateAttributes(changedAttributes) {
+    for (const model of this.getModels()) {
+      this._setModelAttributes(model, changedAttributes);
+    }
+  }
+
   // Calls attribute manager to update any WebGL attributes
-  updateAttributes(props) {
+  _updateAttributes(props) {
     const attributeManager = this.getAttributeManager();
     if (!attributeManager) {
       return;
@@ -407,14 +413,8 @@ export default class Layer extends Component {
       ignoreUnknownAttributes: true
     });
 
-    const models = this.getModels();
-
-    if (models.length > 0) {
-      const changedAttributes = attributeManager.getChangedAttributes({clearChangedFlags: true});
-      for (let i = 0, len = models.length; i < len; ++i) {
-        this._setModelAttributes(models[i], changedAttributes);
-      }
-    }
+    const changedAttributes = attributeManager.getChangedAttributes({clearChangedFlags: true});
+    this.updateAttributes(changedAttributes);
   }
 
   // Update attribute transition
@@ -649,7 +649,7 @@ export default class Layer extends Component {
     } else {
       this.setNeedsRedraw();
       // Add any subclass attributes
-      this.updateAttributes(this.props);
+      this._updateAttributes(this.props);
       this._updateBaseUniforms();
 
       // Note: Automatic instance count update only works for single layers

--- a/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.js
+++ b/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.js
@@ -235,13 +235,10 @@ export default class ScenegraphLayer extends Layer {
     };
   }
 
-  updateAttributes(props) {
-    super.updateAttributes(props);
+  updateAttributes(changedAttributes) {
     this.setState({attributesAvailable: true});
     if (!this.state.scenegraph) return;
 
-    const attributeManager = this.getAttributeManager();
-    const changedAttributes = attributeManager.getChangedAttributes({clearChangedFlags: true});
     this.state.scenegraph.traverse(model => {
       this._setModelAttributes(model.model, changedAttributes);
     });


### PR DESCRIPTION
#### Change List

- Breaking change in `layer.updateAttributes` (this is currently considered private API) - separate `AttributeManager` update, which all layers need, from `model.setAttributes` calls, which some layers may want to override.
- Update ScenegraphLayer
- Update plot example
