### PR TITLE
HeatmapLayer: Add 'colorDomain' prop

### DIFF
--- a/docs/layers/heatmap-layer.md
+++ b/docs/layers/heatmap-layer.md
@@ -9,8 +9,6 @@
 
 `HeatmapLayer` can be used to visualize spatial distribution of data. It internally implements [Gaussian Kernel Density Estimation](https://en.wikipedia.org/wiki/Kernel_(statistics%29#Kernel_functions_in_common_use) to render heatmaps.
 
-* NOTE: Current version of this layer is supported only for WebGL2 enabled browsers, support for WebGL1 browsers will be added in future releases.
-
 ```js
 import DeckGL from '@deck.gl/react';
 import {HeatmapLayer} from '@deck.gl/aggregation-layers';

--- a/docs/layers/heatmap-layer.md
+++ b/docs/layers/heatmap-layer.md
@@ -5,7 +5,7 @@
 </p>
 
 
-# HeatmapLayer **Experimental**
+# HeatmapLayer
 
 `HeatmapLayer` can be used to visualize spatial distribution of data. It internally implements [Gaussian Kernel Density Estimation](https://en.wikipedia.org/wiki/Kernel_(statistics%29#Kernel_functions_in_common_use) to render heatmaps.
 
@@ -97,6 +97,17 @@ Value that is multiplied with the total weight at a pixel to obtain the final we
 The `HeatmapLayer` reduces the opacity of the pixels with relatively low weight to create a fading effect at the edge. A larger `threshold` smoothens the boundaries of color blobs, while making pixels with low relative weight harder to spot (due to low alpha value).
 
 `threshold` is defined as the ratio of the fading weight to the max weight, between `0` and `1`. For example, `0.1` affects all pixels with weight under 10% of the max.
+
+##### `weightDomain` (Array, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
+
+* Default: `[0, 0]`
+
+Weight of each data object is distributed to to all the pixels in a circle centered at the object position, weight a pixel receives is inversely proportional to its distance from the center. Pixels that fall into multiple circles will have sum of all weights. And the weight of the pixel determines its color. Using `weightDomain`, any pixels that are out of the specified range are not rendered. When `weightDomain[1]` is `0`, `HeatmapLayer` automatically calculates the maximum weight, which is the default behavior.
+
+NOTES:
+- It is recommend to use default value for regular use cases.
+- Pixel weights change based on the zoom level, so to keep the rendering same, this range should be increased (when zoomed out) and decreased (when zoomed in) when zoom is changed.
+- On `Windows` browsers due to an ANGLE [issue](https://github.com/uber/deck.gl/issues/3554), auto calculation of maximum weight doesn't work, hence on `Windows`, `weightDomain` should be used with a non zero maximum value.
 
 ### Data Accessors
 

--- a/docs/layers/heatmap-layer.md
+++ b/docs/layers/heatmap-layer.md
@@ -102,7 +102,7 @@ The `HeatmapLayer` reduces the opacity of the pixels with relatively low weight 
 
 * Default: `null`
 
-Weight of each data object is distributed to to all the pixels in a circle centered at the object position, weight a pixel receives is inversely proportional to its distance from the center. Pixels that fall into multiple circles will have sum of all weights. And the weight of the pixel determines its color. When `colorDomain` is specified, all pixels weights are clamped to this range before mapping a color to each pixel.
+Weight of each data object is distributed to to all the pixels in a circle centered at the object position, weight a pixel receives is inversely proportional to its distance from the center. Pixels that fall into multiple circles will have sum of all weights. And the weight of the pixel determines its color. When `colorDomain` is specified, all pixels with weight with in specified `colorDomain` will get mapped to `colorRange`, pixels with weight less than `colorDomain[0]` will fade out (reduced alpha) and pixels with weight more than `colorDomain[1]` will mapped highest color in `colorRange`.
 
 When not specified, `maximum weight` is auto calculated and domain will be set to [`0`, `maximum weight`].
 

--- a/docs/layers/heatmap-layer.md
+++ b/docs/layers/heatmap-layer.md
@@ -100,7 +100,7 @@ The `HeatmapLayer` reduces the opacity of the pixels with relatively low weight 
 
 * Default: `[0, 0]`
 
-Weight of each data object is distributed to to all the pixels in a circle centered at the object position, weight a pixel receives is inversely proportional to its distance from the center. Pixels that fall into multiple circles will have sum of all weights. And the weight of the pixel determines its color. Using `weightDomain`, any pixels that are out of the specified range are not rendered. When `weightDomain[1]` is `0`, `HeatmapLayer` automatically calculates the maximum weight, which is the default behavior.
+Weight of each data object is distributed to to all the pixels in a circle centered at the object position, weight a pixel receives is inversely proportional to its distance from the center. Pixels that fall into multiple circles will have sum of all weights. And the weight of the pixel determines its color. Using `weightDomain`, any pixel with weight below `weightDomain[0] ` is discarded and pixel weights that are more than `weightDomain[1]` are clamped to `weightDomain[1]`. When `weightDomain[1]` is `0`, `HeatmapLayer` automatically calculates the maximum weight, which is the default behavior.
 
 NOTES:
 - It is recommend to use default value for regular use cases.

--- a/docs/layers/heatmap-layer.md
+++ b/docs/layers/heatmap-layer.md
@@ -104,7 +104,7 @@ The `HeatmapLayer` reduces the opacity of the pixels with relatively low weight 
 
 Weight of each data object is distributed to to all the pixels in a circle centered at the object position, weight a pixel receives is inversely proportional to its distance from the center. Pixels that fall into multiple circles will have sum of all weights. And the weight of the pixel determines its color. When `colorDomain` is specified, all pixels with weight with in specified `colorDomain` will get mapped to `colorRange`, pixels with weight less than `colorDomain[0]` will fade out (reduced alpha) and pixels with weight more than `colorDomain[1]` will mapped highest color in `colorRange`.
 
-When not specified, `maximum weight` is auto calculated and domain will be set to [`0`, `maximum weight`].
+When not specified, maximum weight (`maxWeight`) is auto calculated and domain will be set to [`maxWeight * threshold`, `maxWeight`].
 
 NOTES:
 - It is recommend to use default value for regular use cases.

--- a/docs/layers/heatmap-layer.md
+++ b/docs/layers/heatmap-layer.md
@@ -96,16 +96,19 @@ The `HeatmapLayer` reduces the opacity of the pixels with relatively low weight 
 
 `threshold` is defined as the ratio of the fading weight to the max weight, between `0` and `1`. For example, `0.1` affects all pixels with weight under 10% of the max.
 
-##### `weightDomain` (Array, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
+`threshold` is ignored when `colorDomain` is specified.
 
-* Default: `[0, 0]`
+##### `colorDomain` (Array, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
-Weight of each data object is distributed to to all the pixels in a circle centered at the object position, weight a pixel receives is inversely proportional to its distance from the center. Pixels that fall into multiple circles will have sum of all weights. And the weight of the pixel determines its color. Using `weightDomain`, any pixel with weight below `weightDomain[0] ` is discarded and pixel weights that are more than `weightDomain[1]` are clamped to `weightDomain[1]`. When `weightDomain[1]` is `0`, `HeatmapLayer` automatically calculates the maximum weight, which is the default behavior.
+* Default: `null`
+
+Weight of each data object is distributed to to all the pixels in a circle centered at the object position, weight a pixel receives is inversely proportional to its distance from the center. Pixels that fall into multiple circles will have sum of all weights. And the weight of the pixel determines its color. When `colorDomain` is specified, all pixels weights are clamped to this range before mapping a color to each pixel.
+
+When not specified, `maximum weight` is auto calculated and domain will be set to [`0`, `maximum weight`].
 
 NOTES:
 - It is recommend to use default value for regular use cases.
-- Pixel weights change based on the zoom level, so to keep the rendering same, this range should be increased (when zoomed out) and decreased (when zoomed in) when zoom is changed.
-- On `Windows` browsers due to an ANGLE [issue](https://github.com/uber/deck.gl/issues/3554), auto calculation of maximum weight doesn't work, hence on `Windows`, `weightDomain` should be used with a non zero maximum value.
+- On `Windows` browsers due to an ANGLE [issue](https://github.com/uber/deck.gl/issues/3554), auto calculation of maximum weight doesn't work, hence on `Windows`, `colorDomain` should be used with a non zero maximum value.
 
 ### Data Accessors
 

--- a/docs/layers/heatmap-layer.md
+++ b/docs/layers/heatmap-layer.md
@@ -102,7 +102,7 @@ The `HeatmapLayer` reduces the opacity of the pixels with relatively low weight 
 
 * Default: `null`
 
-Weight of each data object is distributed to to all the pixels in a circle centered at the object position, weight a pixel receives is inversely proportional to its distance from the center. Pixels that fall into multiple circles will have sum of all weights. And the weight of the pixel determines its color. When `colorDomain` is specified, all pixels with weight with in specified `colorDomain` will get mapped to `colorRange`, pixels with weight less than `colorDomain[0]` will fade out (reduced alpha) and pixels with weight more than `colorDomain[1]` will mapped highest color in `colorRange`.
+Weight of each data object is distributed to to all the pixels in a circle centered at the object position, weight a pixel receives is inversely proportional to its distance from the center. Pixels that fall into multiple circles will have sum of all weights. And the weight of the pixel determines its color. When `colorDomain` is specified, all pixels with weight with in specified `colorDomain` will get mapped to `colorRange`, pixels with weight less than `colorDomain[0]` will fade out (reduced alpha) and pixels with weight more than `colorDomain[1]` will mapped to the highest color in `colorRange`.
 
 When not specified, maximum weight (`maxWeight`) is auto calculated and domain will be set to [`maxWeight * threshold`, `maxWeight`].
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -69,7 +69,7 @@ A new prop [getTooltip](/docs/api-reference/deck.md#gettooltip-function-optional
 - **Customizable device pixel ratio**: `Deck`'s `useDevicePixels` prop now accepts a number as well as boolean values.
 - **SimpleMeshLayer** and **ScenegraphLayer** now respect the `opacity` prop.
 - **IconLayer** has added a new prop `alphaCutoff` for customizing picking behavior.
-- **HeatmapLayer** is out of `Experimental` phase and can now be rendered using `WebGL1` context. A new prop `weightDomain` added for custom domain specification.
+- **HeatmapLayer** is out of `Experimental` phase and can now be rendered using `WebGL1` context. A new prop `colorDomain` added for custom domain specification.
 
 
 ## deck.gl v7.2

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -69,6 +69,7 @@ A new prop [getTooltip](/docs/api-reference/deck.md#gettooltip-function-optional
 - **Customizable device pixel ratio**: `Deck`'s `useDevicePixels` prop now accepts a number as well as boolean values.
 - **SimpleMeshLayer** and **ScenegraphLayer** now respect the `opacity` prop.
 - **IconLayer** has added a new prop `alphaCutoff` for customizing picking behavior.
+- **HeatmapLayer** is out of `Experimental` phase and can now be rendered using `WebGL1` context. A new prop `weightDomain` added for custom domain specification.
 
 
 ## deck.gl v7.2

--- a/examples/website/heatmap/app.js
+++ b/examples/website/heatmap/app.js
@@ -17,7 +17,6 @@ const INITIAL_VIEW_STATE = {
   pitch: 0,
   bearing: 0
 };
-const COLOR_DOMAIN = [0, 0];
 
 export class App extends PureComponent {
   _renderLayers() {
@@ -26,7 +25,7 @@ export class App extends PureComponent {
       intensity = 1,
       threshold = 0.03,
       radiusPixels = 30,
-      colorDomain = COLOR_DOMAIN
+      colorDomain
     } = this.props;
 
     return [

--- a/examples/website/heatmap/app.js
+++ b/examples/website/heatmap/app.js
@@ -17,10 +17,11 @@ const INITIAL_VIEW_STATE = {
   pitch: 0,
   bearing: 0
 };
+const WEIGHT_DOMAIN = [0, 0];
 
 export class App extends PureComponent {
   _renderLayers() {
-    const {data = DATA_URL, intensity = 1, threshold = 0.03, radiusPixels = 30} = this.props;
+    const {data = DATA_URL, intensity = 1, threshold = 0.03, radiusPixels = 30, weightDomain = WEIGHT_DOMAIN} = this.props;
 
     return [
       new HeatmapLayer({
@@ -32,7 +33,8 @@ export class App extends PureComponent {
         getWeight: d => d[2],
         radiusPixels,
         intensity,
-        threshold
+        threshold,
+        weightDomain
       })
     ];
   }

--- a/examples/website/heatmap/app.js
+++ b/examples/website/heatmap/app.js
@@ -17,7 +17,7 @@ const INITIAL_VIEW_STATE = {
   pitch: 0,
   bearing: 0
 };
-const WEIGHT_DOMAIN = [0, 0];
+const COLOR_DOMAIN = [0, 0];
 
 export class App extends PureComponent {
   _renderLayers() {
@@ -26,7 +26,7 @@ export class App extends PureComponent {
       intensity = 1,
       threshold = 0.03,
       radiusPixels = 30,
-      weightDomain = WEIGHT_DOMAIN
+      colorDomain = COLOR_DOMAIN
     } = this.props;
 
     return [
@@ -40,7 +40,7 @@ export class App extends PureComponent {
         radiusPixels,
         intensity,
         threshold,
-        weightDomain
+        colorDomain
       })
     ];
   }

--- a/examples/website/heatmap/app.js
+++ b/examples/website/heatmap/app.js
@@ -21,7 +21,13 @@ const WEIGHT_DOMAIN = [0, 0];
 
 export class App extends PureComponent {
   _renderLayers() {
-    const {data = DATA_URL, intensity = 1, threshold = 0.03, radiusPixels = 30, weightDomain = WEIGHT_DOMAIN} = this.props;
+    const {
+      data = DATA_URL,
+      intensity = 1,
+      threshold = 0.03,
+      radiusPixels = 30,
+      weightDomain = WEIGHT_DOMAIN
+    } = this.props;
 
     return [
       new HeatmapLayer({

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
@@ -66,7 +66,7 @@ const defaultProps = {
   radiusPixels: {type: 'number', min: 1, max: 100, value: 30},
   colorRange: defaultColorRange,
   threshold: {type: 'number', min: 0, max: 1, value: 0.05},
-  colorDomain: DEFAULT_COLOR_DOMAIN
+  colorDomain: {type: 'array', value: null}
 };
 
 const REQUIRED_FEATURES = [
@@ -125,7 +125,9 @@ export default class HeatmapLayer extends CompositeLayer {
     if (oldProps.colorDomain !== props.colorDomain || changeFlags.viewportChanged) {
       const {viewport} = this.context;
       const domainScale = viewport ? 1024 / viewport.scale : 1;
-      newState.colorDomain = props.colorDomain.map(x => x * domainScale);
+      newState.colorDomain = props.colorDomain
+        ? props.colorDomain.map(x => x * domainScale)
+        : DEFAULT_COLOR_DOMAIN;
     }
 
     this.setState({zoom: opts.context.viewport.zoom, ...newState});

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
@@ -57,7 +57,7 @@ const TEXTURE_OPTIONS = {
   },
   dataFormat: GL.RGBA
 };
-const DEFAULT_WEIGHT_DOMAIN = [0, 0];
+const DEFAULT_COLOR_DOMAIN = [0, 0];
 
 const defaultProps = {
   getPosition: {type: 'accessor', value: x => x.position},
@@ -66,7 +66,7 @@ const defaultProps = {
   radiusPixels: {type: 'number', min: 1, max: 100, value: 30},
   colorRange: defaultColorRange,
   threshold: {type: 'number', min: 0, max: 1, value: 0.05},
-  weightDomain: DEFAULT_WEIGHT_DOMAIN
+  colorDomain: DEFAULT_COLOR_DOMAIN
 };
 
 const REQUIRED_FEATURES = [
@@ -134,7 +134,7 @@ export default class HeatmapLayer extends CompositeLayer {
       maxWeightsTexture,
       colorTexture
     } = this.state;
-    const {updateTriggers, intensity, threshold, weightDomain} = this.props;
+    const {updateTriggers, intensity, threshold, colorDomain} = this.props;
 
     return new TriangleLayer(
       this.getSubLayerProps({
@@ -155,7 +155,7 @@ export default class HeatmapLayer extends CompositeLayer {
         texture: weightsTexture,
         intensity,
         threshold,
-        weightDomain
+        colorDomain
       }
     );
   }

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
@@ -66,7 +66,7 @@ const defaultProps = {
   radiusPixels: {type: 'number', min: 1, max: 100, value: 30},
   colorRange: defaultColorRange,
   threshold: {type: 'number', min: 0, max: 1, value: 0.05},
-  colorDomain: {type: 'array', value: null}
+  colorDomain: {type: 'array', value: null, optional: true}
 };
 
 const REQUIRED_FEATURES = [

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
@@ -57,6 +57,7 @@ const TEXTURE_OPTIONS = {
   },
   dataFormat: GL.RGBA
 };
+const DEFAULT_WEIGHT_DOMAIN = [0, 0];
 
 const defaultProps = {
   getPosition: {type: 'accessor', value: x => x.position},
@@ -64,7 +65,8 @@ const defaultProps = {
   intensity: {type: 'number', min: 0, value: 1},
   radiusPixels: {type: 'number', min: 1, max: 100, value: 30},
   colorRange: defaultColorRange,
-  threshold: {type: 'number', min: 0, max: 1, value: 0.05}
+  threshold: {type: 'number', min: 0, max: 1, value: 0.05},
+  weightDomain: DEFAULT_WEIGHT_DOMAIN
 };
 
 const REQUIRED_FEATURES = [
@@ -132,7 +134,7 @@ export default class HeatmapLayer extends CompositeLayer {
       maxWeightsTexture,
       colorTexture
     } = this.state;
-    const {updateTriggers, intensity, threshold} = this.props;
+    const {updateTriggers, intensity, threshold, weightDomain} = this.props;
 
     return new TriangleLayer(
       this.getSubLayerProps({
@@ -152,7 +154,8 @@ export default class HeatmapLayer extends CompositeLayer {
         colorTexture,
         texture: weightsTexture,
         intensity,
-        threshold
+        threshold,
+        weightDomain
       }
     );
   }

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
@@ -96,7 +96,6 @@ export default class HeatmapLayer extends CompositeLayer {
 
   /* eslint-disable complexity */
   updateState(opts) {
-    const newState = {};
     if (!this.state.supported) {
       return;
     }
@@ -125,12 +124,13 @@ export default class HeatmapLayer extends CompositeLayer {
     if (oldProps.colorDomain !== props.colorDomain || changeFlags.viewportChanged) {
       const {viewport} = this.context;
       const domainScale = viewport ? 1024 / viewport.scale : 1;
-      newState.colorDomain = props.colorDomain
+      const colorDomain = props.colorDomain
         ? props.colorDomain.map(x => x * domainScale)
         : DEFAULT_COLOR_DOMAIN;
+      this.setState({colorDomain});
     }
 
-    this.setState({zoom: opts.context.viewport.zoom, ...newState});
+    this.setState({zoom: opts.context.viewport.zoom});
   }
   /* eslint-enable complexity */
 

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
@@ -94,7 +94,9 @@ export default class HeatmapLayer extends CompositeLayer {
     return changeFlags.somethingChanged;
   }
 
+  /* eslint-disable complexity */
   updateState(opts) {
+    const newState = {};
     if (!this.state.supported) {
       return;
     }
@@ -120,8 +122,15 @@ export default class HeatmapLayer extends CompositeLayer {
       this._updateTextureRenderingBounds();
     }
 
-    this.setState({zoom: opts.context.viewport.zoom});
+    if (oldProps.colorDomain !== props.colorDomain || changeFlags.viewportChanged) {
+      const {viewport} = this.context;
+      const domainScale = viewport ? 1024 / viewport.scale : 1;
+      newState.colorDomain = props.colorDomain.map(x => x * domainScale);
+    }
+
+    this.setState({zoom: opts.context.viewport.zoom, ...newState});
   }
+  /* eslint-enable complexity */
 
   renderLayers() {
     if (!this.state.supported) {
@@ -132,9 +141,10 @@ export default class HeatmapLayer extends CompositeLayer {
       triPositionBuffer,
       triTexCoordBuffer,
       maxWeightsTexture,
-      colorTexture
+      colorTexture,
+      colorDomain
     } = this.state;
-    const {updateTriggers, intensity, threshold, colorDomain} = this.props;
+    const {updateTriggers, intensity, threshold} = this.props;
 
     return new TriangleLayer(
       this.getSubLayerProps({

--- a/modules/aggregation-layers/src/heatmap-layer/triangle-layer-fragment.glsl.js
+++ b/modules/aggregation-layers/src/heatmap-layer/triangle-layer-fragment.glsl.js
@@ -27,15 +27,15 @@ uniform float opacity;
 uniform sampler2D texture;
 varying vec2 vTexCoords;
 uniform sampler2D colorTexture;
-uniform float threshold;
 uniform vec2 weightDomain;
 
-varying float vIntensity;
+varying float vIntensityMin;
+varying float vIntensityMax;
 
 vec4 getLinearColor(float value) {
-  float factor = clamp(value, 0., 1.);
+  float factor = clamp(value * vIntensityMax, 0., 1.);
   vec4 color = texture2D(colorTexture, vec2(factor, 0.5));
-  color.a *= min(value / threshold, 1.0);
+  color.a *= min(value * vIntensityMin, 1.0);
   return color;
 }
 
@@ -45,9 +45,8 @@ void main(void) {
   if (weight <= 0.) {
      discard;
   }
-  // bring weight to custom range, pixel below domain, will fall into least color range.
-  weight = max(weight - weightDomain[0], 0.);
-  vec4 linearColor = getLinearColor(weight * vIntensity);
+
+  vec4 linearColor = getLinearColor(weight);
   linearColor.a *= opacity;
   gl_FragColor =linearColor;
 }

--- a/modules/aggregation-layers/src/heatmap-layer/triangle-layer-fragment.glsl.js
+++ b/modules/aggregation-layers/src/heatmap-layer/triangle-layer-fragment.glsl.js
@@ -27,7 +27,6 @@ uniform float opacity;
 uniform sampler2D texture;
 varying vec2 vTexCoords;
 uniform sampler2D colorTexture;
-uniform vec2 weightDomain;
 
 varying float vIntensityMin;
 varying float vIntensityMax;

--- a/modules/aggregation-layers/src/heatmap-layer/triangle-layer-fragment.glsl.js
+++ b/modules/aggregation-layers/src/heatmap-layer/triangle-layer-fragment.glsl.js
@@ -40,10 +40,13 @@ vec4 getLinearColor(float value) {
 }
 
 void main(void) {
-  float weight = texture2D(texture, vTexCoords).r - weightDomain[0];
+  float weight = texture2D(texture, vTexCoords).r;
+  // discard pixels with 0 weight.
   if (weight <= 0.) {
      discard;
   }
+  // bring weight to custom range, pixel below domain, will fall into least color range.
+  weight = max(weight - weightDomain[0], 0.);
   vec4 linearColor = getLinearColor(weight * vIntensity);
   linearColor.a *= opacity;
   gl_FragColor =linearColor;

--- a/modules/aggregation-layers/src/heatmap-layer/triangle-layer-fragment.glsl.js
+++ b/modules/aggregation-layers/src/heatmap-layer/triangle-layer-fragment.glsl.js
@@ -28,6 +28,7 @@ uniform sampler2D texture;
 varying vec2 vTexCoords;
 uniform sampler2D colorTexture;
 uniform float threshold;
+uniform vec2 weightDomain;
 
 varying float vIntensity;
 
@@ -39,8 +40,8 @@ vec4 getLinearColor(float value) {
 }
 
 void main(void) {
-  float weight = texture2D(texture, vTexCoords).r;
-  if (weight == 0.) {
+  float weight = texture2D(texture, vTexCoords).r - weightDomain[0];
+  if (weight <= 0.) {
      discard;
   }
   vec4 linearColor = getLinearColor(weight * vIntensity);

--- a/modules/aggregation-layers/src/heatmap-layer/triangle-layer-vertex.glsl.js
+++ b/modules/aggregation-layers/src/heatmap-layer/triangle-layer-vertex.glsl.js
@@ -25,24 +25,25 @@ export default `\
 
 uniform sampler2D maxTexture;
 uniform float intensity;
-uniform vec2 weightDomain;
+uniform vec2 colorDomain;
 uniform float threshold;
 
 attribute vec3 positions;
 attribute vec2 texCoords;
 
 varying vec2 vTexCoords;
-varying float vIntensityMax;
 varying float vIntensityMin;
+varying float vIntensityMax;
 
 void main(void) {
   gl_Position = project_position_to_clipspace(positions, vec2(0.0), vec3(0.0));
   vTexCoords = texCoords;
   float maxValue = texture2D(maxTexture, vec2(0.5)).r;
   float minValue = maxValue * threshold;
-  if (weightDomain[1] > 0.) {
-    maxValue = weightDomain[1];
-    minValue = weightDomain[0];
+  if (colorDomain[1] > 0.) {
+    // if user specified custom domain use it.
+    maxValue = colorDomain[1];
+    minValue = colorDomain[0];
   }
   vIntensityMax = intensity / maxValue;
   vIntensityMin = intensity / minValue;

--- a/modules/aggregation-layers/src/heatmap-layer/triangle-layer-vertex.glsl.js
+++ b/modules/aggregation-layers/src/heatmap-layer/triangle-layer-vertex.glsl.js
@@ -26,22 +26,25 @@ export default `\
 uniform sampler2D maxTexture;
 uniform float intensity;
 uniform vec2 weightDomain;
+uniform float threshold;
 
 attribute vec3 positions;
 attribute vec2 texCoords;
 
 varying vec2 vTexCoords;
-varying float vIntensity;
+varying float vIntensityMax;
+varying float vIntensityMin;
 
 void main(void) {
   gl_Position = project_position_to_clipspace(positions, vec2(0.0), vec3(0.0));
   vTexCoords = texCoords;
   float maxValue = texture2D(maxTexture, vec2(0.5)).r;
+  float minValue = maxValue * threshold;
   if (weightDomain[1] > 0.) {
-    // custom domain is specified, overwrite maxValue
-    // weightDomain[0] is subtracted from each pixel weight, adjust the maxValue
-    maxValue = weightDomain[1] - weightDomain[0];
+    maxValue = weightDomain[1];
+    minValue = weightDomain[0];
   }
-  vIntensity = intensity / maxValue;
+  vIntensityMax = intensity / maxValue;
+  vIntensityMin = intensity / minValue;
 }
 `;

--- a/modules/aggregation-layers/src/heatmap-layer/triangle-layer-vertex.glsl.js
+++ b/modules/aggregation-layers/src/heatmap-layer/triangle-layer-vertex.glsl.js
@@ -25,6 +25,7 @@ export default `\
 
 uniform sampler2D maxTexture;
 uniform float intensity;
+uniform vec2 weightDomain;
 
 attribute vec3 positions;
 attribute vec2 texCoords;
@@ -36,6 +37,10 @@ void main(void) {
   gl_Position = project_position_to_clipspace(positions, vec2(0.0), vec3(0.0));
   vTexCoords = texCoords;
   float maxValue = texture2D(maxTexture, vec2(0.5)).r;
+  if (weightDomain[1] > 0.) {
+    // custom domain is specified, overwrite maxValue
+    maxValue = weightDomain[1];
+  }
   vIntensity = intensity / maxValue;
 }
 `;

--- a/modules/aggregation-layers/src/heatmap-layer/triangle-layer-vertex.glsl.js
+++ b/modules/aggregation-layers/src/heatmap-layer/triangle-layer-vertex.glsl.js
@@ -39,7 +39,8 @@ void main(void) {
   float maxValue = texture2D(maxTexture, vec2(0.5)).r;
   if (weightDomain[1] > 0.) {
     // custom domain is specified, overwrite maxValue
-    maxValue = weightDomain[1];
+    // weightDomain[0] is subtracted from each pixel weight, adjust the maxValue
+    maxValue = weightDomain[1] - weightDomain[0];
   }
   vIntensity = intensity / maxValue;
 }

--- a/modules/aggregation-layers/src/heatmap-layer/triangle-layer.js
+++ b/modules/aggregation-layers/src/heatmap-layer/triangle-layer.js
@@ -72,7 +72,8 @@ export default class TriangleLayer extends Layer {
         colorTexture,
         intensity,
         threshold,
-        weightDomain
+        weightDomain,
+        opacity: 1.0
       })
       .draw();
   }

--- a/modules/aggregation-layers/src/heatmap-layer/triangle-layer.js
+++ b/modules/aggregation-layers/src/heatmap-layer/triangle-layer.js
@@ -63,7 +63,11 @@ export default class TriangleLayer extends Layer {
 
   draw({uniforms}) {
     const {model} = this.state;
-    const {texture, maxTexture, colorTexture, intensity, threshold, weightDomain} = this.props;
+    const {viewport} = this.context;
+    const domainScale = viewport ? 1024 / viewport.scale : 1;
+
+    const {texture, maxTexture, colorTexture, intensity, threshold} = this.props;
+    const weightDomain = this.props.weightDomain.map(x => x * domainScale);
     model
       .setUniforms({
         ...uniforms,
@@ -73,7 +77,7 @@ export default class TriangleLayer extends Layer {
         intensity,
         threshold,
         weightDomain,
-        opacity: 1.0
+        domainScale
       })
       .draw();
   }

--- a/modules/aggregation-layers/src/heatmap-layer/triangle-layer.js
+++ b/modules/aggregation-layers/src/heatmap-layer/triangle-layer.js
@@ -67,7 +67,7 @@ export default class TriangleLayer extends Layer {
     const domainScale = viewport ? 1024 / viewport.scale : 1;
 
     const {texture, maxTexture, colorTexture, intensity, threshold} = this.props;
-    const weightDomain = this.props.weightDomain.map(x => x * domainScale);
+    const colorDomain = this.props.colorDomain.map(x => x * domainScale);
     model
       .setUniforms({
         ...uniforms,
@@ -76,7 +76,7 @@ export default class TriangleLayer extends Layer {
         colorTexture,
         intensity,
         threshold,
-        weightDomain,
+        colorDomain,
         domainScale
       })
       .draw();

--- a/modules/aggregation-layers/src/heatmap-layer/triangle-layer.js
+++ b/modules/aggregation-layers/src/heatmap-layer/triangle-layer.js
@@ -63,11 +63,8 @@ export default class TriangleLayer extends Layer {
 
   draw({uniforms}) {
     const {model} = this.state;
-    const {viewport} = this.context;
-    const domainScale = viewport ? 1024 / viewport.scale : 1;
 
-    const {texture, maxTexture, colorTexture, intensity, threshold} = this.props;
-    const colorDomain = this.props.colorDomain.map(x => x * domainScale);
+    const {texture, maxTexture, colorTexture, intensity, threshold, colorDomain} = this.props;
     model
       .setUniforms({
         ...uniforms,
@@ -76,8 +73,7 @@ export default class TriangleLayer extends Layer {
         colorTexture,
         intensity,
         threshold,
-        colorDomain,
-        domainScale
+        colorDomain
       })
       .draw();
   }

--- a/modules/aggregation-layers/src/heatmap-layer/triangle-layer.js
+++ b/modules/aggregation-layers/src/heatmap-layer/triangle-layer.js
@@ -63,9 +63,9 @@ export default class TriangleLayer extends Layer {
 
   draw({uniforms}) {
     const {model} = this.state;
-    const {texture, maxTexture, colorTexture, intensity, threshold} = this.props;
+    const {texture, maxTexture, colorTexture, intensity, threshold, weightDomain} = this.props;
     model
-      .setUniforms({...uniforms, texture, maxTexture, colorTexture, intensity, threshold})
+      .setUniforms({...uniforms, texture, maxTexture, colorTexture, intensity, threshold, weightDomain})
       .draw();
   }
 }

--- a/modules/aggregation-layers/src/heatmap-layer/triangle-layer.js
+++ b/modules/aggregation-layers/src/heatmap-layer/triangle-layer.js
@@ -65,7 +65,15 @@ export default class TriangleLayer extends Layer {
     const {model} = this.state;
     const {texture, maxTexture, colorTexture, intensity, threshold, weightDomain} = this.props;
     model
-      .setUniforms({...uniforms, texture, maxTexture, colorTexture, intensity, threshold, weightDomain})
+      .setUniforms({
+        ...uniforms,
+        texture,
+        maxTexture,
+        colorTexture,
+        intensity,
+        threshold,
+        weightDomain
+      })
       .draw();
   }
 }

--- a/website/src/components/demos/heatmap-demo.js
+++ b/website/src/components/demos/heatmap-demo.js
@@ -16,8 +16,22 @@ export default class HeatmapDemo extends Component {
       radius: {displayName: 'Radius', type: 'range', value: 5, step: 1, min: 1, max: 50},
       intensity: {displayName: 'Intensity', type: 'range', value: 1, step: 0.1, min: 0, max: 5},
       threshold: {displayName: 'Threshold', type: 'range', value: 0.03, step: 0.01, min: 0, max: 1},
-      minWeight: {displayName: 'Minimum Weight', type: 'range', value: 0, step: 10, min: 0, max: 50000},
-      maxWeight: {displayName: 'Maximum Weight', type: 'range', value: 0, step: 10, min: 0, max: 50000}
+      minWeight: {
+        displayName: 'Minimum Weight',
+        type: 'range',
+        value: 0,
+        step: 10,
+        min: 0,
+        max: 50000
+      },
+      maxWeight: {
+        displayName: 'Maximum Weight',
+        type: 'range',
+        value: 0,
+        step: 10,
+        min: 0,
+        max: 50000
+      }
     };
   }
 

--- a/website/src/components/demos/heatmap-demo.js
+++ b/website/src/components/demos/heatmap-demo.js
@@ -56,7 +56,7 @@ export default class HeatmapDemo extends Component {
     const radiusPixels = params.radius.value;
     const intensity = params.intensity.value;
     const threshold = params.threshold.value;
-    const weightDomain = [params.minWeight.value, params.maxWeight.value];
+    const colorDomain = [params.minWeight.value, params.maxWeight.value];
 
     return (
       <App
@@ -65,7 +65,7 @@ export default class HeatmapDemo extends Component {
         intensity={intensity}
         threshold={threshold}
         radiusPixels={radiusPixels}
-        weightDomain={weightDomain}
+        colorDomain={colorDomain}
       />
     );
   }

--- a/website/src/components/demos/heatmap-demo.js
+++ b/website/src/components/demos/heatmap-demo.js
@@ -15,7 +15,9 @@ export default class HeatmapDemo extends Component {
     return {
       radius: {displayName: 'Radius', type: 'range', value: 5, step: 1, min: 1, max: 50},
       intensity: {displayName: 'Intensity', type: 'range', value: 1, step: 0.1, min: 0, max: 5},
-      threshold: {displayName: 'Threshold', type: 'range', value: 0.03, step: 0.01, min: 0, max: 1}
+      threshold: {displayName: 'Threshold', type: 'range', value: 0.03, step: 0.01, min: 0, max: 1},
+      minWeight: {displayName: 'Minimum Weight', type: 'range', value: 0, step: 10, min: 0, max: 50000},
+      maxWeight: {displayName: 'Maximum Weight', type: 'range', value: 0, step: 10, min: 0, max: 50000}
     };
   }
 
@@ -54,6 +56,7 @@ export default class HeatmapDemo extends Component {
     const radiusPixels = params.radius.value;
     const intensity = params.intensity.value;
     const threshold = params.threshold.value;
+    const weightDomain = [params.minWeight.value, params.maxWeight.value];
 
     return (
       <App
@@ -62,6 +65,7 @@ export default class HeatmapDemo extends Component {
         intensity={intensity}
         threshold={threshold}
         radiusPixels={radiusPixels}
+        weightDomain={weightDomain}
       />
     );
   }


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #3591 & #3554 
<!-- For other PRs without open issue -->
#### Background
- Add `weightDomain` prop to specify custom domain range, this is a required as workaround due to ANGLE issues (#3554)
- Docs:
  - Remove `Experimental`
  - Remove restriction of `WebGL2`
  - Document new prop.
  - Update whats-new


![heatmapWeightDomain2Resized](https://user-images.githubusercontent.com/9502731/65735727-5013db80-e08d-11e9-8657-ef2a8def4f83.gif)


<!-- For all the PRs -->
#### Change List
-
