### PR TITLE
ScreenGridLayer: skip aggregation when data is empty

### DIFF
--- a/modules/aggregation-layers/src/screen-grid-layer/screen-grid-layer.js
+++ b/modules/aggregation-layers/src/screen-grid-layer/screen-grid-layer.js
@@ -114,7 +114,13 @@ export default class ScreenGridLayer extends Layer {
     const changeFlags = this._getAggregationChangeFlags(opts);
 
     if (changeFlags) {
-      this._updateAggregation(changeFlags);
+      if (changeFlags.cellSizeChanged || changeFlags.viewportChanged) {
+        this._updateGridParams();
+      }
+      const {pointCount} = this.state;
+      if (pointCount > 0) {
+        this._updateAggregation(changeFlags);
+      }
     }
   }
 
@@ -282,7 +288,7 @@ export default class ScreenGridLayer extends Layer {
       }
     }
     weights.color.values = colorWeights;
-    this.setState({positions});
+    this.setState({positions, pointCount});
   }
 
   // Set a binding point for the aggregation uniform block index
@@ -316,10 +322,6 @@ export default class ScreenGridLayer extends Layer {
 
   _updateAggregation(changeFlags) {
     const attributeManager = this.getAttributeManager();
-    if (changeFlags.cellSizeChanged || changeFlags.viewportChanged) {
-      this._updateGridParams();
-      attributeManager.invalidateAll();
-    }
     const {cellSizePixels, gpuAggregation} = this.props;
 
     const {positions, weights} = this.state;
@@ -391,6 +393,8 @@ export default class ScreenGridLayer extends Layer {
   }
 
   _updateGridParams() {
+    const attributeManager = this.getAttributeManager();
+    attributeManager.invalidateAll();
     const {width, height} = this.context.viewport;
     const {cellSizePixels} = this.props;
     const {gl} = this.context;

--- a/modules/aggregation-layers/src/utils/gpu-grid-aggregation/gpu-grid-aggregator.js
+++ b/modules/aggregation-layers/src/utils/gpu-grid-aggregation/gpu-grid-aggregator.js
@@ -214,7 +214,7 @@ export default class GPUGridAggregator {
       return this.runAggregationOnGPU(aggregationParams);
     }
     if (useGPU) {
-      log.info('GPUGridAggregator: GPU Aggregation not supported, falling back to CPU')();
+      log.warn('GPUGridAggregator: GPU Aggregation not supported, falling back to CPU')();
     }
     return this.runAggregationOnCPU(aggregationParams);
   }


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #3396 

<!-- For other PRs without open issue -->
#### Background
When running website demo, data is not loaded immidetely and aggregation is performed with 0 vertex count, causing following warnings:
`[.WebGL-0x7fef75911400]RENDER WARNING: Render count or primcount is 0.`
Skip aggregation when there is no data.
<!-- For all the PRs -->
#### Change List
- ScreenGridLayer: skip aggregation when data is empty
