### PR TITLE
Add transform and enable options to attribute class

### DIFF
--- a/docs/api-reference/attribute-manager.md
+++ b/docs/api-reference/attribute-manager.md
@@ -64,13 +64,16 @@ Takes a single parameter as a map of attribute descriptor objects:
   + `accessor` (String | Array of strings | Function) - accessor name(s) that will
     trigger an update of this attribute when changed. Used with
     [`updateTriggers`](/docs/api-reference/layer.md#-updatetriggers-object-optional-).
-  + `update` (Function) - the function to be called when data changes
+  + `transform` (Function, optional) - callback to process the result returned by `accessor`.
+  + `update` (Function, optional) - the function to be called when data changes. If not supplied, the attribute will be auto-filled with `accessor`.
+  + `enable` (Function, optional) - callback to determine if the attribute is enabled. If an attribute is disabled, it will receive a constant value that is the `defaultValue`. Default always returns `true`.
   + `instanced` (Boolean, optional) - if this is an instanced attribute
     (a.k.a. divisor). Default to `false`.
   + `isIndexed` (Boolean, optional) - if this is an index attribute
     (a.k.a. indices). Default to `false`.
   + `constant` (Boolean, optional) - if this is a generic attribute
     (same value applied to every vertex). Default to `false`.
+  + `defaultValue` (Number | Array of numbers, optional) - Default `[0, 0, 0, 0]`.
   + `noAlloc` (Boolean, optional) - if this attribute should not be
     automatically allocated. Default to `false`.
   + `shaderAttributes` (Object, optional) - If this attribute maps to multiple

--- a/modules/core/src/index.js
+++ b/modules/core/src/index.js
@@ -87,7 +87,7 @@ export {default as log} from './utils/log';
 import {flattenVertices, fillArray} from './utils/flatten'; // Export? move to luma.gl or math.gl?
 
 export {createIterable} from './utils/iterable-utils';
-export {fp64LowPart} from './utils/math-utils';
+export {fp64LowPart, positionFp64LowPart} from './utils/math-utils';
 import Tesselator from './utils/tesselator'; // Export? move to luma.gl or math.gl?
 import {count} from './utils/count';
 import memoize from './utils/memoize';

--- a/modules/core/src/lib/attribute-manager.js
+++ b/modules/core/src/lib/attribute-manager.js
@@ -232,7 +232,9 @@ export default class AttributeManager {
     for (const attributeName in this.attributes) {
       const attribute = this.attributes[attributeName];
 
-      if (
+      if (!attribute.isEnabled(context)) {
+        attribute.disable();
+      } else if (
         attribute.setExternalBuffer(
           buffers[attributeName] || (data.attributes && data.attributes[attributeName])
         )

--- a/modules/core/src/lib/attribute-manager.js
+++ b/modules/core/src/lib/attribute-manager.js
@@ -240,7 +240,7 @@ export default class AttributeManager {
         )
       ) {
         // Attribute is using external buffer from the props
-      } else if (attribute.setGenericValue(props[attribute.getAccessor()])) {
+      } else if (attribute.setConstantValue(props[attribute.getAccessor()])) {
         // Attribute is using generic value from the props
       } else if (attribute.needsUpdate()) {
         updated = true;

--- a/modules/core/src/lib/attribute.js
+++ b/modules/core/src/lib/attribute.js
@@ -281,12 +281,12 @@ export default class Attribute extends BaseAttribute {
   }
 
   disable() {
-    this.setGenericValue(this.userData.defaultValue);
+    this.setConstantValue(this.userData.defaultValue);
   }
 
   // Use generic value
   // Returns true if successful
-  setGenericValue(value) {
+  setConstantValue(value) {
     const state = this.userData;
 
     if (value === undefined || typeof value === 'function') {
@@ -419,6 +419,8 @@ export default class Attribute extends BaseAttribute {
 
       let objectValue = accessorFunc(object, objectInfo);
       if (transform) {
+        // transform callbacks could be bound to a particular layer instance.
+        // always point `this` to the current layer.
         objectValue = transform.call(this, objectValue);
       }
 

--- a/modules/core/src/utils/math-utils.js
+++ b/modules/core/src/utils/math-utils.js
@@ -110,9 +110,23 @@ export function getFrustumPlanes({aspect, near, far, fovyRadians, position, dire
 
 /**
  * Calculate the low part of a WebGL 64 bit float
- * @param a {number} - the input float number
+ * @param x {number} - the input float number
  * @returns {number} - the lower 32 bit of the number
  */
 export function fp64LowPart(x) {
   return x - Math.fround(x);
+}
+
+/**
+ * Calculate the low part of a position
+ * @param array {number} - the input position
+ * @returns {array} - the lower 32 bit of the position
+ */
+const target = new Array(2);
+export function positionFp64LowPart(array) {
+  target[0] = fp64LowPart(array[0]);
+  target[1] = fp64LowPart(array[1]);
+  // TODO - support 64-bit in z
+  // target[2] = fp64LowPart(array[2] || 0);
+  return target;
 }

--- a/modules/layers/src/arc-layer/arc-layer.js
+++ b/modules/layers/src/arc-layer/arc-layer.js
@@ -187,6 +187,7 @@ export default class ArcLayer extends Layer {
     }
   }
 
+  // TODO - split into two attributes and use attribute transform
   calculateInstancePositions64Low(attribute, {startRow, endRow}) {
     const isFP64 = this.use64bitPositions();
     attribute.constant = !isFP64;

--- a/modules/layers/src/column-layer/column-layer.js
+++ b/modules/layers/src/column-layer/column-layer.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {Layer, createIterable, fp64LowPart} from '@deck.gl/core';
+import {Layer, positionFp64LowPart} from '@deck.gl/core';
 import GL from '@luma.gl/constants';
 import {Model, PhongMaterial} from '@luma.gl/core';
 import ColumnGeometry from './column-geometry';
@@ -83,7 +83,8 @@ export default class ColumnLayer extends Layer {
       instancePositions64xyLow: {
         size: 2,
         accessor: 'getPosition',
-        update: this.calculateInstancePositions64xyLow
+        enable: this.use64bitPositions,
+        transform: positionFp64LowPart
       },
       instanceFillColors: {
         size: this.props.colorFormat.length,
@@ -245,27 +246,6 @@ export default class ColumnLayer extends Layer {
         .setDrawMode(GL.TRIANGLE_STRIP)
         .setUniforms({isStroke: true})
         .draw();
-    }
-  }
-
-  calculateInstancePositions64xyLow(attribute, {startRow, endRow}) {
-    const isFP64 = this.use64bitPositions();
-    attribute.constant = !isFP64;
-
-    if (!isFP64) {
-      attribute.value = new Float32Array(2);
-      return;
-    }
-
-    const {data, getPosition} = this.props;
-    const {value, size} = attribute;
-    let i = startRow * size;
-    const {iterable, objectInfo} = createIterable(data, startRow, endRow);
-    for (const object of iterable) {
-      objectInfo.index++;
-      const position = getPosition(object, objectInfo);
-      value[i++] = fp64LowPart(position[0]);
-      value[i++] = fp64LowPart(position[1]);
     }
   }
 }

--- a/modules/layers/src/icon-layer/icon-manager.js
+++ b/modules/layers/src/icon-layer/icon-manager.js
@@ -208,8 +208,7 @@ export default class IconManager {
     return this._texture || this._externalTexture;
   }
 
-  getIconMapping(object, objectInfo) {
-    const icon = this._getIcon(object, objectInfo);
+  getIconMapping(icon) {
     const id = this._autoPacking ? getIconId(icon) : icon;
     return this._mapping[id] || {};
   }

--- a/modules/layers/src/line-layer/line-layer.js
+++ b/modules/layers/src/line-layer/line-layer.js
@@ -141,6 +141,7 @@ export default class LineLayer extends Layer {
     );
   }
 
+  // TODO - split into two attributes and use attribute transform
   calculateInstanceSourceTargetPositions64xyLow(attribute, {startRow, endRow}) {
     const isFP64 = this.use64bitPositions();
     attribute.constant = !isFP64;

--- a/modules/layers/src/point-cloud-layer/point-cloud-layer.js
+++ b/modules/layers/src/point-cloud-layer/point-cloud-layer.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {Layer, createIterable, fp64LowPart} from '@deck.gl/core';
+import {Layer, positionFp64LowPart} from '@deck.gl/core';
 import GL from '@luma.gl/constants';
 import {Model, Geometry, PhongMaterial} from '@luma.gl/core';
 
@@ -80,7 +80,8 @@ export default class PointCloudLayer extends Layer {
       instancePositions64xyLow: {
         size: 2,
         accessor: 'getPosition',
-        update: this.calculateInstancePositions64xyLow
+        enable: this.use64bitPositions,
+        transform: positionFp64LowPart
       },
       instanceNormals: {
         size: 3,
@@ -152,27 +153,6 @@ export default class PointCloudLayer extends Layer {
         shaderCache: this.context.shaderCache
       })
     );
-  }
-
-  calculateInstancePositions64xyLow(attribute, {startRow, endRow}) {
-    const isFP64 = this.use64bitPositions();
-    attribute.constant = !isFP64;
-
-    if (!isFP64) {
-      attribute.value = new Float32Array(2);
-      return;
-    }
-
-    const {data, getPosition} = this.props;
-    const {value, size} = attribute;
-    let i = startRow * size;
-    const {iterable, objectInfo} = createIterable(data, startRow, endRow);
-    for (const object of iterable) {
-      objectInfo.index++;
-      const position = getPosition(object, objectInfo);
-      value[i++] = fp64LowPart(position[0]);
-      value[i++] = fp64LowPart(position[1]);
-    }
   }
 }
 

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer.js
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {Layer, createIterable, fp64LowPart} from '@deck.gl/core';
+import {Layer, positionFp64LowPart} from '@deck.gl/core';
 import GL from '@luma.gl/constants';
 import {Model, Geometry} from '@luma.gl/core';
 
@@ -67,7 +67,8 @@ export default class ScatterplotLayer extends Layer {
       instancePositions64xyLow: {
         size: 2,
         accessor: 'getPosition',
-        update: this.calculateInstancePositions64xyLow
+        enable: this.use64bitPositions,
+        transform: positionFp64LowPart
       },
       instanceRadius: {
         size: 1,
@@ -164,27 +165,6 @@ export default class ScatterplotLayer extends Layer {
         shaderCache: this.context.shaderCache
       })
     );
-  }
-
-  calculateInstancePositions64xyLow(attribute, {startRow, endRow}) {
-    const isFP64 = this.use64bitPositions();
-    attribute.constant = !isFP64;
-
-    if (!isFP64) {
-      attribute.value = new Float32Array(2);
-      return;
-    }
-
-    const {data, getPosition} = this.props;
-    const {value, size} = attribute;
-    let i = startRow * size;
-    const {iterable, objectInfo} = createIterable(data, startRow, endRow);
-    for (const object of iterable) {
-      objectInfo.index++;
-      const position = getPosition(object, objectInfo);
-      value[i++] = fp64LowPart(position[0]);
-      value[i++] = fp64LowPart(position[1]);
-    }
   }
 }
 

--- a/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer.js
+++ b/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer.js
@@ -59,6 +59,11 @@ export default class MultiIconLayer extends IconLayer {
 
     const attributeManager = this.getAttributeManager();
     attributeManager.addInstanced({
+      instanceOffsets: {
+        size: 2,
+        accessor: 'getIcon',
+        update: this.calculateInstanceOffsets
+      },
       instancePixelOffset: {
         size: 2,
         transition: true,

--- a/modules/main/src/index.js
+++ b/modules/main/src/index.js
@@ -76,6 +76,7 @@ export {
   LayerExtension,
   // Utilities
   fp64LowPart,
+  positionFp64LowPart,
   createIterable
 } from '@deck.gl/core';
 

--- a/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.js
+++ b/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {Layer, createIterable, fp64LowPart} from '@deck.gl/core';
+import {Layer, positionFp64LowPart} from '@deck.gl/core';
 import {ScenegraphNode, isWebGL2, pbr, log} from '@luma.gl/core';
 import {createGLTFObjects} from '@luma.gl/addons';
 import GL from '@luma.gl/constants';
@@ -74,7 +74,8 @@ export default class ScenegraphLayer extends Layer {
       instancePositions64xy: {
         size: 2,
         accessor: 'getPosition',
-        update: this.calculateInstancePositions64xyLow
+        enable: this.use64bitPositions,
+        transform: positionFp64LowPart
       },
       instanceColors: {
         type: GL.UNSIGNED_BYTE,
@@ -266,27 +267,6 @@ export default class ScenegraphLayer extends Layer {
         }
       });
     });
-  }
-
-  calculateInstancePositions64xyLow(attribute, {startRow, endRow}) {
-    const isFP64 = this.use64bitPositions();
-    attribute.constant = !isFP64;
-
-    if (!isFP64) {
-      attribute.value = new Float32Array(2);
-      return;
-    }
-
-    const {data, getPosition} = this.props;
-    const {value, size} = attribute;
-    let i = startRow * size;
-    const {iterable, objectInfo} = createIterable(data, startRow, endRow);
-    for (const point of iterable) {
-      objectInfo.index++;
-      const position = getPosition(point, objectInfo);
-      value[i++] = fp64LowPart(position[0]);
-      value[i++] = fp64LowPart(position[1]);
-    }
   }
 }
 

--- a/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.js
+++ b/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.js
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {Layer, createIterable, fp64LowPart} from '@deck.gl/core';
+import {Layer, positionFp64LowPart} from '@deck.gl/core';
 import GL from '@luma.gl/constants';
 import {Model, Geometry, Texture2D, PhongMaterial, isWebGL2} from '@luma.gl/core';
 
@@ -133,7 +133,8 @@ export default class SimpleMeshLayer extends Layer {
       instancePositions64xy: {
         size: 2,
         accessor: 'getPosition',
-        update: this.calculateInstancePositions64xyLow
+        enable: this.use64bitPositions,
+        transform: positionFp64LowPart
       },
       instanceColors: {
         type: GL.UNSIGNED_BYTE,
@@ -246,27 +247,6 @@ export default class SimpleMeshLayer extends Layer {
         sampler: texture || emptyTexture,
         hasTexture: Boolean(texture)
       });
-    }
-  }
-
-  calculateInstancePositions64xyLow(attribute, {startRow, endRow}) {
-    const isFP64 = this.use64bitPositions();
-    attribute.constant = !isFP64;
-
-    if (!isFP64) {
-      attribute.value = new Float32Array(2);
-      return;
-    }
-
-    const {data, getPosition} = this.props;
-    const {value, size} = attribute;
-    let i = startRow * size;
-    const {iterable, objectInfo} = createIterable(data, startRow, endRow);
-    for (const object of iterable) {
-      objectInfo.index++;
-      const position = getPosition(object, objectInfo);
-      value[i++] = fp64LowPart(position[0]);
-      value[i++] = fp64LowPart(position[1]);
     }
   }
 }

--- a/test/modules/core/lib/attribute-manager.spec.js
+++ b/test/modules/core/lib/attribute-manager.spec.js
@@ -35,6 +35,10 @@ function update(attribute, {data}) {
   }
 }
 
+function enable() {
+  return this.enabled; // eslint-disable-line
+}
+
 const fixture = {
   positions: new Float32Array([0, 1, 0, -1, -1, 0, 1, -1, 0])
 };
@@ -173,6 +177,35 @@ test('AttributeManager.update - external buffers', t => {
   });
 
   t.is(attribute.buffer.accessor.type, gl.UNSIGNED_BYTE, 'colors casted to correct type');
+
+  t.end();
+});
+
+test('AttributeManager.update - disabled attributes', t => {
+  const attributeManager = new AttributeManager(gl);
+  attributeManager.add({
+    positions: {size: 2, update, enable}
+  });
+
+  // First update, should autoalloc and update the value array
+  attributeManager.update({
+    numInstances: 0,
+    data: [{}, {}],
+    context: {enabled: true}
+  });
+
+  let attribute = attributeManager.getAttributes()['positions'];
+  t.deepEqual(attribute.value.slice(0, 4), [0, 1, 2, 3], 'attribute value is populated');
+
+  attributeManager.update({
+    numInstances: 0,
+    data: [{}, {}],
+    context: {enabled: false}
+  });
+
+  attribute = attributeManager.getAttributes()['positions'];
+  t.ok(attribute.constant, 'attribute is set to contant');
+  t.deepEqual(attribute.value, [0, 0], 'attribute is set to default value');
 
   t.end();
 });

--- a/test/modules/core/lib/attribute.spec.js
+++ b/test/modules/core/lib/attribute.spec.js
@@ -259,6 +259,18 @@ test('Attribute#updateBuffer', t => {
       ]
     },
     {
+      title: 'standard accessor with transform',
+      attribute: new Attribute(gl, {
+        id: 'values',
+        type: GL.FLOAT,
+        size: 1,
+        accessor: 'getValue',
+        transform: x => x * 2
+      }),
+      standard: [20, 40, 14, 0],
+      'variable size': [20, 20, 40, 14, 14, 14, 14, 0, 0, 0]
+    },
+    {
       title: 'custom accessor',
       attribute: new Attribute(gl, {
         id: 'values',

--- a/test/modules/core/lib/attribute.spec.js
+++ b/test/modules/core/lib/attribute.spec.js
@@ -117,10 +117,10 @@ test('Attribute#allocate', t => {
   t.ok(attribute.allocate(4), 'allocate successful');
   t.is(attribute.value, allocatedValue, 'reused the same typed array');
 
-  attribute.setGenericValue([1, 1]);
+  attribute.setConstantValue([1, 1]);
   t.notOk(attributeNoAlloc.allocate(4), 'Should not allocate if constant value is used');
 
-  attribute.setGenericValue(undefined);
+  attribute.setConstantValue(undefined);
   t.ok(attribute.allocate(4), 'allocate successful');
   t.is(attribute.value, allocatedValue, 'reused the same typed array');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4688,6 +4688,13 @@ express@^4.16.3:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
+expression-eval@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/expression-eval/-/expression-eval-2.0.0.tgz#156bc71a700b0c7797f47d8a7167ce4fba5c060c"
+  integrity sha512-8cFzfco37CdZQd4DTyZ+ncxQtPUTE0dcxvbGXYc17Ji+3MQSBkT+11GdfC7eO2duvLNuWjN7Ejqb0kLX/u2bBw==
+  dependencies:
+    jsep "^0.3.0"
+
 extend-shallow@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
@@ -6339,6 +6346,11 @@ jsdom@^15.0.0:
     whatwg-url "^7.0.0"
     ws "^7.0.0"
     xml-name-validator "^3.0.0"
+
+jsep@^0.3.0:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/jsep/-/jsep-0.3.4.tgz#55ebd4400c5c5861cb1ff949a7a4cd97fcaacaa0"
+  integrity sha512-ovGD9wE+wvudIIYxZGrRcZCxNyZ3Cl1N7Bzyp7/j4d/tA0BaUwcVM9bu0oZaSrefMiNwv6TwZ9X15gvZosteCQ==
 
 jsesc@^2.5.1:
   version "2.5.1"


### PR DESCRIPTION
#### Background

Since we introduced the partial update feature, it has become increasingly complex for layers to implement their own attribute updaters.

This PR removes the need for a custom updater of the `instancePositions64xyLow` attribute, and will also make it easier when we move to use 3d 64-bit positions in the next major release.

#### Change List
- Add `enable` and `transform` options to `Attribute` class
- Add new core utility `positionFp64LowPart`
- Update primitive layers to use the new API
- Documentation
- Unit tests
