### PR TITLE
Fix multi-picking bug

### DIFF
--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -539,10 +539,13 @@ export default class Layer extends Component {
     return new Uint8ClampedArray(colors.value);
   }
 
-  restorePickingColors(value) {
+  restorePickingColors(oldValue) {
     const {pickingColors, instancePickingColors} = this.getAttributeManager().attributes;
     const colors = pickingColors || instancePickingColors;
 
+    const {value} = colors;
+    // Make sure the attribute's allocated buffer contains the correct value
+    value.set(oldValue);
     colors.update({value});
   }
 


### PR DESCRIPTION
For https://github.com/uber/nebula.gl/issues/275

#### Background

`attribute.value` may be internally allocated or externally provided. Prior to 7.2, the class did not track the distinction, so if an external typed array is used and then `attribute.updateBuffer` is called, the external typed array will be mutated. This bug was fixed in 7.2.

In multi-depth picking, we:
- Make a copy of the original picking colors
- Mutate the picking colors (allocated typed array)
- Restore the original picking colors (external buffer)

If later `data` changes and `pickingColors` need update again, this external buffer is discarded, and the allocated buffer with the mutated values is put in use again.

This was not caught in any tests because neither the layer browser or the picking tests change the data after performing picking.

#### Change List
- Restore attribute value properly
