### PR TITLE
Add domain method to scales

### DIFF
--- a/modules/aggregation-layers/src/utils/scale-utils.js
+++ b/modules/aggregation-layers/src/utils/scale-utils.js
@@ -110,7 +110,12 @@ export function getQuantileScale(domain, range) {
   while (++i < n) {
     thresholds[i - 1] = threshold(sortedDomain, i / n);
   }
-  return value => quantileScale(thresholds, range, value);
+  function scale(value) {
+    return quantileScale(thresholds, range, value);
+  }
+  scale.domain = () => sortedDomain;
+
+  return scale;
 }
 
 // ordinal
@@ -134,5 +139,11 @@ export function getOrdinalScale(domain, range) {
       domainMap.set(key, uniqueDomain.push(d));
     }
   }
-  return value => ordinalScale(uniqueDomain, domainMap, range, value);
+  function scale(value) {
+    return ordinalScale(uniqueDomain, domainMap, range, value);
+  }
+
+  scale.domain = () => uniqueDomain;
+
+  return scale;
 }

--- a/modules/aggregation-layers/src/utils/scale-utils.js
+++ b/modules/aggregation-layers/src/utils/scale-utils.js
@@ -98,8 +98,10 @@ function bisectRight(a, x) {
 }
 
 // return a quantize scale function
-function quantileScale(thresholds, range, value) {
-  return range[bisectRight(thresholds, value)];
+function quantileScale(thresholds) {
+  return (domain, range, value) => {
+    return range[bisectRight(thresholds, value)];
+  };
 }
 
 export function getQuantileScale(domain, range) {
@@ -110,24 +112,23 @@ export function getQuantileScale(domain, range) {
   while (++i < n) {
     thresholds[i - 1] = threshold(sortedDomain, i / n);
   }
-  function scale(value) {
-    return quantileScale(thresholds, range, value);
-  }
-  scale.domain = () => sortedDomain;
+  const quantileScaleThresholds = () => quantileScale(thresholds);
 
-  return scale;
+  return getScale(sortedDomain, range, quantileScaleThresholds());
 }
 
 // ordinal
-function ordinalScale(domain, domainMap, range, value) {
-  const key = `${value}`;
-  let d = domainMap.get(key);
-  if (d === undefined) {
-    // update the domain
-    d = domain.push(value);
-    domainMap.set(key, d);
-  }
-  return range[(d - 1) % range.length];
+function ordinalScale(domainMap) {
+  return (domain, range, value) => {
+    const key = `${value}`;
+    let d = domainMap.get(key);
+    if (d === undefined) {
+      // update the domain
+      d = domain.push(value);
+      domainMap.set(key, d);
+    }
+    return range[(d - 1) % range.length];
+  };
 }
 
 export function getOrdinalScale(domain, range) {
@@ -139,11 +140,7 @@ export function getOrdinalScale(domain, range) {
       domainMap.set(key, uniqueDomain.push(d));
     }
   }
-  function scale(value) {
-    return ordinalScale(uniqueDomain, domainMap, range, value);
-  }
+  const ordinalScaleDomainMap = () => ordinalScale(domainMap);
 
-  scale.domain = () => uniqueDomain;
-
-  return scale;
+  return getScale(uniqueDomain, range, ordinalScaleDomainMap());
 }

--- a/test/modules/aggregation-layers/utils/scale-utils.spec.js
+++ b/test/modules/aggregation-layers/utils/scale-utils.spec.js
@@ -108,6 +108,11 @@ test('scale-utils#quantizeScale', t => {
 test('scale-utils#quantileScale', t => {
   for (const tc of QUANTILE_SCALE_TEST_CASES) {
     const quantileScale = getQuantileScale(tc.domain, tc.range);
+    t.deepEqual(
+      quantileScale.domain(),
+      tc.domain,
+      `quantileScale.domain() ${tc.title} returned expected value`
+    );
     for (const i in tc.values) {
       const result = quantileScale(tc.values[i]);
       t.deepEqual(
@@ -123,6 +128,11 @@ test('scale-utils#quantileScale', t => {
 test('scale-utils#ordinalScale', t => {
   for (const tc of ORDINAL_SCALE_TEST_CASES) {
     const ordinalScale = getOrdinalScale(tc.domain, tc.range);
+    t.deepEqual(
+      ordinalScale.domain(),
+      tc.domain,
+      `ordinalScale.domain() ${tc.title} returned expected value`
+    );
     for (const i in tc.values) {
       const result = ordinalScale(tc.values[i]);
       t.deepEqual(result, tc.results[i], `ordinalScale ${tc.title} returned expected value`);


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #3630
<!-- For other PRs without open issue -->
#### Background
Add `domain` function to existing `getQuantileScale` and `getOrdinalScale`
<!-- For all the PRs -->
#### Change List
- Add domain method in `scale-utils.js`
- Write test for these changes