### PR TITLE
Add alphaCutoff prop to IconLayer

### DIFF
--- a/docs/layers/icon-layer.md
+++ b/docs/layers/icon-layer.md
@@ -208,11 +208,11 @@ The maximum size in pixels.
 
 If on, the icon always faces camera. Otherwise the icon faces up (z)
 
-##### `cutoff` (Number, optional)
+##### `alphaCutoff` (Number, optional)
 
 - Default: `0.05`
 
-Discard pixels whose opacity is below this threshold. This is useful for customizing which part of the icon is pickable, e.g. whether hovering over a hole in the shape should pick the object.
+Discard pixels whose opacity is below this threshold. A discarded pixel would create a "hole" in the icon that is not considered part of the object. This is useful for customizing picking behavior, e.g. setting `alphaCutoff: 0, autoHighlight` will highlight an object whenever the cursor moves into its bounding box, instead of over the visible pixels.
 
 
 ### Data Accessors

--- a/docs/layers/icon-layer.md
+++ b/docs/layers/icon-layer.md
@@ -208,6 +208,13 @@ The maximum size in pixels.
 
 If on, the icon always faces camera. Otherwise the icon faces up (z)
 
+##### `cutoff` (Number, optional)
+
+- Default: `0.05`
+
+Discard pixels whose opacity is below this threshold. This is useful for customizing which part of the icon is pickable, e.g. whether hovering over a hole in the shape should pick the object.
+
+
 ### Data Accessors
 
 ##### `getIcon` ([Function](/docs/developer-guide/using-layers.md#accessors), optional)

--- a/modules/layers/src/icon-layer/icon-layer-fragment.glsl.js
+++ b/modules/layers/src/icon-layer/icon-layer-fragment.glsl.js
@@ -25,7 +25,7 @@ precision highp float;
 
 uniform float opacity;
 uniform sampler2D iconsTexture;
-uniform float cutoff;
+uniform float alphaCutoff;
 
 varying float vColorMode;
 varying vec4 vColor;
@@ -43,7 +43,7 @@ void main(void) {
   // Take the global opacity and the alpha from vColor into account for the alpha component
   float a = texColor.a * opacity * vColor.a;
 
-  if (a < cutoff) {
+  if (a < alphaCutoff) {
     discard;
   }
 

--- a/modules/layers/src/icon-layer/icon-layer-fragment.glsl.js
+++ b/modules/layers/src/icon-layer/icon-layer-fragment.glsl.js
@@ -25,13 +25,12 @@ precision highp float;
 
 uniform float opacity;
 uniform sampler2D iconsTexture;
+uniform float cutoff;
 
 varying float vColorMode;
 varying vec4 vColor;
 varying vec2 vTextureCoords;
 varying vec2 uv;
-
-const float MIN_ALPHA = 0.05;
 
 void main(void) {
   geometry.uv = uv;
@@ -44,7 +43,7 @@ void main(void) {
   // Take the global opacity and the alpha from vColor into account for the alpha component
   float a = texColor.a * opacity * vColor.a;
 
-  if (a < MIN_ALPHA) {
+  if (a < cutoff) {
     discard;
   }
 

--- a/modules/layers/src/icon-layer/icon-layer.js
+++ b/modules/layers/src/icon-layer/icon-layer.js
@@ -57,6 +57,7 @@ const defaultProps = {
   sizeUnits: 'pixels',
   sizeMinPixels: {type: 'number', min: 0, value: 0}, //  min point radius in pixels
   sizeMaxPixels: {type: 'number', min: 0, value: Number.MAX_SAFE_INTEGER}, // max point radius in pixels
+  cutoff: {type: 'number', value: 0.05, min: 0, max: 1},
 
   getPosition: {type: 'accessor', value: x => x.position},
   getIcon: {type: 'accessor', value: x => x.icon},
@@ -175,7 +176,7 @@ export default class IconLayer extends Layer {
   }
 
   draw({uniforms}) {
-    const {sizeScale, sizeMinPixels, sizeMaxPixels, sizeUnits, billboard} = this.props;
+    const {sizeScale, sizeMinPixels, sizeMaxPixels, sizeUnits, billboard, cutoff} = this.props;
     const {iconManager} = this.state;
     const {viewport} = this.context;
 
@@ -190,7 +191,8 @@ export default class IconLayer extends Layer {
               sizeScale * (sizeUnits === 'pixels' ? viewport.distanceScales.metersPerPixel[2] : 1),
             sizeMinPixels,
             sizeMaxPixels,
-            billboard
+            billboard,
+            cutoff
           })
         )
         .draw();

--- a/modules/layers/src/icon-layer/icon-layer.js
+++ b/modules/layers/src/icon-layer/icon-layer.js
@@ -57,7 +57,7 @@ const defaultProps = {
   sizeUnits: 'pixels',
   sizeMinPixels: {type: 'number', min: 0, value: 0}, //  min point radius in pixels
   sizeMaxPixels: {type: 'number', min: 0, value: Number.MAX_SAFE_INTEGER}, // max point radius in pixels
-  cutoff: {type: 'number', value: 0.05, min: 0, max: 1},
+  alphaCutoff: {type: 'number', value: 0.05, min: 0, max: 1},
 
   getPosition: {type: 'accessor', value: x => x.position},
   getIcon: {type: 'accessor', value: x => x.icon},
@@ -176,7 +176,7 @@ export default class IconLayer extends Layer {
   }
 
   draw({uniforms}) {
-    const {sizeScale, sizeMinPixels, sizeMaxPixels, sizeUnits, billboard, cutoff} = this.props;
+    const {sizeScale, sizeMinPixels, sizeMaxPixels, sizeUnits, billboard, alphaCutoff} = this.props;
     const {iconManager} = this.state;
     const {viewport} = this.context;
 
@@ -192,7 +192,7 @@ export default class IconLayer extends Layer {
             sizeMinPixels,
             sizeMaxPixels,
             billboard,
-            cutoff
+            alphaCutoff
           })
         )
         .draw();

--- a/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer-fragment.glsl.js
+++ b/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer-fragment.glsl.js
@@ -26,13 +26,12 @@ precision highp float;
 uniform sampler2D iconsTexture;
 uniform float buffer;
 uniform bool sdf;
+uniform float cutoff;
 
 varying vec4 vColor;
 varying vec2 vTextureCoords;
 varying float vGamma;
 varying vec2 uv;
-
-const float MIN_ALPHA = 0.05;
 
 void main(void) {
   geometry.uv = uv;
@@ -49,7 +48,7 @@ void main(void) {
   // Take the global opacity and the alpha from vColor into account for the alpha component
   float a = alpha * vColor.a;
 
-  if (a < MIN_ALPHA) {
+  if (a < cutoff) {
     discard;
   }
 

--- a/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer-fragment.glsl.js
+++ b/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer-fragment.glsl.js
@@ -26,7 +26,7 @@ precision highp float;
 uniform sampler2D iconsTexture;
 uniform float buffer;
 uniform bool sdf;
-uniform float cutoff;
+uniform float alphaCutoff;
 
 varying vec4 vColor;
 varying vec2 vTextureCoords;
@@ -48,7 +48,7 @@ void main(void) {
   // Take the global opacity and the alpha from vColor into account for the alpha component
   float a = alpha * vColor.a;
 
-  if (a < cutoff) {
+  if (a < alphaCutoff) {
     discard;
   }
 


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/3178#issuecomment-524427608

@danmarshall We cannot make the `TextLayer` background default pickable in a minor release, as it would be a breaking change. However, you will be able to achieve the effect using

```js
new TextLayer({
  // ...
  _subLayerProps: {
    characters: {alphaCutoff: 0}
  }
});
```

![image](https://user-images.githubusercontent.com/2059298/64989669-d573e080-d882-11e9-8554-1e58826b4440.png)


#### Change List
- Add `alphaCutoff` prop to IconLayer
- Documentation
