### PR TITLE
Restore multi depth pick in layer browser

### DIFF
--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -123,7 +123,7 @@ export default class App extends PureComponent {
     this.mapRef.current.pickObjects({x: 0, y: 0, width, height});
   }
 
-  _multiDepthPick(x, y) {
+  _multiDepthPick({x, y}) {
     this.mapRef.current.pickMultipleObjects({x, y});
   }
 
@@ -252,6 +252,7 @@ export default class App extends PureComponent {
         <Map
           ref={this.mapRef}
           layers={this._renderExamples()}
+          onClick={this.state.enableDepthPickOnClick && this._multiDepthPick}
           views={this._getViews()}
           effects={this._getEffects()}
           settings={settings}

--- a/examples/layer-browser/src/map.js
+++ b/examples/layer-browser/src/map.js
@@ -126,8 +126,8 @@ export default class Map extends PureComponent {
   }
 
   _onClick(info) {
-    if (this.state.enableDepthPickOnClick && info) {
-      this._multiDepthPick(info.x, info.y);
+    if (this.props.onClick) {
+      this.props.onClick(info);
     } else {
       console.log('onClick', info); // eslint-disable-line
       this.setState({clickedItem: info});


### PR DESCRIPTION
This was broken in the last layer browser refactor.

#### Change List
- Restore multi depth pick functionality
