### PR TITLE
HeatmpaLayer: update required features for WebGL1 support.

### DIFF
--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
@@ -56,11 +56,11 @@ const defaultProps = {
 };
 
 const REQUIRED_FEATURES = [
-  FEATURES.WEBGL2, // TODO: Remove after trannsform refactor
-  FEATURES.COLOR_ATTACHMENT_RGBA32F, // weight-map generation
   FEATURES.BLEND_EQUATION_MINMAX, // max weight calculation
-  FEATURES.FLOAT_BLEND, // weight-map generation and max weight calculation
   FEATURES.TEXTURE_FLOAT // weight-map as texture
+  // As per WebGL Spec, following two feature are implictly supported when TEXTURE_FLOAT is supported
+  // FEATURES.COLOR_ATTACHMENT_RGBA32F, // weight-map generation
+  // FEATURES.FLOAT_BLEND, // weight-map generation and max weight calculation
 ];
 
 export default class HeatmapLayer extends CompositeLayer {

--- a/modules/aggregation-layers/src/heatmap-layer/max-vs.glsl.js
+++ b/modules/aggregation-layers/src/heatmap-layer/max-vs.glsl.js
@@ -1,7 +1,6 @@
 export default `\
-#version 300 es
-in vec4 inTexture;
-out vec4 outTexture;
+attribute vec4 inTexture;
+varying vec4 outTexture;
 
 void main()
 {


### PR DESCRIPTION
`HeatmapLayer` only uses `Texture` API of `Transform` class and doesn't write to `Buffers`, hence doesn't need `Transform Feedback` which is WebGL2 only. Recent [refactor ](https://github.com/uber/luma.gl/pull/1221)of Transform class , doesn't check for WebGL2 for texture processing. Made following changes to enable `HeatmapLayer` for on `WebGL1`.

- Remove `WebGL2` requirement
- Remove checking for features that are implictly enabled when `FEATURES.TEXTURE_FLOAT` (`OES_texture_float`) is supported.
- Update shaders to use WebGL1 (GLSL 100) syntax.

HeatmapLayer example on Mac + Safari:
<img width="1380" alt="Screen Shot 2019-09-19 at 2 17 35 PM" src="https://user-images.githubusercontent.com/9502731/65283165-664cf500-daeb-11e9-9595-a23b732076a2.png">
