### PR TITLE
Fix arc layer shaders

### DIFF
--- a/modules/geo-layers/src/great-circle-layer/great-circle-vertex.glsl.js
+++ b/modules/geo-layers/src/great-circle-layer/great-circle-vertex.glsl.js
@@ -25,7 +25,7 @@ attribute vec3 positions;
 attribute vec4 instanceSourceColors;
 attribute vec4 instanceTargetColors;
 attribute vec4 instancePositions;
-attribute vec4 instancePositions64Low;
+attribute vec4 instancePositions64xyLow;
 attribute vec3 instancePickingColors;
 attribute float instanceWidths;
 
@@ -105,8 +105,8 @@ void main(void) {
   vec3 currPos = vec3(degrees(interpolate(source, target, angularDist, segmentRatio)), 0.0);
   vec3 nextPos = vec3(degrees(interpolate(source, target, angularDist, nextSegmentRatio)), 0.0);
 
-  vec2 currPos64Low = mix(instancePositions64Low.xy, instancePositions64Low.zw, segmentRatio);
-  vec2 nextPos64Low = mix(instancePositions64Low.xy, instancePositions64Low.zw, nextSegmentRatio);
+  vec2 currPos64Low = mix(instancePositions64xyLow.xy, instancePositions64xyLow.zw, segmentRatio);
+  vec2 nextPos64Low = mix(instancePositions64xyLow.xy, instancePositions64xyLow.zw, nextSegmentRatio);
 
   vec4 curr = project_position_to_clipspace(currPos, currPos64Low, vec3(0.0), geometry.position);
   vec4 next = project_position_to_clipspace(nextPos, nextPos64Low, vec3(0.0));

--- a/modules/layers/src/arc-layer/arc-layer-vertex.glsl.js
+++ b/modules/layers/src/arc-layer/arc-layer-vertex.glsl.js
@@ -25,7 +25,7 @@ attribute vec3 positions;
 attribute vec4 instanceSourceColors;
 attribute vec4 instanceTargetColors;
 attribute vec4 instancePositions;
-attribute vec4 instancePositions64Low;
+attribute vec4 instancePositions64xyLow;
 attribute vec3 instancePickingColors;
 attribute float instanceWidths;
 attribute float instanceHeights;
@@ -82,8 +82,8 @@ void main(void) {
   geometry.worldPosition = vec3(instancePositions.xy, 0.0);
   geometry.worldPositionAlt = vec3(instancePositions.zw, 0.0);
 
-  vec2 source = project_position(geometry.worldPosition, instancePositions64Low.xy).xy;
-  vec2 target = project_position(geometry.worldPositionAlt, instancePositions64Low.zw).xy;
+  vec2 source = project_position(geometry.worldPosition, instancePositions64xyLow.xy).xy;
+  vec2 target = project_position(geometry.worldPositionAlt, instancePositions64xyLow.zw).xy;
 
   float segmentIndex = positions.x;
   float segmentRatio = getSegmentRatio(segmentIndex);


### PR DESCRIPTION

After #3468 all 64-bit attributes are renamed to `*64xyLow`. This is interestingly not caught by the render tests - are the values of an unbound attribute somehow dependent on the memory context?

#### Change List
- Fix attribute names
