### PR TITLE
Relax restrictions for external buffers

### DIFF
--- a/modules/core/src/lib/attribute.js
+++ b/modules/core/src/lib/attribute.js
@@ -36,6 +36,7 @@ export default class Attribute extends BaseAttribute {
     let {defaultValue = [0, 0, 0, 0]} = opts;
     defaultValue = Array.isArray(defaultValue) ? defaultValue : [defaultValue];
 
+    this.defaultType = this.type || GL.FLOAT;
     this.shaderAttributes = {};
     this.hasShaderAttributes = false;
 
@@ -193,7 +194,7 @@ export default class Attribute extends BaseAttribute {
       assert(Number.isFinite(numInstances));
       // Allocate at least one element to ensure a valid buffer
       const allocCount = Math.max(numInstances, 1);
-      const ArrayType = glArrayFromType(this.type || GL.FLOAT);
+      const ArrayType = glArrayFromType(this.defaultType);
       const oldValue = state.allocatedValue;
       const shouldCopy = state.updateRanges !== range.FULL;
 
@@ -305,7 +306,6 @@ export default class Attribute extends BaseAttribute {
     state.needsRedraw = state.needsUpdate || hasChanged;
     this.clearNeedsUpdate();
     state.isExternalBuffer = true;
-    this._updateShaderAttributes();
     return true;
   }
 
@@ -337,23 +337,35 @@ export default class Attribute extends BaseAttribute {
       opts = Object.assign({constant: false}, buffer);
     }
 
-    if (opts.value) {
-      const ArrayType = glArrayFromType(this.type || GL.FLOAT);
-      if (!(opts.value instanceof ArrayType)) {
-        log.warn(`Attribute prop ${this.id} is casted to ${ArrayType.name}`)();
-        // Cast to proper type
-        opts.value = new ArrayType(opts.value);
-      }
-    }
+    this._checkExternalBuffer(opts);
 
     this.update(opts);
+
     state.needsRedraw = true;
 
-    this._updateShaderAttributes();
     return true;
   }
 
   // PRIVATE HELPER METHODS
+  _checkExternalBuffer(opts) {
+    if (!opts.constant && opts.value) {
+      const ArrayType = glArrayFromType(this.defaultType);
+      if (
+        opts.value.BYTES_PER_ELEMENT !== ArrayType.BYTES_PER_ELEMENT &&
+        this.hasShaderAttributes
+      ) {
+        // Shader attributes have hard-coded offsets and strides
+        // TODO - switch to element offsets and element strides?
+        log.warn(`Attribute ${this.id} is casted to ${ArrayType.name}`)();
+        // Cast to proper type
+        opts.value = new ArrayType(opts.value);
+      }
+      if (!(opts.value instanceof ArrayType) && this.normalized && !('normalized' in opts)) {
+        log.warn(`Attribute ${this.id} is normalized`)();
+      }
+    }
+  }
+
   _getVertexOffset(row, bufferLayout) {
     let offset = this.elementOffset;
     if (bufferLayout) {

--- a/test/modules/core/lib/attribute-manager.spec.js
+++ b/test/modules/core/lib/attribute-manager.spec.js
@@ -178,6 +178,15 @@ test('AttributeManager.update - external buffers', t => {
 
   t.is(attribute.type, gl.FLOAT, 'colors accessor is set to correct type');
 
+  attributeManager.update({
+    numInstances: 1,
+    buffers: {
+      positions: new Float32Array([0, 0]),
+      colors: new Uint32Array([0, 0, 0])
+    }
+  });
+  t.is(attribute.type, gl.UNSIGNED_INT, 'colors accessor is set to correct type');
+
   t.end();
 });
 

--- a/test/modules/core/lib/attribute-manager.spec.js
+++ b/test/modules/core/lib/attribute-manager.spec.js
@@ -176,7 +176,7 @@ test('AttributeManager.update - external buffers', t => {
     }
   });
 
-  t.is(attribute.buffer.accessor.type, gl.UNSIGNED_BYTE, 'colors casted to correct type');
+  t.is(attribute.type, gl.FLOAT, 'colors accessor is set to correct type');
 
   t.end();
 });

--- a/test/modules/core/lib/attribute.spec.js
+++ b/test/modules/core/lib/attribute.spec.js
@@ -542,16 +542,14 @@ test('Attribute#setExternalBuffer', t => {
 
   t.ok(attribute.setExternalBuffer(value1), 'should set external buffer to typed array');
   t.is(attribute.value, value1, 'external value is set');
+  t.is(attribute.type, GL.FLOAT, 'attribute type is set correctly');
 
   t.ok(attribute.setExternalBuffer(value2), 'should set external buffer to typed array');
   t.is(attribute.buffer.debugData.constructor.name, 'Uint8Array', 'external value is set');
+  t.is(attribute.type, GL.UNSIGNED_BYTE, 'attribute type is set correctly');
 
-  t.ok(attribute2.setExternalBuffer(value1), 'should set external buffer to typed array');
-  t.is(
-    attribute2.buffer.debugData.constructor.name,
-    'Uint8ClampedArray',
-    'external value is cast to correct type'
-  );
+  t.ok(attribute2.setExternalBuffer(value2), 'external value is set');
+  t.throws(() => attribute2.setExternalBuffer(value1), 'should throw on invalid buffer type');
 
   spy.reset();
   t.ok(
@@ -571,6 +569,7 @@ test('Attribute#setExternalBuffer', t => {
   t.is(attribute.offset, 4, 'attribute accessor is updated');
   t.is(attribute.stride, 8, 'attribute accessor is updated');
   t.is(attribute.value, value1, 'external value is set');
+  t.is(attribute.type, GL.FLOAT, 'attribute type is set correctly');
 
   buffer.delete();
   attribute.delete();

--- a/test/modules/core/lib/attribute.spec.js
+++ b/test/modules/core/lib/attribute.spec.js
@@ -508,6 +508,16 @@ test('Attribute#setExternalBuffer', t => {
     size: 3,
     update: () => {}
   });
+  const attribute2 = new Attribute(gl, {
+    id: 'test-attribute-with-shader-attributes',
+    type: GL.UNSIGNED_BYTE,
+    size: 4,
+    normalized: true,
+    update: () => {},
+    shaderAttributes: {
+      shaderAttribute: {offset: 4}
+    }
+  });
   const buffer = new Buffer(gl, 12);
   const value1 = new Float32Array(4);
   const value2 = new Uint8Array(4);
@@ -534,7 +544,14 @@ test('Attribute#setExternalBuffer', t => {
   t.is(attribute.value, value1, 'external value is set');
 
   t.ok(attribute.setExternalBuffer(value2), 'should set external buffer to typed array');
-  t.is(attribute.value.constructor.name, 'Float32Array', 'external value is cast to correct type');
+  t.is(attribute.buffer.debugData.constructor.name, 'Uint8Array', 'external value is set');
+
+  t.ok(attribute2.setExternalBuffer(value1), 'should set external buffer to typed array');
+  t.is(
+    attribute2.buffer.debugData.constructor.name,
+    'Uint8ClampedArray',
+    'external value is cast to correct type'
+  );
 
   spy.reset();
   t.ok(
@@ -557,6 +574,7 @@ test('Attribute#setExternalBuffer', t => {
 
   buffer.delete();
   attribute.delete();
+  attribute2.delete();
 
   t.end();
 });


### PR DESCRIPTION
For #3447 

#### Change List

- Only cast external buffer array type if necessary
- Allow `attribute.type` to be overwritten
