### PR TITLE
Expose loaders.gl endpoints from the core bundle

### DIFF
--- a/modules/core/bundle/index.js
+++ b/modules/core/bundle/index.js
@@ -3,13 +3,16 @@ const LumaGL = require('./lumagl');
 const deckGLCore = require('../src');
 
 const DeckGL = require('./deckgl').default;
+const {registerLoaders, load, parse} = require('@loaders.gl/core');
 
 /* global window, global */
 const _global = typeof window === 'undefined' ? global : window;
 _global.deck = _global.deck || {};
 _global.luma = _global.luma || {};
+_global.loaders = _global.loaders || {};
 
 Object.assign(_global.deck, deckGLCore, {DeckGL});
 Object.assign(_global.luma, LumaGL);
+Object.assign(_global.loaders, {registerLoaders, load, parse});
 
 module.exports = _global.deck;


### PR DESCRIPTION
#### Background

Users of the pre-bundled version of deck.gl, e.g. the jupyter-widget module, cannot register their own loaders to use with the built-in async loading system. This is because loaders.gl has one global registry per `loaders.gl/core` copy, and the copy that is pre-bundled with `@deck.gl/core` is not exposed.

#### Change List
- Expose loaders core utilities from the copy that is bundled with deck.
