### PR TITLE
Split website bundle

### DIFF
--- a/examples/experimental/sun/src/app.js
+++ b/examples/experimental/sun/src/app.js
@@ -1,7 +1,7 @@
 import React, {Component} from 'react';
 import {render} from 'react-dom';
 import {StaticMap} from 'react-map-gl';
-import DeckGL from 'deck.gl';
+import DeckGL from '@deck.gl/react';
 import {AmbientLight, DirectionalLight, LightingEffect} from '@deck.gl/core';
 import {SolidPolygonLayer} from '@deck.gl/layers';
 import {PhongMaterial} from '@luma.gl/core';

--- a/examples/website/arc/app.js
+++ b/examples/website/arc/app.js
@@ -2,7 +2,8 @@
 import React, {Component} from 'react';
 import {render} from 'react-dom';
 import {StaticMap} from 'react-map-gl';
-import DeckGL, {GeoJsonLayer, ArcLayer} from 'deck.gl';
+import DeckGL from '@deck.gl/react';
+import {GeoJsonLayer, ArcLayer} from '@deck.gl/layers';
 import {scaleQuantile} from 'd3-scale';
 
 // Set your mapbox token here

--- a/examples/website/geojson/app.js
+++ b/examples/website/geojson/app.js
@@ -1,7 +1,8 @@
 import React, {Component} from 'react';
 import {render} from 'react-dom';
 import {StaticMap} from 'react-map-gl';
-import DeckGL, {GeoJsonLayer, PolygonLayer} from 'deck.gl';
+import DeckGL from '@deck.gl/react';
+import {GeoJsonLayer, PolygonLayer} from '@deck.gl/layers';
 import {LightingEffect, AmbientLight, _SunLight as SunLight} from '@deck.gl/core';
 import {scaleThreshold} from 'd3-scale';
 

--- a/examples/website/heatmap/app.js
+++ b/examples/website/heatmap/app.js
@@ -1,7 +1,7 @@
 import React, {PureComponent} from 'react';
 import {render} from 'react-dom';
 import {StaticMap} from 'react-map-gl';
-import DeckGL from 'deck.gl';
+import DeckGL from '@deck.gl/react';
 import {HeatmapLayer} from '@deck.gl/aggregation-layers';
 
 // Set your mapbox token here

--- a/examples/website/highway/app.js
+++ b/examples/website/highway/app.js
@@ -1,7 +1,8 @@
 import React, {Component} from 'react';
 import {render} from 'react-dom';
 import {StaticMap} from 'react-map-gl';
-import DeckGL, {GeoJsonLayer} from 'deck.gl';
+import DeckGL from '@deck.gl/react';
+import {GeoJsonLayer} from '@deck.gl/layers';
 import {scaleLinear, scaleThreshold} from 'd3-scale';
 
 // Set your mapbox token here

--- a/examples/website/icon/app.js
+++ b/examples/website/icon/app.js
@@ -1,7 +1,8 @@
 import React, {Component} from 'react';
 import {render} from 'react-dom';
 import {StaticMap} from 'react-map-gl';
-import DeckGL, {IconLayer} from 'deck.gl';
+import DeckGL from '@deck.gl/react';
+import {IconLayer} from '@deck.gl/layers';
 
 import IconClusterLayer from './icon-cluster-layer';
 

--- a/examples/website/icon/icon-cluster-layer.js
+++ b/examples/website/icon/icon-cluster-layer.js
@@ -1,4 +1,5 @@
-import {CompositeLayer, IconLayer} from 'deck.gl';
+import {CompositeLayer} from '@deck.gl/core';
+import {IconLayer} from '@deck.gl/layers';
 import Supercluster from 'supercluster';
 
 function getIconName(size) {

--- a/examples/website/line/app.js
+++ b/examples/website/line/app.js
@@ -2,7 +2,8 @@ import React, {Component} from 'react';
 import {render} from 'react-dom';
 
 import {StaticMap} from 'react-map-gl';
-import DeckGL, {LineLayer, ScatterplotLayer} from 'deck.gl';
+import DeckGL from '@deck.gl/react';
+import {LineLayer, ScatterplotLayer} from '@deck.gl/layers';
 import GL from '@luma.gl/constants';
 
 // Set your mapbox token here

--- a/examples/website/map-tile/app.js
+++ b/examples/website/map-tile/app.js
@@ -1,7 +1,9 @@
 import React, {PureComponent} from 'react';
 import {render} from 'react-dom';
 
-import DeckGL, {TileLayer, BitmapLayer} from 'deck.gl';
+import DeckGL from '@deck.gl/react';
+import {TileLayer} from '@deck.gl/geo-layers';
+import {BitmapLayer} from '@deck.gl/layers';
 import {load} from '@loaders.gl/core';
 
 const INITIAL_VIEW_STATE = {

--- a/examples/website/mesh/app.js
+++ b/examples/website/mesh/app.js
@@ -1,14 +1,15 @@
 import React, {PureComponent} from 'react';
 import {render} from 'react-dom';
-import DeckGL, {
+import DeckGL from '@deck.gl/react';
+import {
   COORDINATE_SYSTEM,
-  SimpleMeshLayer,
   OrbitView,
-  SolidPolygonLayer,
   DirectionalLight,
   LightingEffect,
   AmbientLight
-} from 'deck.gl';
+} from '@deck.gl/core';
+import {SolidPolygonLayer} from 'deck.gl/layers';
+import {SimpleMeshLayer} from '@deck.gl/mesh-layers';
 
 import {OBJLoader} from '@loaders.gl/obj';
 import {registerLoaders} from '@loaders.gl/core';

--- a/examples/website/plot/app.js
+++ b/examples/website/plot/app.js
@@ -1,6 +1,7 @@
 import React, {Component} from 'react';
 import {render} from 'react-dom';
-import DeckGL, {OrbitView} from 'deck.gl';
+import DeckGL from '@deck.gl/react';
+import {OrbitView} from '@deck.gl/core';
 import PlotLayer from './plot-layer';
 import {scaleLinear} from 'd3-scale';
 

--- a/examples/website/plot/plot-layer/axes-layer.js
+++ b/examples/website/plot/plot-layer/axes-layer.js
@@ -1,4 +1,4 @@
-import {Layer} from 'deck.gl';
+import {Layer} from '@deck.gl/core';
 import GL from '@luma.gl/constants';
 import {Model, Geometry} from '@luma.gl/core';
 

--- a/examples/website/plot/plot-layer/plot-layer.js
+++ b/examples/website/plot/plot-layer/plot-layer.js
@@ -1,4 +1,4 @@
-import {CompositeLayer, COORDINATE_SYSTEM} from 'deck.gl';
+import {CompositeLayer, COORDINATE_SYSTEM} from '@deck.gl/core';
 import {scaleLinear} from 'd3-scale';
 
 import AxesLayer from './axes-layer';

--- a/examples/website/plot/plot-layer/surface-layer.js
+++ b/examples/website/plot/plot-layer/surface-layer.js
@@ -1,4 +1,4 @@
-import {Layer} from 'deck.gl';
+import {Layer} from '@deck.gl/core';
 import GL from '@luma.gl/constants';
 import {Model} from '@luma.gl/core';
 

--- a/examples/website/point-cloud/app.js
+++ b/examples/website/point-cloud/app.js
@@ -1,7 +1,9 @@
 /* eslint-disable no-unused-vars */
 import React, {PureComponent} from 'react';
 import {render} from 'react-dom';
-import DeckGL, {COORDINATE_SYSTEM, PointCloudLayer, OrbitView, LinearInterpolator} from 'deck.gl';
+import DeckGL from '@deck.gl/react';
+import {COORDINATE_SYSTEM, OrbitView, LinearInterpolator} from '@deck.gl/core';
+import {PointCloudLayer} from '@deck.gl/layers';
 
 import {LASWorkerLoader} from '@loaders.gl/las';
 // import {PLYWorkerLoader} from '@loaders.gl/ply';

--- a/examples/website/scatterplot/app.js
+++ b/examples/website/scatterplot/app.js
@@ -1,7 +1,8 @@
 import React, {Component} from 'react';
 import {render} from 'react-dom';
 import {StaticMap} from 'react-map-gl';
-import DeckGL, {ScatterplotLayer} from 'deck.gl';
+import DeckGL from '@deck.gl/react';
+import {ScatterplotLayer} from '@deck.gl/layers';
 
 // Set your mapbox token here
 const MAPBOX_TOKEN = process.env.MapboxAccessToken; // eslint-disable-line

--- a/examples/website/screen-grid/app.js
+++ b/examples/website/screen-grid/app.js
@@ -1,7 +1,8 @@
 import React, {Component} from 'react';
 import {render} from 'react-dom';
 import {StaticMap} from 'react-map-gl';
-import DeckGL, {ScreenGridLayer} from 'deck.gl';
+import DeckGL from '@deck.gl/react';
+import {ScreenGridLayer} from '@deck.gl/layers';
 import {isWebGL2} from '@luma.gl/core';
 
 // Set your mapbox token here

--- a/examples/website/tagmap/app.js
+++ b/examples/website/tagmap/app.js
@@ -2,7 +2,8 @@
 import React, {Component} from 'react';
 import {render} from 'react-dom';
 import {StaticMap} from 'react-map-gl';
-import DeckGL, {TextLayer} from 'deck.gl';
+import DeckGL from '@deck.gl/react';
+import {TextLayer} from '@deck.gl/layers';
 import TagmapLayer from './tagmap-layer';
 
 // Set your mapbox token here

--- a/examples/website/tagmap/tagmap-layer/README.md
+++ b/examples/website/tagmap/tagmap-layer/README.md
@@ -4,7 +4,7 @@
 The tagmap layer generates and visualizes [an occlusion-free label layout on map](https://github.com/rivulet-zhang/tagmap.js).
 
 ```js
-import DeckGL from 'deck.gl';
+import DeckGL from '@deck.gl/react';
 import TagmapLayer from './tagmap-layer';
 
 const App = ({data, viewport}) => {

--- a/examples/website/tagmap/tagmap-layer/tagmap-layer.js
+++ b/examples/website/tagmap/tagmap-layer/tagmap-layer.js
@@ -1,5 +1,6 @@
 /* eslint-disable max-len */
-import {CompositeLayer, TextLayer} from 'deck.gl';
+import {CompositeLayer} from '@deck.gl/core';
+import {TextLayer} from '@deck.gl/layers';
 import {scaleQuantile} from 'd3-scale';
 import TagMapWrapper from './tagmap-wrapper';
 

--- a/examples/website/text-layer/app.js
+++ b/examples/website/text-layer/app.js
@@ -3,7 +3,8 @@
 import React, {Component} from 'react';
 import {render} from 'react-dom';
 import {StaticMap} from 'react-map-gl';
-import DeckGL, {TextLayer} from 'deck.gl';
+import DeckGL from '@deck.gl/react';
+import {TextLayer} from '@deck.gl/layers';
 import GL from '@luma.gl/constants';
 
 // Set your mapbox token here

--- a/website/src/components/demos/layer-demo-base.js
+++ b/website/src/components/demos/layer-demo-base.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import DeckGL from 'deck.gl';
+import DeckGL from '@deck.gl/react';
 import {StaticMap} from 'react-map-gl';
 
 import {MAPBOX_STYLES} from '../../constants/defaults';

--- a/website/src/s2-geometry.js
+++ b/website/src/s2-geometry.js
@@ -1,0 +1,3 @@
+// s2-geometry cannot be directly included in a script tag
+// create a umd bundle
+module.exports = {S2: require('s2-geometry')};

--- a/website/src/s2-geometry.js
+++ b/website/src/s2-geometry.js
@@ -1,3 +1,0 @@
-// s2-geometry cannot be directly included in a script tag
-// create a umd bundle
-module.exports = {S2: require('s2-geometry')};

--- a/website/src/static/index.html
+++ b/website/src/static/index.html
@@ -15,7 +15,7 @@
     <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.3.1/mapbox-gl.js'></script>
 
     <script src="https://unpkg.com/h3-js"></script>
-    <script src="./s2-geometry.js"></script>
+    <script src="https://bundle.run/s2-geometry@1.2.10"></script>
     <script src="https://unpkg.com/deck.gl@~7.3.0-beta/dist.min.js"></script>
 
     <!-— facebook open graph tags -->

--- a/website/src/static/index.html
+++ b/website/src/static/index.html
@@ -7,10 +7,16 @@
     <meta name="description" content="deck.gl is a WebGL-powered framework for visual exploratory data analysis of large datasets.">
 
     <link rel="icon" type="img/ico" href="favicon.ico">
-    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.42.0/mapbox-gl.css' rel='stylesheet' />
     <link rel="stylesheet"
       href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.8/styles/default.min.css">
     <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.8/highlight.min.js"></script>
+
+    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.3.1/mapbox-gl.css' rel='stylesheet' />
+    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.3.1/mapbox-gl.js'></script>
+
+    <script src="https://unpkg.com/h3-js"></script>
+    <script src="./s2-geometry.js"></script>
+    <script src="https://unpkg.com/deck.gl@~7.3.0-beta/dist.min.js"></script>
 
     <!-— facebook open graph tags -->
     <meta property="og:url" content="https://uber.github.io/deck.gl/" />

--- a/website/webpack.config.js
+++ b/website/webpack.config.js
@@ -145,19 +145,6 @@ const addProdConfig = config => {
   });
 };
 
-// s2-geometry cannot be directly included in a script tag
-const S2_CONFIG = {
-  mode: 'production',
-
-  entry: './src/s2-geometry',
-
-  output: {
-    libraryTarget: 'umd',
-    path: resolve(__dirname, './dist'),
-    filename: 's2-geometry.js'
-  }
-};
-
 module.exports = env => {
   env = env || {};
 
@@ -174,5 +161,5 @@ module.exports = env => {
   // Enable to debug config
   // console.warn(JSON.stringify(config, null, 2));
 
-  return [config, S2_CONFIG];
+  return config;
 };

--- a/website/webpack.config.js
+++ b/website/webpack.config.js
@@ -18,7 +18,9 @@ const BABEL_CONFIG = {
   presets: [['@babel/preset-env', {useBuiltIns: 'usage'}], '@babel/preset-react'],
   plugins: [
     ['@babel/plugin-proposal-decorators', {legacy: true}],
-    ['@babel/plugin-proposal-class-properties', {loose: true}]
+    ['@babel/plugin-proposal-class-properties', {loose: true}],
+    'inline-webgl-constants',
+    ['remove-glsl-comments', {patterns: ['**/*.glsl.js']}]
   ]
 };
 
@@ -32,10 +34,6 @@ const COMMON_CONFIG = {
   output: {
     path: resolve(__dirname, './dist'),
     filename: 'bundle.js'
-  },
-
-  externals: {
-    'highlight.js': 'hljs'
   },
 
   module: {
@@ -127,9 +125,37 @@ const addProdConfig = config => {
     })
   );
 
+  config.externals = {
+    'highlight.js': 'hljs',
+    'h3-js': 'h3',
+    'deck.gl': 'deck',
+    '@deck.gl/aggregation-layers': 'deck',
+    '@deck.gl/core': 'deck',
+    '@deck.gl/extensions': 'deck',
+    '@deck.gl/geo-layers': 'deck',
+    '@deck.gl/layers': 'deck',
+    '@deck.gl/mesh-layers': 'deck',
+    '@loaders.gl/core': 'loaders',
+    '@luma.gl/core': 'luma',
+    'mapbox-gl': 'mapboxgl'
+  };
+
   return Object.assign(config, {
     mode: 'production'
   });
+};
+
+// s2-geometry cannot be directly included in a script tag
+const S2_CONFIG = {
+  mode: 'production',
+
+  entry: './src/s2-geometry',
+
+  output: {
+    libraryTarget: 'umd',
+    path: resolve(__dirname, './dist'),
+    filename: 's2-geometry.js'
+  }
 };
 
 module.exports = env => {
@@ -148,5 +174,5 @@ module.exports = env => {
   // Enable to debug config
   // console.warn(JSON.stringify(config, null, 2));
 
-  return config;
+  return [config, S2_CONFIG];
 };


### PR DESCRIPTION
**FOR DISCUSSION**

Requires publishing #3672 and #3674.

Pros:
- Website bundle 5.6M -> 3.2M
- We do not have to republish the website if a bug is fixed in the libraries.
- This helps verify the validity of the pre-bundled version.

Cons:
- Complicate the website setup and potentially harder to debug.

#### Change List
- Production build of the website includes deck, luma, mapboxgl, h3-js, and highlight.js from CDN.
- Avoid using `import DeckGL from 'deck.gl'` in examples.

