### PR TITLE
Fix typos and broken links in the docs

### DIFF
--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -19,9 +19,9 @@ For instructions to set up the dev environment, see [developing deck.gl](../docs
 
 Any new deck.gl feature must start with a GitHub issue. The issue will be used to track the discussion, planning (milestone), implementation (PRs) and release of the feature.
 
-Non-trivial new features should typically be proposed with an RFC (Request for Comments) to make sure we have a complete story before making big modifications to the code base. It also allow the bigger team (as well as the community) to stay engaged, comment and contribute insights. See [RFC Guidelines](./rfc-guidelines.md).
+Non-trivial new features should typically be proposed with an RFC (Request for Comments) to make sure we have a complete story before making big modifications to the code base. It also allows the bigger team (as well as the community) to stay engaged, comment and contribute insights. See [RFC Guidelines](./rfc-guidelines.md).
 
-Small, non-disruptive feature may be implemented without an RFC. The tracking issue should instead describe the background and the proposed change.
+A small, non-disruptive feature may be implemented without an RFC. The tracking issue should instead describe the background and the proposed change.
 
 All proposals will be reviewed and approved by the team before implementation. User-facing API changes should be audited following the [API Guidelines](./deckgl-api-guidelines.md). 
 Breaking changes are scheduled for appropriate releases according to the [Deprecation Guidelines](./deprecation-guidelines.md).
@@ -35,7 +35,7 @@ New code must be covered by tests. We have created a suite of tools that enable 
 
 Additional testing could be done with the [layer browser application](/examples/layer-browser), including the combination of prop values, transitions, etc. Changes to the WebGL rendering pipeline must be tested for additional browsers, see [supported platforms](./platform-support.md).
 
-Documentation should be updated to reflect the changes made to user-facing behavior and APIs. This include the [API documentation](/docs/api-reference) for the modified component, [tutorials](/docs/get-started), [advanced articles](/docs/developer-guide), and the [What's New](/docs/whats-new.md) and [Upgrade Guide](/docs/upgrade-guide) pages.
+Documentation should be updated to reflect the changes made to user-facing behavior and APIs. This includes the [API documentation](/docs/api-reference) for the modified component, [tutorials](/docs/get-started), [advanced articles](/docs/developer-guide), and the [What's New](/docs/whats-new.md) and [Upgrade Guide](/docs/upgrade-guide.md) pages.
 
 All code changes should open PRs on GitHub and be approved by at least one other team member. If the master branch and the current release branch have diverged, a separate PR may be needed to patch the release branch.
 
@@ -45,7 +45,7 @@ All code changes should open PRs on GitHub and be approved by at least one other
 Our frameworks follow the [Semantic Versioning](https://semver.org/) guidelines.
 
 * Patch release: bug-fixes that unblock the usage of the current minor release.
-* Minor release: backward-compatible feature additions, dependency changes, and bug fixes that results in behaviorial/visual changes.
+* Minor release: backward-compatible feature additions, dependency changes, and bug fixes that result in behavioral/visual changes.
 * Major release: breaking API changes.
 
 See [branching and releasing model](./directory-structure.md) for how we track the code changes cross releases.

--- a/dev-docs/code-guidelines.md
+++ b/dev-docs/code-guidelines.md
@@ -3,17 +3,17 @@
 
 ## Language Features
 
-### JavaScript/ECMASCRIPT version
+### JavaScript/ECMAScript version
 
-* We use pure/standard ECMASCRIPT (stage-4 proposals) but no stage-1,2,3 proposals.
-* We only use ECMASCRIPT features that work without transpilation directly in **latest** Chrome and Node versions (this is essentially all stage-4 features).
+* We use pure/standard ECMAScript (stage-4 proposals) but no stage-1,2,3 proposals.
+* We only use ECMAScript features that work without transpilation directly in **latest** Chrome and Node versions (this is essentially all stage-4 features).
 * In rare cases, a specific library
 
 For more information see the appendix about JavaScript versions at the end of this page.
 
 ### JSX
 
-In React-based libraries we avoid using JSX syntax if the amount of React included in the library is small. Instead, we se pure react api (`createElement` etc). This keeps the number of babel transforms to a minimum.
+In React-based libraries, we avoid using JSX syntax if the amount of React included in the library is small. Instead, we use pure react api (`createElement` etc). This keeps the number of babel transforms to a minimum.
 
 ### Markdown
 
@@ -24,7 +24,7 @@ We use the github markdown dialect. We strive to make our docs highly readable (
 
 Prettier and eslint with Uber's standard config are used to enforce coding style, with a few exceptions:
 
-* We allow longer line due to a preference for slightly more compact code (less lines).
+* We allow longer line due to a preference for slightly more compact code (fewer lines).
 
 
 ## Exports
@@ -38,7 +38,7 @@ Prettier and eslint with Uber's standard config are used to enforce coding style
 
 ### Flow/TypeScript
 
-As a general rule, our stance is to avoid using type systems until a broader standard emerges. We want our source code to be easily cut-and-pastable for reuse into any project (whether pure ECMASCRIPT, typescript or flow based). This is probably the principle most often questioned by well-meaning users who have found flow or typescript to be useful in their own projects. It has been extensively discussed, and will only change if the primary developers of each framework want it to change.
+As a general rule, our stance is to avoid using type systems until a broader standard emerges. We want our source code to be easily cut-and-pastable for reuse into any project (whether pure ECMAScript, typescript or flow based). This is probably the principle most often questioned by well-meaning users who have found flow or typescript to be useful in their own projects. It has been extensively discussed, and will only change if the primary developers of each framework want it to change.
 
 At the same time, it is fine for React-focused libraries (such as react-map-gl) to use flow since this is common in the Facebook ecosystem. Also if a new class framework is added to the vis.gl suite from an existing codebase that already includes one of these systems, and the maintainers want to keep it (e.g. nebula.gl) then that is also OK.
 
@@ -59,7 +59,7 @@ As always, exceptions OK where it makes sense (e.g. `AnimationLoop.start` breaks
 
 ## Logging
 
-We use [probe.gl](https://uber-web.github.io/probe.gl) for all information printed to the console. The minimalist library allows us to mange formatting, repeated messages and log priority in one place.
+We use [probe.gl](https://uber-web.github.io/probe.gl) for all information printed to the console. The minimalist library allows us to manage formatting, repeated messages and log priority in one place.
 
 * API deprecation and removal
 * Warnings
@@ -73,7 +73,7 @@ We use `assert`s to check that proper parameters are passed.
 
 We typically do not include any helpful messages to the programmer. These bloat the library and provide little additional value beyond what the developer can glean from his program breaking in the assert.
 
-Exceptions can be made if the particular condition being asserted against is a particular pitfall for programmers and/or dependent on input data (e.g. the failing to conform to the `[lng, lat]` convention in several of our libraries).
+Exceptions can be made if the particular condition being asserted against is a particular pitfall for programmers and/or dependent on input data (e.g. the failure to conform to the `[lng, lat]` convention in several of our libraries).
 
 Our frameworks have local definitions of `assert`, to avoid bundlers injecting the bloated node polyfill.
 
@@ -97,7 +97,7 @@ We removed the messages since we felt that they added bundle size bloat to our a
 
 ### But, asserts are not useful with minified version?
 
-While there are rare cases when an error only happens in minified version, there are so many other limitations with debugging in minified versions.
+While there are rare cases when an error only happens in the minified version, there are so many other limitations with debugging in minified versions.
 
 
 ### Transpiler
@@ -112,7 +112,7 @@ We use buble or babel to transpile examples.
 
 ECMAScript Versions vs. Stage-4 Proposals
 
-- ES2019 is finalized, we just need to make sure latest Chrome (Yes) and Node 11 (?) support it before we start using it.
+- ES2019 is finalized, we just need to make sure the latest Chrome (Yes) and Node 11 (?) support it before we start using it.
 
 ### [ES2016](http://2ality.com/2016/01/ecmascript-2016.html)
 - Exponentiation (x ** y === Math.pow(x, y))
@@ -142,7 +142,7 @@ ECMAScript Versions vs. Stage-4 Proposals
 - Array.prototype.sort() is now required to be stable
 - Internal: Well-formed JSON.stringify, JSON superset, Function.prototype.toString revision
 
-### NOT PART OF ECMASCRIPT
+### NOT PART OF ECMAScript
 - [Class Fields](https://github.com/tc39/proposal-class-fields)
 - [Arrow Methods](https://medium.com/@charpeni/arrow-functions-in-class-properties-might-not-be-as-great-as-we-think-3b3551c440b1) etc
 - ...

--- a/dev-docs/deckgl-api-guidelines.md
+++ b/dev-docs/deckgl-api-guidelines.md
@@ -15,14 +15,14 @@ philosophy.
   If a layer has lots of options and primitives, it's not easy to further
   extend it.
 * **Avoid “Magic”** - deck.gl aims to have a set of transparent APIs that
-  makes the effects bring by them clear to the users.
+  makes the effects brought by them clear to the users.
   Users can choose to learn WebGL and shader programming through deck.gl.
   This aligns with luma.gl, which exposes one class for every WebGL
   type.
 * **Reactive first** - deck.gl is primarily designed to work in a
   [“Reactive architecture”](https://en.wikipedia.org/wiki/Reactive_programming)
   application. It can be used in other programming paradigms but its support
-  come secondary.
+  comes secondary.
 
 ## Design Guidelines
 
@@ -62,16 +62,16 @@ docs, or other places that are easy to track.
   is small. E.g. the line layer can add a z coordinate to its positions
   with very little complexity and performance impact.
 * **Lighting and effects**
-  Layers with extrusion support (2.5D) or 3D should repsond correctly to lights through
+  Layers with extrusion support (2.5D) or 3D should respond correctly to lights through
   the lighting packages provided by deck.gl. This includes providing necessary APIs for
   setting light parameters.
-* **Splitting Layers** - If the code is significantly different different variant of the
+* **Splitting Layers** - If the code is a significantly different variant of the
   same layer (such as 2D and 3D), splitting into two might be necessary - perhaps even
   into two layer groups. Some effort should be done to clean up code and check if code
   reuse is possible.
 * **Functional Variants of Layers**
   Functional variants of layers such are Brushed, Animated, Enhanced etc, will be provided
-  as examples rather than supported layers with the intention to help users implement similar
+  as examples rather than supported layers to help users implement similar
   functionality for themselves.
 
 ## Rules for Data Iteration and Access
@@ -137,7 +137,7 @@ attribute (e.g. as a multiplier, or additive element), to ensure that
 the semantics of the property is easily understood by the user.
 
 * **Naming** For some well-known modifier concepts, like `opacity`
-(which modifies the forth component of the value returned byt the `getColor` accessor),
+(which modifies the fourth component of the value returned by the `getColor` accessor),
 it is natural to stay with the well-accepted term.
 
 * **Naming** Otherwise it is recommended to use a composite noun that
@@ -172,7 +172,7 @@ and additive props to 0.
 
 ### Naming rules for groups of uniform-related props
 
-* If a set of uniforms belong to certain module, it's a common practice to have them
+* If a set of uniforms belong to a certain module, it's a common practice to have them
   come with a common prefix or suffix (e. g. `lightDirection`, `lightColorAmbient`,
   `lightColorDirectional`, …)
 * If a set of uniforms belong to the same module/effect, it could make sense to

--- a/docs/api-reference/composite-layer.md
+++ b/docs/api-reference/composite-layer.md
@@ -133,14 +133,14 @@ Parameters:
 Returns:
 
 * An `info` object with optional fields about what was picked. This object will be passed to the layer's `onHover` or `onClick` callbacks.
-* `null`, if the corresponding event should cancelled with no callback functions called.
+* `null`, if the corresponding event should be cancelled with no callback functions called.
 
 The default implementation returns `pickParams.info` without any change.
 
 
 ##### `getSubLayerProps`
 
-This utility method helps create sublayers that properly inherit a composite layer's basic props. For example, it creates an unique id for the sublayer, and makes sure the sublayer's `coordinateSystem` is set to be the same as the parent.
+This utility method helps create sublayers that properly inherit a composite layer's basic props. For example, it creates a unique id for the sublayer, and makes sure the sublayer's `coordinateSystem` is set to be the same as the parent.
 
 Parameters:
 
@@ -149,9 +149,9 @@ Parameters:
   + `updateTriggers` (Object) - the sublayer's update triggers.
   + Any additional props are optional.
 
-Returns an properties object used to generate a sublayer, with the following keys:
+Returns a properties object used to generate a sublayer, with the following keys:
 
-* `id` - an unique id for the sublayer, by prepending the parent layer id to the sublayer id.
+* `id` - a unique id for the sublayer, by prepending the parent layer id to the sublayer id.
 * `updateTriggers` - merged object of the parent layer update triggers and the sublayer update triggers.
 * Base layer props that are directly forwarded from the base layer:
   + `opacity`
@@ -167,7 +167,7 @@ Returns an properties object used to generate a sublayer, with the following key
   + `wrapLongitude`
   + `positionFormat`
   + `modelMatrix`
-* Any other additional props from the input paramter are directly forwarded.
+* Any other additional props from the input parameter are directly forwarded.
 * Any overriding props specified in `_subLayerProps`.
 
 
@@ -215,7 +215,7 @@ The `row` object, decorated with a reference.
 
 ##### `getSubLayerAccessor`
 
-Used by [adapter layers](/docs/developer-guide/custom-layers/composite-layers.md#transforming-data)) to allow user-provided accessors read the original objects from transformed data.
+Used by [adapter layers](/docs/developer-guide/custom-layers/composite-layers.md#transforming-data)) to allow user-provided accessors to read the original objects from transformed data.
 
 Parameters:
 

--- a/docs/api-reference/first-person-view.md
+++ b/docs/api-reference/first-person-view.md
@@ -6,7 +6,7 @@
 
 The [`FirstPersonView`] class is a subclass of [View](/docs/api-reference/viewport.md) that describes a "camera" placed at the exact position specified by the `viewState`, looking **towards** the direction and orientation specified by the application.
 
-This is in contrast with e.g. [ThirdPersonView](/docs/api-reference/viewport.md) where the camera will be create at a distance from and looking **at** the specified position.
+This is in contrast with e.g. [ThirdPersonView](/docs/api-reference/viewport.md) where the camera will be created at a distance from and looking **at** the specified position.
 
 To render, a `FirstPersonView` needs to be combined with a `viewState` object with the following parameters:
 

--- a/docs/api-reference/layer.md
+++ b/docs/api-reference/layer.md
@@ -643,7 +643,7 @@ Returns:
 
 Note:
 
-* The null picking color is returned when a pixel is picked that is not covered by the layer, or when they layer has selected to render a pixel using the null picking color to make it unpickable.
+* The null picking color is returned when a pixel is picked that is not covered by the layer, or when the layer has selected to render a pixel using the null picking color to make it unpickable.
 
 ##### `encodePickingColor`
 
@@ -668,7 +668,7 @@ Notes:
 
 Returns:
 
-* a "null" picking color which is equal the the color of pixels not covered by the layer. This color is guaranteed not to match any index value greater than or equal to zero.
+* a "null" picking color which is equal the color of pixels not covered by the layer. This color is guaranteed not to match any index value greater than or equal to zero.
 
 ## Source
 

--- a/docs/api-reference/view.md
+++ b/docs/api-reference/view.md
@@ -2,7 +2,7 @@
 
 > For details about deck.gl's views system and code examples, visit the [Views and Projections](/docs/developer-guide/views.md) article.
 
-The `View` class and it subclasses are used to specify where and how your deck.gl layers should be rendered. Applications typically instantitate at least one `View` subclass.
+The `View` class and its subclasses are used to specify where and how your deck.gl layers should be rendered. Applications typically instantiate at least one `View` subclass.
 
 Views allow you to specify:
 
@@ -79,7 +79,7 @@ The `viewState` property is intended to support a number of use cases:
 
 ##### `clear` (Boolean|Object, optional)
 
-Clears the contents (pixels) of the viewport. The value of the `clear` prop is passed as argument to luma.gl's `clear` function. If `true` clears color and depth buffers. If an object, behaviour is controller by the following fields:
+Clears the contents (pixels) of the viewport. The value of the `clear` prop is passed as an argument to luma.gl's `clear` function. If `true` clears color and depth buffers. If an object, behaviour is controlled by the following fields:
 
 * `color` (Boolean or Array) - if not `false`, clears all active color buffers with either the provided color or the currently set clear color.
 * `depth` (Boolean)  - if `true`, clears the depth buffer.
@@ -151,7 +151,7 @@ Note: For speed, deck.gl uses shallow equality. This means that a value of `fals
 View.makeViewport({width, height, viewState})
 ```
 
-Builds a [Viewport](/docs/api-reference/viewport.md) using the viewport type and props in the `View`and provided `width`, `height` and `viewState`. The contents of `viewState` needs to be compatible with the particular `View` sublass in use.
+Builds a [Viewport](/docs/api-reference/viewport.md) using the viewport type and props in the `View` and provided `width`, `height` and `viewState`. The contents of `viewState` needs to be compatible with the particular `View` subclass in use.
 
 
 ##### `getDimensions`

--- a/docs/api-reference/web-mercator-viewport.md
+++ b/docs/api-reference/web-mercator-viewport.md
@@ -93,7 +93,7 @@ Returns:
 
 ##### `getDistanceScales`
 
-Returns an object with scale values supporting first order (linear) and second order (quadratic) approximations of the local Web Mercator projection scale around the viewport center. Error increases with distance from viewport center (very roughly 1% per 100km in linear mode, quadratic approximation does signficantly better).
+Returns an object with scale values supporting first order (linear) and second order (quadratic) approximations of the local Web Mercator projection scale around the viewport center. Error increases with distance from viewport center (very roughly 1% per 100km in linear mode, quadratic approximation does significantly better).
 
 Returns:
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -10,14 +10,14 @@ Note that once your PR is about to be merged, you will be asked to register as a
 
 ## Process and Guidelines
 
-Developer documentaion is available [here](https://github.com/uber/deck.gl/tree/master/dev-docs). We are ready to prepare additional documentation if requested by contributors.
+Developer documentation is available [here](https://github.com/uber/deck.gl/tree/master/dev-docs). We are ready to prepare additional documentation if requested by contributors.
 
 
 ## Developing deck.gl
 
 ### Node Version Requirement
 
-Running deck.gl as a dependency in another project (e.g. via `npm i deck.gl`) requires Node `4.x` or higher. Building deck.gl from source has a dependency on Node `10.x` or higher. Either upgrade to a supported version, or install something like [nvm](https://github.com/creationix/nvm) to manage Node versions.
+Running deck.gl as a dependency in another project (e.g. via `npm i deck.gl`) requires Node `4.x` or higher. Building deck.gl from the source has a dependency on Node `10.x` or higher. Either upgrade to a supported version, or install something like [nvm](https://github.com/creationix/nvm) to manage Node versions.
 
 ### Install yarn
 


### PR DESCRIPTION

#### Background
Upgrade Guide link in Dev Docs readme should point to correct url.
#### Change List
- Fix typos and broken links in docs
