### PR TITLE
Tile combination by zoom level

### DIFF
--- a/modules/geo-layers/src/tile-layer/tile-layer.js
+++ b/modules/geo-layers/src/tile-layer/tile-layer.js
@@ -104,37 +104,6 @@ export default class TileLayer extends CompositeLayer {
       })
     );
   }
-
-  aggregateByZoomLevel(tiles) {
-    const aggregation = tiles.reduce((tilesByZoomLevel, currentTile) => {
-      const tileExists = tilesByZoomLevel.hasOwnProperty(currentTile.z);
-
-      if (!tileExists) {
-        tilesByZoomLevel[currentTile.z] = {
-          data: [],
-          pendingData: [],
-          dataPromiseWrapped: null,
-          z: currentTile.z,
-          tileSet: new Map()
-        };
-      }
-
-      if (currentTile._isLoaded) {
-        tilesByZoomLevel[currentTile.z].data.push(currentTile.data);
-      } else {
-        tilesByZoomLevel[currentTile.z].pendingData.push(currentTile.data);
-        tilesByZoomLevel[currentTile.z].dataPromiseWrapped = Promise.all(
-          tilesByZoomLevel[currentTile.z].pendingData
-        ).then(allData => allData.flat());
-      }
-
-      tilesByZoomLevel[currentTile.z].tileSet.set(currentTile.id, currentTile);
-
-      return tilesByZoomLevel;
-    }, {});
-
-    return Object.values(aggregation);
-  }
 }
 
 TileLayer.layerName = 'TileLayer';

--- a/modules/geo-layers/src/tile-layer/utils/composite-tile.js
+++ b/modules/geo-layers/src/tile-layer/utils/composite-tile.js
@@ -1,0 +1,38 @@
+export default class CompositeTile {
+  constructor({tileset = [], zoomLevel}) {
+    this.tileset = tileset;
+    this.zoomLevel = zoomLevel;
+
+    this.data = [];
+    this.combinedData = [];
+
+    // Remember to refresh aggregation when any tile loads its data
+    this.waitForDataInTiles(this.tileset);
+    // Perform aggregation
+    // this.combineTiles();
+  }
+
+  getData() {
+    const pendingData = Promise.all(this.tileset.map(tile => tile.data)).then(allData =>
+      allData.flat()
+    );
+
+    return this.data.length ? this.data.flat() : pendingData;
+  }
+
+  waitForDataInTiles(pendingTiles) {
+    pendingTiles.forEach(pendingTile => {
+      const tileData = pendingTile.data;
+      const dataStillPending = Boolean(tileData.then);
+
+      if (!dataStillPending) {
+        this.data.push(tileData);
+        return;
+      }
+
+      tileData.then(loadedData => {
+        this.data.push(loadedData);
+      });
+    });
+  }
+}

--- a/modules/geo-layers/src/tile-layer/utils/composite-tile.js
+++ b/modules/geo-layers/src/tile-layer/utils/composite-tile.js
@@ -4,12 +4,8 @@ export default class CompositeTile {
     this.zoomLevel = zoomLevel;
 
     this.data = [];
-    this.combinedData = [];
 
-    // Remember to refresh aggregation when any tile loads its data
     this.waitForDataInTiles(this.tileset);
-    // Perform aggregation
-    // this.combineTiles();
   }
 
   getData() {

--- a/modules/geo-layers/src/tile-layer/utils/composite-tile.js
+++ b/modules/geo-layers/src/tile-layer/utils/composite-tile.js
@@ -17,9 +17,7 @@ export default class CompositeTile {
       return this.data.flat();
     }
 
-    return Promise.all(this.tileset.map(tile => tile.data)).then(allData =>
-      allData.flat()
-    );
+    return Promise.all(this.tileset.map(tile => tile.data)).then(allData => allData.flat());
   }
 
   waitForDataInTiles(pendingTiles) {

--- a/modules/geo-layers/src/tile-layer/utils/composite-tile.js
+++ b/modules/geo-layers/src/tile-layer/utils/composite-tile.js
@@ -13,11 +13,13 @@ export default class CompositeTile {
   }
 
   getData() {
-    const pendingData = Promise.all(this.tileset.map(tile => tile.data)).then(allData =>
+    if (this.data.length) {
+      return this.data.flat();
+    }
+
+    return Promise.all(this.tileset.map(tile => tile.data)).then(allData =>
       allData.flat()
     );
-
-    return this.data.length ? this.data.flat() : pendingData;
   }
 
   waitForDataInTiles(pendingTiles) {


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
For #3695 

<!-- For other PRs without open issue -->
#### Background
While using Deck.gl's TileLayer implementation to render MVT tiles retrieved from our backend, the main issue that we found is that the tile rendering process takes more time than it should to avoid lag and provide a nice user experience while panning and zooming the map.

Understanding [Deck.gl](http://deck.gl)'s TileLayer behaviour, we found out that the TileLayer is a CompositeLayer that renders N sublayers (GeoJSON layer by default), two for each of the tiles within the viewport at least.

Viewport in a 1080p display at fullscreen contains 24 tiles, excluding the main TileLayer and derived layers from points, lines and polygons, which could make a total of 49 layers (or even almost 2x with polygons and fill and stroke layers) if every tile contains 1 geometry at least.

Performing analysis using Chrome DevTools' performance tool, the rendering process for a dataset with 16k lines takes an avg. of 1062ms taking a sample of 10 executions, which is way more to what it is recommended to avoid lag or hangs when interacting with the content.

This is how the flame chart looks like:
![Screenshot 2019-09-26 at 12 59 12](https://user-images.githubusercontent.com/4319728/65698360-acbaca80-e07c-11e9-8eff-9b4a39b87a00.png)

#### Proposal

We thought of combining all tiles within a single zoom level into a single tile to ease the rendering process and make it faster. This is what changes are about in this PR.

We introduced a new concept called CompositeTile, which is just an abstraction for holding a set of tiles and taking care of all data management so that we only create a single layer in `renderLayers` method.

That way we would only render 3 or 4 layers at most in each renderLayers cycle, lowering the time that each requestAnimationHandler cycle takes, and improving the performance.

This is how the flame chart looks like:
![Screenshot 2019-09-26 at 13 04 56](https://user-images.githubusercontent.com/4319728/65698600-1509ac00-e07d-11e9-8f21-7657773b1b4c.png)

We created a set of different examples with different geometries to assess our performance improvements. Those examples are here: https://deck-comparisons.glitch.me. You will find there the examples with the dataset specifications.

#### Performance Improvements
We performed a set of performance comparisons between the production version of D[eck.gl](http://deck.gl) and our custom Deck.gl version with those changes applied.

Tests were executed with the same configuration as in the screenshot above (local assets, advanced paint instrumentation enabled, and no CPU throttling). Measures are taken from the latest animation frame where all layers are rendered to avoid flakiness or tests variation due to network fluctuations.

These are the stats that we got:

**Points' example - 500k points**

|  	| Avg. 	| Median 	| Max. 	| Min. 	| P80 	|
|----------	|----------	|----------	|----------	|----------	|----------	|
| Original 	| 127.42ms 	| 124.89ms 	| 155.85ms 	| 107.26ms 	| 139.57ms 	|
| Improved 	| 78.5ms 	| 69.31ms 	| 143.69ms 	| 51.56ms 	| 97.82ms 	|
| Percentages of Improvement | 38.4% | 44.5% | 7.81% | 51.93% | 29.92% |

**Lines' example - 16k lines**

|  	| Avg. 	| Median 	| Max. 	| Min. 	| P80 	|
|----------	|-----------	|-----------	|----------	|----------	|----------	|
| Original 	| 1062.09ms 	| 993.58ms 	| 1398ms 	| 788.35ms 	| 1319ms 	|
| Improved 	| 343.05ms 	| 336.245ms 	| 457.56ms 	| 289.32ms 	| 368.26ms 	|
| Percentages of Improvement | 67.71% | 66.16% | 67.28% | 63.31% | 72.09% |

Percentages of improvement seem good in both cases and we would like to know what you think about this approach of combining tiles, and if it is good to go for this approach.
