### PR TITLE
Support clicking/dragging during Jupyter widget updates and support two way communication for widget view state

### DIFF
--- a/bindings/python/pydeck/pydeck/bindings/deck.py
+++ b/bindings/python/pydeck/pydeck/bindings/deck.py
@@ -1,3 +1,4 @@
+import json
 import os
 import warnings
 
@@ -95,7 +96,11 @@ class Deck(JSONMixin):
 
         Intended for use in a Jupyter notebook
         """
-        self.deck_widget.json_input = self.to_json()
+        current_config = json.loads(self.to_json())
+        if self.deck_widget.initialized:
+            # Prevent initial view state from getting reset
+            current_config['initialViewState'] = {}
+        self.deck_widget.json_input = json.dumps(current_config)
 
     def to_html(
             self,

--- a/bindings/python/pydeck/pydeck/widget/widget.py
+++ b/bindings/python/pydeck/pydeck/widget/widget.py
@@ -4,7 +4,7 @@
 from __future__ import unicode_literals
 
 import ipywidgets as widgets
-from traitlets import Int, Any, Unicode
+from traitlets import Any, Bool, Int, Unicode
 
 from ._frontend import module_name, module_version
 
@@ -35,7 +35,8 @@ class DeckGLWidget(widgets.DOMWidget):
     _view_module = Unicode(module_name).tag(sync=True)
     _view_module_version = Unicode(module_version).tag(sync=True)
     mapbox_key = Unicode('', allow_none=True).tag(sync=True)
-    json_input = Unicode('').tag(sync=True)
+    json_input = Any(allow_none=True).tag(sync=True)
     height = Int(500).tag(sync=True)
     width = Int(500).tag(sync=True)
-    selected_data = Any().tag(sync=True)
+    initialized = Bool(False).tag(sync=True)
+    selected_data = Any(allow_none=True).tag(sync=True)

--- a/bindings/python/pydeck/tests/test_deckgl_widget.py
+++ b/bindings/python/pydeck/tests/test_deckgl_widget.py
@@ -11,4 +11,4 @@ from pydeck import DeckGLWidget
 
 def test_example_creation_blank():
     w = DeckGLWidget()
-    assert w.json_input == ''
+    assert w.json_input == None

--- a/modules/jupyter-widget/src/utils.js
+++ b/modules/jupyter-widget/src/utils.js
@@ -22,7 +22,14 @@ export function updateDeck(inputJSON, {jsonConverter, deckConfig}) {
   deckConfig.setProps(results);
 }
 
-export function initDeck({mapboxApiKey, container, jsonInput}, onComplete, handleClick) {
+export function initDeck({
+  mapboxApiKey,
+  container,
+  jsonInput,
+  onComplete,
+  handleClick,
+  onViewStateChange
+}) {
   require(['mapbox-gl', 'h3', 'S2'], mapboxgl => {
     require(['deck.gl'], deckgl => {
       try {
@@ -45,6 +52,7 @@ export function initDeck({mapboxApiKey, container, jsonInput}, onComplete, handl
           longitude: 0,
           zoom: 1,
           onClick: handleClick,
+          onViewStateChange,
           container,
           onLoad: () => updateDeck(jsonInput, {jsonConverter, deckConfig})
         });


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #2929 

<!-- For other PRs without open issue -->
#### Background
Specifically addresses the **Provide two way viewport communication** bug in [this comment](https://github.com/uber/deck.gl/issues/2929#issuecomment-500918940)

<!-- For all the PRs -->
#### Change List
- Allow map controls during widget updates
- Support pushing widget state between frontend and backend
