### PR TITLE
Fix ColumnLayer elevationScale example

### DIFF
--- a/website/src/components/demos/layer-demos.js
+++ b/website/src/components/demos/layer-demos.js
@@ -43,12 +43,12 @@ export const ColumnLayerDemo = createLayerDemoClass({
     radius: 250,
     extruded: true,
     pickable: true,
-    elevationScale: 5000,
+    elevationScale: 100,
     getPosition: d => d.centroid,
     getFillColor: d => [48, 128, d.value * 255, 255],
     getLineColor: [0, 0, 0],
     getLineWidth: 20,
-    getElevation: d => d.value
+    getElevation: d => d.value * 50
   }
 });
 

--- a/website/src/utils/layer-params.js
+++ b/website/src/utils/layer-params.js
@@ -57,9 +57,6 @@ export function getLayerParams(layer, propParameters = {}) {
       paramsArray.push({name: key, ...propParameters[key]});
     } else {
       const LAYER_PROPTYPES = layer.constructor._propTypes[key];
-      if (layer.constructor.name === 'ColumnLayer') {
-        LAYER_PROPTYPES.max = 5000;
-      }
       const param = propToParam(key, LAYER_PROPTYPES, layer.props[key]);
       if (param) {
         paramsArray.push(param);

--- a/website/src/utils/layer-params.js
+++ b/website/src/utils/layer-params.js
@@ -56,7 +56,11 @@ export function getLayerParams(layer, propParameters = {}) {
     if (propParameters[key]) {
       paramsArray.push({name: key, ...propParameters[key]});
     } else {
-      const param = propToParam(key, layer.constructor._propTypes[key], layer.props[key]);
+      const LAYER_PROPTYPES = layer.constructor._propTypes[key];
+      if (layer.constructor.name === 'ColumnLayer') {
+        LAYER_PROPTYPES.max = 5000;
+      }
+      const param = propToParam(key, LAYER_PROPTYPES, layer.props[key]);
       if (param) {
         paramsArray.push(param);
       }


### PR DESCRIPTION
Fix #3541

#### Background
ColumnLayer's `elevationScale` in the documentation is set to `5000` initially, but the input range have a default max value of `100`, so it does not move beyond 100 once changed from the initial state.
Here, I pass a `max` prop to input field with value equal to `5000` .

![sol](https://user-images.githubusercontent.com/34404592/64463781-de4a1100-d122-11e9-84a0-2cfca6b5f447.gif)
