### PR TITLE
attribute spring transition

### DIFF
--- a/modules/core/src/lib/attribute-transition-manager.js
+++ b/modules/core/src/lib/attribute-transition-manager.js
@@ -1,5 +1,6 @@
 import {Transform} from '@luma.gl/core';
 import GPUInterpolationTransition from '../transitions/gpu-interpolation-transition';
+import GPUSpringTransition from '../transitions/gpu-spring-transition';
 import log from '../utils/log';
 
 export default class AttributeTransitionManager {
@@ -106,11 +107,28 @@ export default class AttributeTransitionManager {
   // Returns a transition object if a new transition is triggered.
   _updateAttribute(attributeName, attribute, settings) {
     let isNew = false;
-    if (!this.transitions[attributeName]) {
+
+    const transition = this.transitions[attributeName];
+    // an attribute can change transition type when it updates
+    // let's remove the transition when that happens so we can create the new transition type
+    // TODO: when switching transition types, make sure to carry over the attribute's
+    // previous buffers, currentLength, bufferLayout, etc, to be used as the starting point
+    // for the next transition
+    if (!transition || transition.type !== settings.type) {
+      if (transition) {
+        this._removeTransition(attributeName);
+      }
+
       if (settings.type === 'interpolation') {
         this.transitions[attributeName] = new GPUInterpolationTransition({
           attribute,
           timeline: this.timeline,
+          gl: this.gl
+        });
+      } else if (settings.type === 'spring') {
+        this.transitions[attributeName] = new GPUSpringTransition({
+          attribute,
+          transitionSettings: settings,
           gl: this.gl
         });
       } else {

--- a/modules/core/src/lib/attribute-transition-utils.js
+++ b/modules/core/src/lib/attribute-transition-utils.js
@@ -60,11 +60,7 @@ export function getAttributeTypeFromSize(size) {
 }
 
 export function cycleBuffers(buffers) {
-  const firstBuffer = buffers[0];
-  for (let i = 0; i < buffers.length - 1; i++) {
-    buffers[i] = buffers[i + 1];
-  }
-  buffers[buffers.length - 1] = firstBuffer;
+  buffers.push(buffers.shift());
   return buffers;
 }
 

--- a/modules/core/src/lib/attribute-transition-utils.js
+++ b/modules/core/src/lib/attribute-transition-utils.js
@@ -1,4 +1,4 @@
-import {Buffer} from '@luma.gl/core';
+import BaseAttribute from '../lib/base-attribute';
 import {padArray} from '../utils/array-utils';
 
 const noop = () => {};
@@ -9,6 +9,7 @@ const DEFAULT_TRANSITION_SETTINGS = {
   onStart: noop,
   onEnd: noop,
   onInterrupt: noop,
+  onUpdate: noop,
   enter: x => x
 };
 
@@ -25,6 +26,54 @@ export function normalizeTransitionSettings(userSettings, layerSettings = {}) {
   return Object.assign({}, DEFAULT_TRANSITION_SETTINGS, layerSettings, userSettings);
 }
 
+// NOTE: NOT COPYING OVER OFFSET OR STRIDE HERE BECAUSE:
+// (1) WE DON'T SUPPORT INTERLEAVED BUFFERS FOR TRANSITIONS
+// (2) BUFFERS WITH OFFSETS ALWAYS CONTAIN VALUES OF THE SAME SIZE
+// (3) THE OPERATIONS IN THE SHADER ARE PER-COMPONENT (addition and scaling)
+export function getSourceBufferAttribute(gl, attribute) {
+  const {size, value, normalized, constant} = attribute;
+  // The Attribute we pass to Transform as a sourceBuffer must have {divisor: 0}
+  // so we create a copy of the attribute (with divisor=0) to use when running
+  // transform feedback
+  if (constant) {
+    // don't pass normalized here because the `value` from a normalized attribute is
+    // already normalized
+    return new BaseAttribute(gl, {constant, value, size});
+  }
+  const buffer = attribute.getBuffer();
+  return new BaseAttribute(gl, {divisor: 0, constant, buffer, size, normalized});
+}
+
+export function getAttributeTypeFromSize(size) {
+  switch (size) {
+    case 1:
+      return 'float';
+    case 2:
+      return 'vec2';
+    case 3:
+      return 'vec3';
+    case 4:
+      return 'vec4';
+    default:
+      throw new Error(`No defined attribute type for size "${size}"`);
+  }
+}
+
+export function cycleBuffers(buffers) {
+  const firstBuffer = buffers[0];
+  for (let i = 0; i < buffers.length - 1; i++) {
+    buffers[i] = buffers[i + 1];
+  }
+  buffers[buffers.length - 1] = firstBuffer;
+  return buffers;
+}
+
+export function getAttributeBufferLength(attribute, numInstances) {
+  const {doublePrecision, userData, value, size} = attribute;
+  const multiplier = doublePrecision ? 2 : 1;
+  return (userData.noAlloc ? value.length : numInstances * size) * multiplier;
+}
+
 // This helper is used when transitioning attributes from a set of values in one buffer layout
 // to a set of values in a different buffer layout. (Buffer layouts are used when attribute values
 // within a buffer should be grouped for drawElements, like the Polygon layer.) For example, a
@@ -33,39 +82,41 @@ export function normalizeTransitionSettings(userSettings, layerSettings = {}) {
 // function, that looks like this: [A1, A2, A3, A4 (user `enter` fn), B1, B2, 0]. Note: the final
 // 0 in this buffer is because we never shrink buffers, only grow them, for performance reasons.
 export function padBuffer({
-  fromState,
-  toState,
+  buffer,
+  numInstances,
+  attribute,
   fromLength,
-  toLength,
   fromBufferLayout,
-  toBufferLayout,
-  size,
-  offset,
   getData = x => x
 }) {
+  // TODO: move the precisionMultiplier logic to the attribute when retrieving
+  // its `size` and `elementOffset`?
+  const precisionMultiplier = attribute.doublePrecision ? 2 : 1;
+  const size = attribute.size * precisionMultiplier;
+  const offset = attribute.elementOffset * precisionMultiplier;
+  const toBufferLayout = attribute.bufferLayout;
   const hasBufferLayout = fromBufferLayout && toBufferLayout;
+  const toLength = getAttributeBufferLength(attribute, numInstances);
 
   // check if buffer needs to be padded
-  if ((!hasBufferLayout && fromLength >= toLength) || !(fromState instanceof Buffer)) {
+  if (!hasBufferLayout && fromLength >= toLength) {
     return;
   }
 
-  const data = new Float32Array(toLength);
-  const fromData = fromState.getData({length: fromLength});
-
-  const toData = toState.constant ? toState.getValue() : toState.getBuffer().getData({});
-
-  if (toState.normalized) {
+  const toData = attribute.constant ? attribute.getValue() : attribute.getBuffer().getData({});
+  if (attribute.normalized) {
     const getter = getData;
-    getData = (value, chunk) => toState._normalizeConstant(getter(value, chunk));
+    getData = (value, chunk) => attribute._normalizeConstant(getter(value, chunk));
   }
 
-  const getMissingData = toState.constant
+  const getMissingData = attribute.constant
     ? (i, chunk) => getData(toData, chunk)
     : (i, chunk) => getData(toData.subarray(i, i + size), chunk);
 
+  const source = buffer.getData({length: fromLength});
+  const data = new Float32Array(toLength);
   padArray({
-    source: fromData,
+    source,
     target: data,
     sourceLayout: fromBufferLayout,
     targetLayout: toBufferLayout,
@@ -74,5 +125,5 @@ export function padBuffer({
     getData: getMissingData
   });
 
-  fromState.setData({data});
+  buffer.setData({data});
 }

--- a/modules/core/src/transitions/gpu-interpolation-transition.js
+++ b/modules/core/src/transitions/gpu-interpolation-transition.js
@@ -1,56 +1,97 @@
 import GL from '@luma.gl/constants';
 import {Buffer, Transform} from '@luma.gl/core';
-import BaseAttribute from '../lib/base-attribute';
 import Attribute from '../lib/attribute';
-import {padBuffer} from '../lib/attribute-transition-utils';
+import {
+  padBuffer,
+  getAttributeTypeFromSize,
+  getSourceBufferAttribute,
+  getAttributeBufferLength,
+  cycleBuffers
+} from '../lib/attribute-transition-utils';
 import Transition from './transition';
 import assert from '../utils/assert';
 
 export default class GPUInterpolationTransition {
   constructor({gl, attribute, timeline}) {
+    this.type = 'interpolation';
     this.transition = new Transition({timeline});
     this.attribute = attribute;
+    // this is the attribute we return during the transition - note: if it is a constant
+    // attribute, it will be converted and returned as a regular attribute
     // `attribute.userData` is the original options passed when constructing the attribute.
     // This ensures that we set the proper `doublePrecision` flag and shader attributes.
     this.attributeInTransition = new Attribute(gl, attribute.userData);
-    this.bufferLayout = attribute.bufferLayout;
-    // storing curLength because this.buffer may be larger than the actual length we want to use
+    this.currentBufferLayout = attribute.bufferLayout;
+    // storing currentLength because this.buffer may be larger than the actual length we want to use
     // this is because we only reallocate buffers when they grow, not when they shrink,
     // due to performance costs
-    this.curLength = null;
+    this.currentLength = 0;
     this.transform = null;
-    this.buffer = null;
-    this._swapBuffer = null;
+    const usage = GL.DYNAMIC_COPY;
+    const byteLength = 0;
+    this.buffers = [
+      new Buffer(gl, {byteLength, usage}), // from
+      new Buffer(gl, {byteLength, usage}) // current
+    ];
   }
 
   isTransitioning() {
-    return Boolean(this.buffer);
+    return Boolean(this.buffers.length);
   }
 
   getTransitioningAttribute() {
     return this.attributeInTransition;
   }
 
-  // Start a new transition using the current settings
-  // Updates transition state and from/to buffer
-  start(gl, settings, numInstances) {
-    assert(settings.duration > 0);
-    const {fromState, toState, buffer} = this._setupBuffers(gl, settings, numInstances);
-    this.buffer = buffer;
-    const elementCount = Math.floor(this.curLength / this.attribute.size);
-    this.transition.start(settings);
-    if (this.transform) {
-      this.transform.update({
-        ...getBuffers({fromState, toState, buffer}),
-        elementCount
-      });
-    } else {
-      this.transform = new Transform(gl, {
-        elementCount,
-        ...getShaders(this.attribute.size),
-        ...getBuffers({fromState, toState, buffer})
-      });
+  // this is called when an attribute's values have changed and
+  // we need to start animating towards the new values
+  // this also correctly resizes / pads the transform's buffers
+  // in case the attribute's buffer has changed in length or in
+  // bufferLayout
+  start(gl, transitionSettings, numInstances) {
+    assert(
+      transitionSettings.duration > 0,
+      'transition setting must have a duration greater than 0'
+    );
+    // Alternate between two buffers when new transitions start.
+    // Last destination buffer is used as an attribute (from state),
+    // And the other buffer is now the current buffer.
+    cycleBuffers(this.buffers);
+
+    const padBufferOpts = {
+      numInstances,
+      attribute: this.attribute,
+      fromLength: this.currentLength,
+      fromBufferLayout: this.currentBufferLayout,
+      getData: transitionSettings.enter
+    };
+
+    for (const buffer of this.buffers) {
+      padBuffer({buffer, ...padBufferOpts});
     }
+
+    this.currentBufferLayout = this.attribute.bufferLayout;
+    this.currentLength = getAttributeBufferLength(this.attribute, numInstances);
+    this.attributeInTransition.update({
+      buffer: this.buffers[1],
+      // Hack: Float64Array is required for double-precision attributes
+      // to generate correct shader attributes
+      value: this.attribute.value
+    });
+
+    this.transition.start(transitionSettings);
+
+    this.transform = this.transform || new Transform(gl, getShaders(this.attribute.size));
+    this.transform.update({
+      elementCount: Math.floor(this.currentLength / this.attribute.size),
+      sourceBuffers: {
+        aFrom: this.buffers[0],
+        aTo: getSourceBufferAttribute(gl, this.attribute)
+      },
+      feedbackBuffers: {
+        vCurrent: this.buffers[1]
+      }
+    });
   }
 
   update() {
@@ -66,83 +107,11 @@ export default class GPUInterpolationTransition {
   cancel() {
     this.transition.cancel();
     this.transform.delete();
-    if (this.buffer) this.buffer.delete();
-    if (this._swapBuffer) this._swapBuffer.delete();
-  }
-
-  // get current values of an attribute, clipped/padded to the size of the new buffer
-  _setupBuffers(gl, settings, numInstances) {
-    const {size, normalized} = this.attribute;
-    const precisionMultiplier = this.attribute.doublePrecision ? 2 : 1;
-
-    let toState;
-    if (this.attribute.constant) {
-      toState = new BaseAttribute(gl, {constant: true, value: this.attribute.value, size});
-    } else {
-      toState = new BaseAttribute(gl, {
-        constant: false,
-        buffer: this.attribute.getBuffer(),
-        divisor: 0,
-        size,
-        normalized
-      });
+    while (this.buffers.length) {
+      this.buffers.pop().delete();
     }
-
-    const fromState = this.buffer || toState;
-    const toLength =
-      (this.attribute.userData.noAlloc ? this.attribute.value.length : numInstances * size) *
-      precisionMultiplier;
-    const fromLength = this.curLength || toLength;
-
-    // Alternate between two buffers when new transitions start.
-    // Last destination buffer is used as an attribute (from state),
-    // And the other buffer is now the destination buffer.
-    let buffer = this._swapBuffer;
-    this._swapBuffer = this.buffer;
-
-    if (!buffer) {
-      buffer = new Buffer(gl, {
-        data: new Float32Array(toLength),
-        usage: GL.DYNAMIC_COPY
-      });
-    } else if (buffer.getElementCount() < toLength) {
-      // Pad buffers to be the same length with 32-bit floats
-      buffer.reallocate(toLength * 4);
-    }
-
-    this.curLength = toLength;
-    this.attributeInTransition.update({
-      buffer,
-      // Hack: Float64Array is required for double-precision attributes
-      // to generate correct shader attributes
-      value: this.attribute.value
-    });
-
-    // updates the fromState buffer in place
-    padBuffer({
-      fromState,
-      toState,
-      fromLength,
-      toLength,
-      size: size * precisionMultiplier,
-      fromBufferLayout: this.bufferLayout,
-      toBufferLayout: this.attribute.bufferLayout,
-      offset: this.attribute.elementOffset * precisionMultiplier,
-      getData: settings.enter
-    });
-
-    this.bufferLayout = this.attribute.bufferLayout;
-
-    return {toState, buffer, fromState};
   }
 }
-
-const ATTRIBUTE_MAPPING = {
-  1: 'float',
-  2: 'vec2',
-  3: 'vec3',
-  4: 'vec4'
-};
 
 const vs = `
 #define SHADER_NAME interpolation-transition-vertex-shader
@@ -159,24 +128,12 @@ void main(void) {
 `;
 
 function getShaders(attributeSize) {
-  const attributeType = ATTRIBUTE_MAPPING[attributeSize];
+  const attributeType = getAttributeTypeFromSize(attributeSize);
   return {
     vs,
     defines: {
       ATTRIBUTE_TYPE: attributeType
     },
     varyings: ['vCurrent']
-  };
-}
-
-function getBuffers({fromState, toState, buffer}) {
-  return {
-    sourceBuffers: {
-      aFrom: fromState,
-      aTo: toState
-    },
-    feedbackBuffers: {
-      vCurrent: buffer
-    }
   };
 }

--- a/modules/core/src/transitions/gpu-spring-transition.js
+++ b/modules/core/src/transitions/gpu-spring-transition.js
@@ -1,0 +1,167 @@
+/* eslint-disable complexity, max-statements, max-params */
+import GL from '@luma.gl/constants';
+import {Buffer, Transform} from '@luma.gl/core';
+import {
+  padBuffer,
+  getAttributeTypeFromSize,
+  getSourceBufferAttribute,
+  getAttributeBufferLength,
+  cycleBuffers
+} from '../lib/attribute-transition-utils';
+import Attribute from '../lib/attribute';
+
+export default class GPUSpringTransition {
+  constructor({gl, attribute, transitionSettings}) {
+    this.type = 'spring';
+    this.transitionSettings = transitionSettings;
+    this.attribute = attribute;
+    // this is the attribute we return during the transition - note: if it is a constant
+    // attribute, it will be converted and returned as a regular attribute
+    // `attribute.userData` is the original options passed when constructing the attribute.
+    // This ensures that we set the proper `doublePrecision` flag and shader attributes.
+    this.attributeInTransition = new Attribute(gl, attribute.userData);
+    this.currentBufferLayout = attribute.bufferLayout;
+    // storing currentLength because this.buffer may be larger than the actual length we want to use
+    // this is because we only reallocate buffers when they grow, not when they shrink,
+    // due to performance costs
+    this.currentLength = 0;
+    this.transform = null;
+    const usage = GL.DYNAMIC_COPY;
+    const byteLength = 0;
+    this.buffers = [
+      new Buffer(gl, {byteLength, usage}), // previous
+      new Buffer(gl, {byteLength, usage}), // current
+      new Buffer(gl, {byteLength, usage}) // next
+    ];
+  }
+
+  // TODO: implement a check where each vertex renders an `isStillTransitioning` boolean to
+  // a 1x1 framebuffer
+  isTransitioning() {
+    return true;
+  }
+
+  // this will never return a constant attribute, no matter what attribute was passed in
+  getTransitioningAttribute() {
+    return this.attributeInTransition;
+  }
+
+  // this is called when an attribute's values have changed and
+  // we need to start animating towards the new values
+  // this also correctly resizes / pads the transform's buffers
+  // in case the attribute's buffer has changed in length or in
+  // bufferLayout
+  start(gl, transitionSettings, numInstances) {
+    const padBufferOpts = {
+      numInstances,
+      attribute: this.attribute,
+      fromLength: this.currentLength,
+      fromBufferLayout: this.currentBufferLayout,
+      getData: transitionSettings.enter
+    };
+
+    for (const buffer of this.buffers) {
+      padBuffer({buffer, ...padBufferOpts});
+    }
+
+    this.currentBufferLayout = this.attribute.bufferLayout;
+    this.currentLength = getAttributeBufferLength(this.attribute, numInstances);
+    this.attributeInTransition.update({
+      buffer: this.buffers[1],
+      // Hack: Float64Array is required for double-precision attributes
+      // to generate correct shader attributes
+      value: this.attribute.value
+    });
+
+    // when an attribute changes values, a new transition is started. These
+    // are properties that we have to store on this instance but can change
+    // when new transitions are started, so we have to keep them up-to-date. :(
+    this.transitionSettings = transitionSettings;
+    if (this.isTransitioning()) {
+      this.transitionSettings.onInterrupt();
+    }
+
+    this.transform = this.transform || new Transform(gl, getShaders(this.attribute.size));
+    this.transform.update({
+      elementCount: Math.floor(this.currentLength / this.attribute.size),
+      sourceBuffers: {
+        aTo: getSourceBufferAttribute(gl, this.attribute)
+      }
+    });
+  }
+
+  update() {
+    if (!this.isTransitioning()) {
+      return false;
+    }
+
+    // TODO: fire an onStart() event here if the transition has just started
+
+    this.transform.update({
+      sourceBuffers: {
+        aPrev: this.buffers[0],
+        aCur: this.buffers[1]
+      },
+      feedbackBuffers: {
+        vNext: this.buffers[2]
+      }
+    });
+    this.transform.run({
+      uniforms: {
+        stiffness: this.transitionSettings.stiffness,
+        damping: this.transitionSettings.damping
+      }
+    });
+    this.buffers = cycleBuffers(this.buffers);
+    this.attributeInTransition.update({buffer: this.buffers[1]});
+
+    this.transitionSettings.onUpdate();
+
+    // TODO: fire an onEnd() event here if the transition has just ended
+
+    return true;
+  }
+
+  cancel() {
+    this.transitionSettings.onInterrupt();
+    this.transform.delete();
+    while (this.buffers.length) {
+      this.buffers.pop().delete();
+    }
+  }
+}
+
+const vs = `
+#define SHADER_NAME spring-transition-vertex-shader
+
+uniform float stiffness;
+uniform float damping;
+attribute ATTRIBUTE_TYPE aPrev;
+attribute ATTRIBUTE_TYPE aCur;
+attribute ATTRIBUTE_TYPE aTo;
+varying ATTRIBUTE_TYPE vNext;
+
+ATTRIBUTE_TYPE getNextValue(ATTRIBUTE_TYPE cur, ATTRIBUTE_TYPE prev, ATTRIBUTE_TYPE dest) {
+  ATTRIBUTE_TYPE velocity = cur - prev;
+  ATTRIBUTE_TYPE delta = dest - cur;
+  ATTRIBUTE_TYPE spring = delta * stiffness;
+  ATTRIBUTE_TYPE damper = velocity * -1.0 * damping;
+  return spring + damper + velocity + cur;
+}
+
+void main(void) {
+  vNext = getNextValue(aCur, aPrev, aTo);
+  gl_Position = vec4(0.0);
+}
+`;
+
+function getShaders(attributeSize) {
+  const attributeType = getAttributeTypeFromSize(attributeSize);
+  return {
+    vs,
+    defines: {
+      ATTRIBUTE_TYPE: attributeType
+    },
+    varyings: ['vNext']
+  };
+}

--- a/test/apps/attribute-transition/data-generator.js
+++ b/test/apps/attribute-transition/data-generator.js
@@ -14,11 +14,11 @@ function randomInt(min, max) {
 
 export default class DataGenerator {
   constructor({
-    maxDistance = 1000,
-    radiusRange = [100, 300],
+    maxDistance = 250,
+    radiusRange = [25, 75],
     countRange = [1, 5],
     vertexRange = [3, 5],
-    sizeRange = [10, 30]
+    sizeRange = [3, 8]
   } = {}) {
     this.maxDistance = maxDistance;
     this.radiusRange = radiusRange;
@@ -37,7 +37,7 @@ export default class DataGenerator {
     this.polygons = Array.from({length: count}, () => {
       const vertexCount = randomInt(this.vertexRange);
       const a = random(0, Math.PI * 2);
-      const d = random(0, this.maxDistance);
+      const d = Math.sqrt(random(0, 1)) * this.maxDistance;
       const center = [d * Math.cos(a), d * Math.sin(a)];
       const r = random(this.radiusRange);
       const color = [random(0, 255), random(0, 255), random(0, 255)];

--- a/test/modules/core/lib/attribute-transition-manager.spec.js
+++ b/test/modules/core/lib/attribute-transition-manager.spec.js
@@ -75,7 +75,7 @@ if (isWebGL2(gl)) {
     t.ok(manager.hasAttribute('instancePositions'), 'added transition for instancePositions');
 
     const sizeTransition = manager.transitions.instanceSizes;
-    t.is(sizeTransition.buffer.getElementCount(), 1, 'buffer has correct size');
+    t.is(sizeTransition.buffers[0].getElementCount(), 1, 'buffer has correct size');
 
     const positionTransform = manager.transitions.instancePositions.transform;
     t.ok(positionTransform, 'transform is constructed for instancePositions');
@@ -85,7 +85,7 @@ if (isWebGL2(gl)) {
     t.ok(manager.hasAttribute('instanceSizes'), 'added transition for instanceSizes');
     t.notOk(manager.hasAttribute('instancePositions'), 'removed transition for instancePositions');
     t.notOk(positionTransform._handle, 'instancePositions transform is deleted');
-    t.is(sizeTransition.buffer.getElementCount(), 4, 'buffer has correct size');
+    t.is(sizeTransition.buffers[0].getElementCount(), 4, 'buffer has correct size');
 
     attributes.instanceSizes.update({value: new Float32Array(5).fill(1)});
     manager.update({attributes, transitions: {getSize: 1000}, numInstances: 5});


### PR DESCRIPTION
This PR is the first pass at implementing spring transitions for attributes. In the process, I've refactored the `GPUInterpolationTransition` class to simplify it and bring it in line with the new `GPUSpringTransition` class (please see [this comment](https://github.com/uber/deck.gl/pull/3530#issuecomment-530472320) regarding the resulting duplicated code). I've also made some changes to the attribute transition test app to incorporate the new spring transition types.

### Work _not_ implemented in this PR

This PR does not implement spring transitions for uniforms. Also, because the spring transition takes an unscaled step every time the transform is run, it is not currently affected by the application's `Timeline` (we plan to address this in a follow-up). Finally, the `onStart` and `onEnd` events are not yet implemented for spring transitions as they rely on implementing a reliable `isTransitioning` check.

### Follow-up work to do (https://github.com/uber/deck.gl/issues/3574)

 - support switching between transition types (perhaps lift the transitioning buffer management to `AttributeTransitionManager`?)
 - implement spring transition type for uniforms
 - scale the spring's step increments with Timeline
 - implement `isTransitioning` check (and `onStart` / `onEnd` events) for spring transitions (render an "isTransitioning flag" per vertex to a 1x1 framebuffer)

### Screenshot

![attribute-spring-transition](https://user-images.githubusercontent.com/2099249/64629117-9f38eb80-d3c0-11e9-8e54-e2e5637066b7.gif)
