### PR TITLE
Fix PathLayer/trips demo perf regression

### DIFF
--- a/modules/layers/src/path-layer/path-layer-vertex.glsl.js
+++ b/modules/layers/src/path-layer/path-layer-vertex.glsl.js
@@ -130,8 +130,8 @@ vec3 lineJoin(
   offsetScale = mix(offsetScale, 1.0 / max(cosHalfA, 0.001), step(0.5, cornerPosition));
 
   // special treatment for start cap and end cap
-  bool isStartCap = !isEnd && (instanceTypes == 1.0 || instanceTypes == 3.0);
-  bool isEndCap = isEnd && (instanceTypes == 2.0 || instanceTypes == 3.0);
+  bool isStartCap = lenA == 0.0 || (!isEnd && (instanceTypes == 1.0 || instanceTypes == 3.0));
+  bool isEndCap = lenB == 0.0 || (isEnd && (instanceTypes == 2.0 || instanceTypes == 3.0));
   bool isCap = isStartCap || isEndCap;
 
   // 0: center, 1: side

--- a/test/modules/core/lib/pick-layers.spec.js
+++ b/test/modules/core/lib/pick-layers.spec.js
@@ -315,7 +315,7 @@ const TEST_CASES = [
             height: 400
           },
           results: {
-            count: 4
+            count: 3
           }
         },
         {
@@ -409,7 +409,7 @@ const TEST_CASES = [
             height: 400
           },
           results: {
-            count: 33
+            count: 32
           }
         },
         {

--- a/website/src/static/workers/trips-data-decoder.js
+++ b/website/src/static/workers/trips-data-decoder.js
@@ -114,16 +114,18 @@ function decodeTrip(str, segments) {
     return acc.concat(t);
   }, [0]);
   const rT = (endTime - startTime) / projectedTimes[projectedTimes.length - 1];
-
   return {
     vendor,
     startTime,
     endTime,
     segments: segs.reduce(function(acc, seg, i) {
       const t0 = projectedTimes[i];
-      return acc.concat(seg.map(function(s) {
-        return [s[0], s[1], (s[2] + t0) * rT + startTime];
-      }));
+      seg.forEach(function (s, j) {
+        if (i === 0 || j > 0) {
+          acc.push([s[0], s[1], (s[2] + t0) * rT + startTime]);
+        }
+      });
+      return acc;
     }, [])
   };
 }


### PR DESCRIPTION
#### Background

For #3396 

In https://github.com/uber/deck.gl/pull/3211/files#diff-f1f8e62816742b25869f5b5a7c79e7cfR150 we removed the check for very small neighbor segments, and replaced it with explicit end cap flags. Although this reduced ambiguity for end caps, when a path contains two adjacent identical points, the shader produces a big joint triangle which kills rasterization.

This was not caught in testing because we have clean data in layer-browser/render tests. The trips demo has a bug that produces duplicate vertices at navigation points.

#### Change List
- Restore check for neighbor size
- Fix trips demo data decoder
