### PR TITLE
Fix S2Layer bundle dependency

### DIFF
--- a/docs/layers/s2-layer.md
+++ b/docs/layers/s2-layer.md
@@ -74,7 +74,7 @@ new S2Layer({});
 To use pre-bundled scripts:
 
 ```html
-<script src="https://unpkg.com/s2-geometry"></script>
+<script src="https://bundle.run/s2-geometry@1.2.10"></script>
 <script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
 <!-- or -->
 <script src="https://unpkg.com/@deck.gl/core@^7.0.0/dist.min.js"></script>

--- a/scripts/bundle.config.js
+++ b/scripts/bundle.config.js
@@ -18,7 +18,7 @@ function getExternals(packageInfo) {
   let externals = {
     // Hard coded externals
     'h3-js': 'h3',
-    's2-geometry': 'S2'
+    's2-geometry': 's2Geometry'
   };
   const {peerDependencies = {}} = packageInfo;
 


### PR DESCRIPTION
The s2-geometry lib contains a `require` so it's not usable via a script tag.

This change adds dependency to a specific service, which is not ideal. On the up side, it does not affect anyone who's not using S2Layer with the pre-bundled version.

#### Change List
- Support https://bundle.run with bundle config.
- Update example for using S2Layer from pre-built bundles.
