### PR TITLE
Improve shadow for mesh layer

### DIFF
--- a/examples/website/mesh/app.js
+++ b/examples/website/mesh/app.js
@@ -56,7 +56,7 @@ const dirLight = new DirectionalLight({
 
 const lightingEffect = new LightingEffect({ambientLight, dirLight});
 
-const landCover = [
+const background = [
   [[-1000.0, -1000.0, -40], [1000.0, -1000.0, -40], [1000.0, 1000.0, -40], [-1000.0, 1000.0, -40]]
 ];
 
@@ -73,8 +73,8 @@ class Example extends PureComponent {
         getOrientation: d => d.orientation
       }),
       new SolidPolygonLayer({
-        id: 'land',
-        data: landCover,
+        id: 'background',
+        data: background,
         opacity: 1,
         extruded: false,
         coordinateSystem: COORDINATE_SYSTEM.IDENTITY,

--- a/examples/website/mesh/app.js
+++ b/examples/website/mesh/app.js
@@ -1,6 +1,14 @@
 import React, {PureComponent} from 'react';
 import {render} from 'react-dom';
-import DeckGL, {COORDINATE_SYSTEM, SimpleMeshLayer, OrbitView} from 'deck.gl';
+import DeckGL, {
+  COORDINATE_SYSTEM,
+  SimpleMeshLayer,
+  OrbitView,
+  SolidPolygonLayer,
+  DirectionalLight,
+  LightingEffect,
+  AmbientLight
+} from 'deck.gl';
 
 import {OBJLoader} from '@loaders.gl/obj';
 import {registerLoaders} from '@loaders.gl/core';
@@ -34,6 +42,24 @@ const SAMPLE_DATA = (([xCount, yCount], spacing) => {
   return data;
 })([10, 10], 120);
 
+const ambientLight = new AmbientLight({
+  color: [255, 255, 255],
+  intensity: 1.0
+});
+
+const dirLight = new DirectionalLight({
+  color: [255, 255, 255],
+  intensity: 1.0,
+  direction: [-10, -2, -15],
+  _shadow: true
+});
+
+const lightingEffect = new LightingEffect({ambientLight, dirLight});
+
+const landCover = [
+  [[-1000.0, -1000.0, -40], [1000.0, -1000.0, -40], [1000.0, 1000.0, -40], [-1000.0, 1000.0, -40]]
+];
+
 class Example extends PureComponent {
   render() {
     const layers = [
@@ -45,15 +71,30 @@ class Example extends PureComponent {
         getPosition: d => d.position,
         getColor: d => d.color,
         getOrientation: d => d.orientation
+      }),
+      new SolidPolygonLayer({
+        id: 'land',
+        data: landCover,
+        opacity: 1,
+        extruded: false,
+        coordinateSystem: COORDINATE_SYSTEM.IDENTITY,
+        getPolygon: f => f,
+        getFillColor: [0, 0, 0, 0]
       })
     ];
 
     return (
       <DeckGL
-        views={new OrbitView()}
+        views={
+          new OrbitView({
+            near: 0.1,
+            far: 2
+          })
+        }
         initialViewState={INITIAL_VIEW_STATE}
         controller={true}
         layers={layers}
+        effects={[lightingEffect]}
       />
     );
   }

--- a/examples/website/mesh/app.js
+++ b/examples/website/mesh/app.js
@@ -72,6 +72,7 @@ class Example extends PureComponent {
         getColor: d => d.color,
         getOrientation: d => d.orientation
       }),
+      // only needed when using shadows - a plane for shadows to drop on
       new SolidPolygonLayer({
         id: 'background',
         data: background,

--- a/modules/core/src/effects/lighting/lighting-effect.js
+++ b/modules/core/src/effects/lighting/lighting-effect.js
@@ -35,7 +35,7 @@ export default class LightingEffect extends Effect {
 
     this.shadowColor = DEFAULT_SHADOW_COLOR;
     this.shadowPasses = [];
-    this.dummyShadowMaps = [];
+    this.dummyShadowMap = null;
     this.shadow = false;
 
     for (const key in props) {
@@ -74,8 +74,11 @@ export default class LightingEffect extends Effect {
       this._createShadowPasses(gl, pixelRatio);
     }
 
-    if (this.dummyShadowMaps.length === 0) {
-      this._createDummyShadowMaps(gl);
+    if (!this.dummyShadowMap) {
+      this.dummyShadowMap = new Texture2D(gl, {
+        width: 1,
+        height: 1
+      });
     }
 
     const shadowMaps = [];
@@ -89,7 +92,7 @@ export default class LightingEffect extends Effect {
         views,
         effectProps: {
           shadowLightId: i,
-          dummyShadowMaps: this.dummyShadowMaps,
+          dummyShadowMap: this.dummyShadowMap,
           shadowMatrices
         }
       });
@@ -98,7 +101,7 @@ export default class LightingEffect extends Effect {
 
     return {
       shadowMaps,
-      dummyShadowMaps: this.dummyShadowMaps,
+      dummyShadowMap: this.dummyShadowMap,
       shadowColor: this.shadowColor,
       shadowMatrices
     };
@@ -119,10 +122,10 @@ export default class LightingEffect extends Effect {
     }
     this.shadowPasses.length = 0;
 
-    for (const dummyShadowMap of this.dummyShadowMaps) {
-      dummyShadowMap.delete();
+    if (this.dummyShadowMap) {
+      this.dummyShadowMap.delete();
+      this.dummyShadowMap = null;
     }
-    this.dummyShadowMaps.length = 0;
 
     if (this.shadow) {
       this._removeShadowModule();
@@ -144,16 +147,6 @@ export default class LightingEffect extends Effect {
   _createShadowPasses(gl, pixelRatio) {
     for (let i = 0; i < this.directionalLights.length; i++) {
       this.shadowPasses.push(new ShadowPass(gl, {pixelRatio}));
-    }
-  }
-  _createDummyShadowMaps(gl) {
-    for (let i = 0; i < this.directionalLights.length; i++) {
-      this.dummyShadowMaps.push(
-        new Texture2D(gl, {
-          width: 1,
-          height: 1
-        })
-      );
     }
   }
 

--- a/modules/core/src/shaderlib/shadow/shadow.js
+++ b/modules/core/src/shaderlib/shadow/shadow.js
@@ -80,8 +80,9 @@ vec4 shadow_filterShadowColor(vec4 color) {
   }
   if (shadow_uUseShadowMap) {
     float shadowAlpha = 0.0;
-    shadowAlpha += shadow_getShadowWeight(shadow_vPosition[0], shadow_uShadowMap0) * shadow_uColor.a / shadow_uLightCount;
-    shadowAlpha += shadow_getShadowWeight(shadow_vPosition[1], shadow_uShadowMap1) * shadow_uColor.a / shadow_uLightCount;
+    shadowAlpha += shadow_getShadowWeight(shadow_vPosition[0], shadow_uShadowMap0);
+    shadowAlpha += shadow_getShadowWeight(shadow_vPosition[1], shadow_uShadowMap1);
+    shadowAlpha *= shadow_uColor.a / shadow_uLightCount;
     float blendedAlpha = shadowAlpha + color.a * (1.0 - shadowAlpha);
 
     return vec4(
@@ -131,30 +132,17 @@ function getViewportCenterPosition({viewport, center}) {
 function getViewProjectionMatrices({viewport, shadowMatrices}) {
   const projectionMatrices = [];
   const pixelUnprojectionMatrix = viewport.pixelUnprojectionMatrix;
-  let corners = [];
-  if (viewport.isGeospatial) {
-    corners = [
-      [0, 0], // top left ground
-      [viewport.width, 0], // top right ground
-      [0, viewport.height], // bottom left ground
-      [viewport.width, viewport.height], // bottom right ground
-      [0, 0, -1], // top left near
-      [viewport.width, 0, -1], // top right near
-      [0, viewport.height, -1], // bottom left near
-      [viewport.width, viewport.height, -1] // bottom right near
-    ].map(pixel => screenToCommonSpace(pixel, pixelUnprojectionMatrix));
-  } else {
-    corners = [
-      [0, 0, 1], // top left far
-      [viewport.width, 0, 1], // top right far
-      [0, viewport.height, 1], // bottom left far
-      [viewport.width, viewport.height, 1], // bottom right far
-      [0, 0, -1], // top left near
-      [viewport.width, 0, -1], // top right near
-      [0, viewport.height, -1], // bottom left near
-      [viewport.width, viewport.height, -1] // bottom right near
-    ].map(pixel => screenToCommonSpace(pixel, pixelUnprojectionMatrix));
-  }
+  const farZ = viewport.isGeospatial ? undefined : 1;
+  const corners = [
+    [0, 0, farZ], // top left ground
+    [viewport.width, 0, farZ], // top right ground
+    [0, viewport.height, farZ], // bottom left ground
+    [viewport.width, viewport.height, farZ], // bottom right ground
+    [0, 0, -1], // top left near
+    [viewport.width, 0, -1], // top right near
+    [0, viewport.height, -1], // bottom left near
+    [viewport.width, viewport.height, -1] // bottom right near
+  ].map(pixel => screenToCommonSpace(pixel, pixelUnprojectionMatrix));
 
   for (const shadowMatrix of shadowMatrices) {
     const viewMatrix = shadowMatrix.clone().translate(new Vector3(viewport.center).negate());

--- a/modules/core/src/shaderlib/shadow/shadow.js
+++ b/modules/core/src/shaderlib/shadow/shadow.js
@@ -81,7 +81,9 @@ vec4 shadow_filterShadowColor(vec4 color) {
   if (shadow_uUseShadowMap) {
     float shadowAlpha = 0.0;
     shadowAlpha += shadow_getShadowWeight(shadow_vPosition[0], shadow_uShadowMap0);
-    shadowAlpha += shadow_getShadowWeight(shadow_vPosition[1], shadow_uShadowMap1);
+    if(shadow_uLightCount > 1.0) {
+      shadowAlpha += shadow_getShadowWeight(shadow_vPosition[1], shadow_uShadowMap1);
+    }
     shadowAlpha *= shadow_uColor.a / shadow_uLightCount;
     float blendedAlpha = shadowAlpha + color.a * (1.0 - shadowAlpha);
 

--- a/test/modules/core/effects/lighting-effect.spec.js
+++ b/test/modules/core/effects/lighting-effect.spec.js
@@ -117,11 +117,11 @@ test('LightingEffect#prepare and cleanup', t => {
   });
 
   t.equal(lightingEffect.shadowPasses.length, 2, 'LightingEffect prepares shadow passes');
-  t.equal(lightingEffect.dummyShadowMaps.length, 2, 'LightingEffect prepares dummy shadow maps');
+  t.ok(lightingEffect.dummyShadowMap, 'LightingEffect prepares dummy shadow map');
 
   lightingEffect.cleanup();
   t.equal(lightingEffect.shadowPasses.length, 0, 'LightingEffect prepares shadow passes');
-  t.equal(lightingEffect.dummyShadowMaps.length, 0, 'LightingEffect prepares dummy shadow maps');
+  t.notOk(lightingEffect.dummyShadowMap, 'LightingEffect cleans up dummy shadow map');
   t.end();
 });
 

--- a/test/modules/core/shaderlib/shadow/shadow.spec.js
+++ b/test/modules/core/shaderlib/shadow/shadow.spec.js
@@ -1,6 +1,6 @@
 import test from 'tape-catch';
 
-import {MapView} from 'deck.gl';
+import {MapView, OrbitView} from 'deck.gl';
 import {shadow} from '@deck.gl/core/shaderlib';
 import {Matrix4, Vector3} from 'math.gl';
 import {PROJECT_COORDINATE_SYSTEM} from '@deck.gl/core/shaderlib/project/constants';
@@ -26,6 +26,19 @@ const TEST_VIEWPORT2 = new MapView().makeViewport({
     zoom: 15,
     bearing: -30,
     pitch: 40
+  }
+});
+
+const TEST_VIEWPORT3 = new OrbitView({near: 0.1, far: 2}).makeViewport({
+  width: 800,
+  height: 600,
+  viewState: {
+    target: [0, 0, 0],
+    rotationX: 0,
+    rotationOrbit: 0,
+    orbitAxis: 'Y',
+    fov: 30,
+    zoom: 0
   }
 });
 
@@ -73,6 +86,25 @@ const TEST_CASE2 = [
   },
   {
     xyz: [423, 108, 0], // bottom right corner inside
+    result: true
+  }
+];
+
+const TEST_CASE3 = [
+  {
+    xyz: [-746, 559, -556], // top left far corner outside
+    result: false
+  },
+  {
+    xyz: [746, -559, -556], // bottom right far corner outside
+    result: false
+  },
+  {
+    xyz: [-37, 27, 583], // top left near corner inside
+    result: true
+  },
+  {
+    xyz: [37, -27, 583], // bottom right near corner inside
     result: true
   }
 ];
@@ -159,5 +191,29 @@ test('shadow#getUniforms', t => {
     );
   }
 
+  // Non-Geospatial Identity Mode
+  viewport = TEST_VIEWPORT3;
+
+  uniforms = shadow.getUniforms(
+    {
+      viewport,
+      shadowMatrices: [viewMatrix],
+      drawToShadowMap: true,
+      dummyShadowMaps: [true]
+    },
+    {
+      project_uCenter: [0, 0, 0, 0],
+      project_uCoordinateSystem: PROJECT_COORDINATE_SYSTEM.IDENTITY
+    }
+  );
+
+  for (const value of TEST_CASE3) {
+    const result = uniforms[`shadow_uViewProjectionMatrices[0]`].transformVector3(value.xyz);
+    t.equal(
+      insideClipSpace(result),
+      value.result,
+      `Shadow viewProjection matrix in Identity mode is correct!`
+    );
+  }
   t.end();
 });


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background
Mesh layer has a sampler which blocks the binding of shadow map sampler array. Because of that the shadow map texture sampling always returns [0, 0, 0, 0]. Made the full mesh layer rendered with shadow.
<!-- For all the PRs -->
#### Change List
- fix the shadow map sampler issue
- new bounding box for identity mode
- add shadow to mesh example
- unit test
