### PR TITLE
Support double precision in Attribute class

### DIFF
--- a/docs/api-reference/attribute-manager.md
+++ b/docs/api-reference/attribute-manager.md
@@ -66,7 +66,6 @@ Takes a single parameter as a map of attribute descriptor objects:
     [`updateTriggers`](/docs/api-reference/layer.md#-updatetriggers-object-optional-).
   + `transform` (Function, optional) - callback to process the result returned by `accessor`.
   + `update` (Function, optional) - the function to be called when data changes. If not supplied, the attribute will be auto-filled with `accessor`.
-  + `enable` (Function, optional) - callback to determine if the attribute is enabled. If an attribute is disabled, it will receive a constant value that is the `defaultValue`. Default always returns `true`.
   + `instanced` (Boolean, optional) - if this is an instanced attribute
     (a.k.a. divisor). Default to `false`.
   + `isIndexed` (Boolean, optional) - if this is an index attribute
@@ -74,6 +73,7 @@ Takes a single parameter as a map of attribute descriptor objects:
   + `constant` (Boolean, optional) - if this is a generic attribute
     (same value applied to every vertex). Default to `false`.
   + `defaultValue` (Number | Array of numbers, optional) - Default `[0, 0, 0, 0]`.
+  + `doublePrecision` (Bool) - whether to use 64-bit precision. Default `false`.
   + `noAlloc` (Boolean, optional) - if this attribute should not be
     automatically allocated. Default to `false`.
   + `shaderAttributes` (Object, optional) - If this attribute maps to multiple

--- a/modules/core/src/index.js
+++ b/modules/core/src/index.js
@@ -87,7 +87,7 @@ export {default as log} from './utils/log';
 import {flattenVertices, fillArray} from './utils/flatten'; // Export? move to luma.gl or math.gl?
 
 export {createIterable} from './utils/iterable-utils';
-export {fp64LowPart, positionFp64LowPart} from './utils/math-utils';
+export {fp64LowPart} from './utils/math-utils';
 import Tesselator from './utils/tesselator'; // Export? move to luma.gl or math.gl?
 import {count} from './utils/count';
 import memoize from './utils/memoize';

--- a/modules/core/src/lib/attribute-manager.js
+++ b/modules/core/src/lib/attribute-manager.js
@@ -232,9 +232,7 @@ export default class AttributeManager {
     for (const attributeName in this.attributes) {
       const attribute = this.attributes[attributeName];
 
-      if (!attribute.isEnabled(context)) {
-        attribute.disable();
-      } else if (
+      if (
         attribute.setExternalBuffer(
           buffers[attributeName] || (data.attributes && data.attributes[attributeName])
         )

--- a/modules/core/src/lib/attribute-transition-manager.js
+++ b/modules/core/src/lib/attribute-transition-manager.js
@@ -238,7 +238,7 @@ export default class AttributeTransitionManager {
         normalized,
         // attribute's `value` does not match the content of external buffer,
         // will need to call buffer.getData if needed
-        value: attribute.externalBuffer ? null : attribute.value
+        value: attribute.externalBuffer || attribute.doublePrecision ? null : attribute.value
       });
     }
     const fromState = transition.buffer || toState;

--- a/modules/core/src/lib/base-attribute.js
+++ b/modules/core/src/lib/base-attribute.js
@@ -48,6 +48,7 @@ export default class BaseAttribute {
     if (buffer) {
       this.externalBuffer = buffer;
       this.constant = false;
+      this.value = null;
 
       this.type = opts.type || buffer.accessor.type;
       if (buffer.accessor.divisor !== undefined) {

--- a/modules/core/src/utils/math-utils.js
+++ b/modules/core/src/utils/math-utils.js
@@ -1,5 +1,5 @@
 // Extensions to math.gl library. Intended to be folded back.
-
+import typedArrayManager from './typed-array-manager';
 import {Vector3} from 'math.gl';
 
 // Helper, avoids low-precision 32 bit matrices from gl-matrix mat4.create()
@@ -117,16 +117,34 @@ export function fp64LowPart(x) {
   return x - Math.fround(x);
 }
 
+let scratchArray;
+
 /**
- * Calculate the low part of a position
- * @param array {number} - the input position
- * @returns {array} - the lower 32 bit of the position
+ * Split a Float64Array into a double-length Float32Array
+ * @param typedArray {Float64Array}
+ * @param size {Number} - per attribute size
+ * @param [startIndex] {Number} - start index in the source array
+ * @param [endIndex] {Number} - end index in the source array
+ * @returns {Float32Array} - high part, low part for each attribute:
+    [1xHi, 1yHi, 1zHi, 1xLow, 1yLow, 1zLow, 2xHi, ...]
  */
-const target = new Array(2);
-export function positionFp64LowPart(array) {
-  target[0] = fp64LowPart(array[0]);
-  target[1] = fp64LowPart(array[1]);
-  // TODO - support 64-bit in z
-  // target[2] = fp64LowPart(array[2] || 0);
-  return target;
+export function toDoublePrecisionArray(typedArray, {size = 1, startIndex = 0, endIndex}) {
+  if (!Number.isFinite(endIndex)) {
+    endIndex = typedArray.length;
+  }
+  const count = (endIndex - startIndex) / size;
+  scratchArray = typedArrayManager.allocate(scratchArray, count, {
+    type: Float32Array,
+    size: size * 2
+  });
+
+  for (let sourceIndex = startIndex, targetIndex = 0; sourceIndex < endIndex; targetIndex += size) {
+    for (let j = 0; j < size; j++) {
+      const value = typedArray[sourceIndex++];
+      scratchArray[targetIndex + size] = fp64LowPart(value);
+      scratchArray[targetIndex++] = value;
+    }
+  }
+
+  return scratchArray.subarray(0, count * size * 2);
 }

--- a/modules/core/src/utils/math-utils.js
+++ b/modules/core/src/utils/math-utils.js
@@ -138,12 +138,15 @@ export function toDoublePrecisionArray(typedArray, {size = 1, startIndex = 0, en
     size: size * 2
   });
 
-  for (let sourceIndex = startIndex, targetIndex = 0; sourceIndex < endIndex; targetIndex += size) {
+  let sourceIndex = startIndex;
+  let targetIndex = 0;
+  while (sourceIndex < endIndex) {
     for (let j = 0; j < size; j++) {
       const value = typedArray[sourceIndex++];
-      scratchArray[targetIndex + size] = fp64LowPart(value);
-      scratchArray[targetIndex++] = value;
+      scratchArray[targetIndex + j] = value;
+      scratchArray[targetIndex + j + size] = fp64LowPart(value);
     }
+    targetIndex += size * 2;
   }
 
   return scratchArray.subarray(0, count * size * 2);

--- a/modules/core/src/utils/tesselator.js
+++ b/modules/core/src/utils/tesselator.js
@@ -38,10 +38,9 @@ export default class Tesselator {
   }
 
   /* Public methods */
-  updateGeometry({data, getGeometry, positionFormat, fp64, dataChanged}) {
+  updateGeometry({data, getGeometry, positionFormat, dataChanged}) {
     this.data = data;
     this.getGeometry = getGeometry;
-    this.fp64 = fp64;
     this.positionSize = positionFormat === 'XY' ? 2 : 3;
     if (Array.isArray(dataChanged)) {
       // is partial update

--- a/modules/layers/src/arc-layer/arc-layer.js
+++ b/modules/layers/src/arc-layer/arc-layer.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {Layer, createIterable, fp64LowPart} from '@deck.gl/core';
+import {Layer, createIterable} from '@deck.gl/core';
 
 import GL from '@luma.gl/constants';
 import {Model, Geometry} from '@luma.gl/core';
@@ -58,14 +58,10 @@ export default class ArcLayer extends Layer {
     attributeManager.addInstanced({
       instancePositions: {
         size: 4,
+        doublePrecision: this.use64bitPositions(),
         transition: true,
         accessor: ['getSourcePosition', 'getTargetPosition'],
         update: this.calculateInstancePositions
-      },
-      instancePositions64Low: {
-        size: 4,
-        accessor: ['getSourcePosition', 'getTargetPosition'],
-        update: this.calculateInstancePositions64Low
       },
       instanceSourceColors: {
         size: this.props.colorFormat.length,
@@ -184,33 +180,6 @@ export default class ArcLayer extends Layer {
       const targetPosition = getTargetPosition(object, objectInfo);
       value[i++] = targetPosition[0];
       value[i++] = targetPosition[1];
-    }
-  }
-
-  // TODO - split into two attributes and use attribute transform
-  calculateInstancePositions64Low(attribute, {startRow, endRow}) {
-    const isFP64 = this.use64bitPositions();
-    attribute.constant = !isFP64;
-
-    if (!isFP64) {
-      attribute.value = new Float32Array(4);
-      return;
-    }
-
-    const {data, getSourcePosition, getTargetPosition} = this.props;
-    const {value, size} = attribute;
-    let i = startRow * size;
-    const {iterable, objectInfo} = createIterable(data, startRow, endRow);
-    for (const object of iterable) {
-      objectInfo.index++;
-      const sourcePosition = getSourcePosition(object, objectInfo);
-      value[i++] = fp64LowPart(sourcePosition[0]);
-      value[i++] = fp64LowPart(sourcePosition[1]);
-      // Call `getTargetPosition` after `sourcePosition` is used in case both accessors write into
-      // the same temp array
-      const targetPosition = getTargetPosition(object, objectInfo);
-      value[i++] = fp64LowPart(targetPosition[0]);
-      value[i++] = fp64LowPart(targetPosition[1]);
     }
   }
 }

--- a/modules/layers/src/bitmap-layer/bitmap-layer.js
+++ b/modules/layers/src/bitmap-layer/bitmap-layer.js
@@ -20,7 +20,7 @@
 
 /* global HTMLVideoElement */
 import GL from '@luma.gl/constants';
-import {Layer, fp64LowPart} from '@deck.gl/core';
+import {Layer} from '@deck.gl/core';
 import {Model, Geometry, Texture2D} from '@luma.gl/core';
 
 import vs from './bitmap-layer-vertex';
@@ -62,19 +62,16 @@ export default class BitmapLayer extends Layer {
     attributeManager.add({
       positions: {
         size: 3,
+        doublePrecision: this.use64bitPositions(),
         update: this.calculatePositions,
-        value: new Float32Array(12),
-        noAlloc: true
-      },
-      positions64xyLow: {
-        size: 3,
-        update: this.calculatePositions64xyLow,
-        value: new Float32Array(12),
         noAlloc: true
       }
     });
 
-    this.setState({numInstances: 1});
+    this.setState({
+      numInstances: 1,
+      positions: new Float64Array(12)
+    });
   }
 
   updateState({props, oldProps, changeFlags}) {
@@ -95,11 +92,7 @@ export default class BitmapLayer extends Layer {
     const attributeManager = this.getAttributeManager();
 
     if (props.bounds !== oldProps.bounds) {
-      this.setState({
-        positions: this._getPositionsFromBounds(props.bounds)
-      });
       attributeManager.invalidate('positions');
-      attributeManager.invalidate('positions64xyLow');
     }
   }
 
@@ -111,8 +104,9 @@ export default class BitmapLayer extends Layer {
     }
   }
 
-  _getPositionsFromBounds(bounds) {
-    const positions = new Array(12);
+  calculatePositions(attributes) {
+    const {positions} = this.state;
+    const {bounds} = this.props;
     // bounds as [minX, minY, maxX, maxY]
     if (Number.isFinite(bounds[0])) {
       /*
@@ -146,7 +140,7 @@ export default class BitmapLayer extends Layer {
       }
     }
 
-    return positions;
+    attributes.value = positions;
   }
 
   _getModel(gl) {
@@ -249,24 +243,6 @@ export default class BitmapLayer extends Layer {
         })
       });
     }
-  }
-
-  calculatePositions({value}) {
-    const {positions} = this.state;
-    value.set(positions);
-  }
-
-  calculatePositions64xyLow(attribute) {
-    const isFP64 = this.use64bitPositions();
-    attribute.constant = !isFP64;
-
-    if (!isFP64) {
-      attribute.value = new Float32Array(4);
-      return;
-    }
-
-    const {value} = attribute;
-    value.set(this.state.positions.map(fp64LowPart));
   }
 }
 

--- a/modules/layers/src/column-layer/column-layer.js
+++ b/modules/layers/src/column-layer/column-layer.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {Layer, positionFp64LowPart} from '@deck.gl/core';
+import {Layer} from '@deck.gl/core';
 import GL from '@luma.gl/constants';
 import {Model, PhongMaterial} from '@luma.gl/core';
 import ColumnGeometry from './column-geometry';
@@ -72,6 +72,7 @@ export default class ColumnLayer extends Layer {
     attributeManager.addInstanced({
       instancePositions: {
         size: 3,
+        doublePrecision: this.use64bitPositions(),
         transition: true,
         accessor: 'getPosition'
       },
@@ -79,12 +80,6 @@ export default class ColumnLayer extends Layer {
         size: 1,
         transition: true,
         accessor: 'getElevation'
-      },
-      instancePositions64xyLow: {
-        size: 2,
-        accessor: 'getPosition',
-        enable: this.use64bitPositions,
-        transform: positionFp64LowPart
       },
       instanceFillColors: {
         size: this.props.colorFormat.length,

--- a/modules/layers/src/icon-layer/icon-layer.js
+++ b/modules/layers/src/icon-layer/icon-layer.js
@@ -17,7 +17,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-import {Layer, positionFp64LowPart} from '@deck.gl/core';
+import {Layer} from '@deck.gl/core';
 import GL from '@luma.gl/constants';
 import {Model, Geometry} from '@luma.gl/core';
 
@@ -80,14 +80,9 @@ export default class IconLayer extends Layer {
     attributeManager.addInstanced({
       instancePositions: {
         size: 3,
+        doublePrecision: this.use64bitPositions(),
         transition: true,
         accessor: 'getPosition'
-      },
-      instancePositions64xyLow: {
-        size: 2,
-        accessor: 'getPosition',
-        enable: this.use64bitPositions,
-        transform: positionFp64LowPart
       },
       instanceSizes: {
         size: 1,

--- a/modules/layers/src/line-layer/line-layer-vertex.glsl.js
+++ b/modules/layers/src/line-layer/line-layer-vertex.glsl.js
@@ -24,7 +24,8 @@ export default `\
 attribute vec3 positions;
 attribute vec3 instanceSourcePositions;
 attribute vec3 instanceTargetPositions;
-attribute vec4 instanceSourceTargetPositions64xyLow;
+attribute vec2 instanceSourcePositions64xyLow;
+attribute vec2 instanceTargetPositions64xyLow;
 attribute vec4 instanceColors;
 attribute vec3 instancePickingColors;
 attribute float instanceWidths;
@@ -55,8 +56,8 @@ void main(void) {
   // Position
   vec4 source_commonspace;
   vec4 target_commonspace;
-  vec4 source = project_position_to_clipspace(instanceSourcePositions, instanceSourceTargetPositions64xyLow.xy, vec3(0.), source_commonspace);
-  vec4 target = project_position_to_clipspace(instanceTargetPositions, instanceSourceTargetPositions64xyLow.zw, vec3(0.), target_commonspace);
+  vec4 source = project_position_to_clipspace(instanceSourcePositions, instanceSourcePositions64xyLow, vec3(0.), source_commonspace);
+  vec4 target = project_position_to_clipspace(instanceTargetPositions, instanceTargetPositions64xyLow, vec3(0.), target_commonspace);
 
   // Multiply out width and clamp to limits
   float widthPixels = clamp(

--- a/modules/layers/src/path-layer/path-layer-vertex.glsl.js
+++ b/modules/layers/src/path-layer/path-layer-vertex.glsl.js
@@ -28,8 +28,10 @@ attribute vec3 instanceStartPositions;
 attribute vec3 instanceEndPositions;
 attribute vec3 instanceLeftPositions;
 attribute vec3 instanceRightPositions;
-attribute vec4 instanceLeftStartPositions64xyLow;
-attribute vec4 instanceEndRightPositions64xyLow;
+attribute vec2 instanceLeftPositions64xyLow;
+attribute vec2 instanceStartPositions64xyLow;
+attribute vec2 instanceEndPositions64xyLow;
+attribute vec2 instanceRightPositions64xyLow;
 attribute float instanceStrokeWidths;
 attribute vec4 instanceColors;
 attribute vec3 instancePickingColors;
@@ -222,13 +224,13 @@ void main() {
   float isEnd = positions.x;
 
   vec3 prevPosition = mix(instanceLeftPositions, instanceStartPositions, isEnd);
-  vec2 prevPosition64xyLow = mix(instanceLeftStartPositions64xyLow.xy, instanceLeftStartPositions64xyLow.zw, isEnd);
+  vec2 prevPosition64xyLow = mix(instanceLeftPositions64xyLow, instanceStartPositions64xyLow, isEnd);
 
   vec3 currPosition = mix(instanceStartPositions, instanceEndPositions, isEnd);
-  vec2 currPosition64xyLow = mix(instanceLeftStartPositions64xyLow.zw, instanceEndRightPositions64xyLow.xy, isEnd);
+  vec2 currPosition64xyLow = mix(instanceStartPositions64xyLow, instanceEndPositions64xyLow, isEnd);
 
   vec3 nextPosition = mix(instanceEndPositions, instanceRightPositions, isEnd);
-  vec2 nextPosition64xyLow = mix(instanceEndRightPositions64xyLow.xy, instanceEndRightPositions64xyLow.zw, isEnd);
+  vec2 nextPosition64xyLow = mix(instanceEndPositions64xyLow, instanceRightPositions64xyLow, isEnd);
 
   if (billboard) {
     // Extrude in clipspace

--- a/modules/layers/src/path-layer/path-layer.js
+++ b/modules/layers/src/path-layer/path-layer.js
@@ -66,6 +66,7 @@ export default class PathLayer extends Layer {
         // Hack - Attribute class needs this to properly apply partial update
         // The first 3 numbers of the value is just padding
         offset: 12,
+        doublePrecision: this.use64bitPositions(),
         transition: ATTRIBUTE_TRANSITION,
         accessor: 'getPath',
         update: this.calculateStartPositions,
@@ -81,6 +82,7 @@ export default class PathLayer extends Layer {
       },
       endPositions: {
         size: 3,
+        doublePrecision: this.use64bitPositions(),
         transition: ATTRIBUTE_TRANSITION,
         accessor: 'getPath',
         update: this.calculateEndPositions,
@@ -93,18 +95,6 @@ export default class PathLayer extends Layer {
             offset: 12
           }
         }
-      },
-      instanceLeftStartPositions64xyLow: {
-        size: 4,
-        stride: 8,
-        update: this.calculateLeftStartPositions64xyLow,
-        noAlloc
-      },
-      instanceEndRightPositions64xyLow: {
-        size: 4,
-        stride: 8,
-        update: this.calculateEndRightPositions64xyLow,
-        noAlloc
       },
       instanceTypes: {
         size: 1,
@@ -136,7 +126,9 @@ export default class PathLayer extends Layer {
     /* eslint-enable max-len */
 
     this.setState({
-      pathTesselator: new PathTesselator({})
+      pathTesselator: new PathTesselator({
+        fp64: this.use64bitPositions()
+      })
     });
   }
 
@@ -156,7 +148,6 @@ export default class PathLayer extends Layer {
         data: props.data,
         getGeometry: props.getPath,
         positionFormat: props.positionFormat,
-        fp64: this.use64bitPositions(),
         dataChanged: changeFlags.dataChanged
       });
       this.setState({
@@ -310,28 +301,6 @@ export default class PathLayer extends Layer {
 
     attribute.bufferLayout = pathTesselator.bufferLayout;
     attribute.value = pathTesselator.get('segmentTypes');
-  }
-
-  calculateLeftStartPositions64xyLow(attribute) {
-    const isFP64 = this.use64bitPositions();
-    attribute.constant = !isFP64;
-
-    if (isFP64) {
-      attribute.value = this.state.pathTesselator.get('startPositions64XyLow');
-    } else {
-      attribute.value = new Float32Array(4);
-    }
-  }
-
-  calculateEndRightPositions64xyLow(attribute) {
-    const isFP64 = this.use64bitPositions();
-    attribute.constant = !isFP64;
-
-    if (isFP64) {
-      attribute.value = this.state.pathTesselator.get('endPositions64XyLow');
-    } else {
-      attribute.value = new Float32Array(4);
-    }
   }
 
   clearPickingColor(color) {

--- a/modules/layers/src/path-layer/path-tesselator.js
+++ b/modules/layers/src/path-layer/path-tesselator.js
@@ -17,7 +17,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-import {experimental, fp64LowPart} from '@deck.gl/core';
+import {experimental} from '@deck.gl/core';
 const {Tesselator} = experimental;
 
 const START_CAP = 1;
@@ -31,11 +31,10 @@ export default class PathTesselator extends Tesselator {
     super({
       data,
       getGeometry,
-      fp64,
       positionFormat,
       attributes: {
-        startPositions: {size: 3, padding: 3},
-        endPositions: {size: 3, padding: 3},
+        startPositions: {size: 3, padding: 3, type: fp64 ? Float64Array : Float32Array},
+        endPositions: {size: 3, padding: 3, type: fp64 ? Float64Array : Float32Array},
         segmentTypes: {size: 1, type: Uint8ClampedArray},
         startPositions64XyLow: {size: 2, padding: 2, fp64Only: true},
         endPositions64XyLow: {size: 2, padding: 2, fp64Only: true}
@@ -65,14 +64,7 @@ export default class PathTesselator extends Tesselator {
   /* eslint-disable max-statements, complexity */
   updateGeometryAttributes(path, context) {
     const {
-      attributes: {
-        startPositions,
-        endPositions,
-        startPositions64XyLow,
-        endPositions64XyLow,
-        segmentTypes
-      },
-      fp64
+      attributes: {startPositions, endPositions, segmentTypes}
     } = this;
 
     const {geometrySize} = context;
@@ -114,13 +106,6 @@ export default class PathTesselator extends Tesselator {
       endPositions[i * 3] = endPoint[0];
       endPositions[i * 3 + 1] = endPoint[1];
       endPositions[i * 3 + 2] = endPoint[2] || 0;
-
-      if (fp64) {
-        startPositions64XyLow[i * 2 + 2] = fp64LowPart(startPoint[0]);
-        startPositions64XyLow[i * 2 + 3] = fp64LowPart(startPoint[1]);
-        endPositions64XyLow[i * 2] = fp64LowPart(endPoint[0]);
-        endPositions64XyLow[i * 2 + 1] = fp64LowPart(endPoint[1]);
-      }
     }
   }
   /* eslint-enable max-statements, complexity */

--- a/modules/layers/src/point-cloud-layer/point-cloud-layer.js
+++ b/modules/layers/src/point-cloud-layer/point-cloud-layer.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {Layer, positionFp64LowPart} from '@deck.gl/core';
+import {Layer} from '@deck.gl/core';
 import GL from '@luma.gl/constants';
 import {Model, Geometry, PhongMaterial} from '@luma.gl/core';
 
@@ -54,7 +54,6 @@ function normalizeData(data) {
 
   if (attributes.POSITION) {
     attributes.instancePositions = attributes.POSITION;
-    attributes.instancePositions64xyLow = {constant: true, value: new Float32Array(2)};
   }
   if (attributes.NORMAL) {
     attributes.instanceNormals = attributes.NORMAL;
@@ -74,14 +73,9 @@ export default class PointCloudLayer extends Layer {
     this.getAttributeManager().addInstanced({
       instancePositions: {
         size: 3,
+        doublePrecision: this.use64bitPositions(),
         transition: true,
         accessor: 'getPosition'
-      },
-      instancePositions64xyLow: {
-        size: 2,
-        accessor: 'getPosition',
-        enable: this.use64bitPositions,
-        transform: positionFp64LowPart
       },
       instanceNormals: {
         size: 3,

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer.js
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {Layer, positionFp64LowPart} from '@deck.gl/core';
+import {Layer} from '@deck.gl/core';
 import GL from '@luma.gl/constants';
 import {Model, Geometry} from '@luma.gl/core';
 
@@ -61,14 +61,9 @@ export default class ScatterplotLayer extends Layer {
     this.getAttributeManager().addInstanced({
       instancePositions: {
         size: 3,
+        doublePrecision: this.use64bitPositions(),
         transition: true,
         accessor: 'getPosition'
-      },
-      instancePositions64xyLow: {
-        size: 2,
-        accessor: 'getPosition',
-        enable: this.use64bitPositions,
-        transform: positionFp64LowPart
       },
       instanceRadius: {
         size: 1,

--- a/modules/layers/src/solid-polygon-layer/polygon-tesselator.js
+++ b/modules/layers/src/solid-polygon-layer/polygon-tesselator.js
@@ -24,7 +24,7 @@
 // - 3D surfaces (top and sides only)
 // - 3D wireframes (not yet)
 import * as Polygon from './polygon';
-import {experimental, fp64LowPart} from '@deck.gl/core';
+import {experimental} from '@deck.gl/core';
 const {Tesselator} = experimental;
 
 // This class is set up to allow querying one attribute at a time
@@ -34,11 +34,9 @@ export default class PolygonTesselator extends Tesselator {
     super({
       data,
       getGeometry,
-      fp64,
       positionFormat,
       attributes: {
-        positions: {size: 3},
-        positions64xyLow: {size: 2, fp64Only: true},
+        positions: {size: 3, type: fp64 ? Float64Array : Float32Array},
         vertexValid: {type: Uint8ClampedArray, size: 1},
         indices: {type: IndexType, size: 1}
       }
@@ -93,8 +91,7 @@ export default class PolygonTesselator extends Tesselator {
   // Flatten out all the vertices of all the sub subPolygons
   _updatePositions(polygon, {vertexStart, geometrySize}) {
     const {
-      attributes: {positions, positions64xyLow, vertexValid},
-      fp64,
+      attributes: {positions, vertexValid},
       positionSize
     } = this;
 
@@ -109,10 +106,6 @@ export default class PolygonTesselator extends Tesselator {
       positions[i * 3] = x;
       positions[i * 3 + 1] = y;
       positions[i * 3 + 2] = z;
-      if (fp64) {
-        positions64xyLow[i * 2] = fp64LowPart(x);
-        positions64xyLow[i * 2 + 1] = fp64LowPart(y);
-      }
       vertexValid[i] = 1;
       i++;
     }

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -75,6 +75,7 @@ export default class SolidPolygonLayer extends Layer {
     this.setState({
       numInstances: 0,
       polygonTesselator: new PolygonTesselator({
+        fp64: this.use64bitPositions(),
         IndexType: !gl || hasFeature(gl, FEATURES.ELEMENT_INDEX_UINT32) ? Uint32Array : Uint16Array
       })
     });
@@ -89,6 +90,7 @@ export default class SolidPolygonLayer extends Layer {
       indices: {size: 1, isIndexed: true, update: this.calculateIndices, noAlloc},
       positions: {
         size: 3,
+        doublePrecision: this.use64bitPositions(),
         transition: ATTRIBUTE_TRANSITION,
         accessor: 'getPolygon',
         update: this.calculatePositions,
@@ -104,25 +106,6 @@ export default class SolidPolygonLayer extends Layer {
           },
           nextPositions: {
             offset: 12,
-            divisor: 1
-          }
-        }
-      },
-      positions64xyLow: {
-        size: 2,
-        update: this.calculatePositionsLow,
-        noAlloc,
-        shaderAttributes: {
-          positions64xyLow: {
-            offset: 0,
-            divisor: 0
-          },
-          instancePositions64xyLow: {
-            offset: 0,
-            divisor: 1
-          },
-          nextPositions64xyLow: {
-            offset: 8,
             divisor: 1
           }
         }
@@ -351,17 +334,6 @@ export default class SolidPolygonLayer extends Layer {
     const {polygonTesselator} = this.state;
     attribute.bufferLayout = polygonTesselator.bufferLayout;
     attribute.value = polygonTesselator.get('positions');
-  }
-  calculatePositionsLow(attribute) {
-    const isFP64 = this.use64bitPositions();
-    attribute.constant = !isFP64;
-
-    if (!isFP64) {
-      attribute.value = new Float32Array(2);
-      return;
-    }
-
-    attribute.value = this.state.polygonTesselator.get('positions64xyLow');
   }
 
   calculateVertexValid(attribute) {

--- a/modules/main/src/index.js
+++ b/modules/main/src/index.js
@@ -76,7 +76,6 @@ export {
   LayerExtension,
   // Utilities
   fp64LowPart,
-  positionFp64LowPart,
   createIterable
 } from '@deck.gl/core';
 

--- a/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer-vertex.glsl.js
+++ b/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer-vertex.glsl.js
@@ -9,7 +9,7 @@ export default `\
 
 // Instance attributes
 _attribute vec3 instancePositions;
-_attribute vec2 instancePositions64xy;
+_attribute vec2 instancePositions64xyLow;
 _attribute vec4 instanceColors;
 _attribute vec3 instancePickingColors;
 _attribute mat3 instanceModelMatrix;
@@ -70,7 +70,7 @@ void main(void) {
   pos = project_size(pos);
   DECKGL_FILTER_SIZE(pos, geometry);
 
-  gl_Position = project_position_to_clipspace(instancePositions, instancePositions64xy, pos, geometry.position);
+  gl_Position = project_position_to_clipspace(instancePositions, instancePositions64xyLow, pos, geometry.position);
   DECKGL_FILTER_GL_POSITION(gl_Position, geometry);
 
   #ifdef MODULE_PBR

--- a/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.js
+++ b/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {Layer, positionFp64LowPart} from '@deck.gl/core';
+import {Layer} from '@deck.gl/core';
 import {ScenegraphNode, isWebGL2, pbr, log} from '@luma.gl/core';
 import {createGLTFObjects} from '@luma.gl/addons';
 import GL from '@luma.gl/constants';
@@ -68,14 +68,9 @@ export default class ScenegraphLayer extends Layer {
     attributeManager.addInstanced({
       instancePositions: {
         size: 3,
+        doublePrecision: this.use64bitPositions(),
         accessor: 'getPosition',
         transition: true
-      },
-      instancePositions64xy: {
-        size: 2,
-        accessor: 'getPosition',
-        enable: this.use64bitPositions,
-        transform: positionFp64LowPart
       },
       instanceColors: {
         type: GL.UNSIGNED_BYTE,

--- a/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer-vertex.glsl.js
+++ b/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer-vertex.glsl.js
@@ -11,7 +11,7 @@ in vec2 texCoords;
 
 // Instance attributes
 in vec3 instancePositions;
-in vec2 instancePositions64xy;
+in vec2 instancePositions64xyLow;
 in vec4 instanceColors;
 in vec3 instancePickingColors;
 in mat3 instanceModelMatrix;
@@ -38,7 +38,7 @@ void main(void) {
   pos = project_size(pos);
   DECKGL_FILTER_SIZE(pos, geometry);
 
-  gl_Position = project_position_to_clipspace(instancePositions, instancePositions64xy, pos, position_commonspace);
+  gl_Position = project_position_to_clipspace(instancePositions, instancePositions64xyLow, pos, position_commonspace);
   geometry.position = position_commonspace;
   DECKGL_FILTER_GL_POSITION(gl_Position, geometry);
 

--- a/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer-vertex.glsl1.js
+++ b/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer-vertex.glsl1.js
@@ -11,7 +11,7 @@ attribute vec2 texCoords;
 
 // Instance attributes
 attribute vec3 instancePositions;
-attribute vec2 instancePositions64xy;
+attribute vec2 instancePositions64xyLow;
 attribute vec4 instanceColors;
 attribute vec3 instancePickingColors;
 attribute mat3 instanceModelMatrix;
@@ -38,7 +38,7 @@ void main(void) {
   pos = project_size(pos);
   DECKGL_FILTER_SIZE(pos, geometry);
 
-  gl_Position = project_position_to_clipspace(instancePositions, instancePositions64xy, pos, position_commonspace);
+  gl_Position = project_position_to_clipspace(instancePositions, instancePositions64xyLow, pos, position_commonspace);
   geometry.position = position_commonspace;
   DECKGL_FILTER_GL_POSITION(gl_Position, geometry);
 

--- a/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.js
+++ b/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.js
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {Layer, positionFp64LowPart} from '@deck.gl/core';
+import {Layer} from '@deck.gl/core';
 import GL from '@luma.gl/constants';
 import {Model, Geometry, Texture2D, PhongMaterial, isWebGL2} from '@luma.gl/core';
 
@@ -127,14 +127,9 @@ export default class SimpleMeshLayer extends Layer {
     attributeManager.addInstanced({
       instancePositions: {
         transition: true,
+        doublePrecision: this.use64bitPositions(),
         size: 3,
         accessor: 'getPosition'
-      },
-      instancePositions64xy: {
-        size: 2,
-        accessor: 'getPosition',
-        enable: this.use64bitPositions,
-        transform: positionFp64LowPart
       },
       instanceColors: {
         type: GL.UNSIGNED_BYTE,

--- a/test/modules/core/lib/attribute-manager.spec.js
+++ b/test/modules/core/lib/attribute-manager.spec.js
@@ -190,35 +190,6 @@ test('AttributeManager.update - external buffers', t => {
   t.end();
 });
 
-test('AttributeManager.update - disabled attributes', t => {
-  const attributeManager = new AttributeManager(gl);
-  attributeManager.add({
-    positions: {size: 2, update, enable}
-  });
-
-  // First update, should autoalloc and update the value array
-  attributeManager.update({
-    numInstances: 0,
-    data: [{}, {}],
-    context: {enabled: true}
-  });
-
-  let attribute = attributeManager.getAttributes()['positions'];
-  t.deepEqual(attribute.value.slice(0, 4), [0, 1, 2, 3], 'attribute value is populated');
-
-  attributeManager.update({
-    numInstances: 0,
-    data: [{}, {}],
-    context: {enabled: false}
-  });
-
-  attribute = attributeManager.getAttributes()['positions'];
-  t.ok(attribute.constant, 'attribute is set to contant');
-  t.deepEqual(attribute.value, [0, 0], 'attribute is set to default value');
-
-  t.end();
-});
-
 test('AttributeManager.invalidate', t => {
   const attributeManager = new AttributeManager(gl);
   attributeManager.add({positions: {size: 2, update}});

--- a/test/modules/core/utils/math-utils.spec.js
+++ b/test/modules/core/utils/math-utils.spec.js
@@ -1,6 +1,7 @@
 import test from 'tape-catch';
 import {floatEquals, vecEquals} from '../../../utils/utils';
-import {getFrustumPlanes} from '@deck.gl/core/utils/math-utils';
+import {getFrustumPlanes, toDoublePrecisionArray} from '@deck.gl/core/utils/math-utils';
+import {equals} from 'math.gl';
 
 const ROOT2 = 0.7071;
 
@@ -52,6 +53,34 @@ test('getFrustumPlanes#tests', t => {
     t.ok(floatEquals(calculated.distance, expected.distance), 'distance is equal');
     t.ok(vecEquals(calculated.normal, expected.normal), 'normal is equal');
   }
+
+  t.end();
+});
+
+function fromDoublePrecisionArray(array, size) {
+  const result = [];
+  let i = 0;
+  while (i < array.length) {
+    result.push(array[i] + array[i + size]);
+    i++;
+    if (i % size === 0) {
+      i += size;
+    }
+  }
+  return result;
+}
+
+test('toDoublePrecisionArray', t => {
+  const array = Array.from({length: 10}, (d, i) => i + Math.PI);
+  let array64 = toDoublePrecisionArray(array, {size: 2});
+  t.ok(array64 instanceof Float32Array, 'returns correct type');
+  t.is(array64.length, 20, 'returns correct length');
+  t.ok(equals(fromDoublePrecisionArray(array64, 2), array), 'array reconstructs ok');
+
+  array64 = toDoublePrecisionArray(array, {size: 2, startIndex: 4, endIndex: 8});
+  t.ok(array64 instanceof Float32Array, 'returns correct type');
+  t.is(array64.length, 8, 'returns correct length');
+  t.ok(equals(fromDoublePrecisionArray(array64, 2), array.slice(4, 8)), 'array reconstructs ok');
 
   t.end();
 });

--- a/test/modules/layers/bitmap-layer.spec.js
+++ b/test/modules/layers/bitmap-layer.spec.js
@@ -30,10 +30,6 @@ test('BitmapLayer#constructor', t => {
             positionsWithZ,
             'should update positions'
           );
-          t.ok(
-            layer.getAttributeManager().attributes.positions64xyLow,
-            'should add positions64xyLow'
-          );
         }
       },
       {
@@ -46,10 +42,6 @@ test('BitmapLayer#constructor', t => {
             layer.getAttributeManager().attributes.positions.value,
             positions,
             'should update positions'
-          );
-          t.ok(
-            layer.getAttributeManager().attributes.positions64xyLow,
-            'should add positions64xyLow'
           );
         }
       }

--- a/test/modules/layers/core-layers.spec.js
+++ b/test/modules/layers/core-layers.spec.js
@@ -138,7 +138,7 @@ test('ArcLayer#non-iterable', t => {
           );
           t.deepEquals(
             instancePositions.slice(0, 4),
-            [data[0].START[0], data[0].START[1], data[0].END[0], data[0].END[1]].map(Math.fround),
+            [data[0].START[0], data[0].START[1], data[0].END[0], data[0].END[1]],
             'instancePositions has correct content'
           );
         }

--- a/test/modules/layers/path-tesselator.spec.js
+++ b/test/modules/layers/path-tesselator.spec.js
@@ -103,17 +103,6 @@ test('PathTesselator#constructor', t => {
         [2, 2, 0, 3, 3, 0, 0, 0, 0],
         'endPositions is handling loop correctly'
       );
-
-      if (testCase.params.fp64) {
-        t.ok(
-          ArrayBuffer.isView(tesselator.get('startPositions64XyLow')),
-          'PathTesselator.get startPositions64XyLow'
-        );
-        t.ok(
-          ArrayBuffer.isView(tesselator.get('endPositions64XyLow')),
-          'PathTesselator.get endPositions64XyLow'
-        );
-      }
     });
   });
 

--- a/test/modules/layers/polygon-tesselation.spec.js
+++ b/test/modules/layers/polygon-tesselation.spec.js
@@ -155,13 +155,6 @@ test('PolygonTesselator#constructor', t => {
       t.ok(ArrayBuffer.isView(tesselator.get('indices')), 'PolygonTesselator.get indices');
       t.ok(ArrayBuffer.isView(tesselator.get('positions')), 'PolygonTesselator.get positions');
       t.ok(ArrayBuffer.isView(tesselator.get('vertexValid')), 'PolygonTesselator.get vertexValid');
-
-      if (testCase.params.fp64) {
-        t.ok(
-          ArrayBuffer.isView(tesselator.get('positions64xyLow')),
-          'PolygonTesselator.get positions64xyLow'
-        );
-      }
     });
   });
 


### PR DESCRIPTION
In this PR, positions (and potentially other attributes that require high-precision) are packed as `Float64Array` and converted to an interleaved format just before uploading to the GPU. The buffer is automatically mapped to two attributes that respectively represents the high and low parts.

With this change, `attribute.value` no longer reflect what's in the GPU memory. However, it makes writing layers as well as supplying external buffers more intuitive for the user.

#### Change List
- Remove `enable` option and `positionFp64LowPart` added in #3448 
- Add `doublePrecision` option to Attribute class
- Remove explicit packing of 64xyLow attributes in layers