### PR TITLE
Clean up transition classes, avoid crash with `duration:0`

### DIFF
--- a/modules/core/src/lib/attribute-transition-manager.js
+++ b/modules/core/src/lib/attribute-transition-manager.js
@@ -64,7 +64,8 @@ export default class AttributeTransitionManager {
 
   // Returns `true` if attribute is transition-enabled
   hasAttribute(attributeName) {
-    return attributeName in this.transitions;
+    const transition = this.transitions[attributeName];
+    return transition && transition.inProgress;
   }
 
   // Get all the animated attributes
@@ -73,8 +74,8 @@ export default class AttributeTransitionManager {
 
     for (const attributeName in this.transitions) {
       const transition = this.transitions[attributeName];
-      if (transition.isTransitioning()) {
-        animatedAttributes[attributeName] = transition.getAttribute();
+      if (transition.inProgress) {
+        animatedAttributes[attributeName] = transition.attributeInTransition;
       }
     }
 

--- a/modules/core/src/lib/attribute-transition-manager.js
+++ b/modules/core/src/lib/attribute-transition-manager.js
@@ -74,7 +74,7 @@ export default class AttributeTransitionManager {
     for (const attributeName in this.transitions) {
       const transition = this.transitions[attributeName];
       if (transition.isTransitioning()) {
-        animatedAttributes[attributeName] = transition.getTransitioningAttribute();
+        animatedAttributes[attributeName] = transition.getAttribute();
       }
     }
 

--- a/modules/core/src/transitions/gpu-interpolation-transition.js
+++ b/modules/core/src/transitions/gpu-interpolation-transition.js
@@ -26,7 +26,7 @@ export default class GPUInterpolationTransition {
     // this is because we only reallocate buffers when they grow, not when they shrink,
     // due to performance costs
     this.currentLength = 0;
-    this.transform = null;
+    this.transform = getTransform(gl, attribute);
     const bufferOpts = {
       byteLength: 0,
       usage: GL.DYNAMIC_COPY
@@ -81,7 +81,6 @@ export default class GPUInterpolationTransition {
 
     this.transition.start(transitionSettings);
 
-    this.transform = this.transform || new Transform(gl, getShaders(attribute.size));
     this.transform.update({
       elementCount: Math.floor(this.currentLength / attribute.size),
       sourceBuffers: {
@@ -132,13 +131,13 @@ void main(void) {
 }
 `;
 
-function getShaders(attributeSize) {
-  const attributeType = getAttributeTypeFromSize(attributeSize);
-  return {
+function getTransform(gl, attribute) {
+  const attributeType = getAttributeTypeFromSize(attribute.size);
+  return new Transform(gl, {
     vs,
     defines: {
       ATTRIBUTE_TYPE: attributeType
     },
     varyings: ['vCurrent']
-  };
+  });
 }

--- a/modules/core/src/transitions/gpu-interpolation-transition.js
+++ b/modules/core/src/transitions/gpu-interpolation-transition.js
@@ -37,12 +37,8 @@ export default class GPUInterpolationTransition {
     ];
   }
 
-  isTransitioning() {
+  get inProgress() {
     return this.transition.inProgress;
-  }
-
-  getAttribute() { 
-    return this.isTransitioning() ? this.attributeInTransition : this.attribute;
   }
 
   // this is called when an attribute's values have changed and

--- a/modules/core/src/transitions/gpu-spring-transition.js
+++ b/modules/core/src/transitions/gpu-spring-transition.js
@@ -41,12 +41,8 @@ export default class GPUSpringTransition {
     ];
   }
 
-  isTransitioning() {
+  get inProgress() {
     return this.transition.inProgress;
-  }
-
-  getAttribute() { 
-    return this.isTransitioning() ? this.attributeInTransition : this.attribute;
   }
 
   // this is called when an attribute's values have changed and

--- a/modules/core/src/transitions/gpu-spring-transition.js
+++ b/modules/core/src/transitions/gpu-spring-transition.js
@@ -27,9 +27,9 @@ export default class GPUSpringTransition {
     // this is because we only reallocate buffers when they grow, not when they shrink,
     // due to performance costs
     this.currentLength = 0;
-    this.transform = null;
     this.texture = getTexture(gl);
     this.framebuffer = getFramebuffer(gl, this.texture);
+    this.transform = getTransform(gl, attribute, this.framebuffer);
     const bufferOpts = {
       byteLength: 0,
       usage: GL.DYNAMIC_COPY
@@ -79,7 +79,6 @@ export default class GPUSpringTransition {
     // this.transition.start() takes the latest settings and updates them.
     this.transition.start(transitionSettings);
 
-    this.transform = this.transform || getTransform(gl, attribute, this.framebuffer);
     this.transform.update({
       elementCount: Math.floor(this.currentLength / attribute.size),
       sourceBuffers: {


### PR DESCRIPTION
For #3574 

#### Change List
- GPU transition classes: Rename `isTransitioning()` to `inProgress`, remove `getTransitioningAttribute()`
- Do not throw with `duration:0`
- Improve minification
