### PR TITLE
fix firefox invalid date

### DIFF
--- a/examples/website/geojson/app.js
+++ b/examples/website/geojson/app.js
@@ -46,7 +46,7 @@ const ambientLight = new AmbientLight({
 });
 
 const dirLight = new SunLight({
-  timestamp: new Date('2019-08-01 15:00:00 Z-7').getTime(),
+  timestamp: Date.UTC(2019, 7, 1, 22),
   color: [255, 255, 255],
   intensity: 1.0,
   _shadow: true


### PR DESCRIPTION

<!-- For other PRs without open issue -->
#### Background
Date format in firefox is not very flexible, made the new Date() API returns invalid result. 
<!-- For all the PRs -->
#### Change List
- fix  the date format issue
