### PR TITLE
Fix GPUSpringTransition

### DIFF
--- a/modules/core/src/lib/attribute-transition-manager.js
+++ b/modules/core/src/lib/attribute-transition-manager.js
@@ -3,6 +3,11 @@ import GPUInterpolationTransition from '../transitions/gpu-interpolation-transit
 import GPUSpringTransition from '../transitions/gpu-spring-transition';
 import log from '../utils/log';
 
+const TRANSITION_TYPES = {
+  interpolation: GPUInterpolationTransition,
+  spring: GPUSpringTransition
+};
+
 export default class AttributeTransitionManager {
   constructor(gl, {id, timeline}) {
     this.id = id;
@@ -118,16 +123,11 @@ export default class AttributeTransitionManager {
         this._removeTransition(attributeName);
       }
 
-      if (settings.type === 'interpolation') {
-        this.transitions[attributeName] = new GPUInterpolationTransition({
+      const TransitionType = TRANSITION_TYPES[settings.type];
+      if (TransitionType) {
+        this.transitions[attributeName] = new TransitionType({
           attribute,
           timeline: this.timeline,
-          gl: this.gl
-        });
-      } else if (settings.type === 'spring') {
-        this.transitions[attributeName] = new GPUSpringTransition({
-          attribute,
-          transitionSettings: settings,
           gl: this.gl
         });
       } else {
@@ -138,7 +138,7 @@ export default class AttributeTransitionManager {
 
     if (isNew || attribute.needsRedraw()) {
       this.needsRedraw = true;
-      this.transitions[attributeName].start(this.gl, settings, this.numInstances);
+      this.transitions[attributeName].start(settings, this.numInstances);
     }
   }
 }

--- a/modules/core/src/lib/attribute-transition-utils.js
+++ b/modules/core/src/lib/attribute-transition-utils.js
@@ -63,7 +63,6 @@ export function getAttributeTypeFromSize(size) {
 
 export function cycleBuffers(buffers) {
   buffers.push(buffers.shift());
-  return buffers;
 }
 
 export function getAttributeBufferLength(attribute, numInstances) {

--- a/modules/core/src/lib/uniform-transition-manager.js
+++ b/modules/core/src/lib/uniform-transition-manager.js
@@ -37,7 +37,7 @@ export default class UniformTransitionManager {
       log.error(`unsupported transition type '${settings.type}'`)();
       return;
     }
-    const transition = new TransitionType({timeline: this.timeline});
+    const transition = new TransitionType(this.timeline);
     transition.start({
       ...settings,
       fromValue,

--- a/modules/core/src/transitions/cpu-interpolation-transition.js
+++ b/modules/core/src/transitions/cpu-interpolation-transition.js
@@ -6,13 +6,12 @@ export default class CPUInterpolationTransition extends Transition {
     return this._value;
   }
 
-  update() {
-    const updated = super.update();
-
-    if (updated) {
-      const {fromValue, toValue, time} = this;
-      this._value = lerp(fromValue, toValue, time);
-    }
-    return updated;
+  _onUpdate() {
+    const {
+      time,
+      settings: {fromValue, toValue, duration, easing}
+    } = this;
+    const t = easing(time / duration);
+    this._value = lerp(fromValue, toValue, t);
   }
 }

--- a/modules/core/src/transitions/cpu-spring-transition.js
+++ b/modules/core/src/transitions/cpu-spring-transition.js
@@ -69,7 +69,7 @@ export default class CPUSpringTransition extends Transition {
 
     if (delta < EPSILON && velocity < EPSILON) {
       nextValue = toValue;
-      this.end(this);
+      this.end();
     }
 
     this._prevValue = _currValue;

--- a/modules/core/src/transitions/cpu-spring-transition.js
+++ b/modules/core/src/transitions/cpu-spring-transition.js
@@ -57,27 +57,22 @@ export default class CPUSpringTransition extends Transition {
     return this._currValue;
   }
 
-  update() {
-    const updated = super.update();
-    if (updated) {
-      // TODO - use timeline
-      // const {time} = this;
+  _onUpdate() {
+    // TODO - use timeline
+    // const {time} = this;
 
-      const {fromValue, toValue, damping, stiffness} = this;
-      const {_prevValue = fromValue, _currValue = fromValue} = this;
-      let nextValue = updateSpring(_prevValue, _currValue, toValue, damping, stiffness);
-      const delta = distance(nextValue, toValue);
-      const velocity = distance(nextValue, _currValue);
+    const {fromValue, toValue, damping, stiffness} = this.settings;
+    const {_prevValue = fromValue, _currValue = fromValue} = this;
+    let nextValue = updateSpring(_prevValue, _currValue, toValue, damping, stiffness);
+    const delta = distance(nextValue, toValue);
+    const velocity = distance(nextValue, _currValue);
 
-      if (delta < EPSILON && velocity < EPSILON) {
-        nextValue = toValue;
-        this._inProgress = false;
-        this.onEnd(this);
-      }
-
-      this._prevValue = _currValue;
-      this._currValue = nextValue;
+    if (delta < EPSILON && velocity < EPSILON) {
+      nextValue = toValue;
+      this.end(this);
     }
-    return updated;
+
+    this._prevValue = _currValue;
+    this._currValue = nextValue;
   }
 }

--- a/test/modules/core/transitions/transition.spec.js
+++ b/test/modules/core/transitions/transition.spec.js
@@ -3,12 +3,9 @@ import Transition from '@deck.gl/core/transitions/transition';
 import {Timeline} from '@luma.gl/addons';
 
 test('Transition#constructor', t => {
-  let transition = new Transition();
-  t.ok(transition, 'Transition is constructed without props');
-
-  transition = new Transition({customAttribute: 'custom value'});
-  t.ok(transition, 'Transition is constructed with props');
-  t.is(transition.customAttribute, 'custom value', 'Transition has customAttribute');
+  const transition = new Transition(new Timeline());
+  t.ok(transition, 'Transition is constructed');
+  t.ok(transition.settings, 'Transition settings is created');
 
   t.end();
 });
@@ -16,18 +13,20 @@ test('Transition#constructor', t => {
 test('Transition#start', t => {
   let onStartCallCount = 0;
 
-  const transition = new Transition({
-    timeline: new Timeline(),
+  const transition = new Transition(new Timeline());
+  transition.start({
     onStart: () => {
       onStartCallCount++;
-    }
+    },
+    customAttribute: 'custom value'
   });
-  t.notOk(transition.inProgress, 'Transition is not in progress');
-
-  transition.start({customAttribute: 'custom value'});
   t.ok(transition.inProgress, 'Transition is in progress');
   t.ok(transition._handle, 'Sub-timeline is created');
-  t.is(transition.customAttribute, 'custom value', 'Transition has customAttribute');
+  t.is(
+    transition.settings.customAttribute,
+    'custom value',
+    'Transition has customAttribute in settings'
+  );
   t.is(onStartCallCount, 1, 'onStart is called once');
 
   t.end();
@@ -39,20 +38,18 @@ test('Transition#update', t => {
   let onEndCallCount = 0;
   const timeline = new Timeline();
 
-  const transition = new Transition({
-    timeline,
-    onUpdate: () => {
-      onUpdateCallCount++;
-    },
-    onEnd: () => {
-      onEndCallCount++;
-    }
-  });
+  const transition = new Transition(timeline);
 
   transition.update();
   t.notOk(transition.inProgress, 'Transition is not in progress');
 
   transition.start({
+    onUpdate: () => {
+      onUpdateCallCount++;
+    },
+    onEnd: () => {
+      onEndCallCount++;
+    },
     duration: 1,
     easing: time => time * time
   });
@@ -64,7 +61,7 @@ test('Transition#update', t => {
   timeline.setTime(0.5);
   transition.update();
   t.ok(transition.inProgress, 'Transition is in progress');
-  t.is(transition.time, 0.25, 'time is correct');
+  t.is(transition.time, 0.5, 'time is correct');
 
   timeline.setTime(1.5);
   transition.update();
@@ -76,7 +73,7 @@ test('Transition#update', t => {
   t.notOk(transition.inProgress, 'Transition has ended');
 
   t.is(onUpdateCallCount, 3, 'onUpdate is called 3 times');
-  t.is(onEndCallCount, 1, 'onEnd is called 3 times');
+  t.is(onEndCallCount, 1, 'onEnd is called once');
 
   t.end();
 });
@@ -85,15 +82,16 @@ test('Transition#interrupt', t => {
   let onInterruptCallCount = 0;
   const timeline = new Timeline();
 
-  const transition = new Transition({
-    timeline,
+  const transition = new Transition(timeline);
+  const settings = {
     onInterrupt: () => {
       onInterruptCallCount++;
-    }
-  });
+    },
+    duration: 1
+  };
+  transition.start(settings);
+  transition.start(settings);
 
-  transition.start({duration: 1});
-  transition.start({duration: 1});
   t.is(onInterruptCallCount, 1, 'starting another transition - onInterrupt is called');
 
   timeline.setTime(0.5);
@@ -103,7 +101,7 @@ test('Transition#interrupt', t => {
   transition.cancel();
   t.is(onInterruptCallCount, 2, 'cancelling transition - onInterrupt is called');
 
-  transition.start({duration: 1});
+  transition.start(settings);
   timeline.setTime(1);
   transition.update();
   timeline.setTime(2);


### PR DESCRIPTION
For #3574 

Broken due to default callbacks removed from `normalizeTransitionSettings` in #3621 

#### Change List
- Generalize `Transition` class, remove `duration` and `easing` references
- Store transition settings in dedicated object in `Transition` instance
- Add `end` method to `Transition`
- Use `Transition` class to handle callbacks in `GPUSpringTransition`
- Align code style in `GPUSpringTransition` and `GPUInterpolationTransition`
