### PR TITLE
Simplify pydeck widget build

### DIFF
--- a/bindings/python/pydeck/pydeck/io/templates/imports.j2
+++ b/bindings/python/pydeck/pydeck/io/templates/imports.j2
@@ -1,4 +1,7 @@
-<script src='https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js'></script>
-<link rel="stylesheet" href="https://api.tiles.mapbox.com/mapbox-gl-js/v{{mapbox_gl_version}}/mapbox-gl.css" />
+<script src="https://unpkg.com/s2-geometry@1.2.10/src/s2geometry.js"></script>
+<script src="https://unpkg.com/h3-js@3.4.3/dist/h3-js.umd.js"></script>
+<script src="https://api.tiles.mapbox.com/mapbox-gl-js/v0.53.0/mapbox-gl.js"></script>
+<script src="https://unpkg.com/deck.gl@~7.2.0/dist.min.js"></script>
+<link rel="stylesheet" href="https://api.tiles.mapbox.com/mapbox-gl-js/v0.53.0/mapbox-gl.css" />
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap-theme.min.css" />
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/bindings/python/pydeck/pydeck/io/templates/js.j2
+++ b/bindings/python/pydeck/pydeck/io/templates/js.j2
@@ -1,16 +1,3 @@
-requirejs.config({
-  paths: {
-    deck: 'https://unpkg.com/deck.gl@{{release_version}}/dist.min',
-    mapboxgl: 'https://api.tiles.mapbox.com/mapbox-gl-js/v{{mapbox_gl_version}}/mapbox-gl',
-    h3: 'https://unpkg.com/h3-js@3.4.3/dist/h3-js.umd',
-    S2: 'https://unpkg.com/s2-geometry@1.2.10/src/s2geometry'
-  },
-  shim : {
-    'deck': ['h3', 'S2']
-  }
-
-});
-
 let config, mapLayer, jsonInput, jsonConverter;
 
 jsonInput = JSON.parse(JSON.stringify({{json_input}}));

--- a/bindings/python/pydeck/setup.py
+++ b/bindings/python/pydeck/setup.py
@@ -25,7 +25,7 @@ log.info('setup.py entered')
 log.info('$PATH=%s' % os.environ['PATH'])
 
 PATH_TO_WIDGET = '../../../modules/jupyter-widget'
-PATH_TO_REPO_ROOT = '../../../..'
+PATH_TO_REPO_ROOT = '../../..'
 
 yarn_root = os.path.join(here, PATH_TO_REPO_ROOT)
 widget_dir = os.path.join(here, PATH_TO_WIDGET)

--- a/modules/jupyter-widget/package.json
+++ b/modules/jupyter-widget/package.json
@@ -24,17 +24,10 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "echo No operation. This package is not currently built for distribution on NPM",
-    "notebook-bundle": "webpack"
+    "build": "webpack"
   },
   "dependencies": {
-    "@deck.gl/aggregation-layers": "7.2.0-beta.3",
-    "@deck.gl/core": "7.2.0-beta.3",
-    "@deck.gl/json": "7.2.0-beta.3",
-    "@deck.gl/layers": "7.2.0-beta.3",
-    "@jupyter-widgets/base": "^1.1.10",
-    "@luma.gl/constants": "^7.2.0",
-    "mapbox-gl": "^0.53.1"
+    "@jupyter-widgets/base": "^1.1.10"
   },
   "private": true
 }

--- a/modules/jupyter-widget/src/utils.js
+++ b/modules/jupyter-widget/src/utils.js
@@ -1,8 +1,4 @@
-/* global document,setTimeout */
-/**
- * Gets CSS from a given URL and appends it to the document head
- * @param url URL of CSS page
- */
+/* global document */
 function loadCss(url) {
   const link = document.createElement('link');
   link.type = 'text/css';
@@ -11,54 +7,26 @@ function loadCss(url) {
   document.getElementsByTagName('head')[0].appendChild(link);
 }
 
-/**
- * Creates a div of a default 500px by 500px for the Jupyter widget
- * @param idName ID attribute of div
- * @param width Width of div in pixels (defaults to 500)
- * @param height Height of div in pixels (defaults to 500)
- * @return div object for appending to the document
- */
-function createWidgetDiv(idName, width = 500, height = 500) {
-  const div = document.createElement('div');
-  div.style.width = `${width}px`;
-  div.style.height = `${height}px`;
-  div.id = idName;
-  return div;
+function addScriptTag(el, src) {
+  const script = document.createElement('script');
+  script.src = src;
+  el.appendChild(script);
 }
 
-/**
- * Creates a canvas for the Jupyter widget
- * @param idName ID attribute of canvas
- * @return canvas canvas for appending
- */
-function createCanvas(idName) {
-  const canvas = document.createElement('canvas');
-  Object.assign(canvas.style, {
-    width: '100%',
-    height: '100%',
-    position: 'absolute',
-    'z-index': 2
-  });
-  canvas.id = idName;
-  return canvas;
-}
-
-/**
- * Creates a div for the Jupyter widget's basemap
- * @param idName ID attribute of div
- * @return div object for appending to the document
- */
-function createMapDiv(idName) {
+function createWidgetDiv(parentDiv, idName, width = 500, height = 500) {
   const div = document.createElement('div');
-  Object.assign(div.style, {
-    'pointer-events': 'none',
-    height: '100%',
-    width: '100%',
-    position: 'absolute',
-    'z-index': 1
-  });
-  div.id = idName;
-  return div;
+
+  const CDN_DEPENDENCIES = [
+    'https://unpkg.com/h3-js@3.4.3/dist/h3-js.umd',
+    'https://unpkg.com/s2-geometry@1.2.10/src/s2geometry.js',
+    'https://api.tiles.mapbox.com/mapbox-gl-js/v0.53.0/mapbox-gl.js',
+    'https://unpkg.com/deck.gl@~7.2.0/dist.min.js'
+  ];
+
+  for (const src of CDN_DEPENDENCIES) {
+    addScriptTag(parentDiv, src);
+  }
+  parentDiv.appendChild(div);
 }
 
 /**
@@ -71,81 +39,4 @@ function hideMapboxCSSWarning() {
   }
 }
 
-/**
- * Creates and appends all DOM elements for the deck.gl widget at the specified root node
- * @param rootElement ID attribute of div
- * @uid Unique tag for the element ID
- * @width Width of widget div element, in pixels
- * @height Height of widget div element, in pixels
- */
-function createDeckScaffold(rootElement, uid, width = 500, height = 500) {
-  const mapNode = createMapDiv(`map-${uid}`);
-  const canvasNode = createCanvas(`deck-map-container-${uid}`);
-  const mapWrapperNode = createWidgetDiv(`deck-map-wrapper-${uid}`, width, height);
-  mapWrapperNode.appendChild(canvasNode);
-  mapWrapperNode.appendChild(mapNode);
-  rootElement
-    .appendChild(createWidgetDiv(`deck-container-${uid}`, width, height))
-    .appendChild(mapWrapperNode);
-}
-
-/**
- * Awaits an element to display before running another action
- * @param selector Attribute to await
- * @param time Check interval in milliseconds
- * @param cb Callback to execute when the element is found
- */
-function waitForElementToDisplay(selector, time, cb) {
-  if (document.querySelector(selector) !== null) {
-    cb();
-    return;
-  }
-  setTimeout(() => {
-    waitForElementToDisplay(selector, time, cb);
-  }, time);
-}
-
-/**
- * Sets common properties for basemap
- * @param map ID attribute of div
- * @param props ID attribute of div
- * @return div object for appending to the document
- */
-function setMapProps(map, props) {
-  if ('viewState' in props && props.viewState.longitude && props.viewState.latitude) {
-    const {viewState} = props;
-    map.jumpTo({
-      center: [viewState.longitude, viewState.latitude],
-      zoom: Number.isFinite(viewState.zoom) ? viewState.zoom : 10,
-      bearing: viewState.bearing || 0,
-      pitch: viewState.pitch || 0
-    });
-  }
-
-  if (props.map && 'style' in props.map) {
-    if (props.map.style !== map.deckStyle) {
-      map.setStyle(props.map.style);
-      map.deckStyle = props.map.style;
-    }
-  }
-}
-
-/**
- * Creates a v4 UUID
- */
-function uuidv4() {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
-    const r = (Math.random() * 16) | 0;
-    const v = c === 'x' ? r : (r & 0x3) | 0x8;
-    return v.toString(16);
-  });
-}
-
-export {
-  createDeckScaffold,
-  loadCss,
-  hideMapboxCSSWarning,
-  setMapProps,
-  waitForElementToDisplay,
-  uuidv4
-};
+export {createWidgetDiv, loadCss, hideMapboxCSSWarning};

--- a/modules/jupyter-widget/src/utils.js
+++ b/modules/jupyter-widget/src/utils.js
@@ -1,4 +1,4 @@
-/* global document */
+/* global requirejs, define, document */
 function loadCss(url) {
   const link = document.createElement('link');
   link.type = 'text/css';
@@ -7,26 +7,35 @@ function loadCss(url) {
   document.getElementsByTagName('head')[0].appendChild(link);
 }
 
-function addScriptTag(el, src) {
-  const script = document.createElement('script');
-  script.src = src;
-  el.appendChild(script);
+// Note: This code executes in a Jupyter notebook environment
+// Jupyter notebooks most often load JS modules via RequireJS and
+// include RequireJS globally
+function setDependencies(callback) {
+  requirejs.config({
+    paths: {
+      deckgl: 'https://unpkg.com/deck.gl@~7.2.0/dist.min',
+      mapboxgl: 'https://api.tiles.mapbox.com/mapbox-gl-js/v0.53.1/mapbox-gl',
+      h3: 'https://unpkg.com/h3-js@3.4.3/dist/h3-js.umd',
+      S2: 'https://unpkg.com/s2-geometry@1.2.10/src/s2geometry'
+    },
+    shim: {
+      deckgl: ['h3', 'S2']
+    }
+  });
+
+  define(['deckgl', 'mapboxgl'], (deckLib, mapboxLib) => {
+    callback(deckLib, mapboxLib);
+  });
 }
 
-function createWidgetDiv(parentDiv, idName, width = 500, height = 500) {
+function createWidgetDiv({parentDiv, idName, done, width = 500, height = 500}) {
   const div = document.createElement('div');
+  div.style.height = `${height}px`;
+  div.style.width = `${width}px`;
+  div.id = idName;
 
-  const CDN_DEPENDENCIES = [
-    'https://unpkg.com/h3-js@3.4.3/dist/h3-js.umd',
-    'https://unpkg.com/s2-geometry@1.2.10/src/s2geometry.js',
-    'https://api.tiles.mapbox.com/mapbox-gl-js/v0.53.0/mapbox-gl.js',
-    'https://unpkg.com/deck.gl@~7.2.0/dist.min.js'
-  ];
-
-  for (const src of CDN_DEPENDENCIES) {
-    addScriptTag(parentDiv, src);
-  }
   parentDiv.appendChild(div);
+  done();
 }
 
 /**
@@ -39,4 +48,4 @@ function hideMapboxCSSWarning() {
   }
 }
 
-export {createWidgetDiv, loadCss, hideMapboxCSSWarning};
+export {createWidgetDiv, loadCss, hideMapboxCSSWarning, setDependencies};

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "bootstrap": "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true yarn && ocular-bootstrap",
     "clean": "ocular-clean",
-    "build": "ocular-clean && ocular-build",
+    "build": "ocular-clean && ocular-build && lerna run build",
     "version": "ocular-build core,main",
     "lint": "ocular-lint",
     "cover": "ocular-test cover",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4688,6 +4688,13 @@ express@^4.16.3:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
+expression-eval@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/expression-eval/-/expression-eval-2.0.0.tgz#156bc71a700b0c7797f47d8a7167ce4fba5c060c"
+  integrity sha512-8cFzfco37CdZQd4DTyZ+ncxQtPUTE0dcxvbGXYc17Ji+3MQSBkT+11GdfC7eO2duvLNuWjN7Ejqb0kLX/u2bBw==
+  dependencies:
+    jsep "^0.3.0"
+
 extend-shallow@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
@@ -6339,6 +6346,11 @@ jsdom@^15.0.0:
     whatwg-url "^7.0.0"
     ws "^7.0.0"
     xml-name-validator "^3.0.0"
+
+jsep@^0.3.0:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/jsep/-/jsep-0.3.4.tgz#55ebd4400c5c5861cb1ff949a7a4cd97fcaacaa0"
+  integrity sha512-ovGD9wE+wvudIIYxZGrRcZCxNyZ3Cl1N7Bzyp7/j4d/tA0BaUwcVM9bu0oZaSrefMiNwv6TwZ9X15gvZosteCQ==
 
 jsesc@^2.5.1:
   version "2.5.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1453,7 +1453,7 @@
     "@luma.gl/constants" "7.2.0"
     math.gl "^2.3.0"
 
-"@luma.gl/constants@7.2.0", "@luma.gl/constants@^7.2.0":
+"@luma.gl/constants@7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@luma.gl/constants/-/constants-7.2.0.tgz#0fbc4aa07839e6e0454f80658a4e361b855deb67"
   integrity sha512-VQFdTM3N8pxFLfjpLq5vO3CBVcbvyRKseTZ8zmkMFL3uCYrorE9v32vDHW+3hABaYaQc/Xw4J1mOrtyfzKtv3w==
@@ -6851,7 +6851,7 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-mapbox-gl@^0.53.1, mapbox-gl@~0.53.0:
+mapbox-gl@~0.53.0:
   version "0.53.1"
   resolved "https://registry.yarnpkg.com/mapbox-gl/-/mapbox-gl-0.53.1.tgz#08a956d8da54b04bc7f29ab1319bddb9c97ddedf"
   integrity sha512-dTtW/qlkUowKGlqOhE8fqII2Tj4lcokvlZwUDLnkjy4uQ9zMFnVBULGeSzzTVkj9HtQZ3Zbey10/jmoVPV9t5w==


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #2929 
<!-- For other PRs without open issue -->
#### Background


<!-- For all the PRs -->
#### Change List
- Support a way of developing on pydeck with local deck.gl build (instead of importing from CDNs) [WIP]
- Slim built deck.gl jupyter-widget npm module by using RequireJS to load in dependencies at execution time rather than bundling them with the jupyter-widget module.
- Use yarn instead of NPM in the Python build script (setup.py).
- Use script tags instead of RequireJS in the standalone HTML renderer (the part of pydeck that writes HTML files rather than expects a jupyter installation).