### PR TITLE
Fix GPUGridLayer unhandled cellsize

### DIFF
--- a/docs/layers/gpu-grid-layer.md
+++ b/docs/layers/gpu-grid-layer.md
@@ -94,7 +94,7 @@ Inherits from all [Base Layer](/docs/api-reference/layer.md) and [CompositeLayer
 
 * Default: `1000`
 
-Size of each cell in meters
+Size of each cell in meters. Must be greater than `0`.
 
 ##### `colorRange` (Array, optional)
 

--- a/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-layer.js
+++ b/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-layer.js
@@ -44,7 +44,7 @@ const defaultProps = {
   elevationScale: {type: 'number', min: 0, value: 1},
 
   // grid
-  cellSize: {type: 'number', min: 0, max: 1000, value: 1000},
+  cellSize: {type: 'number', min: 1, max: 1000, value: 1000},
   coverage: {type: 'number', min: 0, max: 1, value: 1},
   getPosition: {type: 'accessor', value: x => x.position},
   extruded: false,

--- a/modules/aggregation-layers/src/utils/gpu-grid-aggregation/grid-aggregation-utils.js
+++ b/modules/aggregation-layers/src/utils/gpu-grid-aggregation/grid-aggregation-utils.js
@@ -29,6 +29,7 @@ export function pointToDensityGridData({
     gridData = parseGridData(data, getPosition, weightParams);
     boundingBox = gridData.boundingBox;
   }
+  log.assert(cellSizeMeters >= 0);
   let cellSize = [cellSizeMeters, cellSizeMeters];
   let worldOrigin = [0, 0];
   log.assert(

--- a/modules/aggregation-layers/src/utils/gpu-grid-aggregation/grid-aggregation-utils.js
+++ b/modules/aggregation-layers/src/utils/gpu-grid-aggregation/grid-aggregation-utils.js
@@ -29,7 +29,7 @@ export function pointToDensityGridData({
     gridData = parseGridData(data, getPosition, weightParams);
     boundingBox = gridData.boundingBox;
   }
-  log.assert(cellSizeMeters >= 0);
+  log.assert(cellSizeMeters > 0);
   let cellSize = [cellSizeMeters, cellSizeMeters];
   let worldOrigin = [0, 0];
   log.assert(


### PR DESCRIPTION
Fix #3534

<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
<!-- For other PRs without open issue -->
#### Background
GPU Grid Layer currently doesn't handles the case when cell size is zero. Hence, some variables get `Infinity` or `NaN` values.
