### PR TITLE
Remove attribute-transitions that have null settings

### DIFF
--- a/modules/core/src/lib/attribute-transition-manager.js
+++ b/modules/core/src/lib/attribute-transition-manager.js
@@ -55,7 +55,7 @@ export default class AttributeTransitionManager {
 
     for (const attributeName in this.transitions) {
       const attribute = attributes[attributeName];
-      if (!attribute || !attribute.supportsTransition()) {
+      if (!attribute || !attribute.getTransitionSetting(transitions)) {
         // Animated attribute has been removed
         this._removeTransition(attributeName);
       }


### PR DESCRIPTION
This makes sure we remove existing attribute transitions that now have `null` settings as a result of new transition settings being applied.