### PR TITLE
Fix GPUGridLayer crash when used with GridLayer

### DIFF
--- a/examples/layer-browser/src/examples/additional-layers.js
+++ b/examples/layer-browser/src/examples/additional-layers.js
@@ -17,16 +17,25 @@ import * as dataSamples from '../data-samples';
 
 registerLoaders([PLYLoader]);
 
+const gridLayerProps = {
+  id: 'grid-layer',
+  cellSize: 200,
+  opacity: 1,
+  extruded: true,
+  pickable: false,
+  getPosition: d => d.COORDINATES
+};
+
+const GPUGridLayerProps = Object.assign({}, gridLayerProps, {id: 'gpu-grid-layer'});
+
 const GRID_LAYER_PROPS = {
   getData: () => dataSamples.points,
-  props: {
-    id: 'gpu-grid-layer',
-    cellSize: 200,
-    opacity: 1,
-    extruded: true,
-    pickable: false,
-    getPosition: d => d.COORDINATES
-  }
+  props: gridLayerProps
+};
+
+const GPU_GRID_LAYER_PROPS = {
+  getData: () => dataSamples.points,
+  props: GPUGridLayerProps
 };
 
 const HEAT_LAYER_PROPS = {
@@ -39,7 +48,7 @@ const HEAT_LAYER_PROPS = {
   }
 };
 
-const GPUGridLayerExample = Object.assign({}, {layer: GPUGridLayer}, GRID_LAYER_PROPS);
+const GPUGridLayerExample = Object.assign({}, {layer: GPUGridLayer}, GPU_GRID_LAYER_PROPS);
 const GridLayerExample = Object.assign({}, {layer: GridLayer}, GRID_LAYER_PROPS);
 const HeatmapLayerExample = Object.assign({}, {layer: HeatmapLayer}, HEAT_LAYER_PROPS);
 

--- a/examples/layer-browser/src/examples/additional-layers.js
+++ b/examples/layer-browser/src/examples/additional-layers.js
@@ -17,7 +17,7 @@ import * as dataSamples from '../data-samples';
 
 registerLoaders([PLYLoader]);
 
-const gridLayerProps = {
+const GRID_LAYER_PROPS_OBJECT = {
   id: 'grid-layer',
   cellSize: 200,
   opacity: 1,
@@ -26,16 +26,16 @@ const gridLayerProps = {
   getPosition: d => d.COORDINATES
 };
 
-const GPUGridLayerProps = Object.assign({}, gridLayerProps, {id: 'gpu-grid-layer'});
+const GPU_GRID_LAYER_PROPS_OBJECT = Object.assign({}, GRID_LAYER_PROPS_OBJECT, {id: 'gpu-grid-layer'});
 
 const GRID_LAYER_PROPS = {
   getData: () => dataSamples.points,
-  props: gridLayerProps
+  props: GRID_LAYER_PROPS_OBJECT
 };
 
 const GPU_GRID_LAYER_PROPS = {
   getData: () => dataSamples.points,
-  props: GPUGridLayerProps
+  props: GPU_GRID_LAYER_PROPS_OBJECT
 };
 
 const HEAT_LAYER_PROPS = {

--- a/examples/layer-browser/src/examples/additional-layers.js
+++ b/examples/layer-browser/src/examples/additional-layers.js
@@ -26,7 +26,9 @@ const GRID_LAYER_PROPS_OBJECT = {
   getPosition: d => d.COORDINATES
 };
 
-const GPU_GRID_LAYER_PROPS_OBJECT = Object.assign({}, GRID_LAYER_PROPS_OBJECT, {id: 'gpu-grid-layer'});
+const GPU_GRID_LAYER_PROPS_OBJECT = Object.assign({}, GRID_LAYER_PROPS_OBJECT, {
+  id: 'gpu-grid-layer'
+});
 
 const GRID_LAYER_PROPS = {
   getData: () => dataSamples.points,


### PR DESCRIPTION
close #3525

<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #3525
<!-- For other PRs without open issue -->
#### Background
GPUGridLayer crashes when used with GridLayer as both the layers are given same id from `GRID_LAYER_PROPS` object.
#### Change List
- Made different objects to provide props with different id to each layer
