### PR TITLE
deck layer visibility on zoom less than 3

### DIFF
--- a/modules/google-maps/src/utils.js
+++ b/modules/google-maps/src/utils.js
@@ -106,8 +106,14 @@ export function getViewState(map, overlay) {
   const nw = projection.fromContainerPixelToLatLng(nwContainerPx);
   const nwDivPx = projection.fromLatLngToDivPixel(nw);
 
+  // checking the number of maps visible on container
+  var mapCount = width / projection.getWorldWidth()
+  if (mapCount >= 1) {
+    nwDivPx.x = nwDivPx.x - projection.getWorldWidth()
+  }
+
   // Compute fractional zoom.
-  const scale = (topRight.x - bottomLeft.x) / width;
+  var scale = (bottomLeft.y - topRight.y) / height;
   const zoom = Math.log2(scale) + map.getZoom() - 1;
 
   // Compute fractional center.

--- a/modules/google-maps/src/utils.js
+++ b/modules/google-maps/src/utils.js
@@ -107,13 +107,13 @@ export function getViewState(map, overlay) {
   const nwDivPx = projection.fromLatLngToDivPixel(nw);
 
   // checking the number of maps visible on container
-  var mapCount = width / projection.getWorldWidth()
+  const mapCount = width / projection.getWorldWidth()
   if (mapCount >= 1) {
     nwDivPx.x = nwDivPx.x - projection.getWorldWidth()
   }
 
   // Compute fractional zoom.
-  var scale = (bottomLeft.y - topRight.y) / height;
+  const scale = (bottomLeft.y - topRight.y) / height;
   const zoom = Math.log2(scale) + map.getZoom() - 1;
 
   // Compute fractional center.


### PR DESCRIPTION
Bug fix for deck layer visibility on zoom level below 3
On google maps when zoom is changed to 2 or 1, the deck layer does not render
as canvas is shifted to extreme right.
