### PR TITLE
Website reference ES5 transpiled version of supercluster dependency

### DIFF
--- a/website/webpack.config.js
+++ b/website/webpack.config.js
@@ -76,7 +76,8 @@ const COMMON_CONFIG = {
     modules: [resolve('./node_modules'), resolve('../node_modules')],
     alias: Object.assign({}, ALIASES, {
       'website-examples': resolve('../examples/website'),
-      'viewport-mercator-project': resolve('../node_modules/viewport-mercator-project')
+      'viewport-mercator-project': resolve('../node_modules/viewport-mercator-project'),
+      supercluster: resolve('../node_modules/supercluster/dist/supercluster.js')
     })
   },
 


### PR DESCRIPTION
The default path loads ES6 code into the bundle.