### PR TITLE
Add warnings for invalid layer types in JSONConverter

### DIFF
--- a/modules/json/src/parsers/convert-json.js
+++ b/modules/json/src/parsers/convert-json.js
@@ -74,7 +74,7 @@ function convertJSONMapProps(jsonProps, configuration) {
 function convertJSONLayers(jsonLayers, configuration) {
   for (const layer of jsonLayers) {
     if (!configuration.layers[layer.type]) {
-      log.warn(`Unknown layer ${layer.type}`);
+      log.warn(`Unknown layer ${layer.type}`)();
     }
   }
   return [

--- a/modules/json/src/parsers/convert-json.js
+++ b/modules/json/src/parsers/convert-json.js
@@ -117,9 +117,6 @@ export function getJSONLayers(jsonLayers = [], configuration) {
   const layerCatalog = configuration.layers || {};
   return jsonLayers.map(jsonLayer => {
     const Layer = layerCatalog[jsonLayer.type];
-    if (!Layer) {
-      log.warn(`No layer named ${jsonLayer.type}`)();
-    }
     const props = getJSONLayerProps(Layer, jsonLayer, configuration);
     props.fetch = enhancedFetch;
     return Layer && new Layer(props);

--- a/modules/json/src/parsers/convert-json.js
+++ b/modules/json/src/parsers/convert-json.js
@@ -8,8 +8,11 @@
 // * Optionally, error checking could be applied, but ideally should leverage
 //   non-JSON specific mechanisms like prop types.
 
+import {log} from '@deck.gl/core';
+
 import {MapView, FirstPersonView, OrbitView, OrthographicView} from '@deck.gl/core';
 import JSONLayer from '../json-layer/json-layer';
+
 import parseStringExpression from './parse-string-expression';
 // TODO - replace with loaders.gl
 import enhancedFetch from './enhanced-fetch';
@@ -69,6 +72,11 @@ function convertJSONMapProps(jsonProps, configuration) {
 
 // Use the composite JSONLayer to render any JSON layers
 function convertJSONLayers(jsonLayers, configuration) {
+  for (const layer of jsonLayers) {
+    if (!configuration.layers[layer.type]) {
+      log.warn(`Unknown layer ${layer.type}`);
+    }
+  }
   return [
     new JSONLayer({
       data: jsonLayers,
@@ -109,6 +117,9 @@ export function getJSONLayers(jsonLayers = [], configuration) {
   const layerCatalog = configuration.layers || {};
   return jsonLayers.map(jsonLayer => {
     const Layer = layerCatalog[jsonLayer.type];
+    if (!Layer) {
+      log.warn(`No layer named ${jsonLayer.type}`)();
+    }
     const props = getJSONLayerProps(Layer, jsonLayer, configuration);
     props.fetch = enhancedFetch;
     return Layer && new Layer(props);

--- a/test/modules/json/json-converter.spec.js
+++ b/test/modules/json/json-converter.spec.js
@@ -1,5 +1,9 @@
 import test from 'tape-catch';
+
+import {makeSpy} from '@probe.gl/test-utils';
 import {_JSONConverter as JSONConverter, _JSONLayer as JSONLayer} from '@deck.gl/json';
+
+import {log} from '@deck.gl/core';
 
 import {COORDINATE_SYSTEM} from '@deck.gl/core';
 import GL from '@luma.gl/constants';
@@ -79,5 +83,17 @@ test('JSONConverter#convert', t => {
   t.is(layer && layer.constructor, JSONLayer, 'JSONConverter created JSONLayer');
   t.is(layer.props.data.length, 2, 'JSONLayer has data');
 
+  t.end();
+});
+
+test('JSONConverter#badConvert', t => {
+  makeSpy(log, 'warn');
+  const jsonConverter = new JSONConverter({configuration});
+  t.ok(jsonConverter, 'JSONConverter created');
+  const badData = JSON.parse(JSON.stringify(JSON_DATA));
+  badData.layers[0].type = 'InvalidLayer';
+  jsonConverter.convertJsonToDeckProps(badData);
+  t.ok(log.warn.called, 'should produce a warning message if the layer type is invalid');
+  log.warn.restore();
   t.end();
 });


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #2929 
<!-- For other PRs without open issue -->
#### Background
This helps support additional alerting for pydeck and warns a user if a layer name passed is invalid
<!-- For all the PRs -->
#### Change List
- Add warning to json converter
