### PR TITLE
Fix/Viewport Transitions FlyTo webpack config

### DIFF
--- a/test/apps/viewport-transitions-flyTo/package.json
+++ b/test/apps/viewport-transitions-flyTo/package.json
@@ -5,16 +5,16 @@
   },
   "dependencies": {
     "deck.gl": "^6.0.0",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0",
+    "react": "^16.3.0",
+    "react-dom": "^16.3.0",
     "react-map-gl": "^3.3.0"
   },
   "devDependencies": {
-    "babel-preset-es2015": "^6.18.0",
-    "babel-preset-react": "^6.16.0",
-    "babel-preset-stage-2": "^6.18.0",
-    "buble-loader": "^0.4.0",
-    "webpack": "^2.4.0",
-    "webpack-dev-server": "^3.1.11"
+    "@babel/core": "^7.4.0",
+    "@babel/preset-react": "^7.0.0",
+    "babel-loader": "^8.0.5",
+    "webpack": "^4.20.2",
+    "webpack-cli": "^3.1.2",
+    "webpack-dev-server": "^3.1.1"
   }
 }


### PR DESCRIPTION
Close #3555

<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
<!-- For other PRs without open issue -->
#### Background
Viewport Transitions FlyTo example webpack is configured incorrectly. Hence, the example is not running.
<!-- For all the PRs -->
#### Change List
- Updated dependencies in `package.json`
- Created `webpack.config.js` for Webpack 4
