### PR TITLE
Fail gracefully in the event of a hexbin projection error

### DIFF
--- a/modules/aggregation-layers/src/hexagon-layer/hexagon-aggregator.js
+++ b/modules/aggregation-layers/src/hexagon-layer/hexagon-aggregator.js
@@ -42,9 +42,14 @@ export function pointToHexbin({data, radius, getPosition}, viewport) {
     const position = getPosition(object, objectInfo);
     const arrayIsFinite = Number.isFinite(position[0]) && Number.isFinite(position[1]);
     if (arrayIsFinite) {
-      screenPoints.push({
-        screenCoord: viewport.projectFlat(position)
-      });
+      screenPoints.push(
+        Object.assign(
+          {
+            screenCoord: viewport.projectFlat(position)
+          },
+          object
+        )
+      );
     } else {
       log.warn('HexagonLayer: invalid position')();
     }

--- a/modules/aggregation-layers/src/hexagon-layer/hexagon-aggregator.js
+++ b/modules/aggregation-layers/src/hexagon-layer/hexagon-aggregator.js
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 import {hexbin} from 'd3-hexbin';
-import {createIterable} from '@deck.gl/core';
+import {createIterable, log} from '@deck.gl/core';
 
 /**
  * Use d3-hexbin to performs hexagonal binning from geo points to hexagons
@@ -39,14 +39,23 @@ export function pointToHexbin({data, radius, getPosition}, viewport) {
   const {iterable, objectInfo} = createIterable(data);
   for (const object of iterable) {
     objectInfo.index++;
-    screenPoints.push(
-      Object.assign(
-        {
-          screenCoord: viewport.projectFlat(getPosition(object, objectInfo))
-        },
-        object
-      )
-    );
+    try {
+      screenPoints.push(
+        Object.assign(
+          {
+            screenCoord: viewport.projectFlat(getPosition(object, objectInfo))
+          },
+          object
+        )
+      );
+    } catch (err) {
+      log.warn(
+        `Failed processing datum, skipping entry.
+         Row number: ${objectInfo.index}
+         Datum: ${object}
+         Error message: ${err}`.replace(/  +/g, '')
+      );
+    }
   }
 
   const newHexbin = hexbin()

--- a/modules/aggregation-layers/src/hexagon-layer/hexagon-aggregator.js
+++ b/modules/aggregation-layers/src/hexagon-layer/hexagon-aggregator.js
@@ -50,9 +50,9 @@ export function pointToHexbin({data, radius, getPosition}, viewport) {
       );
     } catch (err) {
       log.warn(
-        `Failed processing datum, skipping entry.
+        `Failed processing row, skipping entry.
          Row number: ${objectInfo.index}
-         Datum: ${object}
+         Datum: ${String(object)}
          Error message: ${err}`.replace(/  +/g, '')
       );
     }

--- a/modules/aggregation-layers/src/hexagon-layer/hexagon-aggregator.js
+++ b/modules/aggregation-layers/src/hexagon-layer/hexagon-aggregator.js
@@ -37,7 +37,6 @@ export function pointToHexbin({data, radius, getPosition}, viewport) {
   // add world space coordinates to points
   const screenPoints = [];
   let position;
-  let shouldWarn = false;
   const {iterable, objectInfo} = createIterable(data);
   for (const object of iterable) {
     objectInfo.index++;
@@ -53,14 +52,10 @@ export function pointToHexbin({data, radius, getPosition}, viewport) {
         )
       );
     } else {
-      shouldWarn = true;
+      log.warn(
+        'At least one row was ignored for hexbinning because it had a non-finite position value'
+      )();
     }
-  }
-
-  if (shouldWarn) {
-    log.warn(
-      'At least one row was ignored for hexbinning because it had a non-finite position value'
-    )();
   }
 
   const newHexbin = hexbin()

--- a/modules/aggregation-layers/src/hexagon-layer/hexagon-aggregator.js
+++ b/modules/aggregation-layers/src/hexagon-layer/hexagon-aggregator.js
@@ -60,7 +60,7 @@ export function pointToHexbin({data, radius, getPosition}, viewport) {
   if (shouldWarn) {
     log.warn(
       'At least one row was ignored for hexbinning because it had a non-finite position value'
-    );
+    )();
   }
 
   const newHexbin = hexbin()

--- a/modules/aggregation-layers/src/hexagon-layer/hexagon-aggregator.js
+++ b/modules/aggregation-layers/src/hexagon-layer/hexagon-aggregator.js
@@ -36,25 +36,17 @@ export function pointToHexbin({data, radius, getPosition}, viewport) {
 
   // add world space coordinates to points
   const screenPoints = [];
-  let position;
   const {iterable, objectInfo} = createIterable(data);
   for (const object of iterable) {
     objectInfo.index++;
-    position = getPosition(object, objectInfo);
+    const position = getPosition(object, objectInfo);
     const arrayIsFinite = Number.isFinite(position[0]) && Number.isFinite(position[1]);
     if (arrayIsFinite) {
-      screenPoints.push(
-        Object.assign(
-          {
-            screenCoord: viewport.projectFlat(position)
-          },
-          object
-        )
-      );
+      screenPoints.push({
+        screenCoord: viewport.projectFlat(position)
+      });
     } else {
-      log.warn(
-        'At least one row was ignored for hexbinning because it had a non-finite position value'
-      )();
+      log.warn('HexagonLayer: invalid position')();
     }
   }
 

--- a/test/modules/aggregation-layers/hexagon-aggregator.spec.js
+++ b/test/modules/aggregation-layers/hexagon-aggregator.spec.js
@@ -23,6 +23,8 @@ import test from 'tape-catch';
 import * as FIXTURES from 'deck.gl-test/data';
 
 import {pointToHexbin} from '@deck.gl/aggregation-layers/hexagon-layer/hexagon-aggregator';
+import {makeSpy} from '@probe.gl/test-utils';
+import {log} from '@deck.gl/core';
 
 const getPosition = d => d.COORDINATES;
 const iterableData = new Set(FIXTURES.points);
@@ -34,5 +36,20 @@ test('pointToHexbin', t => {
     typeof pointToHexbin({data: iterableData, radius, getPosition}, viewport) === 'object',
     'should work with iterables'
   );
+  t.end();
+});
+
+test.only('pointToHexbin#invalidData', t => {
+  makeSpy(log, 'warn');
+  const onePoint = FIXTURES.points[0];
+  onePoint.COORDINATES = ['', ''];
+  t.ok(
+    typeof pointToHexbin({data: [onePoint], radius, getPosition}, viewport) === 'object',
+    'should still produce an object in the presence of non-finite values'
+  );
+
+  t.ok(log.warn.called, 'should produce a warning message in the presence of non-finite values');
+
+  log.warn.restore();
   t.end();
 });

--- a/test/modules/aggregation-layers/hexagon-aggregator.spec.js
+++ b/test/modules/aggregation-layers/hexagon-aggregator.spec.js
@@ -39,7 +39,7 @@ test('pointToHexbin', t => {
   t.end();
 });
 
-test.only('pointToHexbin#invalidData', t => {
+test('pointToHexbin#invalidData', t => {
   makeSpy(log, 'warn');
   const onePoint = FIXTURES.points[0];
   onePoint.COORDINATES = ['', ''];


### PR DESCRIPTION
For #2929 and #3079
#### Background

Hexbin aggregation has been failing in pydeck in 7.2.
This is also causing an issue in the JSON browser demo.
This PR gives a useful error without blocking rendering.