### PR TITLE
Fix bug that makes undefined key appear in aggregate layer pickingInfo

### DIFF
--- a/modules/aggregation-layers/src/utils/cpu-aggregator.js
+++ b/modules/aggregation-layers/src/utils/cpu-aggregator.js
@@ -133,7 +133,6 @@ export default class CPUAggregator {
 
     this._getCellSize = opts.getCellSize || defaultGetCellSize;
     this._getAggregator = opts.getAggregator;
-
     this._addDimension(opts.dimensions || defaultDimensions);
   }
 
@@ -246,10 +245,11 @@ export default class CPUAggregator {
     });
   }
 
-  getDimensionUpdaters({key, accessor, getBins, getDomain, getScaleFunc, nullValue}) {
+  getDimensionUpdaters({key, accessor, pickingInfo, getBins, getDomain, getScaleFunc, nullValue}) {
     return {
       key,
       accessor,
+      pickingInfo,
       getBins: Object.assign({updater: this.getDimensionSortedBins}, getBins),
       getDomain: Object.assign({updater: this.getDimensionValueDomain}, getDomain),
       getScaleFunc: Object.assign({updater: this.getDimensionScale}, getScaleFunc),


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
pickingInfo.object has a null elevationValue in the current deck.gl
beta.


To reproduce, you can add the following `onHover` parameter in
`deck.gl/examples/playground/src/deck-with-maps.js` and look at the
console output:
```
    return (
      <DeckGL
        id="json-deck"
        {...this.props}
        viewState={viewState}
        onHover={x => (x.picked ? console.log(x.object) : null)}
        onViewStateChange={this._onViewStateChange}
      >
```


<!-- For other PRs without open issue -->
#### Background
HexagonLayers were returning `undefined` keys in tooltips in pydeck–this change should fix that.
<!-- For all the PRs -->
#### Change List
- Add pickingInfo name to CPU aggregator output