### PR TITLE
Upgrade to loaders.gl@1.2.0

### DIFF
--- a/examples/website/map-tile/app.js
+++ b/examples/website/map-tile/app.js
@@ -2,7 +2,7 @@ import React, {PureComponent} from 'react';
 import {render} from 'react-dom';
 
 import DeckGL, {TileLayer, BitmapLayer} from 'deck.gl';
-import {loadImage} from '@loaders.gl/images';
+import {load} from '@loaders.gl/core';
 
 const INITIAL_VIEW_STATE = {
   latitude: 47.65,
@@ -54,7 +54,7 @@ export class App extends PureComponent {
         minZoom: 0,
         maxZoom: 19,
 
-        getTileData: ({x, y, z}) => loadImage(`${tileServer}/${z}/${x}/${y}.png`),
+        getTileData: ({x, y, z}) => load(`${tileServer}/${z}/${x}/${y}.png`),
 
         renderSubLayers: props => {
           const {

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -30,8 +30,8 @@
     "prepublishOnly": "npm run build-bundle && npm run build-bundle -- --env.dev"
   },
   "dependencies": {
-    "@loaders.gl/core": "^1.1.6",
-    "@loaders.gl/images": "^1.1.6",
+    "@loaders.gl/core": "^1.2.0-beta.4",
+    "@loaders.gl/images": "^1.2.0-beta.4",
     "@luma.gl/core": "^7.2.0-beta.1",
     "gl-matrix": "^3.0.0",
     "math.gl": "^2.3.0",

--- a/modules/core/src/lib/init.js
+++ b/modules/core/src/lib/init.js
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 import {registerLoaders} from '@loaders.gl/core';
-import {HTMLImageLoader} from '@loaders.gl/images';
+import {ImageLoader} from '@loaders.gl/images';
 
 import {global} from '../utils/globals';
 import log from '../utils/log';
@@ -47,7 +47,7 @@ if (!global.deck) {
     log
   };
 
-  registerLoaders([jsonLoader, HTMLImageLoader]);
+  registerLoaders([jsonLoader, [ImageLoader, {imageOrientation: 'flipY'}]]);
 
   initializeShaderModules();
 }

--- a/modules/layers/package.json
+++ b/modules/layers/package.json
@@ -29,7 +29,7 @@
     "prepublishOnly": "npm run build-bundle && npm run build-bundle -- --env.dev"
   },
   "dependencies": {
-    "@loaders.gl/images": "^1.1.6",
+    "@loaders.gl/images": "^1.2.0-beta.4",
     "@mapbox/tiny-sdf": "^1.1.0",
     "earcut": "^2.0.6"
   },

--- a/modules/layers/src/bitmap-layer/bitmap-layer.js
+++ b/modules/layers/src/bitmap-layer/bitmap-layer.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-/* global Image, HTMLCanvasElement, HTMLVideoElement */
+/* global HTMLVideoElement */
 import GL from '@luma.gl/constants';
 import {Layer, fp64LowPart} from '@deck.gl/core';
 import {Model, Geometry, Texture2D} from '@luma.gl/core';
@@ -230,17 +230,6 @@ export default class BitmapLayer extends Layer {
 
     if (image instanceof Texture2D) {
       this.setState({bitmapTexture: image});
-    } else if (
-      // browser object
-      image instanceof Image ||
-      image instanceof HTMLCanvasElement
-    ) {
-      this.setState({
-        bitmapTexture: new Texture2D(gl, {
-          data: image,
-          parameters: DEFAULT_TEXTURE_PARAMETERS
-        })
-      });
     } else if (image instanceof HTMLVideoElement) {
       // Initialize an empty texture while we wait for the video to load
       this.setState({
@@ -249,6 +238,13 @@ export default class BitmapLayer extends Layer {
           height: 1,
           parameters: DEFAULT_TEXTURE_PARAMETERS,
           mipmaps: false
+        })
+      });
+    } else if (image) {
+      this.setState({
+        bitmapTexture: new Texture2D(gl, {
+          data: image,
+          parameters: DEFAULT_TEXTURE_PARAMETERS
         })
       });
     }

--- a/modules/layers/src/bitmap-layer/bitmap-layer.js
+++ b/modules/layers/src/bitmap-layer/bitmap-layer.js
@@ -241,6 +241,7 @@ export default class BitmapLayer extends Layer {
         })
       });
     } else if (image) {
+      // Browser object: Image, ImageData, HTMLCanvasElement, ImageBitmap
       this.setState({
         bitmapTexture: new Texture2D(gl, {
           data: image,

--- a/modules/layers/src/icon-layer/icon-manager.js
+++ b/modules/layers/src/icon-layer/icon-manager.js
@@ -1,4 +1,4 @@
-/* global document, Image, HTMLCanvasElement */
+/* global document */
 import GL from '@luma.gl/constants';
 import {Texture2D, readPixelsToBuffer} from '@luma.gl/core';
 import {loadImage} from '@loaders.gl/images';
@@ -248,11 +248,7 @@ export default class IconManager {
 
       this._externalTexture = iconAtlas;
       this.onUpdate();
-    } else if (
-      // browser object
-      iconAtlas instanceof Image ||
-      iconAtlas instanceof HTMLCanvasElement
-    ) {
+    } else if (iconAtlas) {
       this._texture = new Texture2D(this.gl, {
         data: iconAtlas,
         parameters: DEFAULT_TEXTURE_PARAMETERS

--- a/modules/layers/src/icon-layer/icon-manager.js
+++ b/modules/layers/src/icon-layer/icon-manager.js
@@ -249,6 +249,7 @@ export default class IconManager {
       this._externalTexture = iconAtlas;
       this.onUpdate();
     } else if (iconAtlas) {
+      // Browser object: Image, ImageData, HTMLCanvasElement, ImageBitmap
       this._texture = new Texture2D(this.gl, {
         data: iconAtlas,
         parameters: DEFAULT_TEXTURE_PARAMETERS

--- a/test/modules/layers/core-layers.spec.js
+++ b/test/modules/layers/core-layers.spec.js
@@ -226,11 +226,16 @@ test('GridCellLayer', t => {
 });
 
 test('IconLayer', t => {
+  /* global document */
+  const canvas = document.createElement('canvas');
+  canvas.width = 24;
+  canvas.height = 24;
+
   const testCases = generateLayerTests({
     Layer: IconLayer,
     sampleProps: {
       data: FIXTURES.points,
-      iconAtlas: {},
+      iconAtlas: canvas,
       iconMapping: {
         marker: {x: 0, y: 0, width: 24, height: 24}
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1411,10 +1411,10 @@
   dependencies:
     "@babel/runtime" "^7.3.1"
 
-"@loaders.gl/core@^1.1.6":
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/core/-/core-1.1.6.tgz#6963e14e93663d9582238f39e70607b01a172c36"
-  integrity sha512-/byPhredVzkxAMVR8CAaD8uzB72p6/pWAmgkvZmDeI7dHrCiQGt59EolmTJoQ5c50FMAFKQ75tidXor7D+fObA==
+"@loaders.gl/core@^1.2.0-beta.4":
+  version "1.2.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/core/-/core-1.2.0-beta.4.tgz#2bd1ffa573fc788f6060076af51745ab91c0a643"
+  integrity sha512-jh/Veu8du4ephwsDPQtyymougIELf8iIRFfs8TU58+wDK7MVUPre2P62gOjghPGNkY/qa+T8SXhu5AKT4LDgAA==
   dependencies:
     "@babel/runtime" "^7.3.1"
 
@@ -1432,10 +1432,10 @@
   resolved "https://registry.yarnpkg.com/@loaders.gl/images/-/images-1.1.5.tgz#50636376db4235d993e98144809020714429bf5a"
   integrity sha512-bpDBqowkdUrPGJrPYYBD5BnqqAJ5WbD1VteS8u9kqhFX7TC7y3Jvvsv3+8cuFOeKhBGDCFFW8HlnUKcv1Fvfiw==
 
-"@loaders.gl/images@^1.1.6":
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/images/-/images-1.1.6.tgz#21dd3238c97ad1164f7c0ed43d18edaec49d97e1"
-  integrity sha512-Ad63Uj0VGzmA71ucThnyc+VYsJJKZqYKkmANsQDDFe8p9UiR8JaI8DNLTJCfEtusyl5KVBWzWIdqXGPoT2uLWA==
+"@loaders.gl/images@^1.2.0-beta.4":
+  version "1.2.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/images/-/images-1.2.0-beta.4.tgz#49dc255b383601864cff3f528499be7ca9011f5b"
+  integrity sha512-mvNqaw6KyABdHdlJIoReAid9MQvr+ie6bBh8I1AbHALVJFRdkEjmW9OH6luj/MBqdpBZ851fJLNv8+0L7F6YHQ==
 
 "@loaders.gl/loader-utils@1.1.5":
   version "1.1.5"


### PR DESCRIPTION
#### Change List
- Use `ImageLoader` instead of `HTMLImageLoader` (web worker compatible)
- Support `ImageBitmap` in `IconManager` and `BitmapLayer`
