### PR TITLE
More picking bug fix

### DIFF
--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -441,7 +441,7 @@ export default class Layer extends Component {
     return this.props;
   }
 
-  calculateInstancePickingColors(attribute, {numInstances}) {
+  calculateInstancePickingColors(attribute, {numInstances, startRow, endRow}) {
     const {value, size} = attribute;
 
     // calculateInstancePickingColors always generates the same sequence.
@@ -465,11 +465,8 @@ export default class Layer extends Component {
     }
 
     // Copy the last calculated picking color sequence into the attribute
-    value.set(
-      numInstances < cacheSize
-        ? pickingColorCache.subarray(0, numInstances * size)
-        : pickingColorCache
-    );
+    endRow = Math.min(endRow, numInstances);
+    value.set(pickingColorCache.subarray(startRow * size, endRow * size));
   }
 
   _setModelAttributes(model, changedAttributes) {

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -444,13 +444,6 @@ export default class Layer extends Component {
   calculateInstancePickingColors(attribute, {numInstances}) {
     const {value, size} = attribute;
 
-    if (value[0] === 1) {
-      // This can happen when data has changed, but the attribute value typed array
-      // has sufficient size and does not need to be re-allocated.
-      // This attribute is already populated, we do not have to recalculate it
-      return;
-    }
-
     // calculateInstancePickingColors always generates the same sequence.
     // pickingColorCache saves the largest generated sequence for reuse
     const cacheSize = pickingColorCache.length / size;

--- a/test/modules/core/lib/layer.spec.js
+++ b/test/modules/core/lib/layer.spec.js
@@ -417,3 +417,44 @@ test('Layer#uniformTransitions', t => {
 
   t.end();
 });
+
+test('Layer#calculateInstancePickingColors', t => {
+  const testCases = [
+    {
+      props: {
+        data: new Array(2).fill(0)
+      },
+      onAfterUpdate: ({layer}) => {
+        const {instancePickingColors} = layer.getAttributeManager().getAttributes()
+        t.deepEquals(instancePickingColors.value.subarray(0, 6), [1, 0, 0, 2, 0, 0], 'instancePickingColors is populated');
+      }
+    },
+    {
+      updateProps: {
+        data: new Array(3).fill(0)
+      },
+      onAfterUpdate: ({layer}) => {
+        const {instancePickingColors} = layer.getAttributeManager().getAttributes()
+        t.deepEquals(instancePickingColors.value.subarray(0, 9), [1, 0, 0, 2, 0, 0, 3, 0, 0], 'instancePickingColors is populated');
+      }
+    },
+    {
+      updateProps: {
+        data: new Array(3).fill(0)
+      },
+      onBeforeUpdate: ({layer}) => {
+        const colors = layer.copyPickingColors();
+        layer.clearPickingColor(new Uint8Array([2, 0, 0]));
+        layer.restorePickingColors(colors);
+      },
+      onAfterUpdate: ({layer}) => {
+        const {instancePickingColors} = layer.getAttributeManager().getAttributes()
+        t.deepEquals(instancePickingColors.value.subarray(0, 9), [1, 0, 0, 2, 0, 0, 3, 0, 0], 'instancePickingColors is populated');
+      }
+    }
+  ];
+
+  testLayer({Layer: SubLayer2, testCases, onError: t.notOk});
+
+  t.end();
+});

--- a/test/modules/core/lib/layer.spec.js
+++ b/test/modules/core/lib/layer.spec.js
@@ -425,8 +425,12 @@ test('Layer#calculateInstancePickingColors', t => {
         data: new Array(2).fill(0)
       },
       onAfterUpdate: ({layer}) => {
-        const {instancePickingColors} = layer.getAttributeManager().getAttributes()
-        t.deepEquals(instancePickingColors.value.subarray(0, 6), [1, 0, 0, 2, 0, 0], 'instancePickingColors is populated');
+        const {instancePickingColors} = layer.getAttributeManager().getAttributes();
+        t.deepEquals(
+          instancePickingColors.value.subarray(0, 6),
+          [1, 0, 0, 2, 0, 0],
+          'instancePickingColors is populated'
+        );
       }
     },
     {
@@ -434,8 +438,12 @@ test('Layer#calculateInstancePickingColors', t => {
         data: new Array(3).fill(0)
       },
       onAfterUpdate: ({layer}) => {
-        const {instancePickingColors} = layer.getAttributeManager().getAttributes()
-        t.deepEquals(instancePickingColors.value.subarray(0, 9), [1, 0, 0, 2, 0, 0, 3, 0, 0], 'instancePickingColors is populated');
+        const {instancePickingColors} = layer.getAttributeManager().getAttributes();
+        t.deepEquals(
+          instancePickingColors.value.subarray(0, 9),
+          [1, 0, 0, 2, 0, 0, 3, 0, 0],
+          'instancePickingColors is populated'
+        );
       }
     },
     {
@@ -448,8 +456,12 @@ test('Layer#calculateInstancePickingColors', t => {
         layer.restorePickingColors(colors);
       },
       onAfterUpdate: ({layer}) => {
-        const {instancePickingColors} = layer.getAttributeManager().getAttributes()
-        t.deepEquals(instancePickingColors.value.subarray(0, 9), [1, 0, 0, 2, 0, 0, 3, 0, 0], 'instancePickingColors is populated');
+        const {instancePickingColors} = layer.getAttributeManager().getAttributes();
+        t.deepEquals(
+          instancePickingColors.value.subarray(0, 9),
+          [1, 0, 0, 2, 0, 0, 3, 0, 0],
+          'instancePickingColors is populated'
+        );
       }
     }
   ];


### PR DESCRIPTION
Follow up of #3652 

#### Background
The `instancePickingColor` updater used to check the first element of the picking color array as an indicator whether the array has been populated. In 7.2 we start to over-allocate and reuse typed arrays, so this approach is no longer valid.

#### Change List
- Always set the picking colors array
- Support partial update