### PR TITLE
Misc test error/warning fixes

### DIFF
--- a/modules/core/src/lifecycle/component-state.js
+++ b/modules/core/src/lifecycle/component-state.js
@@ -116,9 +116,11 @@ export default class ComponentState {
 
     // interpret value string as url and start a new load tracked by a promise
     if (typeof value === 'string') {
-      const {fetch} = this.layer.props;
+      const fetch = this.layer && this.layer.props.fetch;
       const url = value;
-      value = fetch(url, {propName, layer: this.layer});
+      if (fetch) {
+        value = fetch(url, {propName, layer: this.layer});
+      }
     }
 
     // interprets promise and track the "loading"
@@ -184,7 +186,7 @@ export default class ComponentState {
         data = this._postProcessValue(propName, data);
         this._setAsyncPropValue(propName, data, loadCount);
 
-        const {onDataLoad} = this.layer.props;
+        const onDataLoad = this.layer && this.layer.props.onDataLoad;
         if (propName === 'data' && onDataLoad) {
           onDataLoad(data, {propName, layer: this.layer});
         }
@@ -217,7 +219,7 @@ export default class ComponentState {
       this._setAsyncPropValue(propName, data, loadCount);
     }
 
-    const {onDataLoad} = this.layer.props;
+    const onDataLoad = this.layer && this.layer.props.onDataLoad;
     if (onDataLoad) {
       onDataLoad(data, {propName, layer: this.layer});
     }

--- a/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer.js
+++ b/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer.js
@@ -61,7 +61,7 @@ export default class MultiIconLayer extends IconLayer {
     attributeManager.addInstanced({
       instanceOffsets: {
         size: 2,
-        accessor: 'getIcon',
+        accessor: ['getIcon', 'getAnchorX', 'getAnchorY'],
         update: this.calculateInstanceOffsets
       },
       instancePixelOffset: {

--- a/test/modules/json/json-converter.spec.js
+++ b/test/modules/json/json-converter.spec.js
@@ -45,7 +45,7 @@ export const JSON_DATA = {
       type: 'ScatterplotLayer',
       data: [{position: [-122.45, 37.8]}],
       getPosition: 'position',
-      getColor: [255, 0, 0, 255],
+      getFillColor: [255, 0, 0, 255],
       getRadius: 1000
     },
     {

--- a/test/modules/json/json-layer.spec.js
+++ b/test/modules/json/json-layer.spec.js
@@ -73,10 +73,12 @@ test('JSONLayer#fetch', t => {
     data: [
       {
         type: 'TextLayer',
+        id: 'text-layer-1',
         data: 'data.json'
       },
       {
         type: 'TextLayer',
+        id: 'text-layer-2',
         data: 'data.csv',
         getPosition: d => [d.lon, d.lat],
         getText: d => d.text


### PR DESCRIPTION
#### Change List
- Fix: uncaught promise error in `ComponentState` when `layer` is not set
- Fix: MultiIconLayer `getAnchorX` and `getAnchorY` update trigger warnings
- Fix: json module test case deprecated prop warning
- Fix: json module test case duplicate layer id warning
