### PR TITLE
Always generate 64xyLow attributes for positions

### DIFF
--- a/modules/core/src/lib/attribute.js
+++ b/modules/core/src/lib/attribute.js
@@ -73,6 +73,10 @@ export default class Attribute extends BaseAttribute {
     this.hasShaderAttributes = false;
     this.doublePrecision = doublePrecision;
 
+    if (doublePrecision && opts.fp64 === false) {
+      this.defaultType = GL.FLOAT;
+    }
+
     let shaderAttributes = opts.shaderAttributes || (doublePrecision && {[this.id]: {}});
 
     if (shaderAttributes) {

--- a/modules/core/src/lib/attribute.js
+++ b/modules/core/src/lib/attribute.js
@@ -73,6 +73,10 @@ export default class Attribute extends BaseAttribute {
     this.hasShaderAttributes = false;
     this.doublePrecision = doublePrecision;
 
+    // `fp64: false` tells a double-precision attribute to allocate Float32Arrays
+    // by default when using auto-packing. This is more efficient in use cases where
+    // high precision is unnecessary, but the `64xyLow` attribute is still required
+    // by the shader.
     if (doublePrecision && opts.fp64 === false) {
       this.defaultType = GL.FLOAT;
     }

--- a/modules/core/src/lib/attribute.js
+++ b/modules/core/src/lib/attribute.js
@@ -286,13 +286,12 @@ export default class Attribute extends BaseAttribute {
       for (const [startRow, endRow] of updateRanges) {
         update.call(context, this, {data, startRow, endRow, props, numInstances, bufferLayout});
       }
+      const doublePrecision = this.doublePrecision && this.value instanceof Float64Array;
       if (this.constant || !this.buffer || this.buffer.byteLength < this.value.byteLength) {
         const attributeValue = this.value;
         // call base clas `update` method to upload value to GPU
         this.update({
-          value: this.doublePrecision
-            ? toDoublePrecisionArray(attributeValue, this)
-            : attributeValue,
+          value: doublePrecision ? toDoublePrecisionArray(attributeValue, this) : attributeValue,
           constant: this.constant
         });
         // Save the 64-bit version
@@ -308,7 +307,7 @@ export default class Attribute extends BaseAttribute {
 
           // Only update the changed part of the attribute
           this.buffer.subData({
-            data: this.doublePrecision
+            data: doublePrecision
               ? toDoublePrecisionArray(this.value, {
                   size: this.size,
                   startIndex: startOffset,

--- a/modules/layers/src/arc-layer/arc-layer.js
+++ b/modules/layers/src/arc-layer/arc-layer.js
@@ -58,7 +58,8 @@ export default class ArcLayer extends Layer {
     attributeManager.addInstanced({
       instancePositions: {
         size: 4,
-        type: this.use64bitPositions() ? GL.DOUBLE : GL.FLOAT,
+        type: GL.DOUBLE,
+        fp64: this.use64bitPositions(),
         transition: true,
         accessor: ['getSourcePosition', 'getTargetPosition'],
         update: this.calculateInstancePositions

--- a/modules/layers/src/bitmap-layer/bitmap-layer.js
+++ b/modules/layers/src/bitmap-layer/bitmap-layer.js
@@ -62,7 +62,8 @@ export default class BitmapLayer extends Layer {
     attributeManager.add({
       positions: {
         size: 3,
-        type: this.use64bitPositions() ? GL.DOUBLE : GL.FLOAT,
+        type: GL.DOUBLE,
+        fp64: this.use64bitPositions(),
         update: this.calculatePositions,
         noAlloc: true
       }

--- a/modules/layers/src/column-layer/column-layer.js
+++ b/modules/layers/src/column-layer/column-layer.js
@@ -72,7 +72,8 @@ export default class ColumnLayer extends Layer {
     attributeManager.addInstanced({
       instancePositions: {
         size: 3,
-        type: this.use64bitPositions() ? GL.DOUBLE : GL.FLOAT,
+        type: GL.DOUBLE,
+        fp64: this.use64bitPositions(),
         transition: true,
         accessor: 'getPosition'
       },

--- a/modules/layers/src/icon-layer/icon-layer.js
+++ b/modules/layers/src/icon-layer/icon-layer.js
@@ -81,7 +81,8 @@ export default class IconLayer extends Layer {
     attributeManager.addInstanced({
       instancePositions: {
         size: 3,
-        type: this.use64bitPositions() ? GL.DOUBLE : GL.FLOAT,
+        type: GL.DOUBLE,
+        fp64: this.use64bitPositions(),
         transition: true,
         accessor: 'getPosition'
       },

--- a/modules/layers/src/line-layer/line-layer.js
+++ b/modules/layers/src/line-layer/line-layer.js
@@ -54,13 +54,15 @@ export default class LineLayer extends Layer {
     attributeManager.addInstanced({
       instanceSourcePositions: {
         size: 3,
-        type: this.use64bitPositions() ? GL.DOUBLE : GL.FLOAT,
+        type: GL.DOUBLE,
+        fp64: this.use64bitPositions(),
         transition: true,
         accessor: 'getSourcePosition'
       },
       instanceTargetPositions: {
         size: 3,
-        type: this.use64bitPositions() ? GL.DOUBLE : GL.FLOAT,
+        type: GL.DOUBLE,
+        fp64: this.use64bitPositions(),
         transition: true,
         accessor: 'getTargetPosition'
       },

--- a/modules/layers/src/path-layer/path-layer.js
+++ b/modules/layers/src/path-layer/path-layer.js
@@ -66,7 +66,8 @@ export default class PathLayer extends Layer {
         // Hack - Attribute class needs this to properly apply partial update
         // The first 3 numbers of the value is just padding
         offset: 12,
-        type: this.use64bitPositions() ? GL.DOUBLE : GL.FLOAT,
+        type: GL.DOUBLE,
+        fp64: this.use64bitPositions(),
         transition: ATTRIBUTE_TRANSITION,
         accessor: 'getPath',
         update: this.calculateStartPositions,
@@ -82,7 +83,8 @@ export default class PathLayer extends Layer {
       },
       endPositions: {
         size: 3,
-        type: this.use64bitPositions() ? GL.DOUBLE : GL.FLOAT,
+        type: GL.DOUBLE,
+        fp64: this.use64bitPositions(),
         transition: ATTRIBUTE_TRANSITION,
         accessor: 'getPath',
         update: this.calculateEndPositions,

--- a/modules/layers/src/point-cloud-layer/point-cloud-layer.js
+++ b/modules/layers/src/point-cloud-layer/point-cloud-layer.js
@@ -73,7 +73,8 @@ export default class PointCloudLayer extends Layer {
     this.getAttributeManager().addInstanced({
       instancePositions: {
         size: 3,
-        type: this.use64bitPositions() ? GL.DOUBLE : GL.FLOAT,
+        type: GL.DOUBLE,
+        fp64: this.use64bitPositions(),
         transition: true,
         accessor: 'getPosition'
       },

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer.js
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer.js
@@ -61,7 +61,8 @@ export default class ScatterplotLayer extends Layer {
     this.getAttributeManager().addInstanced({
       instancePositions: {
         size: 3,
-        type: this.use64bitPositions() ? GL.DOUBLE : GL.FLOAT,
+        type: GL.DOUBLE,
+        fp64: this.use64bitPositions(),
         transition: true,
         accessor: 'getPosition'
       },

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -90,7 +90,8 @@ export default class SolidPolygonLayer extends Layer {
       indices: {size: 1, isIndexed: true, update: this.calculateIndices, noAlloc},
       positions: {
         size: 3,
-        type: this.use64bitPositions() ? GL.DOUBLE : GL.FLOAT,
+        type: GL.DOUBLE,
+        fp64: this.use64bitPositions(),
         transition: ATTRIBUTE_TRANSITION,
         accessor: 'getPolygon',
         update: this.calculatePositions,

--- a/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.js
+++ b/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.js
@@ -70,7 +70,8 @@ export default class ScenegraphLayer extends Layer {
     attributeManager.addInstanced({
       instancePositions: {
         size: 3,
-        type: this.use64bitPositions() ? GL.DOUBLE : GL.FLOAT,
+        type: GL.DOUBLE,
+        fp64: this.use64bitPositions(),
         accessor: 'getPosition',
         transition: true
       },

--- a/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.js
+++ b/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.js
@@ -128,7 +128,8 @@ export default class SimpleMeshLayer extends Layer {
     attributeManager.addInstanced({
       instancePositions: {
         transition: true,
-        type: this.use64bitPositions() ? GL.DOUBLE : GL.FLOAT,
+        type: GL.DOUBLE,
+        fp64: this.use64bitPositions(),
         size: 3,
         accessor: 'getPosition'
       },

--- a/test/modules/core/lib/attribute.spec.js
+++ b/test/modules/core/lib/attribute.spec.js
@@ -578,15 +578,9 @@ test('Attribute#setExternalBuffer', t => {
   t.end();
 });
 
-test('Attribute#doublePrecision', t => {
-  const attribute = new Attribute(gl, {
-    id: 'positions',
-    type: GL.DOUBLE,
-    size: 3,
-    accessor: 'getPosition'
-  });
+test('Attribute#doublePrecision', t0 => {
 
-  const validateShaderAttributes = is64Bit => {
+  const validateShaderAttributes = (t, attribute, is64Bit) => {
     const shaderAttributes = attribute.getShaderAttributes();
     t.deepEqual(
       Object.keys(shaderAttributes),
@@ -633,38 +627,94 @@ test('Attribute#doublePrecision', t => {
     }
   };
 
-  attribute.allocate(2);
-  attribute.updateBuffer({
-    numInstances: 2,
-    data: [0, 1],
-    props: {
-      getPosition: d => [d, 1, 2]
-    }
+  test('Attribute#doublePrecision#fp64:true', t => {
+    const attribute = new Attribute(gl, {
+      id: 'positions',
+      type: GL.DOUBLE,
+      size: 3,
+      accessor: 'getPosition'
+    });
+
+    attribute.allocate(2);
+    attribute.updateBuffer({
+      numInstances: 2,
+      data: [0, 1],
+      props: {
+        getPosition: d => [d, 1, 2]
+      }
+    });
+    t.ok(attribute.value instanceof Float64Array, 'Attribute is Float64Array');
+    t.deepEqual(attribute.value.slice(0, 6), [0, 1, 2, 1, 1, 2], 'Attribute value is populated');
+    validateShaderAttributes(t, attribute, true);
+
+    attribute.setExternalBuffer(new Uint32Array([3, 4, 5, 4, 4, 5]));
+    t.ok(attribute.value instanceof Uint32Array, 'Attribute is Uint32Array');
+    t.deepEqual(attribute.buffer.debugData.slice(0, 6), [3, 4, 5, 4, 4, 5], 'Attribute value is set');
+    validateShaderAttributes(t, attribute, false);
+
+    t.throws(
+      () => attribute.setExternalBuffer(new Uint8Array([3, 4, 5, 4, 4, 5])),
+      'should throw on invalid buffer'
+    );
+
+    attribute.setExternalBuffer(new Float64Array([3, 4, 5, 4, 4, 5]));
+    t.ok(attribute.value instanceof Float64Array, 'Attribute is Float64Array');
+    t.deepEqual(attribute.buffer.debugData.slice(0, 6), [3, 4, 5, 0, 0, 0], 'Attribute value is set');
+    validateShaderAttributes(t, attribute, true);
+
+    const buffer = new Buffer(gl, 12);
+    attribute.setExternalBuffer(buffer);
+    validateShaderAttributes(t, attribute, false);
+
+    buffer.delete();
+    attribute.delete();
+    t.end();
   });
-  t.ok(attribute.value instanceof Float64Array, 'Attribute is Float64Array');
-  t.deepEqual(attribute.value.slice(0, 6), [0, 1, 2, 1, 1, 2], 'Attribute value is populated');
-  validateShaderAttributes(true);
 
-  attribute.setExternalBuffer(new Uint32Array([3, 4, 5, 4, 4, 5]));
-  t.ok(attribute.value instanceof Uint32Array, 'Attribute is Uint32Array');
-  t.deepEqual(attribute.buffer.debugData.slice(0, 6), [3, 4, 5, 4, 4, 5], 'Attribute value is set');
-  validateShaderAttributes(false);
+  test('Attribute#doublePrecision#fp64:false', t => {
+    const attribute = new Attribute(gl, {
+      id: 'positions',
+      type: GL.DOUBLE,
+      fp64: false,
+      size: 3,
+      accessor: 'getPosition'
+    });
 
-  t.throws(
-    () => attribute.setExternalBuffer(new Uint8Array([3, 4, 5, 4, 4, 5])),
-    'should throw on invalid buffer'
-  );
+    attribute.allocate(2);
+    attribute.updateBuffer({
+      numInstances: 2,
+      data: [0, 1],
+      props: {
+        getPosition: d => [d, 1, 2]
+      }
+    });
+    t.ok(attribute.value instanceof Float32Array, 'Attribute is Float32Array');
+    t.deepEqual(attribute.value.slice(0, 6), [0, 1, 2, 1, 1, 2], 'Attribute value is populated');
+    validateShaderAttributes(t, attribute, false);
 
-  attribute.setExternalBuffer(new Float64Array([3, 4, 5, 4, 4, 5]));
-  t.ok(attribute.value instanceof Float64Array, 'Attribute is Float64Array');
-  t.deepEqual(attribute.buffer.debugData.slice(0, 6), [3, 4, 5, 0, 0, 0], 'Attribute value is set');
-  validateShaderAttributes(true);
+    attribute.setExternalBuffer(new Uint32Array([3, 4, 5, 4, 4, 5]));
+    t.ok(attribute.value instanceof Uint32Array, 'Attribute is Uint32Array');
+    t.deepEqual(attribute.buffer.debugData.slice(0, 6), [3, 4, 5, 4, 4, 5], 'Attribute value is set');
+    validateShaderAttributes(t, attribute, false);
 
-  const buffer = new Buffer(gl, 12);
-  attribute.setExternalBuffer(buffer);
-  validateShaderAttributes(false);
+    t.throws(
+      () => attribute.setExternalBuffer(new Uint8Array([3, 4, 5, 4, 4, 5])),
+      'should throw on invalid buffer'
+    );
 
-  buffer.delete();
-  attribute.delete();
-  t.end();
+    attribute.setExternalBuffer(new Float64Array([3, 4, 5, 4, 4, 5]));
+    t.ok(attribute.value instanceof Float64Array, 'Attribute is Float64Array');
+    t.deepEqual(attribute.buffer.debugData.slice(0, 6), [3, 4, 5, 0, 0, 0], 'Attribute value is set');
+    validateShaderAttributes(t, attribute, true);
+
+    const buffer = new Buffer(gl, 12);
+    attribute.setExternalBuffer(buffer);
+    validateShaderAttributes(t, attribute, false);
+
+    buffer.delete();
+    attribute.delete();
+    t.end();
+  });
+
+  t0.end();
 });

--- a/test/modules/core/lib/attribute.spec.js
+++ b/test/modules/core/lib/attribute.spec.js
@@ -579,7 +579,6 @@ test('Attribute#setExternalBuffer', t => {
 });
 
 test('Attribute#doublePrecision', t0 => {
-
   const validateShaderAttributes = (t, attribute, is64Bit) => {
     const shaderAttributes = attribute.getShaderAttributes();
     t.deepEqual(
@@ -649,7 +648,11 @@ test('Attribute#doublePrecision', t0 => {
 
     attribute.setExternalBuffer(new Uint32Array([3, 4, 5, 4, 4, 5]));
     t.ok(attribute.value instanceof Uint32Array, 'Attribute is Uint32Array');
-    t.deepEqual(attribute.buffer.debugData.slice(0, 6), [3, 4, 5, 4, 4, 5], 'Attribute value is set');
+    t.deepEqual(
+      attribute.buffer.debugData.slice(0, 6),
+      [3, 4, 5, 4, 4, 5],
+      'Attribute value is set'
+    );
     validateShaderAttributes(t, attribute, false);
 
     t.throws(
@@ -659,7 +662,11 @@ test('Attribute#doublePrecision', t0 => {
 
     attribute.setExternalBuffer(new Float64Array([3, 4, 5, 4, 4, 5]));
     t.ok(attribute.value instanceof Float64Array, 'Attribute is Float64Array');
-    t.deepEqual(attribute.buffer.debugData.slice(0, 6), [3, 4, 5, 0, 0, 0], 'Attribute value is set');
+    t.deepEqual(
+      attribute.buffer.debugData.slice(0, 6),
+      [3, 4, 5, 0, 0, 0],
+      'Attribute value is set'
+    );
     validateShaderAttributes(t, attribute, true);
 
     const buffer = new Buffer(gl, 12);
@@ -694,7 +701,11 @@ test('Attribute#doublePrecision', t0 => {
 
     attribute.setExternalBuffer(new Uint32Array([3, 4, 5, 4, 4, 5]));
     t.ok(attribute.value instanceof Uint32Array, 'Attribute is Uint32Array');
-    t.deepEqual(attribute.buffer.debugData.slice(0, 6), [3, 4, 5, 4, 4, 5], 'Attribute value is set');
+    t.deepEqual(
+      attribute.buffer.debugData.slice(0, 6),
+      [3, 4, 5, 4, 4, 5],
+      'Attribute value is set'
+    );
     validateShaderAttributes(t, attribute, false);
 
     t.throws(
@@ -704,7 +715,11 @@ test('Attribute#doublePrecision', t0 => {
 
     attribute.setExternalBuffer(new Float64Array([3, 4, 5, 4, 4, 5]));
     t.ok(attribute.value instanceof Float64Array, 'Attribute is Float64Array');
-    t.deepEqual(attribute.buffer.debugData.slice(0, 6), [3, 4, 5, 0, 0, 0], 'Attribute value is set');
+    t.deepEqual(
+      attribute.buffer.debugData.slice(0, 6),
+      [3, 4, 5, 0, 0, 0],
+      'Attribute value is set'
+    );
     validateShaderAttributes(t, attribute, true);
 
     const buffer = new Buffer(gl, 12);


### PR DESCRIPTION
Fixes Tile3DLayer rendering in Safari.

#### Background

When using `COORDINATE_SYSTEM.METER_OFFSETS`, the positions attributes are assigned `type: GL.FLOAT`, so no 64xyLow attributes are generated. This seems to be fine in most of the cases, but some layers in Safari have the `positions64xyLow` attribute compiled to location 0, which cannot be disabled.

The fix is to always mark the positions attributes as `type: GL.DOUBLE`, but change their default allocation type to `GL.FLOAT` when high precision is not required. This way we always define the 64xyLow attributes, and there is no perf hit when auto-packing meter offset positions.

As a side effect, this change will also allow external `Float64Array` supplied to positions attributes in the meter offset coordinate system.

#### Change List
- Add optional `fp64` flag to attribute options
- Update all primitive layers
