### PR TITLE
[POC] generic prop transition

### DIFF
--- a/dev-docs/RFCs/v7.x/property-transition-rfc.md
+++ b/dev-docs/RFCs/v7.x/property-transition-rfc.md
@@ -2,8 +2,8 @@
 
 > Note: This RFC Makes a strong distinction between "animation" and "transitions". For information the distinction, see the introduction, for more information aboutabout property animation, see the complementary RFC about that topic.
 
-* **Authors**: Ib Green, ...
-* **Date**: Aug 2018 (Initial version Aug 2017)
+* **Authors**: Ib Green, Xiaoji Chen
+* **Date**: Aug 2019 (Initial version Aug 2017)
 * **Status**: **Draft**
 
 
@@ -41,11 +41,15 @@ The following types of animations are not included in this RFC.
 
 ### Background - Current State
 
-In deck.gl v4.1:
-* layers are only redrawn when the dirty flag of at least one layer is set, or when the viewport changes.
-* layer dirty flags are only set when new layers are actually provided by the application (which typically happens when application state changes).
+In deck.gl v7.2:
 
-
+* layers support attribute transition with the `transitions` prop, where accessor names are used as keys.
+* layers are redrawn if:
+  - user provided a new layer instance with changed props (as defined by the prop type)
+  - the viewport changes
+  - there is an ongoing attribute transition
+  - an async prop is loaded
+  - layer state has changed via calling `setState` internally
 
 ## Proposal: Automatic interpolation of properties
 
@@ -66,7 +70,7 @@ Options:
 
 ### Issue: Dependence on a PropTypes System
 
-Reference: See the separate [prop-types RFC]()
+Reference: See the separate [prop-types RFC](/dev-docs/RFCs/v6.3/prop-types-rfc.md)
 
 A prop-types system would allow deck.gl to see if a certain property is interpolatable at all. If the prop is an integer or a float, or a color the interpolation strategy is clear, if a function or string we should not attempt interpolation. And deck.gl could start small, and gradually add interpolation support for more types as the system was built out.
 

--- a/examples/website/3d-heatmap/app.js
+++ b/examples/website/3d-heatmap/app.js
@@ -1,4 +1,3 @@
-/* global window */
 import React, {Component} from 'react';
 import {render} from 'react-dom';
 import {StaticMap} from 'react-map-gl';
@@ -95,7 +94,7 @@ export class App extends Component {
         material,
 
         transitions: {
-          elevationScale: 1000
+          elevationScale: 3000
         }
       })
     ];

--- a/examples/website/3d-heatmap/app.js
+++ b/examples/website/3d-heatmap/app.js
@@ -72,50 +72,6 @@ export class App extends Component {
     this.state = {
       elevationScale: elevationScale.min
     };
-
-    this.startAnimationTimer = null;
-    this.intervalTimer = null;
-
-    this._startAnimate = this._startAnimate.bind(this);
-    this._animateHeight = this._animateHeight.bind(this);
-  }
-
-  componentDidMount() {
-    this._animate();
-  }
-
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.data && this.props.data && nextProps.data.length !== this.props.data.length) {
-      this._animate();
-    }
-  }
-
-  componentWillUnmount() {
-    this._stopAnimate();
-  }
-
-  _animate() {
-    this._stopAnimate();
-
-    // wait 1.5 secs to start animation so that all data are loaded
-    this.startAnimationTimer = window.setTimeout(this._startAnimate, 1500);
-  }
-
-  _startAnimate() {
-    this.intervalTimer = window.setInterval(this._animateHeight, 20);
-  }
-
-  _stopAnimate() {
-    window.clearTimeout(this.startAnimationTimer);
-    window.clearTimeout(this.intervalTimer);
-  }
-
-  _animateHeight() {
-    if (this.state.elevationScale === elevationScale.max) {
-      this._stopAnimate();
-    } else {
-      this.setState({elevationScale: this.state.elevationScale + 1});
-    }
   }
 
   _renderLayers() {
@@ -128,7 +84,7 @@ export class App extends Component {
         coverage,
         data,
         elevationRange: [0, 3000],
-        elevationScale: this.state.elevationScale,
+        elevationScale: data && data.length ? 50 : 0,
         extruded: true,
         getPosition: d => d,
         onHover: this.props.onHover,
@@ -136,7 +92,11 @@ export class App extends Component {
         pickable: Boolean(this.props.onHover),
         radius,
         upperPercentile,
-        material
+        material,
+
+        transitions: {
+          elevationScale: 1000
+        }
       })
     ];
   }

--- a/modules/aggregation-layers/src/hexagon-layer/hexagon-layer.js
+++ b/modules/aggregation-layers/src/hexagon-layer/hexagon-layer.js
@@ -411,6 +411,8 @@ export default class HexagonLayer extends CompositeLayer {
         getFillColor: this._onGetSublayerColor.bind(this),
         getElevation: this._onGetSublayerElevation.bind(this),
         transitions: transitions && {
+          elevationScale: transitions.elevationScale,
+          coverage: transitions.coverage,
           getFillColor: transitions.getColorValue || transitions.getColorWeight,
           getElevation: transitions.getElevationValue || transitions.getElevationWeight
         }

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -33,6 +33,7 @@
     "@loaders.gl/core": "^1.2.0-beta.4",
     "@loaders.gl/images": "^1.2.0-beta.4",
     "@luma.gl/core": "^7.2.0",
+    "@luma.gl/addons": "^7.2.0",
     "gl-matrix": "^3.0.0",
     "math.gl": "^2.3.0",
     "mjolnir.js": "^2.1.2",

--- a/modules/core/src/lib/attribute-transition-manager.js
+++ b/modules/core/src/lib/attribute-transition-manager.js
@@ -7,15 +7,6 @@ import Transition from '../transitions/transition';
 import log from '../utils/log';
 import assert from '../utils/assert';
 
-const noop = () => {};
-const DEFAULT_TRANSITION_SETTINGS = {
-  duration: 0,
-  easing: t => t,
-  onStart: noop,
-  onEnd: noop,
-  onInterrupt: noop
-};
-
 export default class AttributeTransitionManager {
   constructor(gl, {id}) {
     this.id = id;
@@ -289,11 +280,9 @@ export default class AttributeTransitionManager {
 
     this.needsRedraw = true;
 
-    const transitionSettings = Object.assign({}, DEFAULT_TRANSITION_SETTINGS, settings);
-
     // Attribute descriptor to transition from
     transition.start(
-      Object.assign({}, this._getNextTransitionStates(transition, settings), transitionSettings)
+      Object.assign({}, this._getNextTransitionStates(transition, settings), settings)
     );
   }
 }

--- a/modules/core/src/lib/attribute-transition-utils.js
+++ b/modules/core/src/lib/attribute-transition-utils.js
@@ -8,6 +8,28 @@ const ATTRIBUTE_MAPPING = {
   4: 'vec4'
 };
 
+const noop = () => {};
+const DEFAULT_TRANSITION_SETTINGS = {
+  duration: 0,
+  easing: t => t,
+  onStart: noop,
+  onEnd: noop,
+  onInterrupt: noop
+};
+
+export function normalizeTransitionSettings(settings) {
+  if (!settings) {
+    return null;
+  }
+  if (Number.isFinite(settings)) {
+    settings = {duration: settings};
+  }
+  if (!settings.duration) {
+    return null;
+  }
+  return Object.assign({}, DEFAULT_TRANSITION_SETTINGS, settings);
+}
+
 export function getShaders(transitions) {
   // Build shaders
   const varyings = [];

--- a/modules/core/src/lib/attribute.js
+++ b/modules/core/src/lib/attribute.js
@@ -8,6 +8,7 @@ import * as range from '../utils/range';
 import log from '../utils/log';
 import BaseAttribute from './base-attribute';
 import typedArrayManager from '../utils/typed-array-manager';
+import {normalizeTransitionSettings} from './attribute-transition-utils';
 
 const DEFAULT_STATE = {
   isExternalBuffer: false,
@@ -143,11 +144,9 @@ export default class Attribute extends BaseAttribute {
     let settings = Array.isArray(accessor) ? opts[accessor.find(a => opts[a])] : opts[accessor];
 
     // Shorthand: use duration instead of parameter object
-    if (Number.isFinite(settings)) {
-      settings = {duration: settings};
-    }
+    settings = normalizeTransitionSettings(settings);
 
-    if (settings && settings.duration > 0) {
+    if (settings) {
       return Object.assign({}, transition, settings);
     }
 

--- a/modules/core/src/lib/layer-manager.js
+++ b/modules/core/src/lib/layer-manager.js
@@ -20,6 +20,7 @@
 
 import assert from '../utils/assert';
 import {_ShaderCache as ShaderCache} from '@luma.gl/core';
+import {Timeline} from '@luma.gl/addons';
 import seer from 'seer';
 import Layer from './layer';
 import {LIFECYCLE} from '../lifecycle/constants';
@@ -45,7 +46,6 @@ const INITIAL_CONTEXT = Object.seal({
   layerManager: null,
   deck: null,
   gl: null,
-  time: -1,
 
   // Settings
   useDevicePixels: true, // Exposed in case custom layers need to adjust sizes
@@ -88,7 +88,8 @@ export default class LayerManager {
       shaderCache: gl && new ShaderCache({gl, _cachePrograms: true}),
       stats: stats || new Stats({id: 'deck.gl'}),
       // Make sure context.viewport is not empty on the first layer initialization
-      viewport: viewport || new Viewport({id: 'DEFAULT-INITIAL-VIEWPORT'}) // Current viewport, exposed to layers for project* function
+      viewport: viewport || new Viewport({id: 'DEFAULT-INITIAL-VIEWPORT'}), // Current viewport, exposed to layers for project* function
+      timeline: new Timeline()
     });
 
     this._needsRedraw = 'Initial render';
@@ -208,7 +209,7 @@ export default class LayerManager {
   // Update layers from last cycle if `setNeedsUpdate()` has been called
   updateLayers(animationProps = {}) {
     if ('time' in animationProps) {
-      this.context.time = animationProps.time;
+      this.context.timeline.setTime(animationProps.time);
     }
     // NOTE: For now, even if only some layer has changed, we update all layers
     // to ensure that layer id maps etc remain consistent even if different

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -23,6 +23,7 @@
 import {COORDINATE_SYSTEM} from './constants';
 import AttributeManager from './attribute-manager';
 import {removeLayerInSeer} from './seer-integration';
+import UniformTransitionManager from './uniform-transition-manager';
 import {diffProps, validateProps} from '../lifecycle/props';
 import {count} from '../utils/count';
 import log from '../utils/log';
@@ -324,6 +325,13 @@ export default class Layer extends Component {
         attributeManager.invalidateAll();
       }
     }
+
+    if (!this.isComposite && changeFlags.transitionsChanged) {
+      for (const key in changeFlags.transitionsChanged) {
+        // prop changed and transition is enabled
+        this.internalState.transitions.add(key, oldProps[key], props[key], props.transitions[key]);
+      }
+    }
   }
 
   // Called once when layer is no longer matched and state will be discarded
@@ -336,6 +344,7 @@ export default class Layer extends Component {
     if (attributeManager) {
       attributeManager.finalize();
     }
+    this.internalState.transitions.clear();
   }
 
   // If state has a model, draw it with supplied uniforms
@@ -417,12 +426,24 @@ export default class Layer extends Component {
     this.updateAttributes(changedAttributes);
   }
 
-  // Update attribute transition
+  // Update attribute and uniform transitions, returns props in transition
   updateTransition() {
     const attributeManager = this.getAttributeManager();
     if (attributeManager) {
-      attributeManager.updateTransition(this.context.time);
+      attributeManager.updateTransition(this.context.timeline.getTime());
     }
+
+    const {transitions} = this.internalState;
+    if (transitions.size > 0) {
+      // clone props
+      const propsInTransition = transitions.update();
+      const props = Object.create(this.props);
+      for (const key in propsInTransition) {
+        Object.defineProperty(props, key, {value: propsInTransition[key]});
+      }
+      return props;
+    }
+    return this.props;
   }
 
   calculateInstancePickingColors(attribute, {numInstances}) {
@@ -650,7 +671,6 @@ export default class Layer extends Component {
       this.setNeedsRedraw();
       // Add any subclass attributes
       this._updateAttributes(this.props);
-      this._updateBaseUniforms();
 
       // Note: Automatic instance count update only works for single layers
       if (this.state.model) {
@@ -679,21 +699,19 @@ export default class Layer extends Component {
 
   // Calculates uniforms
   drawLayer({moduleParameters = null, uniforms = {}, parameters = {}}) {
+    const currentProps = this.props;
     if (!uniforms.picking_uActive) {
-      this.updateTransition();
+      // Overwrite this.props during redraw to use in-transition prop values
+      this.props = this.updateTransition();
     }
+
+    const {opacity} = this.props;
+    // apply gamma to opacity to make it visually "linear"
+    uniforms.opacity = Math.pow(opacity, 1 / 2.2);
 
     // TODO/ib - hack move to luma Model.draw
     if (moduleParameters) {
       this.setModuleParameters(moduleParameters);
-    }
-
-    // Hack/ib - define a public luma function
-    const {animationProps} = this.context;
-    if (animationProps) {
-      for (const model of this.getModels()) {
-        model._setAnimationProps(animationProps);
-      }
     }
 
     // Apply polygon offset to avoid z-fighting
@@ -707,6 +725,12 @@ export default class Layer extends Component {
       this.draw({moduleParameters, uniforms, parameters, context: this.context});
     });
     // End lifecycle method
+
+    this.props = currentProps;
+    if (this.internalState.transitions.size) {
+      // contains animation
+      this.setNeedsRedraw();
+    }
   }
 
   // {uniforms = {}, ...opts}
@@ -766,6 +790,7 @@ export default class Layer extends Component {
       changeFlags.stateChanged = flags.stateChanged;
       log.log(LOG_PRIORITY_UPDATE + 1, () => `stateChanged: ${flags.stateChanged} in ${this.id}`)();
     }
+    changeFlags.transitionsChanged = changeFlags.transitionsChanged || flags.transitionsChanged;
 
     // Update composite flags
     const propsOrDataChanged =
@@ -903,7 +928,7 @@ ${flags.viewportChanged ? 'viewport' : ''}\
     this.state = {};
     // TODO deprecated, for backwards compatibility with older layers
     this.state.attributeManager = attributeManager;
-
+    this.internalState.transitions = new UniformTransitionManager(this.context.timeline);
     this.internalState.onAsyncPropUpdated = this._onAsyncPropUpdated.bind(this);
 
     // Ensure any async props are updated
@@ -949,19 +974,6 @@ ${flags.viewportChanged ? 'viewport' : ''}\
   // Operate on each changed triggers, will be called when an updateTrigger changes
   _activeUpdateTrigger(propName) {
     this.invalidateAttribute(propName);
-  }
-
-  _updateBaseUniforms() {
-    const uniforms = {
-      // apply gamma to opacity to make it visually "linear"
-      opacity:
-        typeof this.props.opacity === 'function'
-          ? animationProps => Math.pow(this.props.opacity(animationProps), 1 / 2.2)
-          : Math.pow(this.props.opacity, 1 / 2.2)
-    };
-    for (const model of this.getModels()) {
-      model.setUniforms(uniforms);
-    }
   }
 
   // DEPRECATED METHODS

--- a/modules/core/src/lib/uniform-transition-manager.js
+++ b/modules/core/src/lib/uniform-transition-manager.js
@@ -1,0 +1,67 @@
+import {lerp} from 'math.gl';
+import {normalizeTransitionSettings} from './attribute-transition-utils';
+
+export default class UniformTransitionManager {
+  constructor(timeline) {
+    this.transitions = new Map();
+    this.timeline = timeline;
+  }
+
+  get size() {
+    return this.transitions.size;
+  }
+
+  add(key, fromValue, toValue, settings) {
+    const {transitions} = this;
+    const existingTransition = transitions.get(key);
+    if (existingTransition) {
+      existingTransition.onInterrupt();
+      this.remove(key);
+    }
+
+    settings = normalizeTransitionSettings(settings);
+    if (!settings) {
+      return;
+    }
+    transitions.set(key, Object.assign({fromValue, toValue}, settings));
+  }
+
+  remove(key) {
+    const {transitions} = this;
+    this.timeline.removeChannel(transitions.get(key).handle);
+    transitions.delete(key);
+  }
+
+  update() {
+    const propsInTransition = {};
+    const {timeline} = this;
+
+    for (const [key, transition] of this.transitions) {
+      const {fromValue, toValue, duration, easing} = transition;
+      let time = 0;
+      if (transition.handle) {
+        time = timeline.getTime(transition.handle);
+      } else {
+        transition.onStart();
+        transition.handle = timeline.addChannel({
+          delay: timeline.getTime(),
+          duration: transition.duration
+        });
+      }
+
+      if (time >= duration) {
+        transition.onEnd();
+        this.remove(key);
+      }
+      propsInTransition[key] = lerp(fromValue, toValue, easing(time / duration));
+    }
+
+    return propsInTransition;
+  }
+
+  clear() {
+    for (const key of this.transitions.keys()) {
+      this.remove(key);
+    }
+  }
+}

--- a/modules/core/src/lifecycle/props.js
+++ b/modules/core/src/lifecycle/props.js
@@ -19,7 +19,7 @@ export function diffProps(props, oldProps) {
     newProps: props,
     oldProps,
     propTypes: getPropTypes(props),
-    ignoreProps: {data: null, updateTriggers: null, extensions: null}
+    ignoreProps: {data: null, updateTriggers: null, extensions: null, transitions: null}
   });
 
   // Now check if any data related props have changed
@@ -36,8 +36,27 @@ export function diffProps(props, oldProps) {
     dataChanged: dataChangedReason,
     propsChanged: propsChangedReason,
     updateTriggersChanged: updateTriggersChangedReason,
-    extensionsChanged: diffExtensions(props, oldProps)
+    extensionsChanged: diffExtensions(props, oldProps),
+    transitionsChanged: diffTransitions(props, oldProps)
   };
+}
+
+function diffTransitions(props, oldProps) {
+  if (!props.transitions) {
+    return null;
+  }
+  const result = {};
+  const propTypes = getPropTypes(props);
+
+  for (const key in props.transitions) {
+    const propType = propTypes[key];
+    const type = propType && propType.type;
+    const isTransitionable = type === 'number' || type === 'color' || type === 'array';
+    if (isTransitionable && comparePropValues(props[key], oldProps[key], propType)) {
+      result[key] = true;
+    }
+  }
+  return result;
 }
 
 /**


### PR DESCRIPTION
For https://github.com/uber/deck.gl/blob/master/dev-docs/RFCs/v7.x/property-transition-rfc.md

#### Change List

- Update prop transition RFC
- Drop support for luma-style function uniforms
- Support uniform transition in primitive layers
- Support `elevationScale` and `coverage` transitions in HexagonLayer
- Update HexagonLayer example

#### TODO

- Update all composite layers to map prop transition settings
- Update layer docs to mark transition-enabled props
- Tests