### PR TITLE
Respect layer opacity in SimpleMeshLayer

### DIFF
--- a/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer-fragment.glsl.js
+++ b/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer-fragment.glsl.js
@@ -6,6 +6,7 @@ precision highp float;
 uniform bool hasTexture;
 uniform sampler2D sampler;
 uniform bool flatShading;
+uniform float opacity;
 
 in vec2 vTexCoord;
 in vec3 cameraPosition;
@@ -27,7 +28,7 @@ void main(void) {
 
   vec4 color = hasTexture ? texture(sampler, vTexCoord) : vColor;
   vec3 lightColor = lighting_getLightColor(color.rgb, cameraPosition, position_commonspace.xyz, normal);
-  fragColor = vec4(lightColor, color.a);
+  fragColor = vec4(lightColor, color.a * opacity);
 
   DECKGL_FILTER_COLOR(fragColor, geometry);
 }

--- a/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer-fragment.glsl1.js
+++ b/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer-fragment.glsl1.js
@@ -13,6 +13,7 @@ precision highp float;
 uniform bool hasTexture;
 uniform sampler2D sampler;
 uniform bool flatShading;
+uniform float opacity;
 
 varying vec2 vTexCoord;
 varying vec3 cameraPosition;
@@ -32,7 +33,7 @@ void main(void) {
 
   vec4 color = hasTexture ? texture2D(sampler, vTexCoord) : vColor;
   vec3 lightColor = lighting_getLightColor(color.rgb, cameraPosition, position_commonspace.xyz, normal);
-  gl_FragColor = vec4(lightColor, color.a);
+  gl_FragColor = vec4(lightColor, color.a * opacity);
 
   DECKGL_FILTER_COLOR(gl_FragColor, geometry);
 }

--- a/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.js
+++ b/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.js
@@ -92,6 +92,7 @@ const defaultProps = {
     depthTest: true,
     depthFunc: GL.LEQUAL
   },
+  opacity: 1.0,
 
   // NOTE(Tarek): Quick and dirty wireframe. Just draws
   // the same mesh with LINE_STRIPS. Won't follow edges


### PR DESCRIPTION
#### Background
SimpleMeshLayer is completely unimpressed by changes to its opacity value. This change makes the layer transparent when the opacity is <1.0.
Possible problem: The default layer opacity is 0.8 but SimpleMeshLayer was always rendered as if it was 1.0. It might be a good idea to set the default opacity of SimpleMeshLayer to 1.0 so existing implementations don't experience sudden transparency. On the other hand this would introduce inconsistency, so I will leave this topic to the experts.
#### Change List
- Multiplying opacity value with existing alpha channel value in SimpleMeshLayers fragment shaders.
