### PR TITLE
Consolidate picking injection

### DIFF
--- a/docs/developer-guide/custom-layers/writing-shaders.md
+++ b/docs/developer-guide/custom-layers/writing-shaders.md
@@ -138,6 +138,7 @@ Arguments:
 - `vec3 normal` - The normal at the current vertex in common space. Only populated for 3D layers.
 - `vec2 uv` - The uv position at the current vertex.
 - `vec4 position` - The position of the current vertex in common space. Populated during projection.
+- `vec3 pickingColor` - The picking color of the current vertex.
 
 ### FragmentGeometry struct
 

--- a/modules/core/src/shaderlib/index.js
+++ b/modules/core/src/shaderlib/index.js
@@ -19,12 +19,13 @@
 // THE SOFTWARE.
 
 import {registerShaderModules, ProgramManager} from '@luma.gl/core';
-import {fp32, picking, gouraudlighting, phonglighting} from '@luma.gl/core';
+import {fp32, gouraudlighting, phonglighting} from '@luma.gl/core';
 import geometry from './misc/geometry';
 import project from './project/project';
 import project32 from './project32/project32';
 import project64 from './project64/project64';
 import shadow from './shadow/shadow';
+import picking from './picking/picking';
 
 const DEFAULT_MODULES = [geometry, project];
 
@@ -34,22 +35,6 @@ const SHADER_HOOKS = [
   'vs:DECKGL_FILTER_COLOR(inout vec4 color, VertexGeometry geometry)',
   'fs:DECKGL_FILTER_COLOR(inout vec4 color, FragmentGeometry geometry)'
 ];
-
-const MODULE_INJECTIONS = {
-  picking: [
-    {
-      hook: 'fs:DECKGL_FILTER_COLOR',
-      order: 99,
-      injection: `
-    // use highlight color if this fragment belongs to the selected object.
-    color = picking_filterHighlightColor(color);
-
-    // use picking color if rendering to picking FBO.
-    color = picking_filterPickingColor(color);
-  `
-    }
-  ]
-};
 
 export function initializeShaderModules() {
   registerShaderModules([fp32, project, project32, gouraudlighting, phonglighting, picking]);
@@ -63,11 +48,6 @@ export function createProgramManager(gl) {
   }
   for (const shaderHook of SHADER_HOOKS) {
     programManager.addShaderHook(shaderHook);
-  }
-  for (const moduleName in MODULE_INJECTIONS) {
-    for (const injection of MODULE_INJECTIONS[moduleName]) {
-      programManager.addModuleInjection(moduleName, injection);
-    }
   }
 
   return programManager;

--- a/modules/core/src/shaderlib/misc/geometry.js
+++ b/modules/core/src/shaderlib/misc/geometry.js
@@ -25,6 +25,7 @@ struct VertexGeometry {
   vec3 worldPositionAlt;
   vec3 normal;
   vec2 uv;
+  vec3 pickingColor;
 } geometry;
 `;
 

--- a/modules/core/src/shaderlib/picking/picking.js
+++ b/modules/core/src/shaderlib/picking/picking.js
@@ -1,0 +1,22 @@
+import {picking, createModuleInjection} from '@luma.gl/core';
+
+createModuleInjection('picking', {
+  hook: 'vs:DECKGL_FILTER_COLOR',
+  injection: `
+    picking_setPickingColor(geometry.pickingColor);
+`
+});
+
+createModuleInjection('picking', {
+  hook: 'fs:DECKGL_FILTER_COLOR',
+  order: 99,
+  injection: `
+    // use highlight color if this fragment belongs to the selected object.
+    color = picking_filterHighlightColor(color);
+
+    // use picking color if rendering to picking FBO.
+    color = picking_filterPickingColor(color);
+  `
+});
+
+export default picking;

--- a/modules/geo-layers/src/great-circle-layer/great-circle-vertex.glsl.js
+++ b/modules/geo-layers/src/great-circle-layer/great-circle-vertex.glsl.js
@@ -91,6 +91,7 @@ void main(void) {
   float segmentRatio = getSegmentRatio(segmentIndex);
   uv = vec2(segmentRatio, positions.y);
   geometry.uv = uv;
+  geometry.pickingColor = instancePickingColors;
   
   // if it's the first point, use next - current as direction
   // otherwise use current - prev
@@ -129,8 +130,5 @@ void main(void) {
   vec4 color = mix(instanceSourceColors, instanceTargetColors, segmentRatio);
   vColor = vec4(color.rgb, color.a * opacity);
   DECKGL_FILTER_COLOR(vColor, geometry);
-
-  // Set color to be rendered to picking fbo (also used to check for selection highlight).
-  picking_setPickingColor(instancePickingColors);
 }
 `;

--- a/modules/layers/src/arc-layer/arc-layer-vertex.glsl.js
+++ b/modules/layers/src/arc-layer/arc-layer-vertex.glsl.js
@@ -99,6 +99,7 @@ void main(void) {
   geometry.position = vec4(currPos, 1.0);
   uv = vec2(segmentRatio, positions.y);
   geometry.uv = uv;
+  geometry.pickingColor = instancePickingColors;
 
   // Multiply out width and clamp to limits
   // mercator pixels are interpreted as screen pixels
@@ -118,8 +119,5 @@ void main(void) {
   vec4 color = mix(instanceSourceColors, instanceTargetColors, segmentRatio);
   vColor = vec4(color.rgb, color.a * opacity);
   DECKGL_FILTER_COLOR(vColor, geometry);
-
-  // Set color to be rendered to picking fbo (also used to check for selection highlight).
-  picking_setPickingColor(instancePickingColors);
 }
 `;

--- a/modules/layers/src/bitmap-layer/bitmap-layer-vertex.js
+++ b/modules/layers/src/bitmap-layer/bitmap-layer-vertex.js
@@ -11,12 +11,11 @@ varying vec2 vTexCoord;
 void main(void) {
   geometry.worldPosition = positions;
   geometry.uv = texCoords;
+  geometry.pickingColor = instancePickingColors;
 
   gl_Position = project_position_to_clipspace(positions, positions64xyLow, vec3(0.0), geometry.position);
   DECKGL_FILTER_GL_POSITION(gl_Position, geometry);
 
   vTexCoord = texCoords;
-
-  picking_setPickingColor(instancePickingColors);
 }
 `;

--- a/modules/layers/src/column-layer/column-layer-vertex.glsl.js
+++ b/modules/layers/src/column-layer/column-layer-vertex.glsl.js
@@ -51,7 +51,9 @@ uniform float widthMaxPixels;
 // Result
 varying vec4 vColor;
 
-void main(void) {  
+void main(void) {
+  geometry.worldPosition = instancePositions;
+
   vec4 color = isStroke ? instanceLineColors : instanceFillColors;
   // rotate primitive position and normal
   mat2 rotationMatrix = mat2(cos(angle), sin(angle), -sin(angle), cos(angle));
@@ -81,7 +83,6 @@ void main(void) {
   vec3 centroidPosition = vec3(instancePositions.xy, instancePositions.z + elevation);
   vec2 centroidPosition64xyLow = instancePositions64xyLow;
   vec3 pos = vec3(project_size(rotationMatrix * positions.xy * strokeOffsetRatio + offset) * dotRadius, 0.);
-  geometry.worldPosition = centroidPosition;
   DECKGL_FILTER_SIZE(pos, geometry);
 
   gl_Position = project_position_to_clipspace(centroidPosition, centroidPosition64xyLow, pos, geometry.position);

--- a/modules/layers/src/column-layer/column-layer-vertex.glsl.js
+++ b/modules/layers/src/column-layer/column-layer-vertex.glsl.js
@@ -51,9 +51,7 @@ uniform float widthMaxPixels;
 // Result
 varying vec4 vColor;
 
-void main(void) {
-  geometry.worldPosition = instancePositions;
-  
+void main(void) {  
   vec4 color = isStroke ? instanceLineColors : instanceFillColors;
   // rotate primitive position and normal
   mat2 rotationMatrix = mat2(cos(angle), sin(angle), -sin(angle), cos(angle));
@@ -77,11 +75,13 @@ void main(void) {
   float dotRadius = radius * coverage * shouldRender;
 
   geometry.normal = project_normal(vec3(rotationMatrix * normals.xy, normals.z));
+  geometry.pickingColor = instancePickingColors;
 
   // project center of column
   vec3 centroidPosition = vec3(instancePositions.xy, instancePositions.z + elevation);
   vec2 centroidPosition64xyLow = instancePositions64xyLow;
   vec3 pos = vec3(project_size(rotationMatrix * positions.xy * strokeOffsetRatio + offset) * dotRadius, 0.);
+  geometry.worldPosition = centroidPosition;
   DECKGL_FILTER_SIZE(pos, geometry);
 
   gl_Position = project_position_to_clipspace(centroidPosition, centroidPosition64xyLow, pos, geometry.position);
@@ -95,8 +95,5 @@ void main(void) {
     vColor = vec4(color.rgb, color.a * opacity);
   }
   DECKGL_FILTER_COLOR(vColor, geometry);
-
-  // Set color to be rendered to picking fbo (also used to check for selection highlight).
-  picking_setPickingColor(instancePickingColors);
 }
 `;

--- a/modules/layers/src/icon-layer/icon-layer-vertex.glsl.js
+++ b/modules/layers/src/icon-layer/icon-layer-vertex.glsl.js
@@ -55,6 +55,7 @@ vec2 rotate_by_angle(vec2 vertex, float angle) {
 void main(void) {
   geometry.worldPosition = instancePositions;
   geometry.uv = positions;
+  geometry.pickingColor = instancePickingColors;
   uv = positions;
 
   vec2 iconSize = instanceIconFrames.zw;
@@ -99,8 +100,5 @@ void main(void) {
   DECKGL_FILTER_COLOR(vColor, geometry);
 
   vColorMode = instanceColorModes;
-
-  // Set color to be rendered to picking fbo (also used to check for selection highlight).
-  picking_setPickingColor(instancePickingColors);
 }
 `;

--- a/modules/layers/src/line-layer/line-layer-vertex.glsl.js
+++ b/modules/layers/src/line-layer/line-layer-vertex.glsl.js
@@ -71,6 +71,7 @@ void main(void) {
   geometry.position = mix(source_commonspace, target_commonspace, segmentIndex);
   uv = positions.xy;
   geometry.uv = uv;
+  geometry.pickingColor = instancePickingColors;
 
   // extrude
   vec3 offset = vec3(
@@ -83,8 +84,5 @@ void main(void) {
   // Color
   vColor = vec4(instanceColors.rgb, instanceColors.a * opacity);
   DECKGL_FILTER_COLOR(vColor, geometry);
-
-  // Set color to be rendered to picking fbo (also used to check for selection highlight).
-  picking_setPickingColor(instancePickingColors);
 }
 `;

--- a/modules/layers/src/path-layer/path-layer-vertex.glsl.js
+++ b/modules/layers/src/path-layer/path-layer-vertex.glsl.js
@@ -215,11 +215,9 @@ void clipLine(inout vec4 position, vec4 refPosition) {
 void main() {
   geometry.worldPosition = instanceStartPositions;
   geometry.worldPositionAlt = instanceEndPositions;
+  geometry.pickingColor = instancePickingColors;
 
   vColor = vec4(instanceColors.rgb, instanceColors.a * opacity);
-
-  // Set color to be rendered to picking fbo (also used to check for selection highlight).
-  picking_setPickingColor(instancePickingColors);
 
   float isEnd = positions.x;
 

--- a/modules/layers/src/point-cloud-layer/point-cloud-layer-vertex.glsl.js
+++ b/modules/layers/src/point-cloud-layer/point-cloud-layer-vertex.glsl.js
@@ -41,6 +41,7 @@ void main(void) {
   // position on the containing square in [-1, 1] space
   unitPosition = positions.xy;
   geometry.uv = unitPosition;
+  geometry.pickingColor = instancePickingColors;
 
   // Find the center of the point and add the current vertex
   vec3 offset = vec3(positions.xy * radiusPixels, 0.0);
@@ -56,8 +57,5 @@ void main(void) {
   // Apply opacity to instance color, or return instance picking color
   vColor = vec4(lightColor, instanceColors.a * opacity);
   DECKGL_FILTER_COLOR(vColor, geometry);
-
-  // Set color to be rendered to picking fbo (also used to check for selection highlight).
-  picking_setPickingColor(instancePickingColors);
 }
 `;

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer-vertex.glsl.js
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer-vertex.glsl.js
@@ -67,6 +67,7 @@ void main(void) {
   // position on the containing square in [-1, 1] space
   unitPosition = positions.xy;
   geometry.uv = unitPosition;
+  geometry.pickingColor = instancePickingColors;
 
   innerUnitRadius = 1.0 - stroked * lineWidthPixels / outerRadiusPixels;
   
@@ -80,8 +81,5 @@ void main(void) {
   DECKGL_FILTER_COLOR(vFillColor, geometry);
   vLineColor = vec4(instanceLineColors.rgb, instanceLineColors.a * opacity);
   DECKGL_FILTER_COLOR(vLineColor, geometry);
-  
-  // Set color to be rendered to picking fbo (also used to check for selection highlight).
-  picking_setPickingColor(instancePickingColors);
 }
 `;

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-main.glsl.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-main.glsl.js
@@ -73,10 +73,7 @@ void calculatePosition(PolygonProps props) {
 #endif
 
   if (extruded) {
-    float elevation = props.elevations * vertexPositions.y * elevationScale;
-    pos.z += elevation;
-    geometry.worldPosition.z += elevation;
-    geometry.worldPositionAlt.z += elevation;
+    pos.z += props.elevations * vertexPositions.y * elevationScale;
     
 #ifdef IS_SIDE_VERTEX
     normal = vec3(props.positions.y - props.nextPositions.y, props.nextPositions.x - props.positions.x, 0.0);

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-main.glsl.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-main.glsl.js
@@ -60,6 +60,7 @@ void calculatePosition(PolygonProps props) {
 
   geometry.worldPosition = props.positions;
   geometry.worldPositionAlt = props.nextPositions;
+  geometry.pickingColor = props.pickingColors;
 
 #ifdef IS_SIDE_VERTEX
   pos = mix(props.positions, props.nextPositions, vertexPositions.x);
@@ -72,7 +73,10 @@ void calculatePosition(PolygonProps props) {
 #endif
 
   if (extruded) {
-    pos.z += props.elevations * vertexPositions.y * elevationScale;
+    float elevation = props.elevations * vertexPositions.y * elevationScale;
+    pos.z += elevation;
+    geometry.worldPosition.z += elevation;
+    geometry.worldPositionAlt.z += elevation;
     
 #ifdef IS_SIDE_VERTEX
     normal = vec3(props.positions.y - props.nextPositions.y, props.nextPositions.x - props.positions.x, 0.0);
@@ -93,8 +97,5 @@ void calculatePosition(PolygonProps props) {
     vColor = vec4(colors.rgb, colors.a * opacity);
   }
   DECKGL_FILTER_COLOR(vColor, geometry);
-
-  // Set color to be rendered to picking fbo (also used to check for selection highlight).
-  picking_setPickingColor(props.pickingColors);
 }
 `;

--- a/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer-vertex.glsl.js
+++ b/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer-vertex.glsl.js
@@ -60,6 +60,7 @@ vec2 rotate_by_angle(vec2 vertex, float angle) {
 void main(void) {
   geometry.worldPosition = instancePositions;
   geometry.uv = positions;
+  geometry.pickingColor = instancePickingColors;
   uv = positions;
 
   vec2 iconSize = instanceIconFrames.zw;
@@ -103,7 +104,6 @@ void main(void) {
 
   vColor = vec4(instanceColors.rgb, instanceColors.a * opacity);
   DECKGL_FILTER_COLOR(vColor, geometry);
-  picking_setPickingColor(instancePickingColors);
 
   vGamma = gamma / (sizeScale * iconSize.y);
 }

--- a/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer-vertex.glsl.js
+++ b/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer-vertex.glsl.js
@@ -51,6 +51,7 @@ void main(void) {
   #endif
 
   geometry.worldPosition = instancePositions;
+  geometry.pickingColor = instancePickingColors;
 
   #ifdef MODULE_PBR
     // set PBR data
@@ -87,7 +88,5 @@ void main(void) {
 
   vColor = instanceColors;
   DECKGL_FILTER_COLOR(vColor, geometry);
-
-  picking_setPickingColor(instancePickingColors);
 }
 `;

--- a/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer-vertex.glsl.js
+++ b/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer-vertex.glsl.js
@@ -27,6 +27,7 @@ out vec4 vColor;
 void main(void) {
   geometry.worldPosition = instancePositions;
   geometry.uv = texCoords;
+  geometry.pickingColor = instancePickingColors;
 
   vTexCoord = texCoords;
   cameraPosition = project_uCameraPosition;
@@ -43,7 +44,5 @@ void main(void) {
   DECKGL_FILTER_GL_POSITION(gl_Position, geometry);
 
   DECKGL_FILTER_COLOR(vColor, geometry);
-
-  picking_setPickingColor(instancePickingColors);
 }
 `;

--- a/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer-vertex.glsl1.js
+++ b/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer-vertex.glsl1.js
@@ -27,6 +27,7 @@ varying vec4 vColor;
 void main(void) {
   geometry.worldPosition = instancePositions;
   geometry.uv = texCoords;
+  geometry.pickingColor = instancePickingColors;
 
   vTexCoord = texCoords;
   cameraPosition = project_uCameraPosition;
@@ -43,7 +44,5 @@ void main(void) {
   DECKGL_FILTER_GL_POSITION(gl_Position, geometry);
 
   DECKGL_FILTER_COLOR(vColor, geometry);
-
-  picking_setPickingColor(instancePickingColors);
 }
 `;


### PR DESCRIPTION
For #3719

#### Background

This change removes picking module-specific calls from individual shaders. This is in preparation of adding more sophisticated picking logic.

#### Change List
- Add `pickingColor` to `geometry` struct
- Remove `picking_setPickingColor` calls from layer vertex shaders.
