### PR TITLE
Improve multi-picking performance

### DIFF
--- a/modules/core/src/lib/attribute.js
+++ b/modules/core/src/lib/attribute.js
@@ -291,11 +291,9 @@ export default class Attribute extends BaseAttribute {
         this.value = attributeValue;
       } else {
         for (const [startRow, endRow] of updateRanges) {
-          const startOffset = Number.isFinite(startRow)
-            ? this._getVertexOffset(startRow, this.bufferLayout)
-            : 0;
+          const startOffset = Number.isFinite(startRow) ? this.getVertexOffset(startRow) : 0;
           const endOffset = Number.isFinite(endRow)
-            ? this._getVertexOffset(endRow, this.bufferLayout)
+            ? this.getVertexOffset(endRow)
             : noAlloc || !Number.isFinite(numInstances)
               ? this.value.length
               : numInstances * this.size;
@@ -429,7 +427,7 @@ export default class Attribute extends BaseAttribute {
     }
   }
 
-  _getVertexOffset(row, bufferLayout) {
+  getVertexOffset(row, bufferLayout = this.bufferLayout) {
     let offset = this.elementOffset;
     if (bufferLayout) {
       let index = 0;
@@ -487,7 +485,7 @@ export default class Attribute extends BaseAttribute {
 
     assert(typeof accessorFunc === 'function', `accessor "${accessor}" is not a function`);
 
-    let i = attribute._getVertexOffset(startRow, bufferLayout);
+    let i = attribute.getVertexOffset(startRow, bufferLayout);
     const {iterable, objectInfo} = createIterable(data, startRow, endRow);
     for (const object of iterable) {
       objectInfo.index++;

--- a/modules/core/src/lib/deck-picker.js
+++ b/modules/core/src/lib/deck-picker.js
@@ -180,10 +180,7 @@ export default class DeckPicker {
       // we have not exhausted the requested depth.
       if (pickInfo.pickedColor && i + 1 < depth) {
         const layerId = pickInfo.pickedColor[3] - 1;
-        if (!affectedLayers[layerId]) {
-          // backup original colors
-          affectedLayers[layerId] = layers[layerId].copyPickingColors();
-        }
+        affectedLayers[layerId] = true;
         layers[layerId].clearPickingColor(pickInfo.pickedColor);
       }
 
@@ -214,9 +211,9 @@ export default class DeckPicker {
     }
 
     // reset only affected buffers
-    Object.keys(affectedLayers).forEach(layerId =>
-      layers[layerId].restorePickingColors(affectedLayers[layerId])
-    );
+    for (const layerId in affectedLayers) {
+      layers[layerId].restorePickingColors();
+    }
 
     return {result, emptyInfo: infos && infos.get(null)};
   }

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -466,7 +466,7 @@ export default class Layer extends Component {
 
     // Copy the last calculated picking color sequence into the attribute
     endRow = Math.min(endRow, numInstances);
-    value.set(pickingColorCache.subarray(startRow * size, endRow * size));
+    value.set(pickingColorCache.subarray(startRow * size, endRow * size), startRow * size);
   }
 
   _setModelAttributes(model, changedAttributes) {
@@ -482,61 +482,25 @@ export default class Layer extends Component {
   }
 
   // Sets the specified instanced picking color to null picking color. Used for multi picking.
-  _clearInstancePickingColor(color) {
-    const {instancePickingColors} = this.getAttributeManager().attributes;
-    const {value, size} = instancePickingColors;
+  clearPickingColor(color) {
+    const {pickingColors, instancePickingColors} = this.getAttributeManager().attributes;
+    const colors = pickingColors || instancePickingColors;
 
     const i = this.decodePickingColor(color);
-    value[i * size + 0] = 0;
-    value[i * size + 1] = 0;
-    value[i * size + 2] = 0;
+    const start = colors.getVertexOffset(i);
+    const end = colors.getVertexOffset(i + 1);
 
-    // TODO: Optimize this to use sub-buffer update!
-    instancePickingColors.update({value});
+    // Fill the sub buffer with 0s
+    colors.buffer.subData({
+      data: new Uint8Array(end - start),
+      offset: start // 1 byte per element
+    });
   }
 
-  // Sets all occurrences of the specified picking color to null picking color. Used for multi picking.
-  _clearPickingColor(color) {
-    const {pickingColors} = this.getAttributeManager().attributes;
-    const {value} = pickingColors;
-
-    for (let i = 0; i < value.length; i += 3) {
-      if (value[i + 0] === color[0] && value[i + 1] === color[1] && value[i + 2] === color[2]) {
-        value[i + 0] = 0;
-        value[i + 1] = 0;
-        value[i + 2] = 0;
-      }
-    }
-
-    // TODO: Optimize this to use sub-buffer update!
-    pickingColors.update({value});
-  }
-
-  // This method figures out if we use instance colors or not
-  // and calls _clearInstancePickingColor or _clearPickingColor
-  clearPickingColor(color) {
-    if (this.getAttributeManager().attributes.pickingColors) {
-      this._clearPickingColor(color);
-    } else {
-      this._clearInstancePickingColor(color);
-    }
-  }
-
-  copyPickingColors() {
+  restorePickingColors() {
     const {pickingColors, instancePickingColors} = this.getAttributeManager().attributes;
     const colors = pickingColors || instancePickingColors;
-
-    return new Uint8ClampedArray(colors.value);
-  }
-
-  restorePickingColors(oldValue) {
-    const {pickingColors, instancePickingColors} = this.getAttributeManager().attributes;
-    const colors = pickingColors || instancePickingColors;
-
-    const {value} = colors;
-    // Make sure the attribute's allocated buffer contains the correct value
-    value.set(oldValue);
-    colors.update({value});
+    colors.update({value: colors.value});
   }
 
   // Deduces numer of instances. Intention is to support:

--- a/modules/layers/src/path-layer/path-layer.js
+++ b/modules/layers/src/path-layer/path-layer.js
@@ -301,24 +301,6 @@ export default class PathLayer extends Layer {
     attribute.bufferLayout = pathTesselator.bufferLayout;
     attribute.value = pathTesselator.get('segmentTypes');
   }
-
-  clearPickingColor(color) {
-    const pickedPathIndex = this.decodePickingColor(color);
-    const {bufferLayout} = this.state.pathTesselator;
-    const numVertices = bufferLayout[pickedPathIndex];
-
-    let startInstanceIndex = 0;
-    for (let pathIndex = 0; pathIndex < pickedPathIndex; pathIndex++) {
-      startInstanceIndex += bufferLayout[pathIndex];
-    }
-
-    const {instancePickingColors} = this.getAttributeManager().attributes;
-
-    const {value} = instancePickingColors;
-    const endInstanceIndex = startInstanceIndex + numVertices;
-    value.fill(0, startInstanceIndex * 3, endInstanceIndex * 3);
-    instancePickingColors.update({value});
-  }
 }
 
 PathLayer.layerName = 'PathLayer';

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -337,24 +337,6 @@ export default class SolidPolygonLayer extends Layer {
   calculateVertexValid(attribute) {
     attribute.value = this.state.polygonTesselator.get('vertexValid');
   }
-
-  clearPickingColor(color) {
-    const pickedPolygonIndex = this.decodePickingColor(color);
-    const {bufferLayout} = this.state.polygonTesselator;
-    const numVertices = bufferLayout[pickedPolygonIndex];
-
-    let startInstanceIndex = 0;
-    for (let polygonIndex = 0; polygonIndex < pickedPolygonIndex; polygonIndex++) {
-      startInstanceIndex += bufferLayout[polygonIndex];
-    }
-
-    const {pickingColors} = this.getAttributeManager().attributes;
-
-    const {value} = pickingColors;
-    const endInstanceIndex = startInstanceIndex + numVertices;
-    value.fill(0, startInstanceIndex * 3, endInstanceIndex * 3);
-    pickingColors.update({value});
-  }
 }
 
 SolidPolygonLayer.layerName = 'SolidPolygonLayer';

--- a/test/modules/core/lib/layer.spec.js
+++ b/test/modules/core/lib/layer.spec.js
@@ -451,9 +451,8 @@ test('Layer#calculateInstancePickingColors', t => {
         data: new Array(3).fill(0)
       },
       onBeforeUpdate: ({layer}) => {
-        const colors = layer.copyPickingColors();
         layer.clearPickingColor(new Uint8Array([2, 0, 0]));
-        layer.restorePickingColors(colors);
+        layer.restorePickingColors();
       },
       onAfterUpdate: ({layer}) => {
         const {instancePickingColors} = layer.getAttributeManager().getAttributes();


### PR DESCRIPTION
#### Change List
- Use `buffer.subData` in `clearPickingColor` instead of mutating the cached array. This also eliminates the need for `copyPickingColors`.
- Promote `attribute.getVertexOffset` to a public method
- Consolidate special-case handling in `PathLayer` and `SolidPolygonLayer`