### PR TITLE
HeatmapLayer minor optimizations

### DIFF
--- a/docs/layers/heatmap-layer.md
+++ b/docs/layers/heatmap-layer.md
@@ -106,7 +106,7 @@ Method called to retrieve the position of each point.
 
 ##### `getWeight` ([Function](/docs/developer-guide/using-layers.md#accessors), optional)
 
-* Default: `object => 1`
+* Default: `1`
 
 Method called to retrieve weight of each point. By default each point will use a weight of `1`.
 

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer-utils.js
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer-utils.js
@@ -1,12 +1,10 @@
 // true if currentBounds contains targetBounds, false otherwise
 export function boundsContain(currentBounds, targetBounds) {
-  const [currentMin, currentMax] = currentBounds;
-  const [targetMin, targetMax] = targetBounds;
-
   if (
-    targetMin[0] >= currentMin[0] &&
-    targetMax[0] <= currentMax[0] &&
-    (targetMin[1] >= currentMin[1] && targetMax[1] <= currentMax[1])
+    targetBounds[0] >= currentBounds[0] &&
+    targetBounds[2] <= currentBounds[2] &&
+    targetBounds[1] >= currentBounds[1] &&
+    targetBounds[3] <= currentBounds[3]
   ) {
     return true;
   }
@@ -42,9 +40,9 @@ export function getTriangleVertices(opts = {}) {
   return new Float32Array([xMin, yMin, xMax, yMin, xMax, yMax, xMin, yMin, xMax, yMax, xMin, yMax]);
 }
 
-// Expands boundingBox:[[xMin, yMin], [xMax, yMax]] to match aspect ratio of given width and height
+// Expands boundingBox:[xMin, yMin, xMax, yMax] to match aspect ratio of given width and height
 export function scaleToAspectRatio(boundingBox, width, height) {
-  const [[xMin, yMin], [xMax, yMax]] = boundingBox;
+  const [xMin, yMin, xMax, yMax] = boundingBox;
 
   const currentWidth = xMax - xMin;
   const currentHeight = yMax - yMin;
@@ -67,20 +65,22 @@ export function scaleToAspectRatio(boundingBox, width, height) {
   const yCenter = (yMax + yMin) / 2;
 
   return [
-    [xCenter - newWidth / 2, yCenter - newHeight / 2],
-    [xCenter + newWidth / 2, yCenter + newHeight / 2]
+    xCenter - newWidth / 2,
+    yCenter - newHeight / 2,
+    xCenter + newWidth / 2,
+    yCenter + newHeight / 2
   ];
 }
 
 // Scales texture coordiante range to a sub rectangel
 export function getTextureCoordinates(originalRect, subRect) {
-  const [[xMin, yMin], [xMax, yMax]] = originalRect;
-  const [[subXMin, subYMin], [subXMax, subYMax]] = subRect;
+  const [xMin, yMin, xMax, yMax] = originalRect;
+  const [subXMin, subYMin, subXMax, subYMax] = subRect;
   const width = xMax - xMin;
   const height = yMax - yMin;
   const tXMin = (subXMin - xMin) / width;
   const tXMax = (subXMax - xMin) / width;
   const tYMin = (subYMin - yMin) / height;
   const tYMax = (subYMax - yMin) / height;
-  return [[tXMin, tYMin], [tXMax, tYMax]];
+  return [tXMin, tYMin, tXMax, tYMax];
 }

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer-utils.js
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer-utils.js
@@ -1,3 +1,16 @@
+export function getBounds(points) {
+  // Now build bounding box in world space (aligned to world coordiante system)
+  const x = points.map(p => p[0]);
+  const y = points.map(p => p[1]);
+
+  const xMin = Math.min.apply(null, x);
+  const xMax = Math.max.apply(null, x);
+  const yMin = Math.min.apply(null, y);
+  const yMax = Math.max.apply(null, y);
+
+  return [xMin, yMin, xMax, yMax];
+}
+
 // true if currentBounds contains targetBounds, false otherwise
 export function boundsContain(currentBounds, targetBounds) {
   if (
@@ -11,33 +24,17 @@ export function boundsContain(currentBounds, targetBounds) {
   return false;
 }
 
-// For given rectangle bounds generates two triangles vertices that coverit completely
-export function getTriangleVertices(opts = {}) {
-  const {xMin = 0, yMin = 0, xMax = 1, yMax = 1, addZ = false} = opts;
+const scratchArray = new Float32Array(12);
 
-  if (addZ) {
-    return new Float32Array([
-      xMin,
-      yMin,
-      0,
-      xMax,
-      yMin,
-      0,
-      xMax,
-      yMax,
-      0,
-      xMin,
-      yMin,
-      0,
-      xMax,
-      yMax,
-      0,
-      xMin,
-      yMax,
-      0
-    ]);
+// For given rectangle bounds generates two triangles vertices that coverit completely
+export function packVertices(points, dimensions = 2) {
+  let index = 0;
+  for (const point of points) {
+    for (let i = 0; i < dimensions; i++) {
+      scratchArray[index++] = point[i] || 0;
+    }
   }
-  return new Float32Array([xMin, yMin, xMax, yMin, xMax, yMax, xMin, yMin, xMax, yMax, xMin, yMax]);
+  return scratchArray;
 }
 
 // Expands boundingBox:[xMin, yMin, xMax, yMax] to match aspect ratio of given width and height
@@ -56,7 +53,7 @@ export function scaleToAspectRatio(boundingBox, width, height) {
     newHeight = (height / width) * currentWidth;
   }
 
-  if (newWidth < width || newHeight < height) {
+  if (newWidth < width) {
     newWidth = width;
     newHeight = height;
   }
@@ -72,15 +69,8 @@ export function scaleToAspectRatio(boundingBox, width, height) {
   ];
 }
 
-// Scales texture coordiante range to a sub rectangel
-export function getTextureCoordinates(originalRect, subRect) {
-  const [xMin, yMin, xMax, yMax] = originalRect;
-  const [subXMin, subYMin, subXMax, subYMax] = subRect;
-  const width = xMax - xMin;
-  const height = yMax - yMin;
-  const tXMin = (subXMin - xMin) / width;
-  const tXMax = (subXMax - xMin) / width;
-  const tYMin = (subYMin - yMin) / height;
-  const tYMax = (subYMax - yMin) / height;
-  return [tXMin, tYMin, tXMax, tYMax];
+// Get texture coordiante of point inside a bounding box
+export function getTextureCoordinates(point, bounds) {
+  const [xMin, yMin, xMax, yMax] = bounds;
+  return [(point[0] - xMin) / (xMax - xMin), (point[1] - yMin) / (yMax - yMin)];
 }

--- a/modules/aggregation-layers/src/heatmap-layer/triangle-layer.js
+++ b/modules/aggregation-layers/src/heatmap-layer/triangle-layer.js
@@ -47,15 +47,15 @@ export default class TriangleLayer extends Layer {
   }
 
   _getModel(gl) {
-    const {count} = this.props;
+    const {vertexCount} = this.props;
 
     return new Model(
       gl,
       Object.assign({}, this.getShaders(), {
         id: this.props.id,
         geometry: new Geometry({
-          drawMode: GL.TRIANGLES,
-          vertexCount: count
+          drawMode: GL.TRIANGLE_FAN,
+          vertexCount
         }),
         shaderCache: this.context.shaderCache
       })

--- a/test/modules/aggregation-layers/heatmap-layer/heatmap-layer.spec.js
+++ b/test/modules/aggregation-layers/heatmap-layer/heatmap-layer.spec.js
@@ -88,12 +88,12 @@ test('HeatmapLayer#updates', t => {
           pickable: false
         },
         onAfterUpdate({layer, subLayer}) {
-          const {worldBounds, normalizedCommonBounds} = layer.state;
+          const {worldBounds, viewportCorners} = layer.state;
 
           t.ok(subLayer instanceof TriangleLayer, 'Sublayer Triangle layer rendered');
 
           t.ok(worldBounds, 'should compute worldBounds');
-          t.ok(normalizedCommonBounds, 'should compute commonBounds');
+          t.ok(viewportCorners, 'should compute viewportCorners');
         }
       },
       {
@@ -118,7 +118,6 @@ test('HeatmapLayer#updates', t => {
         spies: [
           '_updateColorTexture',
           '_updateBounds',
-          '_updateWeightmapAttributes',
           '_updateWeightmap',
           '_updateTextureRenderingBounds'
         ],
@@ -126,10 +125,6 @@ test('HeatmapLayer#updates', t => {
           const {zoom} = layer.state;
           t.notOk(spies._updateColorTexture.called, 'should not update color texture');
           t.ok(spies._updateBounds.called, 'viewport changed, should call _updateBounds');
-          t.notOk(
-            spies._updateWeightmapAttributes.called,
-            'data not changed, should not call _updateWeightmapAttributes'
-          );
           t.ok(spies._updateWeightmap.called, 'boundsChanged changed, should _updateWeightmap');
           t.ok(
             spies._updateTextureRenderingBounds.called,
@@ -138,7 +133,6 @@ test('HeatmapLayer#updates', t => {
           t.equal(zoom, viewport1.zoom, 'should update state.zoom');
           spies._updateColorTexture.restore();
           spies._updateBounds.restore();
-          spies._updateWeightmapAttributes.restore();
           spies._updateWeightmap.restore();
           spies._updateTextureRenderingBounds.restore();
         }


### PR DESCRIPTION
#### Change List
- Only render the quad of visible pixels
- Flatten bounds object
- More efficient attribute updates (reuse typed array and `subData` instead of `setData`)
