### PR TITLE
Transition system refactor (1/2): use timeline

### DIFF
--- a/modules/core/src/controllers/controller.js
+++ b/modules/core/src/controllers/controller.js
@@ -187,8 +187,8 @@ export default class Controller {
   }
   /* eslint-enable complexity, max-statements */
 
-  updateTransition(timestamp) {
-    this.transitionManager.updateTransition(timestamp);
+  updateTransition() {
+    this.transitionManager.updateTransition();
   }
 
   toggleEvents(eventNames, enabled) {

--- a/modules/core/src/controllers/transition-manager.js
+++ b/modules/core/src/controllers/transition-manager.js
@@ -26,15 +26,16 @@ export default class TransitionManager {
     this.ControllerState = ControllerState;
     this.props = Object.assign({}, DEFAULT_PROPS, props);
     this.propsInTransition = null;
-    this.time = 0;
-    this.transition = new Transition();
+    this.transition = new Transition({timeline: props.timeline});
 
     this.onViewStateChange = props.onViewStateChange;
 
     this._onTransitionUpdate = this._onTransitionUpdate.bind(this);
   }
 
-  finalize() {}
+  finalize() {
+    this.transition.cancel();
+  }
 
   // Returns current transitioned viewport.
   getViewportInTransition() {
@@ -74,9 +75,8 @@ export default class TransitionManager {
     return transitionTriggered;
   }
 
-  updateTransition(timestamp) {
-    this.time = timestamp;
-    this._updateTransition();
+  updateTransition() {
+    this.transition.update();
   }
 
   // Helper methods
@@ -133,11 +133,7 @@ export default class TransitionManager {
       onInterrupt: this._onTransitionEnd(endProps.onTransitionInterrupt),
       onEnd: this._onTransitionEnd(endProps.onTransitionEnd)
     });
-    this._updateTransition();
-  }
-
-  _updateTransition() {
-    this.transition.update(this.time);
+    this.updateTransition();
   }
 
   _onTransitionEnd(callback) {

--- a/modules/core/src/lib/attribute-manager.js
+++ b/modules/core/src/lib/attribute-manager.js
@@ -112,7 +112,7 @@ export default class AttributeManager {
    * change detection, but instead makes it easy to build such detection
    * by offering the ability to "invalidate" each attribute separately.
    */
-  constructor(gl, {id = 'attribute-manager', stats} = {}) {
+  constructor(gl, {id = 'attribute-manager', stats, timeline} = {}) {
     this.id = id;
     this.gl = gl;
 
@@ -126,7 +126,8 @@ export default class AttributeManager {
     this.stats = stats;
 
     this.attributeTransitionManager = new AttributeTransitionManager(gl, {
-      id: `${id}-transitions`
+      id: `${id}-transitions`,
+      timeline
     });
 
     // For debugging sanity, prevent uninitialized members
@@ -273,9 +274,9 @@ export default class AttributeManager {
 
   // Update attribute transition to the current timestamp
   // Returns `true` if any transition is in progress
-  updateTransition(timestamp) {
+  updateTransition() {
     const {attributeTransitionManager} = this;
-    const transitionUpdated = attributeTransitionManager.setCurrentTime(timestamp);
+    const transitionUpdated = attributeTransitionManager.run();
     this.needsRedraw = this.needsRedraw || transitionUpdated;
     return transitionUpdated;
   }

--- a/modules/core/src/lib/layer-manager.js
+++ b/modules/core/src/lib/layer-manager.js
@@ -57,7 +57,6 @@ const INITIAL_CONTEXT = Object.seal({
   shaderCache: null,
   pickingFBO: null, // Screen-size framebuffer that layers can reuse
 
-  animationProps: null,
   mousePosition: null,
 
   userData: {} // Place for any custom app `context`
@@ -207,7 +206,7 @@ export default class LayerManager {
   }
 
   // Update layers from last cycle if `setNeedsUpdate()` has been called
-  updateLayers(animationProps = {}) {
+  updateLayers() {
     // NOTE: For now, even if only some layer has changed, we update all layers
     // to ensure that layer id maps etc remain consistent even if different
     // sublayers are rendered

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -427,12 +427,14 @@ export default class Layer extends Component {
   }
 
   // Update attribute and uniform transitions, returns props in transition
-  updateTransition() {
+  _updateAttributeTransition() {
     const attributeManager = this.getAttributeManager();
     if (attributeManager) {
-      attributeManager.updateTransition(this.context.timeline.getTime());
+      attributeManager.updateTransition();
     }
+  }
 
+  _updateUniformTransition() {
     const {uniformTransitions} = this.internalState;
     if (uniformTransitions.active) {
       // clone props
@@ -647,7 +649,7 @@ export default class Layer extends Component {
   // Common code for _initialize and _update
   _updateState() {
     const currentProps = this.props;
-    const propsInTransition = this.updateTransition();
+    const propsInTransition = this._updateUniformTransition();
     this.internalState.propsInTransition = propsInTransition;
     // Overwrite this.props during update to use in-transition prop values
     this.props = propsInTransition;
@@ -707,6 +709,8 @@ export default class Layer extends Component {
 
   // Calculates uniforms
   drawLayer({moduleParameters = null, uniforms = {}, parameters = {}}) {
+    this._updateAttributeTransition();
+
     const currentProps = this.props;
     // Overwrite this.props during redraw to use in-transition prop values
     this.props = this.internalState.propsInTransition;
@@ -912,7 +916,8 @@ ${flags.viewportChanged ? 'viewport' : ''}\
   _getAttributeManager() {
     return new AttributeManager(this.context.gl, {
       id: this.props.id,
-      stats: this.context.stats
+      stats: this.context.stats,
+      timeline: this.context.timeline
     });
   }
 

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -426,7 +426,7 @@ export default class Layer extends Component {
     this.updateAttributes(changedAttributes);
   }
 
-  // Update attribute and uniform transitions, returns props in transition
+  // Update attribute transitions. This is called in drawLayer, no model updates required.
   _updateAttributeTransition() {
     const attributeManager = this.getAttributeManager();
     if (attributeManager) {
@@ -434,6 +434,7 @@ export default class Layer extends Component {
     }
   }
 
+  // Update uniform (prop) transitions. This is called in updateState, may result in model updates.
   _updateUniformTransition() {
     const {uniformTransitions} = this.internalState;
     if (uniformTransitions.active) {

--- a/modules/core/src/lib/view-manager.js
+++ b/modules/core/src/lib/view-manager.js
@@ -33,6 +33,7 @@ export default class ViewManager {
     this.height = 100;
     this.viewState = {};
     this.controllers = {};
+    this.timeline = props.timeline;
 
     this._viewports = []; // Generated viewports
     this._viewportMap = {};
@@ -78,13 +79,11 @@ export default class ViewManager {
   }
 
   // Checks each viewport for transition updates
-  updateViewStates(animationProps = {}) {
-    if ('time' in animationProps) {
-      for (const viewId in this.controllers) {
-        const controller = this.controllers[viewId];
-        if (controller) {
-          controller.updateTransition(animationProps.time);
-        }
+  updateViewStates() {
+    for (const viewId in this.controllers) {
+      const controller = this.controllers[viewId];
+      if (controller) {
+        controller.updateTransition();
       }
     }
   }
@@ -254,6 +253,7 @@ export default class ViewManager {
     const controller = new Controller(
       Object.assign(
         {
+          timeline: this.timeline,
           eventManager: this._eventManager,
           // Set an internal callback that calls the prop callback if provided
           onViewStateChange: this._onViewStateChange.bind(this, props.id),

--- a/test/modules/core/controllers/test-controller.js
+++ b/test/modules/core/controllers/test-controller.js
@@ -1,3 +1,5 @@
+import {Timeline} from '@luma.gl/addons';
+
 function makeEvents(events, opts = {}) {
   return events.map((type, i) => makeEvent(type, opts, i));
 }
@@ -175,8 +177,9 @@ export default function testController(t, ViewClass, defaultProps, blackList = [
   let onViewStateChangeCalled = 0;
   let affectedStates = null;
 
+  const timeline = new Timeline();
   const controllerProps = new ViewClass({controller: true}).controller;
-  Object.assign(defaultProps, BASE_PROPS, controllerProps);
+  Object.assign(defaultProps, BASE_PROPS, controllerProps, {timeline});
   const ControllerClass = controllerProps.type;
   const controller = new ControllerClass(defaultProps);
 

--- a/test/modules/core/lib/transition-manager.spec.js
+++ b/test/modules/core/lib/transition-manager.spec.js
@@ -2,6 +2,7 @@ import test from 'tape-catch';
 import TransitionManager from '@deck.gl/core/controllers/transition-manager';
 import {testExports} from '@deck.gl/core/controllers/map-controller';
 const {MapState} = testExports;
+import {Timeline} from '@luma.gl/addons';
 
 /* global global, setTimeout, clearTimeout */
 // backfill requestAnimationFrame on Node
@@ -113,7 +114,8 @@ test('TransitionManager#constructor', t => {
 });
 
 test('TransitionManager#processViewStateChange', t => {
-  const mergeProps = props => Object.assign({}, TransitionManager.defaultProps, props);
+  const timeline = new Timeline();
+  const mergeProps = props => Object.assign({timeline}, TransitionManager.defaultProps, props);
 
   TEST_CASES.forEach(testCase => {
     const transitionManager = new TransitionManager(MapState, mergeProps(testCase.initialProps));
@@ -131,6 +133,7 @@ test('TransitionManager#processViewStateChange', t => {
 });
 
 test('TransitionManager#callbacks', t => {
+  const timeline = new Timeline();
   const testCase = TEST_CASES[1];
 
   let startCount = 0;
@@ -165,7 +168,8 @@ test('TransitionManager#callbacks', t => {
     }
   };
 
-  const mergeProps = props => Object.assign({}, TransitionManager.defaultProps, callbacks, props);
+  const mergeProps = props =>
+    Object.assign({timeline}, TransitionManager.defaultProps, callbacks, props);
 
   const transitionManager = new TransitionManager(MapState, mergeProps(testCase.initialProps));
 
@@ -174,10 +178,14 @@ test('TransitionManager#callbacks', t => {
     transitionManager.processViewStateChange(transitionProps);
   });
 
-  transitionManager.updateTransition(200);
-  transitionManager.updateTransition(400);
-  transitionManager.updateTransition(600);
-  transitionManager.updateTransition(800);
+  timeline.setTime(200);
+  transitionManager.updateTransition();
+  timeline.setTime(400);
+  transitionManager.updateTransition();
+  timeline.setTime(600);
+  transitionManager.updateTransition();
+  timeline.setTime(800);
+  transitionManager.updateTransition();
 
   t.is(startCount, 2, 'onTransitionStart() called twice');
   t.is(interruptCount, 1, 'onTransitionInterrupt() called once');

--- a/test/modules/core/transitions/transition.spec.js
+++ b/test/modules/core/transitions/transition.spec.js
@@ -1,5 +1,12 @@
 import test from 'tape-catch';
-import Transition, {TRANSITION_STATE} from '@deck.gl/core/transitions/transition';
+import Transition from '@deck.gl/core/transitions/transition';
+import {Timeline} from '@luma.gl/addons';
+
+// transition states
+const STATE_NONE = 0;
+const STATE_PENDING = 1;
+const STATE_IN_PROGRESS = 2;
+const STATE_ENDED = 3;
 
 test('Transition#constructor', t => {
   let transition = new Transition();
@@ -20,11 +27,11 @@ test('Transition#start', t => {
       onStartCallCount++;
     }
   });
-  t.is(transition.state, TRANSITION_STATE.NONE, 'Transition has initial state');
+  t.is(transition.state, STATE_NONE, 'Transition has initial state');
   t.notOk(transition.inProgress, 'inProgress returns correct result');
 
   transition.start({customAttribute: 'custom value'});
-  t.is(transition.state, TRANSITION_STATE.PENDING, 'Transition has started');
+  t.is(transition.state, STATE_PENDING, 'Transition has started');
   t.ok(transition.inProgress, 'inProgress returns correct result');
   t.is(transition.customAttribute, 'custom value', 'Transition has customAttribute');
   t.is(onStartCallCount, 1, 'onStart is called once');
@@ -32,11 +39,14 @@ test('Transition#start', t => {
   t.end();
 });
 
+/* eslint-disable max-statements */
 test('Transition#update', t => {
   let onUpdateCallCount = 0;
   let onEndCallCount = 0;
+  const timeline = new Timeline();
 
   const transition = new Transition({
+    timeline,
     onUpdate: () => {
       onUpdateCallCount++;
     },
@@ -45,30 +55,33 @@ test('Transition#update', t => {
     }
   });
 
-  transition.update(0);
-  t.is(transition.state, TRANSITION_STATE.NONE, 'Transition is not in progress');
+  transition.update();
+  t.is(transition.state, STATE_NONE, 'Transition is not in progress');
 
   transition.start({
     duration: 1,
     easing: time => time * time
   });
 
-  transition.update(0);
-  t.is(transition.state, TRANSITION_STATE.IN_PROGRESS, 'Transition is in progress');
+  transition.update();
+  t.is(transition.state, STATE_IN_PROGRESS, 'Transition is in progress');
   t.ok(transition.inProgress, 'inProgress returns correct result');
   t.is(transition.time, 0, 'time is correct');
 
-  transition.update(0.5);
-  t.is(transition.state, TRANSITION_STATE.IN_PROGRESS, 'Transition is in progress');
+  timeline.setTime(0.5);
+  transition.update();
+  t.is(transition.state, STATE_IN_PROGRESS, 'Transition is in progress');
   t.is(transition.time, 0.25, 'time is correct');
 
-  transition.update(1.5);
-  t.is(transition.state, TRANSITION_STATE.ENDED, 'Transition has ended');
+  timeline.setTime(1.5);
+  transition.update();
+  t.is(transition.state, STATE_ENDED, 'Transition has ended');
   t.notOk(transition.inProgress, 'inProgress returns correct result');
   t.is(transition.time, 1, 'time is correct');
 
-  transition.update(2);
-  t.is(transition.state, TRANSITION_STATE.ENDED, 'Transition has ended');
+  timeline.setTime(2);
+  transition.update();
+  t.is(transition.state, STATE_ENDED, 'Transition has ended');
 
   t.is(onUpdateCallCount, 3, 'onUpdate is called 3 times');
   t.is(onEndCallCount, 1, 'onEnd is called 3 times');
@@ -78,8 +91,10 @@ test('Transition#update', t => {
 
 test('Transition#interrupt', t => {
   let onInterruptCallCount = 0;
+  const timeline = new Timeline();
 
   const transition = new Transition({
+    timeline,
     onInterrupt: () => {
       onInterruptCallCount++;
     }
@@ -89,14 +104,18 @@ test('Transition#interrupt', t => {
   transition.start({duration: 1});
   t.is(onInterruptCallCount, 1, 'starting another transition - onInterrupt is called');
 
-  transition.update(0.5);
-  transition.update(0.6);
+  timeline.setTime(0.5);
+  transition.update();
+  timeline.setTime(0.6);
+  transition.update();
   transition.cancel();
   t.is(onInterruptCallCount, 2, 'cancelling transition - onInterrupt is called');
 
   transition.start({duration: 1});
-  transition.update(1);
-  transition.update(2);
+  timeline.setTime(1);
+  transition.update();
+  timeline.setTime(2);
+  transition.update();
   transition.cancel();
   t.is(onInterruptCallCount, 2, 'cancelling after transition ends - onInterrupt is not called');
 


### PR DESCRIPTION
#### Change List
- Use deck's timeline in `AttributeTransitionManager` and (viewstate) `TransitionManager`, remove dependence on `AnimationProps`
- Use `Transition` class to manage timeline channels
- Tests
