### PR TITLE
Use HTMLImageLoader for browser compatibility

### DIFF
--- a/modules/core/src/lib/init.js
+++ b/modules/core/src/lib/init.js
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 import {registerLoaders} from '@loaders.gl/core';
-import {ImageLoader} from '@loaders.gl/images';
+import {HTMLImageLoader} from '@loaders.gl/images';
 
 import {global} from '../utils/globals';
 import log from '../utils/log';
@@ -47,7 +47,7 @@ if (!global.deck) {
     log
   };
 
-  registerLoaders([jsonLoader, [ImageLoader, {imageOrientation: 'flipY'}]]);
+  registerLoaders([jsonLoader, HTMLImageLoader]);
 
   initializeShaderModules();
 }


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/3436

Revert back to HTMLImageLoader for now to unblock. In the long term:

- loaders.gl should detect browser support before using `options` in `createImageBitmap`
- To remove the need for `flipY` option in `createImageBitmap`, we need to flip all textures by setting `unpackFlipY: false` for `Texture2D` (only works for DOM elements as data source) and update the shaders. This will be a breaking change. We may also want to introduce a layer prop to revert the behavior.

#### Change List
- Fix texture loading in FF
