### PR TITLE
Fix highway safety demo bugs

### DIFF
--- a/modules/core/src/lib/attribute-transition-manager.js
+++ b/modules/core/src/lib/attribute-transition-manager.js
@@ -223,7 +223,7 @@ export default class AttributeTransitionManager {
   // get current values of an attribute, clipped/padded to the size of the new buffer
   _getNextTransitionStates(transition, settings) {
     const {attribute} = transition;
-    const {size, offset} = attribute;
+    const {size, offset, normalized} = attribute;
 
     let toState;
     if (attribute.constant) {
@@ -235,6 +235,7 @@ export default class AttributeTransitionManager {
         divisor: 0,
         size,
         offset,
+        normalized,
         // attribute's `value` does not match the content of external buffer,
         // will need to call buffer.getData if needed
         value: attribute.externalBuffer ? null : attribute.value

--- a/modules/layers/src/path-layer/path-tesselator.js
+++ b/modules/layers/src/path-layer/path-tesselator.js
@@ -55,7 +55,11 @@ export default class PathTesselator extends Tesselator {
       // invalid path
       return 0;
     }
-    return this.isClosed(path) ? numPoints + 1 : Math.max(0, numPoints - 1);
+    if (this.isClosed(path)) {
+      // minimum 3 vertices
+      return numPoints < 3 ? 0 : numPoints + 1;
+    }
+    return numPoints - 1;
   }
 
   /* eslint-disable max-statements, complexity */

--- a/test/modules/layers/path-tesselator.spec.js
+++ b/test/modules/layers/path-tesselator.spec.js
@@ -25,6 +25,7 @@ import PathTesselator from '@deck.gl/layers/path-layer/path-tesselator';
 const SAMPLE_DATA = [
   {path: [], width: 1, dashArray: [0, 0], color: [0, 0, 0]},
   {path: [[1, 1]], width: 1, dashArray: [0, 0], color: [0, 0, 0]},
+  {path: [[1, 1], [1, 1]], width: 1, dashArray: [0, 0], color: [0, 0, 0]},
   {path: [[1, 1], [2, 2], [3, 3]], width: 2, dashArray: [0, 0], color: [255, 0, 0]},
   {path: new Float64Array([1, 1, 2, 2, 3, 3]), width: 1, dashArray: [0, 0], color: [0, 0, 0]},
   {path: [[1, 1], [2, 2], [3, 3], [1, 1]], width: 3, dashArray: [2, 1], color: [0, 0, 255]}


### PR DESCRIPTION

For #3396 

#### Change List
- Fix crashing bug in `PathTesselator` when a path consists of two identical points; add test case
- Fix `AttributeTransitionManager` handling of normalized attributes
