### PR TITLE
Add update trigger tests to generated tests

### DIFF
--- a/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
+++ b/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
@@ -87,6 +87,9 @@ const defaultProps = Object.assign({}, PolygonLayer.defaultProps, {
   getColor: null
 });
 
+// not supported
+delete defaultProps.getLineDashArray;
+
 /**
  * A subclass of HexagonLayer that uses H3 hexagonIds in data objects
  * rather than centroid lat/longs. The shape of each hexagon is determined
@@ -213,10 +216,8 @@ export default class H3HexagonLayer extends CompositeLayer {
       getLineColor,
       getLineWidth,
       updateTriggers: {
-        getFillColor: updateTriggers.getColor || updateTriggers.getFillColor,
-        getElevation: updateTriggers.getElevation,
-        getLineColor: updateTriggers.getLineColor,
-        getLineWidth: updateTriggers.getLineWidth
+        ...updateTriggers,
+        getFillColor: updateTriggers.getColor || updateTriggers.getFillColor
       }
     };
   }

--- a/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
+++ b/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
@@ -216,8 +216,10 @@ export default class H3HexagonLayer extends CompositeLayer {
       getLineColor,
       getLineWidth,
       updateTriggers: {
-        ...updateTriggers,
-        getFillColor: updateTriggers.getColor || updateTriggers.getFillColor
+        getFillColor: updateTriggers.getColor || updateTriggers.getFillColor,
+        getElevation: updateTriggers.getElevation,
+        getLineColor: updateTriggers.getLineColor,
+        getLineWidth: updateTriggers.getLineWidth
       }
     };
   }

--- a/modules/test-utils/src/lifecycle-test.js
+++ b/modules/test-utils/src/lifecycle-test.js
@@ -169,8 +169,6 @@ function injectSpies(layer, spies) {
 
 /* eslint-disable max-params, no-loop-func */
 function runLayerTests(layerManager, deckRenderer, layer, testCases, spies, onError) {
-  let combinedProps = {};
-
   // Run successive update tests
   for (let i = 0; i < testCases.length; i++) {
     const testCase = testCases[i];
@@ -184,15 +182,6 @@ function runLayerTests(layerManager, deckRenderer, layer, testCases, spies, onEr
 
     spies = testCase.spies || spies;
 
-    // Test case can reset the props on every iteration
-    if (props) {
-      combinedProps = Object.assign({}, props);
-    }
-    // Test case can override with new props on every iteration
-    if (updateProps) {
-      Object.assign(combinedProps, updateProps);
-    }
-
     // copy old state before update
     const oldState = Object.assign({}, layer.state);
 
@@ -200,7 +189,14 @@ function runLayerTests(layerManager, deckRenderer, layer, testCases, spies, onEr
       onBeforeUpdate({layer, testCase});
     }
 
-    layer = layer.clone(combinedProps);
+    if (props) {
+      // Test case can reset the props on every iteration
+      layer = new layer.constructor(props);
+    } else if (updateProps) {
+      // Test case can override with new props on every iteration
+      layer = layer.clone(updateProps);
+    }
+
     // Create a map of spies that the test case can inspect
     const spyMap = injectSpies(layer, spies);
 

--- a/test/modules/layers/core-layers.spec.js
+++ b/test/modules/layers/core-layers.spec.js
@@ -77,7 +77,7 @@ test('ScatterplotLayer', t => {
     },
     assert: t.ok,
     onBeforeUpdate: ({testCase}) => t.comment(testCase.title),
-    onAfterUpdate: ({testCase, layer}) => {
+    onAfterUpdate: ({layer}) => {
       t.is(
         layer.state.model.getUniforms().radiusScale,
         layer.props.radiusScale,

--- a/test/modules/layers/core-layers.spec.js
+++ b/test/modules/layers/core-layers.spec.js
@@ -56,7 +56,7 @@ test('ScreenGridLayer', t => {
     onBeforeUpdate: ({testCase}) => t.comment(testCase.title),
     onAfterUpdate: ({layer}) => {
       t.deepEquals(
-        layer.state.model.program.uniforms.cellScale,
+        layer.state.model.getUniforms().cellScale,
         layer.state.cellScale,
         'should update cellScale'
       );
@@ -77,9 +77,9 @@ test('ScatterplotLayer', t => {
     },
     assert: t.ok,
     onBeforeUpdate: ({testCase}) => t.comment(testCase.title),
-    onAfterUpdate: ({layer}) => {
+    onAfterUpdate: ({testCase, layer}) => {
       t.is(
-        layer.state.model.program.uniforms.radiusScale,
+        layer.state.model.getUniforms().radiusScale,
         layer.props.radiusScale,
         'should update radiusScale'
       );
@@ -161,7 +161,7 @@ test('PointCloudLayer', t => {
     onBeforeUpdate: ({testCase}) => t.comment(testCase.title),
     onAfterUpdate: ({layer}) => {
       t.is(
-        layer.state.model.program.uniforms.pointSize,
+        layer.state.model.getUniforms().pointSize,
         layer.props.radiusPixels,
         'should update pointSize'
       );
@@ -263,7 +263,7 @@ test('PathLayer', t => {
     onBeforeUpdate: ({testCase}) => t.comment(testCase.title),
     onAfterUpdate: ({layer}) => {
       t.is(
-        layer.state.model.program.uniforms.widthMinPixels,
+        layer.state.model.getUniforms().widthMinPixels,
         layer.props.widthMinPixels,
         'should update widthMinPixels'
       );

--- a/test/modules/layers/geojson-layer.spec.js
+++ b/test/modules/layers/geojson-layer.spec.js
@@ -29,7 +29,7 @@ test('GeoJsonLayer#tests', t => {
   const testCases = generateLayerTests({
     Layer: GeoJsonLayer,
     sampleProps: {
-      data: FIXTURES.choropleths
+      data: FIXTURES.geojson
     },
     assert: t.ok,
     onBeforeUpdate: ({testCase}) => t.comment(testCase.title),
@@ -38,7 +38,7 @@ test('GeoJsonLayer#tests', t => {
       const hasData = layer.props && layer.props.data && Object.keys(layer.props.data).length;
       t.is(
         subLayers.length,
-        !hasData ? 0 : layer.props.stroked ? 2 : 1,
+        !hasData ? 0 : layer.props.stroked && !layer.props.extruded ? 4 : 3,
         'correct number of sublayers'
       );
     }


### PR DESCRIPTION

#### Change List
- Make updateTrigger tests with `generateLayerTests`
- Fix an issue in `testLayers` where non-incremental prop update is not respected
- Remove unsupported `getLineDashArray` from `H3HexagonLayer`'s default props
