### PR TITLE
Attribute: use `type: GL.DOUBLE` for double precision

### DIFF
--- a/docs/api-reference/attribute-manager.md
+++ b/docs/api-reference/attribute-manager.md
@@ -60,6 +60,7 @@ Takes a single parameter as a map of attribute descriptor objects:
 
 * keys are attribute names
 * values are objects with attribute definitions:
+  + `type` (Enum, optional) - data type of the attribute, can be one of the following: `GL.FLOAT`, `GL.DOUBLE`, `GL.UNSIGNED_SHORT`, `GL.UNSIGNED_INT`, `GL.UNSIGNED_BYTE`, `GL.BYTE`, `GL.SHORT`, and `GL.INT`.
   + `size` (Number) - number of elements per object
   + `accessor` (String | Array of strings | Function) - accessor name(s) that will
     trigger an update of this attribute when changed. Used with

--- a/docs/api-reference/attribute-manager.md
+++ b/docs/api-reference/attribute-manager.md
@@ -60,30 +60,30 @@ Takes a single parameter as a map of attribute descriptor objects:
 
 * keys are attribute names
 * values are objects with attribute definitions:
-  + `type` (Enum, optional) - data type of the attribute, can be one of the following: `GL.FLOAT`, `GL.DOUBLE`, `GL.UNSIGNED_SHORT`, `GL.UNSIGNED_INT`, `GL.UNSIGNED_BYTE`, `GL.BYTE`, `GL.SHORT`, and `GL.INT`.
-  + `size` (Number) - number of elements per object
-  + `accessor` (String | Array of strings | Function) - accessor name(s) that will
-    trigger an update of this attribute when changed. Used with
-    [`updateTriggers`](/docs/api-reference/layer.md#-updatetriggers-object-optional-).
-  + `transform` (Function, optional) - callback to process the result returned by `accessor`.
-  + `update` (Function, optional) - the function to be called when data changes. If not supplied, the attribute will be auto-filled with `accessor`.
-  + `instanced` (Boolean, optional) - if this is an instanced attribute
-    (a.k.a. divisor). Default to `false`.
-  + `isIndexed` (Boolean, optional) - if this is an index attribute
-    (a.k.a. indices). Default to `false`.
-  + `constant` (Boolean, optional) - if this is a generic attribute
-    (same value applied to every vertex). Default to `false`.
-  + `defaultValue` (Number | Array of numbers, optional) - Default `[0, 0, 0, 0]`.
-  + `doublePrecision` (Bool) - whether to use 64-bit precision. Default `false`.
-  + `noAlloc` (Boolean, optional) - if this attribute should not be
-    automatically allocated. Default to `false`.
-  + `shaderAttributes` (Object, optional) - If this attribute maps to multiple
+  - luma.gl [accessor parameters](https://luma.gl/#/documentation/api-reference/webgl-2-classes/accessor):
+    * `type` (Enum, optional) - data type of the attribute, see "Remarks" section below.
+    * `size` (Number) - number of elements per object
+    * `offset` (Number) - default `0`
+    * `stride` (Number) - default `0`
+    * `normalized` (Boolean) - default `false`
+    * `integer` (Boolean) - WebGL2 only, default `false`
+    * `divisor` (Boolean, optional) - `1` if this is an instanced attribute
+      (a.k.a. divisor). Default to `0`.
+  - deck.gl attribute configurations:
+    * `isIndexed` (Boolean, optional) - if this is an index attribute
+      (a.k.a. indices). Default to `false`.
+    * `accessor` (String | Array of strings | Function) - accessor name(s) that will
+      trigger an update of this attribute when changed. Used with
+      [`updateTriggers`](/docs/api-reference/layer.md#-updatetriggers-object-optional-).
+    * `transform` (Function, optional) - callback to process the result returned by `accessor`.
+    * `update` (Function, optional) - the function to be called when data changes. If not supplied, the attribute will be auto-filled with `accessor`.
+    * `defaultValue` (Number | Array of numbers, optional) - Default `[0, 0, 0, 0]`.
+    * `noAlloc` (Boolean, optional) - if this attribute should not be
+      automatically allocated. Default to `false`.
+  - `shaderAttributes` (Object, optional) - If this attribute maps to multiple
     attributes in the vertex shader, that mapping can be defined here. All
     `shaderAttributes` will share a single buffer created based on the `size`
-    parameter. This can be used to interleave attributes. Shader attribute properties are:
-    * `size` (Number) - Number of elements per object.
-    * `offset` (Number) - Offset of the initial element.
-    * `stride` (Number) - Stride between elements.
+    parameter. This can be used to interleave attributes. Each shader attribute object may contain any of the [accessor parameters](https://luma.gl/#/documentation/api-reference/webgl-2-classes/accessor) to override the parent attribute's with.
 
 ##### `addInstanced`
 
@@ -149,6 +149,22 @@ Notes:
 * Any preallocated buffers in "buffers" matching registered attribute names will be used. No update will happen in this case.
 * Calls onUpdateStart and onUpdateEnd log callbacks before and after.
 
+## Remarks
+
+### Attribute Type
+
+The following `type` values are supported for attribute definitions:
+
+| type | value array type | notes |
+| ---- | ---------------- | ----- |
+| `GL.FLOAT` | `Float32Array` | |
+| `GL.DOUBLE` | `Float64Array` | Because 64-bit floats are not supported by WebGL, the value is converted to an interleaved `Float32Array` before uploading to the GPU. It is exposed to the vertex shader as two attributes, `<attribute_name>` and `<attribute_name>64xyLow`, the sum of which is the 64-bit value. |
+| `GL.BYTE` | `Int8Array` | |
+| `GL.SHORT` | `Int16Array` | |
+| `GL.INT` | `Int32Array` | |
+| `GL.UNSIGNED_BYTE` | `Uint8ClampedArray` | |
+| `GL.UNSIGNED_SHORT` | `Uint16Array` | |
+| `GL.UNSIGNED_INT` | `Uint32Array` | |
 
 ## Source
 

--- a/examples/webpack.config.local.js
+++ b/examples/webpack.config.local.js
@@ -28,6 +28,7 @@ function makeLocalDevConfig(EXAMPLE_DIR = LIB_DIR, linkToLuma) {
     '@luma.gl/addons': `${ROOT_DIR}/../luma.gl/modules/addons/src`
   };
   const LUMA_LOCAL_ALIASES = {
+    '@luma.gl/constants': `${ROOT_DIR}/node_modules/@luma.gl/constants`,
     '@luma.gl/core': `${ROOT_DIR}/node_modules/@luma.gl/core`,
     '@luma.gl/webgl': `${ROOT_DIR}/node_modules/@luma.gl/webgl`,
     '@luma.gl/webgl-state-tracker': `${ROOT_DIR}/node_modules/@luma.gl/webgl-state-tracker`,

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@loaders.gl/core": "^1.2.0-beta.4",
     "@loaders.gl/images": "^1.2.0-beta.4",
-    "@luma.gl/core": "^7.2.0",
+    "@luma.gl/core": "^7.3.0-alpha.1",
     "gl-matrix": "^3.0.0",
     "math.gl": "^2.3.0",
     "mjolnir.js": "^2.1.2",

--- a/modules/jupyter-widget/package.json
+++ b/modules/jupyter-widget/package.json
@@ -33,7 +33,7 @@
     "@deck.gl/json": "7.2.0-beta.3",
     "@deck.gl/layers": "7.2.0-beta.3",
     "@jupyter-widgets/base": "^1.1.10",
-    "@luma.gl/constants": "^7.2.0",
+    "@luma.gl/constants": "^7.3.0-alpha.1",
     "mapbox-gl": "^0.53.1"
   },
   "private": true

--- a/modules/layers/src/arc-layer/arc-layer.js
+++ b/modules/layers/src/arc-layer/arc-layer.js
@@ -58,7 +58,7 @@ export default class ArcLayer extends Layer {
     attributeManager.addInstanced({
       instancePositions: {
         size: 4,
-        doublePrecision: this.use64bitPositions(),
+        type: this.use64bitPositions() ? GL.DOUBLE : GL.FLOAT,
         transition: true,
         accessor: ['getSourcePosition', 'getTargetPosition'],
         update: this.calculateInstancePositions

--- a/modules/layers/src/bitmap-layer/bitmap-layer.js
+++ b/modules/layers/src/bitmap-layer/bitmap-layer.js
@@ -62,7 +62,7 @@ export default class BitmapLayer extends Layer {
     attributeManager.add({
       positions: {
         size: 3,
-        doublePrecision: this.use64bitPositions(),
+        type: this.use64bitPositions() ? GL.DOUBLE : GL.FLOAT,
         update: this.calculatePositions,
         noAlloc: true
       }

--- a/modules/layers/src/column-layer/column-layer.js
+++ b/modules/layers/src/column-layer/column-layer.js
@@ -72,7 +72,7 @@ export default class ColumnLayer extends Layer {
     attributeManager.addInstanced({
       instancePositions: {
         size: 3,
-        doublePrecision: this.use64bitPositions(),
+        type: this.use64bitPositions() ? GL.DOUBLE : GL.FLOAT,
         transition: true,
         accessor: 'getPosition'
       },

--- a/modules/layers/src/icon-layer/icon-layer.js
+++ b/modules/layers/src/icon-layer/icon-layer.js
@@ -80,7 +80,7 @@ export default class IconLayer extends Layer {
     attributeManager.addInstanced({
       instancePositions: {
         size: 3,
-        doublePrecision: this.use64bitPositions(),
+        type: this.use64bitPositions() ? GL.DOUBLE : GL.FLOAT,
         transition: true,
         accessor: 'getPosition'
       },

--- a/modules/layers/src/line-layer/line-layer.js
+++ b/modules/layers/src/line-layer/line-layer.js
@@ -54,13 +54,13 @@ export default class LineLayer extends Layer {
     attributeManager.addInstanced({
       instanceSourcePositions: {
         size: 3,
-        doublePrecision: this.use64bitPositions(),
+        type: this.use64bitPositions() ? GL.DOUBLE : GL.FLOAT,
         transition: true,
         accessor: 'getSourcePosition'
       },
       instanceTargetPositions: {
         size: 3,
-        doublePrecision: this.use64bitPositions(),
+        type: this.use64bitPositions() ? GL.DOUBLE : GL.FLOAT,
         transition: true,
         accessor: 'getTargetPosition'
       },

--- a/modules/layers/src/path-layer/path-layer.js
+++ b/modules/layers/src/path-layer/path-layer.js
@@ -66,7 +66,7 @@ export default class PathLayer extends Layer {
         // Hack - Attribute class needs this to properly apply partial update
         // The first 3 numbers of the value is just padding
         offset: 12,
-        doublePrecision: this.use64bitPositions(),
+        type: this.use64bitPositions() ? GL.DOUBLE : GL.FLOAT,
         transition: ATTRIBUTE_TRANSITION,
         accessor: 'getPath',
         update: this.calculateStartPositions,
@@ -82,7 +82,7 @@ export default class PathLayer extends Layer {
       },
       endPositions: {
         size: 3,
-        doublePrecision: this.use64bitPositions(),
+        type: this.use64bitPositions() ? GL.DOUBLE : GL.FLOAT,
         transition: ATTRIBUTE_TRANSITION,
         accessor: 'getPath',
         update: this.calculateEndPositions,

--- a/modules/layers/src/point-cloud-layer/point-cloud-layer.js
+++ b/modules/layers/src/point-cloud-layer/point-cloud-layer.js
@@ -73,7 +73,7 @@ export default class PointCloudLayer extends Layer {
     this.getAttributeManager().addInstanced({
       instancePositions: {
         size: 3,
-        doublePrecision: this.use64bitPositions(),
+        type: this.use64bitPositions() ? GL.DOUBLE : GL.FLOAT,
         transition: true,
         accessor: 'getPosition'
       },

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer.js
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer.js
@@ -61,7 +61,7 @@ export default class ScatterplotLayer extends Layer {
     this.getAttributeManager().addInstanced({
       instancePositions: {
         size: 3,
-        doublePrecision: this.use64bitPositions(),
+        type: this.use64bitPositions() ? GL.DOUBLE : GL.FLOAT,
         transition: true,
         accessor: 'getPosition'
       },

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -90,7 +90,7 @@ export default class SolidPolygonLayer extends Layer {
       indices: {size: 1, isIndexed: true, update: this.calculateIndices, noAlloc},
       positions: {
         size: 3,
-        doublePrecision: this.use64bitPositions(),
+        type: this.use64bitPositions() ? GL.DOUBLE : GL.FLOAT,
         transition: ATTRIBUTE_TRANSITION,
         accessor: 'getPolygon',
         update: this.calculatePositions,

--- a/modules/mesh-layers/package.json
+++ b/modules/mesh-layers/package.json
@@ -33,6 +33,6 @@
     "@deck.gl/core": "^7.0.0"
   },
   "dependencies": {
-    "@luma.gl/addons": "^7.2.0"
+    "@luma.gl/addons": "^7.3.0-alpha.1"
   }
 }

--- a/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.js
+++ b/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.js
@@ -68,7 +68,7 @@ export default class ScenegraphLayer extends Layer {
     attributeManager.addInstanced({
       instancePositions: {
         size: 3,
-        doublePrecision: this.use64bitPositions(),
+        type: this.use64bitPositions() ? GL.DOUBLE : GL.FLOAT,
         accessor: 'getPosition',
         transition: true
       },

--- a/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.js
+++ b/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.js
@@ -127,7 +127,7 @@ export default class SimpleMeshLayer extends Layer {
     attributeManager.addInstanced({
       instancePositions: {
         transition: true,
-        doublePrecision: this.use64bitPositions(),
+        type: this.use64bitPositions() ? GL.DOUBLE : GL.FLOAT,
         size: 3,
         accessor: 'getPosition'
       },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "jsdom": false
   },
   "devDependencies": {
-    "@luma.gl/effects": "^7.2.0",
+    "@luma.gl/effects": "^7.3.0-alpha.1",
     "@probe.gl/bench": "^3.0.2",
     "@probe.gl/test-utils": "^3.1.0-alpha.8",
     "babel-loader": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@probe.gl/bench": "^3.0.2",
     "@probe.gl/test-utils": "^3.1.0-alpha.8",
     "babel-loader": "^8.0.0",
-    "babel-plugin-inline-webgl-constants": "^1.0.0",
+    "babel-plugin-inline-webgl-constants": "^1.0.1",
     "babel-plugin-remove-glsl-comments": "^0.1.0",
     "babel-preset-minify": "^0.5.0",
     "canvas": "^2.6.0",

--- a/test/modules/core/lib/attribute.spec.js
+++ b/test/modules/core/lib/attribute.spec.js
@@ -581,8 +581,7 @@ test('Attribute#setExternalBuffer', t => {
 test('Attribute#doublePrecision', t => {
   const attribute = new Attribute(gl, {
     id: 'positions',
-    type: GL.FLOAT,
-    doublePrecision: true,
+    type: GL.DOUBLE,
     size: 3,
     accessor: 'getPosition'
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1432,6 +1432,11 @@
   resolved "https://registry.yarnpkg.com/@loaders.gl/images/-/images-1.2.0.tgz#d4e66771d097f02220071c58fa545064c110e61d"
   integrity sha512-XTomGXsucrFNQj4lLTZ3rXZmOgtjUnNYWBTBkq0Dznpz8IwWSbc3deSfbNqhULyqWO3ZUfH/xMQvGfHD3HYySg==
 
+"@loaders.gl/images@^1.2.0":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/images/-/images-1.2.1.tgz#558b45fdeb55f783acf4d34b3df5fc974d8efa6d"
+  integrity sha512-Ec/UAqfsQifdQjUdW2yvLf0KyHAwv6Ej4xEKyIC6JWD6KE2Z1hfAKrwdhIsiLBPHIonvxy41jSuVEJeoVYonEA==
+
 "@loaders.gl/images@^1.2.0-beta.4":
   version "1.2.0-beta.4"
   resolved "https://registry.yarnpkg.com/@loaders.gl/images/-/images-1.2.0-beta.4.tgz#49dc255b383601864cff3f528499be7ca9011f5b"
@@ -1444,80 +1449,76 @@
   dependencies:
     "@babel/runtime" "^7.3.1"
 
-"@luma.gl/addons@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@luma.gl/addons/-/addons-7.2.0.tgz#981cccb25ebb3fc7e2d603e6a191e3407972a76b"
-  integrity sha512-LmS1lJAKLCmk56JKgCgN9fCk1YhUnw/aGlQt02Fh02+4cfyoBCNfHxfbzaMVIVVWK8IMsFDlX+eNVtKDCUItQw==
+"@luma.gl/addons@^7.3.0-alpha.1":
+  version "7.3.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@luma.gl/addons/-/addons-7.3.0-alpha.1.tgz#8d0417639284cf05c1706a71a3cb2590b3ba3eee"
+  integrity sha512-XL81tmUljplH7NpGNyz+eGrzqPKAUeIpU6A9DPtf4ZJSkIEaBP5r7Kpao6t5P5+F20+xps4XTzDosJST0c7q1w==
   dependencies:
     "@loaders.gl/gltf" "^1.2.0"
-    "@luma.gl/constants" "7.2.0"
+    "@loaders.gl/images" "^1.2.0"
+    "@luma.gl/constants" "7.3.0-alpha.1"
     math.gl "^2.3.0"
 
-"@luma.gl/constants@7.2.0", "@luma.gl/constants@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@luma.gl/constants/-/constants-7.2.0.tgz#0fbc4aa07839e6e0454f80658a4e361b855deb67"
-  integrity sha512-VQFdTM3N8pxFLfjpLq5vO3CBVcbvyRKseTZ8zmkMFL3uCYrorE9v32vDHW+3hABaYaQc/Xw4J1mOrtyfzKtv3w==
+"@luma.gl/constants@7.3.0-alpha.1", "@luma.gl/constants@^7.0.0-alpha.6", "@luma.gl/constants@^7.3.0-alpha.1":
+  version "7.3.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@luma.gl/constants/-/constants-7.3.0-alpha.1.tgz#e7097d725e42130fc5afdc4df724b98e21f56857"
+  integrity sha512-DKBJkPEYGLUYY//+UPEc5ABvoqFm7KoSlpA7Q8flgl5JpibKED4QoFtLwZpDO6AVO0VVI+75/MOcs7XYL0tUtw==
 
-"@luma.gl/constants@^7.0.0-alpha.6":
-  version "7.0.0-alpha.19"
-  resolved "https://registry.yarnpkg.com/@luma.gl/constants/-/constants-7.0.0-alpha.19.tgz#f9dcb21ebb53d1736be27aad68073c1562bc3d81"
-  integrity sha512-7vxAjPSX80eRkDiAp5ro8NWZS5syIgHiaNfG6yhvHDXFfR8nghks1EHA3CqToUy8RDZn7p08pv4P2V8dFhs64Q==
-
-"@luma.gl/core@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@luma.gl/core/-/core-7.2.0.tgz#fc8556ce7c9afe4a352cc795783fac501a2f1e01"
-  integrity sha512-KbsgopiE62suHedDjUY7to6o9IdJA0dnE2aqDIk2uKcY0OcMWsoZGh25Y0N66Ouvy0sxAg/6dlS1v3qoLDcVyA==
+"@luma.gl/core@^7.3.0-alpha.1":
+  version "7.3.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@luma.gl/core/-/core-7.3.0-alpha.1.tgz#3af2bf2023d453fed074cb2846a4701ac69e115d"
+  integrity sha512-K8tSk0bqF6Qt9Gp4DcN6NSvKbMZkUP5sWCGzwi8pvVBL7+psfdflgKMzaAtv5sV6ULxxPjvVf73IonMOtnJVyg==
   dependencies:
     "@babel/runtime" "^7.0.0"
-    "@luma.gl/constants" "7.2.0"
-    "@luma.gl/shadertools" "7.2.0"
-    "@luma.gl/webgl" "7.2.0"
-    "@luma.gl/webgl-state-tracker" "7.2.0"
-    "@luma.gl/webgl2-polyfill" "7.2.0"
+    "@luma.gl/constants" "7.3.0-alpha.1"
+    "@luma.gl/shadertools" "7.3.0-alpha.1"
+    "@luma.gl/webgl" "7.3.0-alpha.1"
+    "@luma.gl/webgl-state-tracker" "7.3.0-alpha.1"
+    "@luma.gl/webgl2-polyfill" "7.3.0-alpha.1"
     math.gl "^2.3.0"
     probe.gl "^3.0.2"
     seer "^0.2.4"
 
-"@luma.gl/effects@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@luma.gl/effects/-/effects-7.2.0.tgz#76056f25647ca49da208fbfb044f2cdc7f372958"
-  integrity sha512-gTx//GkhujxhGez76jggcqPsK9xOELIqvw47tjUVjTDRzFsERE69Hpgiw3oPK/haNYiky/0jShwQ5+2O7beO8A==
+"@luma.gl/effects@^7.3.0-alpha.1":
+  version "7.3.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@luma.gl/effects/-/effects-7.3.0-alpha.1.tgz#b0e914e415f7e9053c59dfe11fccdaf7dd573e10"
+  integrity sha512-uX4SqnwZKynAV/AH4FT7BHGxB5HbaMcPbA6u1AjCv3/5+uC/YfWUh838UAS/aa5jNACwly0vfqqOsCyFNhk1aw==
   dependencies:
-    "@luma.gl/constants" "7.2.0"
+    "@luma.gl/constants" "7.3.0-alpha.1"
 
-"@luma.gl/shadertools@7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@luma.gl/shadertools/-/shadertools-7.2.0.tgz#3a56e243195ddbe3ab92028163a8a86d0f104477"
-  integrity sha512-j4Bmc3fNTewi2El0xT/0hm5woLxKs635OJMuql8geznuXTEeWdxRziATN+ouhe1VbFTjjbu/L3CCYGrpiKZSjQ==
+"@luma.gl/shadertools@7.3.0-alpha.1":
+  version "7.3.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@luma.gl/shadertools/-/shadertools-7.3.0-alpha.1.tgz#875ef22b86ef682ebb9b39ebc493f780293766e1"
+  integrity sha512-8q/l4Adkpw94P2fR5FXk4tQM21IIF/e/fFEMecj8SdpfgrmaRf8eJnBZBy3vnw2wBXUg7MVcqsd7Q3+oD34pPQ==
   dependencies:
     "@babel/runtime" "^7.0.0"
     math.gl "^2.3.0"
 
-"@luma.gl/webgl-state-tracker@7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@luma.gl/webgl-state-tracker/-/webgl-state-tracker-7.2.0.tgz#dff5a64934663fc8f3508cff16703efcecff467b"
-  integrity sha512-RKiE0ksGTaPt+FmJA4iGKsPP9uYvqIr/auB0oZUKa4dNq8EqnvlhNSqpkkJrM9ZIuUreWuCQvDZYCU9rgTyrvw==
+"@luma.gl/webgl-state-tracker@7.3.0-alpha.1":
+  version "7.3.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@luma.gl/webgl-state-tracker/-/webgl-state-tracker-7.3.0-alpha.1.tgz#4cf31de01d9e11a83685f5bfc5bec86a8e77e51e"
+  integrity sha512-jxy/14tpmqB6JCBRSEbyzboaF8FHcW4l4CH2NOoImwicEBukjIb1uKZCjBQ9AHGgHowNjgvZ2R+FWi1U9lfFtw==
   dependencies:
     "@babel/runtime" "^7.0.0"
-    "@luma.gl/constants" "7.2.0"
+    "@luma.gl/constants" "7.3.0-alpha.1"
 
-"@luma.gl/webgl2-polyfill@7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@luma.gl/webgl2-polyfill/-/webgl2-polyfill-7.2.0.tgz#9393a60a72875a18ef93da1932702f75fae9be8a"
-  integrity sha512-al/o8RyBhcK3a1RL0JsCvQXbl6QMmx6qazOOKNiRuHhFTa6H1Gh8Z6XcelT1F2dB6ys68/6Cg/QfAcAvwQlVyw==
+"@luma.gl/webgl2-polyfill@7.3.0-alpha.1":
+  version "7.3.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@luma.gl/webgl2-polyfill/-/webgl2-polyfill-7.3.0-alpha.1.tgz#af471bfc2527833a51c357673b5d8e241ddb97d5"
+  integrity sha512-InQXu8cGsQMa+4QWf72RmorU2szldaYUwstQSdy2J+ZPWStZVP/H7Rq06tgskmUSOt1Oy4cncdM2FEmxxIrr1Q==
   dependencies:
     "@babel/runtime" "^7.0.0"
-    "@luma.gl/constants" "7.2.0"
+    "@luma.gl/constants" "7.3.0-alpha.1"
 
-"@luma.gl/webgl@7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@luma.gl/webgl/-/webgl-7.2.0.tgz#5eab507b7705a37ff117254cc7ed52a1f160d6e6"
-  integrity sha512-4KrhxZpGIZfIeBbGV1eyA0AJSwu72SgPiF+DWOm7KByK76pYTBSJviHxFAJtLxIoCkp1kgH7jQ/TCzLkg8GOeQ==
+"@luma.gl/webgl@7.3.0-alpha.1":
+  version "7.3.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@luma.gl/webgl/-/webgl-7.3.0-alpha.1.tgz#830d19698a25753a56016151f910f0eabd3bc8ef"
+  integrity sha512-jaMMIzicXgDWQPBUxrMs+vSGp6mPifKbnLi1oDS9khcHfi+v0DNTB3D05wNFAFckyDxChZlIdd1erAMznynahQ==
   dependencies:
     "@babel/runtime" "^7.0.0"
-    "@luma.gl/constants" "7.2.0"
-    "@luma.gl/webgl-state-tracker" "7.2.0"
-    "@luma.gl/webgl2-polyfill" "7.2.0"
+    "@luma.gl/constants" "7.3.0-alpha.1"
+    "@luma.gl/webgl-state-tracker" "7.3.0-alpha.1"
+    "@luma.gl/webgl2-polyfill" "7.3.0-alpha.1"
     probe.gl "^3.0.2"
 
 "@mapbox/geojson-area@0.2.2":

--- a/yarn.lock
+++ b/yarn.lock
@@ -1459,7 +1459,7 @@
     "@luma.gl/constants" "7.3.0-alpha.1"
     math.gl "^2.3.0"
 
-"@luma.gl/constants@7.3.0-alpha.1", "@luma.gl/constants@^7.0.0-alpha.6", "@luma.gl/constants@^7.3.0-alpha.1":
+"@luma.gl/constants@7.3.0-alpha.1", "@luma.gl/constants@^7.3.0-alpha.1":
   version "7.3.0-alpha.1"
   resolved "https://registry.yarnpkg.com/@luma.gl/constants/-/constants-7.3.0-alpha.1.tgz#e7097d725e42130fc5afdc4df724b98e21f56857"
   integrity sha512-DKBJkPEYGLUYY//+UPEc5ABvoqFm7KoSlpA7Q8flgl5JpibKED4QoFtLwZpDO6AVO0VVI+75/MOcs7XYL0tUtw==
@@ -2417,12 +2417,12 @@ babel-loader@^8.0.0:
     mkdirp "^0.5.1"
     util.promisify "^1.0.0"
 
-babel-plugin-inline-webgl-constants@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-inline-webgl-constants/-/babel-plugin-inline-webgl-constants-1.0.0.tgz#206548c03df77ea800c40bf59622000fbd976753"
-  integrity sha512-50aOuF9zgvZZn8RA+cxHtjSlbQEQDeus6LJlA5DLMobq8LzIhs/RaTkZmVDRfwT3+I5h9+sSVwiOppKOY19GXA==
+babel-plugin-inline-webgl-constants@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-inline-webgl-constants/-/babel-plugin-inline-webgl-constants-1.0.1.tgz#ca81b3e3c3816356a23414a44bf367f51c5b7a89"
+  integrity sha512-PG2gJZF69mYywdvMFiix1rHBDJGvfzCm34niP4Lsedk6JXUuvQndY+jm53jNSPxe5wohBWsnM60LmWhxE5j6Bw==
   dependencies:
-    "@luma.gl/constants" "^7.0.0-alpha.6"
+    "@luma.gl/constants" "^7.3.0-alpha.1"
 
 babel-plugin-istanbul@^5.0.0:
   version "5.1.1"


### PR DESCRIPTION
Follow up of #3468 

#### Change List
- Bump luma.gl dependencies
- Remove `doublePrecision` option, use `type: GL.DOUBLE`
