### PR TITLE
Implement isTransitioning check for attribute spring-transitions

### DIFF
--- a/modules/core/src/transitions/gpu-spring-transition.js
+++ b/modules/core/src/transitions/gpu-spring-transition.js
@@ -1,6 +1,6 @@
 /* eslint-disable complexity, max-statements, max-params */
 import GL from '@luma.gl/constants';
-import {Buffer, Transform} from '@luma.gl/core';
+import {Buffer, Transform, Framebuffer, Texture2D, readPixelsToArray} from '@luma.gl/core';
 import {
   padBuffer,
   getAttributeTypeFromSize,
@@ -16,6 +16,7 @@ export default class GPUSpringTransition {
     this.gl = gl;
     this.type = 'spring';
     this.transition = new Transition(timeline);
+    this._isTransitioning = false;
     this.attribute = attribute;
     // this is the attribute we return during the transition - note: if it is a constant
     // attribute, it will be converted and returned as a regular attribute
@@ -28,6 +29,8 @@ export default class GPUSpringTransition {
     // due to performance costs
     this.currentLength = 0;
     this.transform = null;
+    this.texture = getTexture(gl);
+    this.framebuffer = getFramebuffer(gl, this.texture);
     const usage = GL.DYNAMIC_COPY;
     const byteLength = 0;
     this.buffers = [
@@ -37,10 +40,8 @@ export default class GPUSpringTransition {
     ];
   }
 
-  // TODO: implement a check where each vertex renders an `isStillTransitioning` boolean to
-  // a 1x1 framebuffer
   isTransitioning() {
-    return true;
+    return this._isTransitioning;
   }
 
   // this will never return a constant attribute, no matter what attribute was passed in
@@ -76,17 +77,19 @@ export default class GPUSpringTransition {
     });
 
     // when an attribute changes values, a new transition is started. These
-    // are properties that we have to store on this instance but can change
-    // when new transitions are started, so we have to keep them up-to-date. :(
+    // are properties that we have to store on this.transition but can change
+    // when new transitions are started, so we have to keep them up-to-date.
+    // this.transition.start() takes the latest settings and updates them.
     this.transition.start(transitionSettings);
 
-    this.transform = this.transform || new Transform(this.gl, getShaders(this.attribute.size));
+    this.transform = this.transform || getTransform(this.gl, this.attribute, this.framebuffer);
     this.transform.update({
       elementCount: Math.floor(this.currentLength / this.attribute.size),
       sourceBuffers: {
         aTo: getSourceBufferAttribute(this.gl, this.attribute)
       }
     });
+    this._isTransitioning = true;
   }
 
   update() {
@@ -94,8 +97,6 @@ export default class GPUSpringTransition {
     if (!updated) {
       return false;
     }
-
-    // TODO: fire an onStart() event here if the transition has just started
 
     this.transform.update({
       sourceBuffers: {
@@ -107,16 +108,30 @@ export default class GPUSpringTransition {
       }
     });
     this.transform.run({
+      framebuffer: this.framebuffer,
+      discard: false,
+      clearRenderTarget: true,
       uniforms: {
         stiffness: this.transition.settings.stiffness,
         damping: this.transition.settings.damping
+      },
+      parameters: {
+        depthTest: false,
+        blend: true,
+        viewport: [0, 0, 1, 1],
+        blendFunc: [GL.ONE, GL.ONE],
+        blendEquation: [GL.MAX, GL.MAX]
       }
     });
+
     cycleBuffers(this.buffers);
     this.attributeInTransition.update({buffer: this.buffers[1]});
 
-    // TODO: fire the event here if the transition has just ended
-    // transition.end();
+    this._isTransitioning = readPixelsToArray(this.framebuffer)[0] > 0;
+
+    if (!this.isTransitioning()) {
+      this.transition.end();
+    }
 
     return true;
   }
@@ -127,11 +142,21 @@ export default class GPUSpringTransition {
     while (this.buffers.length) {
       this.buffers.pop().delete();
     }
+    this.texture.delete();
+    this.texture = null;
+    this.framebuffer.delete();
+    this.framebuffer = null;
   }
 }
 
-const vs = `
+function getTransform(gl, attribute, framebuffer) {
+  const attributeType = getAttributeTypeFromSize(attribute.size);
+  return new Transform(gl, {
+    framebuffer,
+    vs: `
 #define SHADER_NAME spring-transition-vertex-shader
+
+#define EPSILON 0.00001
 
 uniform float stiffness;
 uniform float damping;
@@ -139,6 +164,7 @@ attribute ATTRIBUTE_TYPE aPrev;
 attribute ATTRIBUTE_TYPE aCur;
 attribute ATTRIBUTE_TYPE aTo;
 varying ATTRIBUTE_TYPE vNext;
+varying float vIsTransitioningFlag;
 
 ATTRIBUTE_TYPE getNextValue(ATTRIBUTE_TYPE cur, ATTRIBUTE_TYPE prev, ATTRIBUTE_TYPE dest) {
   ATTRIBUTE_TYPE velocity = cur - prev;
@@ -149,18 +175,52 @@ ATTRIBUTE_TYPE getNextValue(ATTRIBUTE_TYPE cur, ATTRIBUTE_TYPE prev, ATTRIBUTE_T
 }
 
 void main(void) {
-  vNext = getNextValue(aCur, aPrev, aTo);
-  gl_Position = vec4(0.0);
-}
-`;
+  bool isTransitioning = length(aCur - aPrev) > EPSILON || length(aTo - aCur) > EPSILON;
+  vIsTransitioningFlag = isTransitioning ? 1.0 : 0.0;
 
-function getShaders(attributeSize) {
-  const attributeType = getAttributeTypeFromSize(attributeSize);
-  return {
-    vs,
+  vNext = getNextValue(aCur, aPrev, aTo);
+  gl_Position = vec4(0, 0, 0, 1);
+  gl_PointSize = 100.0;
+}
+`,
+    fs: `
+#define SHADER_NAME spring-transition-is-transitioning-fragment-shader
+
+varying float vIsTransitioningFlag;
+
+void main(void) {
+  if (vIsTransitioningFlag == 0.0) {
+    discard;
+  }
+  gl_FragColor = vec4(1.0);
+}`,
     defines: {
       ATTRIBUTE_TYPE: attributeType
     },
     varyings: ['vNext']
-  };
+  });
+}
+
+function getTexture(gl) {
+  return new Texture2D(gl, {
+    data: new Uint8Array(4),
+    format: GL.RGBA,
+    type: GL.UNSIGNED_BYTE,
+    border: 0,
+    mipmaps: false,
+    dataFormat: GL.RGBA,
+    width: 1,
+    height: 1
+  });
+}
+
+function getFramebuffer(gl, texture) {
+  return new Framebuffer(gl, {
+    id: 'spring-transition-is-transitioning-framebuffer',
+    width: 1,
+    height: 1,
+    attachments: {
+      [GL.COLOR_ATTACHMENT0]: texture
+    }
+  });
 }

--- a/test/apps/attribute-transition/app.js
+++ b/test/apps/attribute-transition/app.js
@@ -1,4 +1,4 @@
-/* global document */
+/* global document console */
 /* eslint-disable no-console */
 import React, {Component} from 'react';
 import {render} from 'react-dom';
@@ -13,7 +13,7 @@ class Root extends Component {
     this._dataGenerator = new DataGenerator();
 
     this.state = {
-      transitionType: 'interpolation',
+      transitionType: 'spring',
       points: this._dataGenerator.points,
       polygons: this._dataGenerator.polygons,
       viewState: {
@@ -43,26 +43,39 @@ class Root extends Component {
   render() {
     const {points, polygons, viewState} = this.state;
 
+    const interpolationSettings = {
+      duration: 600,
+      onStart: () => {
+        console.log('onStart');
+      },
+      onEnd: () => {
+        console.log('onEnd');
+      },
+      onInterrupt: () => {
+        console.log('onInterrupt');
+      }
+    };
+
     const springSettings = {
       type: 'spring',
       stiffness: 0.01,
-      damping: 0.15
+      damping: 0.15,
+      onStart: () => {
+        console.log('onStart');
+      },
+      onEnd: () => {
+        console.log('onEnd');
+      },
+      onInterrupt: () => {
+        console.log('onInterrupt');
+      }
     };
 
     const scatterplotTransitionsByType = {
       interpolation: {
-        getPosition: {
-          duration: 600,
-          enter: () => [0, 0]
-        },
-        getRadius: {
-          duration: 600,
-          enter: () => [0]
-        },
-        getFillColor: {
-          duration: 600,
-          enter: ([r, g, b]) => [r, g, b, 0]
-        }
+        getPosition: Object.assign({}, interpolationSettings, {enter: () => [0, 0]}),
+        getRadius: Object.assign({}, interpolationSettings, {enter: () => [0]}),
+        getFillColor: Object.assign({}, interpolationSettings, {enter: ([r, g, b]) => [r, g, b, 0]})
       },
       spring: {
         getPosition: Object.assign({}, springSettings, {enter: () => [0, 0]}),
@@ -74,14 +87,12 @@ class Root extends Component {
     const polygonTransitionsByType = {
       interpolation: {
         getPolygon: 600,
-        getLineColor: {
-          duration: 600,
+        getLineColor: Object.assign({}, interpolationSettings, {
           enter: ([r, g, b]) => [r, g, b, 0]
-        },
-        getFillColor: {
-          duration: 600,
+        }),
+        getFillColor: Object.assign({}, interpolationSettings, {
           enter: ([r, g, b]) => [r, g, b, 0]
-        },
+        }),
         getLineWidth: 600
       },
       spring: {


### PR DESCRIPTION
This PR adds an `isTransitioning` check to spring-transitions and implements the `onStart`, `onInterrupt`, and `onEnd` events using the `isTransitioning` check. (This is one of the blockers listed in this issue: https://github.com/uber/deck.gl/issues/3574)

It accomplishes this by having each transitioning value render an `isTransitioning` flag to a 1x1 fragment. The fragments are blended, taking the max value, and if the resulting pixel has a value greater than `0`, at least one of the transitions is still in progress.

I'd like to flag a concern here about scalability. This has not been tried with millions of values, yet, though, so I wonder if the blend step is performant enough to be run on every frame for those types of numbers.