### PR TITLE
Display rendering stats in layer browser

### DIFF
--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -67,7 +67,7 @@ export default class App extends PureComponent {
       },
 
       enableDepthPickOnClick: false,
-      randomCamera: false
+      randomCamera: false // Shake camera to force rendering every frame
     };
 
     this.mapRef = React.createRef();

--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -66,7 +66,8 @@ export default class App extends PureComponent {
         // effects: false,
       },
 
-      enableDepthPickOnClick: false
+      enableDepthPickOnClick: false,
+      randomCamera: false
     };
 
     this.mapRef = React.createRef();
@@ -228,6 +229,7 @@ export default class App extends PureComponent {
           views={this._getViews()}
           effects={this._getEffects()}
           settings={settings}
+          randomCamera={this.state.randomCamera}
         />
         <div id="control-panel">
           <div style={{textAlign: 'center', padding: '5px 0 5px'}}>
@@ -240,6 +242,9 @@ export default class App extends PureComponent {
               }
             >
               <b>Multi Depth Pick ({this.state.enableDepthPickOnClick ? 'ON' : 'OFF'})</b>
+            </button>
+            <button onClick={() => this.setState({randomCamera: !this.state.randomCamera})}>
+              <b>Random Camera ({this.state.randomCamera ? 'ON' : 'OFF'})</b>
             </button>
           </div>
           <LayerControls

--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -67,7 +67,7 @@ export default class App extends PureComponent {
       },
 
       enableDepthPickOnClick: false,
-      randomCamera: false // Shake camera to force rendering every frame
+      shakeCamera: false // Shake camera to force rendering every frame
     };
 
     this.mapRef = React.createRef();
@@ -229,7 +229,7 @@ export default class App extends PureComponent {
           views={this._getViews()}
           effects={this._getEffects()}
           settings={settings}
-          randomCamera={this.state.randomCamera}
+          shakeCamera={this.state.shakeCamera}
         />
         <div id="control-panel">
           <div style={{textAlign: 'center', padding: '5px 0 5px'}}>
@@ -243,8 +243,8 @@ export default class App extends PureComponent {
             >
               <b>Multi Depth Pick ({this.state.enableDepthPickOnClick ? 'ON' : 'OFF'})</b>
             </button>
-            <button onClick={() => this.setState({randomCamera: !this.state.randomCamera})}>
-              <b>Random Camera ({this.state.randomCamera ? 'ON' : 'OFF'})</b>
+            <button onClick={() => this.setState({shakeCamera: !this.state.shakeCamera})}>
+              <b>Shake Camera ({this.state.shakeCamera ? 'ON' : 'OFF'})</b>
             </button>
           </div>
           <LayerControls

--- a/examples/layer-browser/src/index.js
+++ b/examples/layer-browser/src/index.js
@@ -1,7 +1,6 @@
 /* global document */
 import React, {Component} from 'react';
 import ReactDOM from 'react-dom';
-import FPSStats from 'react-stats-zavatta';
 
 class Root extends Component {
   constructor(props) {
@@ -18,7 +17,6 @@ class Root extends Component {
 
     return (
       <div>
-        <FPSStats isActive left={100} />
         <AppComponent state={this._appState} onStateChange={this._onAppStateChange.bind(this)} />
       </div>
     );

--- a/examples/layer-browser/src/map.js
+++ b/examples/layer-browser/src/map.js
@@ -97,7 +97,7 @@ export default class Map extends PureComponent {
     if (this.deckRef.current) {
       const deck = this.deckRef.current.deck;
       this.setState({metrics: Object.assign({}, deck.metrics)});
-      if (this.props.randomCamera) {
+      if (this.props.shakeCamera) {
         const viewState = deck.viewManager.getViewState();
         deck.setProps({
           viewState: Object.assign({}, viewState, {

--- a/examples/layer-browser/src/map.js
+++ b/examples/layer-browser/src/map.js
@@ -65,15 +65,15 @@ export default class Map extends PureComponent {
     };
 
     this.deckRef = React.createRef();
-    this.metricsLoopHandle = null;
+    this.cameraShakeHandle = null;
   }
 
   componentDidMount() {
-    this.metricsLoopHandle = window.requestAnimationFrame(this._metricsLoop);
+    this.cameraShakeHandle = window.requestAnimationFrame(this._cameraShake);
   }
 
   componentWillUnmount() {
-    window.cancelAnimationFrame(this.metricsLoopHandle);
+    window.cancelAnimationFrame(this.cameraShakeHandle);
   }
 
   pickObjects(opts) {
@@ -92,21 +92,22 @@ export default class Map extends PureComponent {
     }
   }
 
-  _metricsLoop() {
-    this.metricsLoopHandle = window.requestAnimationFrame(this._metricsLoop);
-    if (this.deckRef.current) {
+  _cameraShake() {
+    this.cameraShakeHandle = window.requestAnimationFrame(this._cameraShake);
+    if (this.deckRef.current && this.props.shakeCamera) {
       const deck = this.deckRef.current.deck;
-      this.setState({metrics: Object.assign({}, deck.metrics)});
-      if (this.props.shakeCamera) {
-        const viewState = deck.viewManager.getViewState();
-        deck.setProps({
-          viewState: Object.assign({}, viewState, {
-            latitude: viewState.latitude + (Math.random() * 0.0002 - 0.0001),
-            longitude: viewState.longitude + (Math.random() * 0.0002 - 0.0001)
-          })
-        });
-      }
+      const viewState = deck.viewManager.getViewState();
+      deck.setProps({
+        viewState: Object.assign({}, viewState, {
+          latitude: viewState.latitude + (Math.random() * 0.0002 - 0.0001),
+          longitude: viewState.longitude + (Math.random() * 0.0002 - 0.0001)
+        })
+      });
     }
+  }
+
+  _onMetrics(metrics) {
+    this.setState({metrics: Object.assign({}, metrics)});
   }
 
   _onViewStateChange({viewState, viewId}) {
@@ -170,6 +171,7 @@ export default class Map extends PureComponent {
           debug={true}
           drawPickingColors={drawPickingColors}
           ContextProvider={MapContext.Provider}
+          _onMetrics={this._onMetrics}
         >
           <View id="basemap">
             <StaticMap

--- a/examples/layer-browser/src/map.js
+++ b/examples/layer-browser/src/map.js
@@ -8,7 +8,7 @@ import DeckGL from '@deck.gl/react';
 import {COORDINATE_SYSTEM, View} from '@deck.gl/core';
 
 import LayerInfo from './components/layer-info';
-import {RenderStats} from './render-stats';
+import {RenderMetrics} from './render-metrics';
 
 /* eslint-disable no-process-env */
 const MapboxAccessToken =
@@ -65,15 +65,15 @@ export default class Map extends PureComponent {
     };
 
     this.deckRef = React.createRef();
-    this.rafLoop = null;
+    this.metricsLoopHandle = null;
   }
 
   componentDidMount() {
-    this.rafLoop = window.requestAnimationFrame(this._rafLoop);
+    this.metricsLoopHandle = window.requestAnimationFrame(this._metricsLoop);
   }
 
   componentWillUnmount() {
-    window.cancelAnimationFrame(this.rafLoop);
+    window.cancelAnimationFrame(this.metricsLoopHandle);
   }
 
   pickObjects(opts) {
@@ -92,8 +92,8 @@ export default class Map extends PureComponent {
     }
   }
 
-  _rafLoop() {
-    this.rafLoop = window.requestAnimationFrame(this._rafLoop);
+  _metricsLoop() {
+    this.metricsLoopHandle = window.requestAnimationFrame(this._metricsLoop);
     if (this.deckRef.current) {
       const deck = this.deckRef.current.deck;
       this.setState({metrics: Object.assign({}, deck.metrics)});
@@ -152,7 +152,7 @@ export default class Map extends PureComponent {
     return (
       <div style={{backgroundColor: '#eeeeee'}}>
         <div style={{position: 'absolute', top: '10px', left: '100px', zIndex: 999}}>
-          <RenderStats stats={this.state.metrics} />
+          <RenderMetrics metrics={this.state.metrics} />
         </div>
         <DeckGL
           ref={this.deckRef}

--- a/examples/layer-browser/src/render-metrics.js
+++ b/examples/layer-browser/src/render-metrics.js
@@ -4,25 +4,25 @@ const kB = 1024;
 const MB = 1024 * 1024;
 const GB = 1024 * 1024 * 1024;
 
-export function RenderStats(props) {
-  const stats = props.stats;
+export function RenderMetrics(props) {
+  const metrics = props.metrics;
 
-  if (!stats) {
+  if (!metrics) {
     return null;
   }
 
   return (
     <div>
-      <div>FPS: {Math.round(stats.fps)}</div>
+      <div>FPS: {Math.round(metrics.fps)}</div>
       <div>
-        GPU Frame Time: {stats.gpuTimePerFrame.toFixed(2)}
+        GPU Frame Time: {metrics.gpuTimePerFrame.toFixed(2)}
         ms
       </div>
       <div>
-        CPU Frame Time: {stats.cpuTimePerFrame.toFixed(2)}
+        CPU Frame Time: {metrics.cpuTimePerFrame.toFixed(2)}
         ms
       </div>
-      <div>GPU Memory: {formatMemory(stats.gpuMemory)}</div>
+      <div>GPU Memory: {formatMemory(metrics.gpuMemory)}</div>
     </div>
   );
 }

--- a/examples/layer-browser/src/render-stats.js
+++ b/examples/layer-browser/src/render-stats.js
@@ -1,0 +1,49 @@
+import React from 'react';
+
+const kB = 1024;
+const MB = 1024 * 1024;
+const GB = 1024 * 1024 * 1024;
+
+export function RenderStats(props) {
+  const stats = props.stats;
+
+  if (!stats) {
+    return null;
+  }
+
+  return (
+    <div>
+      <div>FPS: {Math.round(stats.fps)}</div>
+      <div>
+        GPU Frame Time: {stats.gpuTimePerFrame.toFixed(2)}
+        ms
+      </div>
+      <div>
+        CPU Frame Time: {stats.cpuTimePerFrame.toFixed(2)}
+        ms
+      </div>
+      <div>GPU Memory: {formatMemory(stats.gpuMemory)}</div>
+    </div>
+  );
+}
+
+function formatMemory(mem) {
+  let unit;
+  let val;
+
+  if (mem < kB) {
+    val = mem;
+    unit = ' bytes';
+  } else if (mem < MB) {
+    val = mem / kB;
+    unit = 'kB';
+  } else if (mem < GB) {
+    val = mem / MB;
+    unit = 'MB';
+  } else {
+    val = mem / GB;
+    unit = 'GB';
+  }
+
+  return `${val.toFixed(2)}${unit}`;
+}


### PR DESCRIPTION
- Display stats from `Deck.metrics` on screen in the layer browser. Currently displaying FPS, GPU frame time, CPU frame time and GPU memory. Can easily add more layer.
- Add an option to cause the camera to randomly shake to ensure rendering occurs every frame.
- Remove old FPS stats display from layer browser.