### PR TITLE
Composite layer should rerender when state updates

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -1,5 +1,11 @@
 # Upgrade Guide
 
+## Upgrading from deck.gl v7.2 to v7.3
+
+#### Deprecations
+
+- `layer.setLayerNeedsUpdate` is renamed to `layer.setNeedsUpdate()` and will be removed in the next major release.
+
 ## Upgrading from deck.gl v7.1 to v7.2
 
 #### Breaking Changes

--- a/modules/core/src/lib/composite-layer.js
+++ b/modules/core/src/lib/composite-layer.js
@@ -34,6 +34,10 @@ export default class CompositeLayer extends Layer {
   // Provide empty definition to disable check for missing definition
   initializeState() {}
 
+  shouldUpdateState({oldProps, props, context, changeFlags}) {
+    return changeFlags.propsOrDataChanged || changeFlags.stateChanged;
+  }
+
   // Updates selected state members and marks the composite layer to need rerender
   setState(updateObject) {
     super.setState(updateObject);

--- a/modules/core/src/lib/composite-layer.js
+++ b/modules/core/src/lib/composite-layer.js
@@ -37,7 +37,7 @@ export default class CompositeLayer extends Layer {
   // Updates selected state members and marks the composite layer to need rerender
   setState(updateObject) {
     super.setState(updateObject);
-    this.setLayerNeedsUpdate();
+    this.setNeedsUpdate();
   }
 
   // called to augment the info object that is bubbled up from a sublayer

--- a/modules/core/src/lib/composite-layer.js
+++ b/modules/core/src/lib/composite-layer.js
@@ -34,13 +34,14 @@ export default class CompositeLayer extends Layer {
   // Provide empty definition to disable check for missing definition
   initializeState() {}
 
-  shouldUpdateState({oldProps, props, context, changeFlags}) {
-    return changeFlags.propsOrDataChanged || changeFlags.stateChanged;
-  }
-
   // Updates selected state members and marks the composite layer to need rerender
   setState(updateObject) {
     super.setState(updateObject);
+    // Trigger a layer update
+    // Although conceptually layer.draw and compositeLayer.renderLayers are equivalent,
+    // they are executed during different lifecycles.
+    // draw can be called without calling updateState (e.g. most viewport changes),
+    // while renderLayers can only be called during a recursive layer update.
     this.setNeedsUpdate();
   }
 

--- a/modules/core/src/lib/layer-manager.js
+++ b/modules/core/src/lib/layer-manager.js
@@ -177,9 +177,9 @@ export default class LayerManager {
   /* eslint-enable complexity, max-statements */
 
   // Supply a new layer list, initiating sublayer generation and layer matching
-  setLayers(newLayers, force) {
+  setLayers(newLayers, forceUpdate = false) {
     // TODO - something is generating state updates that cause rerender of the same
-    if (!force && newLayers === this.lastRenderedLayers) {
+    if (!forceUpdate && newLayers === this.lastRenderedLayers) {
       log.log(3, 'Ignoring layer update due to layer array not changed')();
       return this;
     }
@@ -217,7 +217,8 @@ export default class LayerManager {
     if (reason) {
       this.setNeedsRedraw(`updating layers: ${reason}`);
       // Force a full update
-      this.setLayers(this.lastRenderedLayers, true);
+      const forceUpdate = true;
+      this.setLayers(this.lastRenderedLayers, forceUpdate);
     }
   }
 

--- a/modules/core/src/lib/layer-manager.js
+++ b/modules/core/src/lib/layer-manager.js
@@ -177,9 +177,9 @@ export default class LayerManager {
   /* eslint-enable complexity, max-statements */
 
   // Supply a new layer list, initiating sublayer generation and layer matching
-  setLayers(newLayers) {
+  setLayers(newLayers, force) {
     // TODO - something is generating state updates that cause rerender of the same
-    if (newLayers === this.lastRenderedLayers) {
+    if (!force && newLayers === this.lastRenderedLayers) {
       log.log(3, 'Ignoring layer update due to layer array not changed')();
       return this;
     }
@@ -216,8 +216,8 @@ export default class LayerManager {
     const reason = this.needsUpdate();
     if (reason) {
       this.setNeedsRedraw(`updating layers: ${reason}`);
-      // HACK - Call with a copy of lastRenderedLayers to trigger a full update
-      this.setLayers([...this.lastRenderedLayers]);
+      // Force a full update
+      this.setLayers(this.lastRenderedLayers, true);
     }
   }
 

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -122,11 +122,9 @@ export default class Layer extends Component {
   }
 
   // This layer needs a deep update
-  setNeedsUpdate(update = true) {
-    if (update) {
-      this.context.layerManager.setNeedsUpdate(String(this));
-    }
-    this.internalState.needsUpdate = update;
+  setNeedsUpdate() {
+    this.context.layerManager.setNeedsUpdate(String(this));
+    this.internalState.needsUpdate = true;
   }
 
   // Checks state of attributes and model
@@ -660,7 +658,7 @@ export default class Layer extends Component {
     }
 
     this.clearChangeFlags();
-    this.setNeedsUpdate(false);
+    this.internalState.needsUpdate = false;
     this.internalState.resetOldProps();
   }
 

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -122,11 +122,8 @@ export default class Layer extends Component {
   }
 
   // This layer needs a deep update
-  setNeedsUpdate(update = true) {
-    if (update) {
-      this.context.layerManager.setNeedsUpdate(String(this));
-    }
-    this.internalState.needsUpdate = update;
+  setNeedsUpdate() {
+    this.context.layerManager.setNeedsUpdate(String(this));
   }
 
   // Checks state of attributes and model
@@ -137,7 +134,7 @@ export default class Layer extends Component {
   // Checks if layer attributes needs updating
   needsUpdate() {
     // Call subclass lifecycle method
-    return this.internalState.needsUpdate || this.shouldUpdateState(this._getUpdateParams());
+    return this.shouldUpdateState(this._getUpdateParams());
     // End lifecycle method
   }
 
@@ -660,7 +657,6 @@ export default class Layer extends Component {
     }
 
     this.clearChangeFlags();
-    this.setNeedsUpdate(false);
     this.internalState.resetOldProps();
   }
 

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -122,8 +122,11 @@ export default class Layer extends Component {
   }
 
   // This layer needs a deep update
-  setNeedsUpdate() {
-    this.context.layerManager.setNeedsUpdate(String(this));
+  setNeedsUpdate(update = true) {
+    if (update) {
+      this.context.layerManager.setNeedsUpdate(String(this));
+    }
+    this.internalState.needsUpdate = update;
   }
 
   // Checks state of attributes and model
@@ -134,7 +137,7 @@ export default class Layer extends Component {
   // Checks if layer attributes needs updating
   needsUpdate() {
     // Call subclass lifecycle method
-    return this.shouldUpdateState(this._getUpdateParams());
+    return this.internalState.needsUpdate || this.shouldUpdateState(this._getUpdateParams());
     // End lifecycle method
   }
 
@@ -657,6 +660,7 @@ export default class Layer extends Component {
     }
 
     this.clearChangeFlags();
+    this.setNeedsUpdate(false);
     this.internalState.resetOldProps();
   }
 

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -122,10 +122,11 @@ export default class Layer extends Component {
   }
 
   // This layer needs a deep update
-  // TODO - Need to align with existing needsUpdate before uncommenting
-  // For now async props will call layerManager directly
-  setLayerNeedsUpdate() {
-    this.context.layerManager.setNeedsUpdate(String(this));
+  setNeedsUpdate(update = true) {
+    if (update) {
+      this.context.layerManager.setNeedsUpdate(String(this));
+    }
+    this.internalState.needsUpdate = update;
   }
 
   // Checks state of attributes and model
@@ -136,7 +137,7 @@ export default class Layer extends Component {
   // Checks if layer attributes needs updating
   needsUpdate() {
     // Call subclass lifecycle method
-    return this.shouldUpdateState(this._getUpdateParams());
+    return this.internalState.needsUpdate || this.shouldUpdateState(this._getUpdateParams());
     // End lifecycle method
   }
 
@@ -659,6 +660,7 @@ export default class Layer extends Component {
     }
 
     this.clearChangeFlags();
+    this.setNeedsUpdate(false);
     this.internalState.resetOldProps();
   }
 
@@ -943,7 +945,7 @@ ${flags.viewportChanged ? 'viewport' : ''}\
 
   _onAsyncPropUpdated() {
     this.diffProps(this.props, this.internalState.getOldProps());
-    this.setLayerNeedsUpdate();
+    this.setNeedsUpdate();
   }
 
   // Operate on each changed triggers, will be called when an updateTrigger changes
@@ -965,6 +967,12 @@ ${flags.viewportChanged ? 'viewport' : ''}\
   }
 
   // DEPRECATED METHODS
+
+  // TODO - remove in v8
+  setLayerNeedsUpdate() {
+    log.deprecated('layer.setLayerNeedsUpdate', 'layer.setNeedsUpdate')();
+    this.setNeedsUpdate();
+  }
 
   // Updates selected state members and marks the object for redraw
   setUniforms(uniformMap) {


### PR DESCRIPTION
#### Background

Current behavior:

If `setState` is called inside of a composite layer, a full update is triggered on `layerManager` but sublayer props are not updated. This is because `shouldUpdateState` by default returns `false` on just state change.

Expected behavior:

If `setState` is called inside of a composite layer, `compositeLayer.renderLayers()` should be called to "redraw" sublayers.

#### Change List
- update composite layers on state change
- rename `setLayerNeedsUpdate` to `setNeedsUpdate` to align with other classes
- add tests
