### PR TITLE
Picking 3D point

### DIFF
--- a/docs/api-reference/deck.md
+++ b/docs/api-reference/deck.md
@@ -399,6 +399,7 @@ deck.pickObject({x, y, radius, layerIds})
 * `y` (Number) - y position in pixels
 * `radius` (Number, optional) - radius of tolerance in pixels. Default `0`.
 * `layerIds` (Array, optional) - a list of layer ids to query from. If not specified, then all pickable and visible layers are queried.
+* `unproject3D` (Boolean, optional) - if `true`, `info.coordinate` will be a 3D point by unprojecting the `x, y` screen coordinates onto the picked geometry. Default `false`.
 
 Returns:
 
@@ -418,6 +419,7 @@ deck.pickMultipleObjects({x, y, radius, layerIds, depth})
 * `radius`=`0` (Number, optional) - radius of tolerance in pixels.
 * `layerIds`=`null` (Array, optional) - a list of layer ids to query from. If not specified, then all pickable and visible layers are queried.
 * `depth`=`10` - Specifies the max
+* `unproject3D` (Boolean, optional) - if `true`, `info.coordinate` will be a 3D point by unprojecting the `x, y` screen coordinates onto the picked geometry. Default `false`.
 
 Returns:
 

--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -124,7 +124,7 @@ export default class App extends PureComponent {
   }
 
   _multiDepthPick({x, y}) {
-    this.mapRef.current.pickMultipleObjects({x, y});
+    this.mapRef.current.pickMultipleObjects({x, y, unproject3D: true});
   }
 
   _renderExampleLayer(example, settings, index) {

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -32,8 +32,8 @@
   "dependencies": {
     "@loaders.gl/core": "^1.3.3",
     "@loaders.gl/images": "^1.3.3",
-    "@luma.gl/addons": "^7.3.0",
-    "@luma.gl/core": "^7.3.0",
+    "@luma.gl/addons": "^7.4.0-alpha.1",
+    "@luma.gl/core": "^7.4.0-alpha.1",
     "gl-matrix": "^3.0.0",
     "math.gl": "^3.0.0",
     "mjolnir.js": "^2.1.2",

--- a/modules/core/src/lib/deck-picker.js
+++ b/modules/core/src/lib/deck-picker.js
@@ -187,7 +187,7 @@ export default class DeckPicker {
         deviceRect
       });
 
-      let z = 0;
+      let z;
       if (pickInfo.pickedLayer && unproject3D) {
         const zValues = this.drawAndSamplePickingBuffer({
           layers: [pickInfo.pickedLayer],
@@ -198,7 +198,7 @@ export default class DeckPicker {
           drawZ: true
         });
 
-        z = zValues[0] * 255 + zValues[1] + zValues[2] / 255;
+        z = (zValues[0] / 256 + zValues[1] + zValues[2] * 256) / 16;
         z *= viewports[0].distanceScales.metersPerPixel[2];
       }
 

--- a/modules/core/src/lib/deck-picker.js
+++ b/modules/core/src/lib/deck-picker.js
@@ -195,10 +195,10 @@ export default class DeckPicker {
           onViewportActive,
           deviceRect: {x: pickInfo.pickedX, y: pickInfo.pickedY, width: 1, height: 1},
           redrawReason: 'pick-z',
-          drawZ: true
+          pickZ: true
         });
 
-        z = (zValues[0] / 256 + zValues[1] + zValues[2] * 256) / 16;
+        z = (zValues[0] / 65536 + zValues[1] / 256 + zValues[2]) / 256 * viewports[0].height * pixelRatio;
         z *= viewports[0].distanceScales.metersPerPixel[2];
       }
 
@@ -311,7 +311,7 @@ export default class DeckPicker {
     onViewportActive,
     deviceRect,
     redrawReason,
-    drawZ
+    pickZ
   }) {
     assert(deviceRect);
     assert(Number.isFinite(deviceRect.width) && deviceRect.width > 0, '`width` must be > 0');
@@ -335,7 +335,7 @@ export default class DeckPicker {
       deviceRect,
       redrawReason,
       effectProps,
-      drawZ
+      pickZ
     });
 
     // Read from an already rendered picking buffer

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -219,6 +219,11 @@ export default class Deck {
       this.deckRenderer = null;
     }
 
+    if (this.deckPicker) {
+      this.deckPicker.finalize();
+      this.deckPicker = null;
+    }
+
     if (this.eventManager) {
       this.eventManager.destroy();
     }

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -351,7 +351,7 @@ export default class Deck {
     return this.viewManager.getViewports(rect);
   }
 
-  pickObject({x, y, radius = 0, layerIds = null}) {
+  pickObject({x, y, radius = 0, layerIds = null, unproject3D}) {
     this.stats.get('Pick Count').incrementCount();
     this.stats.get('pickObject Time').timeStart();
     const layers = this.layerManager.getLayers({layerIds});
@@ -360,6 +360,7 @@ export default class Deck {
       x,
       y,
       radius,
+      unproject3D,
       layers,
       viewports: this.getViewports({x, y}),
       activateViewport,
@@ -370,7 +371,7 @@ export default class Deck {
     return selectedInfos.length ? selectedInfos[0] : null;
   }
 
-  pickMultipleObjects({x, y, radius = 0, layerIds = null, depth = 10}) {
+  pickMultipleObjects({x, y, radius = 0, layerIds = null, unproject3D, depth = 10}) {
     this.stats.get('Pick Count').incrementCount();
     this.stats.get('pickMultipleObjects Time').timeStart();
     const layers = this.layerManager.getLayers({layerIds});
@@ -379,6 +380,7 @@ export default class Deck {
       x,
       y,
       radius,
+      unproject3D,
       layers,
       viewports: this.getViewports({x, y}),
       activateViewport,

--- a/modules/core/src/lib/picking/pick-info.js
+++ b/modules/core/src/lib/picking/pick-info.js
@@ -29,8 +29,7 @@ export function processPickInfo({
   viewports,
   x,
   y,
-  deviceX,
-  deviceY,
+  z,
   pixelRatio
 }) {
   const {pickedColor, pickedLayer, pickedObjectIndex} = pickInfo;
@@ -64,7 +63,7 @@ export function processPickInfo({
   }
 
   const viewport = getViewportFromCoordinates({viewports}); // TODO - add coords
-  const coordinate = viewport && viewport.unproject([x, y]);
+  const coordinate = viewport && viewport.unproject([x, y], {targetZ: z});
 
   const baseInfo = {
     color: null,
@@ -77,7 +76,7 @@ export function processPickInfo({
     coordinate,
     // TODO remove the lngLat prop after compatibility check
     lngLat: coordinate,
-    devicePixel: [deviceX, deviceY],
+    devicePixel: [pickInfo.pickedX, pickInfo.pickedY],
     pixelRatio
   };
 

--- a/modules/core/src/lib/picking/query-object.js
+++ b/modules/core/src/lib/picking/query-object.js
@@ -80,7 +80,9 @@ export function getClosestObject({
       const pickedLayer = layers[pickedLayerIndex];
       if (pickedLayer) {
         const pickedObjectIndex = pickedLayer.decodePickingColor(pickedColor);
-        return {pickedColor, pickedLayer, pickedObjectIndex};
+        const dy = Math.floor(closestPixelIndex / 4 / width);
+        const dx = closestPixelIndex / 4 - dy * width;
+        return {pickedColor, pickedLayer, pickedObjectIndex, pickedX: x + dx, pickedY: y + dy};
       }
       log.error('Picked non-existent layer. Is picking buffer corrupt?')();
     }

--- a/modules/core/src/passes/pick-layers-pass.js
+++ b/modules/core/src/passes/pick-layers-pass.js
@@ -20,8 +20,11 @@ export default class PickLayersPass extends LayersPass {
     pickingFBO,
     effectProps,
     deviceRect: {x, y, width, height},
-    redrawReason = ''
+    redrawReason = '',
+    drawZ
   }) {
+    effectProps.drawZ = drawZ;
+
     const gl = this.gl;
     // Make sure we clear scissor test and fbo bindings in case of exceptions
     // We are only interested in one pixel, no need to render anything else
@@ -37,6 +40,24 @@ export default class PickLayersPass extends LayersPass {
         clearColor: [0, 0, 0, 0]
       },
       () => {
+        const parameters = {
+          blend: true,
+          blendFunc: [gl.ONE, gl.ZERO, gl.CONSTANT_ALPHA, gl.ZERO],
+          blendEquation: gl.FUNC_ADD,
+          blendColor: [0, 0, 0, 0],
+          // When used as Mapbox custom layer, the context state may be dirty
+          // TODO - Remove when mapbox fixes this issue
+          // https://github.com/mapbox/mapbox-gl-js/issues/7801
+          depthMask: true,
+          depthTest: true,
+          depthRange: [0, 1],
+          colorMask: [true, true, true, true]
+        };
+
+        if (drawZ) {
+          parameters.blend = false;
+        }
+
         this.drawLayers({
           layers,
           viewports,
@@ -44,20 +65,7 @@ export default class PickLayersPass extends LayersPass {
           pass: 'picking',
           redrawReason,
           effectProps,
-          parameters: {
-            blend: true,
-            blendFunc: [gl.ONE, gl.ZERO, gl.CONSTANT_ALPHA, gl.ZERO],
-            blendEquation: gl.FUNC_ADD,
-            blendColor: [0, 0, 0, 0],
-
-            // When used as Mapbox custom layer, the context state may be dirty
-            // TODO - Remove when mapbox fixes this issue
-            // https://github.com/mapbox/mapbox-gl-js/issues/7801
-            depthMask: true,
-            depthTest: true,
-            depthRange: [0, 1],
-            colorMask: [true, true, true, true]
-          }
+          parameters
         });
       }
     );
@@ -78,6 +86,7 @@ export default class PickLayersPass extends LayersPass {
     const moduleParameters = Object.assign(Object.create(layer.props), {
       viewport: layer.context.viewport,
       pickingActive: 1,
+      pickingDrawZ: effectProps.drawZ,
       devicePixelRatio: cssToDeviceRatio(this.gl)
     });
 

--- a/modules/core/src/passes/pick-layers-pass.js
+++ b/modules/core/src/passes/pick-layers-pass.js
@@ -21,9 +21,9 @@ export default class PickLayersPass extends LayersPass {
     effectProps,
     deviceRect: {x, y, width, height},
     redrawReason = '',
-    drawZ
+    pickZ
   }) {
-    effectProps.drawZ = drawZ;
+    effectProps.pickZ = pickZ;
 
     const gl = this.gl;
     // Make sure we clear scissor test and fbo bindings in case of exceptions
@@ -54,7 +54,7 @@ export default class PickLayersPass extends LayersPass {
           colorMask: [true, true, true, true]
         };
 
-        if (drawZ) {
+        if (pickZ) {
           parameters.blend = false;
         }
 
@@ -86,7 +86,7 @@ export default class PickLayersPass extends LayersPass {
     const moduleParameters = Object.assign(Object.create(layer.props), {
       viewport: layer.context.viewport,
       pickingActive: 1,
-      pickingDrawZ: effectProps.drawZ,
+      pickingAttribute: effectProps.pickZ,
       devicePixelRatio: cssToDeviceRatio(this.gl)
     });
 

--- a/modules/core/src/shaderlib/picking/picking.js
+++ b/modules/core/src/shaderlib/picking/picking.js
@@ -3,7 +3,11 @@ import {picking, createModuleInjection} from '@luma.gl/core';
 createModuleInjection('picking', {
   hook: 'vs:DECKGL_FILTER_COLOR',
   injection: `
+  if (picking_uDrawZ) {
+    picking_setZ(geometry.position.z, geometry.pickingColor);
+  } else {
     picking_setPickingColor(geometry.pickingColor);
+  }
 `
 });
 
@@ -11,12 +15,51 @@ createModuleInjection('picking', {
   hook: 'fs:DECKGL_FILTER_COLOR',
   order: 99,
   injection: `
+  if (picking_uDrawZ) {
+    color = picking_getZColor();
+  } else {
     // use highlight color if this fragment belongs to the selected object.
     color = picking_filterHighlightColor(color);
 
     // use picking color if rendering to picking FBO.
     color = picking_filterPickingColor(color);
-  `
+  }
+`
 });
 
-export default picking;
+export default {
+  ...picking,
+  dependencies: ['project'],
+  getUniforms: opts => {
+    const uniforms = picking.getUniforms(opts);
+    if (opts && opts.pickingActive !== undefined) {
+      uniforms.picking_uDrawZ = Boolean(opts.pickingActive && opts.pickingDrawZ);
+    }
+    return uniforms;
+  },
+  vs: `\
+const vec3 bitPackShift = vec3(1.0 / 65025.0, 1.0 / 255.0, 1.0);
+
+uniform bool picking_uDrawZ;
+${picking.vs}
+
+void picking_setZ(float z, vec3 pickingColor) {
+  vec3 rgbZ = fract(z * bitPackShift);
+  rgbZ.rg -= rgbZ.gb / 255.0;
+  picking_vRGBcolor_Aselected.rgb = rgbZ;
+  // Use alpha as the validity flag. If pickingColor is [0, 0, 0] fragment is non-pickable
+  picking_vRGBcolor_Aselected.a = step(0.5, length(pickingColor));
+}
+`,
+  fs: `\
+uniform bool picking_uDrawZ;
+${picking.fs}
+
+vec4 picking_getZColor() {
+  if (picking_vRGBcolor_Aselected.a == 0.0) {
+    discard;
+  }
+  return picking_vRGBcolor_Aselected;
+}
+`
+};

--- a/modules/core/src/shaderlib/picking/picking.js
+++ b/modules/core/src/shaderlib/picking/picking.js
@@ -29,7 +29,6 @@ createModuleInjection('picking', {
 
 export default {
   ...picking,
-  dependencies: ['project'],
   getUniforms: opts => {
     const uniforms = picking.getUniforms(opts);
     if (opts && opts.pickingActive !== undefined) {
@@ -38,15 +37,18 @@ export default {
     return uniforms;
   },
   vs: `\
-const vec3 bitPackShift = vec3(1.0 / 65025.0, 1.0 / 255.0, 1.0);
+// z is in common space (pixels). This packing supports up to 4096p viewport @resolution 1/256/16 (0.02%)
+const vec3 bitPackShift = vec3(16.0, 1.0 / 16.0, 1.0 / 4096.0);
+const float packUpscale = 256.0 / 255.0;
+const float shiftRight = 1. / 256.;
 
 uniform bool picking_uDrawZ;
 ${picking.vs}
 
 void picking_setZ(float z, vec3 pickingColor) {
   vec3 rgbZ = fract(z * bitPackShift);
-  rgbZ.rg -= rgbZ.gb / 255.0;
-  picking_vRGBcolor_Aselected.rgb = rgbZ;
+  rgbZ.gb -= rgbZ.rg * shiftRight;
+  picking_vRGBcolor_Aselected.rgb = rgbZ * packUpscale;
   // Use alpha as the validity flag. If pickingColor is [0, 0, 0] fragment is non-pickable
   picking_vRGBcolor_Aselected.a = step(0.5, length(pickingColor));
 }

--- a/modules/core/src/shaderlib/picking/picking.js
+++ b/modules/core/src/shaderlib/picking/picking.js
@@ -3,8 +3,10 @@ import {picking, createModuleInjection} from '@luma.gl/core';
 createModuleInjection('picking', {
   hook: 'vs:DECKGL_FILTER_COLOR',
   injection: `
-  if (picking_uDrawZ) {
-    picking_setZ(geometry.position.z, geometry.pickingColor);
+  if (picking_uAttribute) {
+    // z is in common space (pixels). Normalize it by viewport height
+    float z = geometry.position.z / project_uViewportSize.y;
+    picking_setPickingAttribute(geometry.pickingColor, z);
   } else {
     picking_setPickingColor(geometry.pickingColor);
   }
@@ -15,53 +17,12 @@ createModuleInjection('picking', {
   hook: 'fs:DECKGL_FILTER_COLOR',
   order: 99,
   injection: `
-  if (picking_uDrawZ) {
-    color = picking_getZColor();
-  } else {
     // use highlight color if this fragment belongs to the selected object.
     color = picking_filterHighlightColor(color);
 
     // use picking color if rendering to picking FBO.
     color = picking_filterPickingColor(color);
-  }
 `
 });
 
-export default {
-  ...picking,
-  getUniforms: opts => {
-    const uniforms = picking.getUniforms(opts);
-    if (opts && opts.pickingActive !== undefined) {
-      uniforms.picking_uDrawZ = Boolean(opts.pickingActive && opts.pickingDrawZ);
-    }
-    return uniforms;
-  },
-  vs: `\
-// z is in common space (pixels). This packing supports up to 4096p viewport @resolution 1/256/16 (0.02%)
-const vec3 bitPackShift = vec3(16.0, 1.0 / 16.0, 1.0 / 4096.0);
-const float packUpscale = 256.0 / 255.0;
-const float shiftRight = 1. / 256.;
-
-uniform bool picking_uDrawZ;
-${picking.vs}
-
-void picking_setZ(float z, vec3 pickingColor) {
-  vec3 rgbZ = fract(z * bitPackShift);
-  rgbZ.gb -= rgbZ.rg * shiftRight;
-  picking_vRGBcolor_Aselected.rgb = rgbZ * packUpscale;
-  // Use alpha as the validity flag. If pickingColor is [0, 0, 0] fragment is non-pickable
-  picking_vRGBcolor_Aselected.a = step(0.5, length(pickingColor));
-}
-`,
-  fs: `\
-uniform bool picking_uDrawZ;
-${picking.fs}
-
-vec4 picking_getZColor() {
-  if (picking_vRGBcolor_Aselected.a == 0.0) {
-    discard;
-  }
-  return picking_vRGBcolor_Aselected;
-}
-`
-};
+export default picking;

--- a/modules/core/src/shaderlib/picking/picking.js
+++ b/modules/core/src/shaderlib/picking/picking.js
@@ -3,13 +3,9 @@ import {picking, createModuleInjection} from '@luma.gl/core';
 createModuleInjection('picking', {
   hook: 'vs:DECKGL_FILTER_COLOR',
   injection: `
-  if (picking_uAttribute) {
-    // z is in common space (pixels). Normalize it by viewport height
-    float z = geometry.position.z / project_uViewportSize.y;
-    picking_setPickingAttribute(geometry.pickingColor, z);
-  } else {
     picking_setPickingColor(geometry.pickingColor);
-  }
+    // for picking depth values
+    picking_setPickingAttribute(geometry.position.z);
 `
 });
 

--- a/modules/mesh-layers/package.json
+++ b/modules/mesh-layers/package.json
@@ -33,6 +33,6 @@
     "@deck.gl/core": "^7.3.0-beta"
   },
   "dependencies": {
-    "@luma.gl/addons": "^7.3.0"
+    "@luma.gl/addons": "^7.4.0-alpha.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "jsdom": false
   },
   "devDependencies": {
-    "@luma.gl/effects": "^7.3.0",
+    "@luma.gl/effects": "^7.4.0-alpha.1",
     "@probe.gl/bench": "^3.1.1",
     "@probe.gl/test-utils": "^3.1.1",
     "@loaders.gl/csv": "^1.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1591,81 +1591,81 @@
     stream-to-async-iterator "^0.2.0"
     through "^2.3.8"
 
-"@luma.gl/addons@^7.3.0":
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/@luma.gl/addons/-/addons-7.3.0.tgz#ad094d54e9b178de17c97a5ab0550ea4a5ba3e3b"
-  integrity sha512-MOQqXFF90lhGa8CxfjEmKad2XZ9twLlCbvgyQmC+8zgaPcZRFPLIQQ7D1vGYgld7Wyp5hOBKUDuOCTmd6A18yA==
+"@luma.gl/addons@^7.4.0-alpha.1":
+  version "7.4.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@luma.gl/addons/-/addons-7.4.0-alpha.1.tgz#7f08fb04b9bc8848ede1f83eda0e7a3fdebc6f0a"
+  integrity sha512-xg5h7r9z97oAgVH18QT7CVF13M4luGHvb9ZGkO3+Q4zVrMvRcwmTnav7+4cl6jem0unIw/47vwbbRGSkr8i/Dg==
   dependencies:
     "@loaders.gl/gltf" "^1.3.0"
     "@loaders.gl/images" "^1.3.0"
-    "@luma.gl/constants" "7.3.0"
+    "@luma.gl/constants" "7.4.0-alpha.1"
     math.gl "^3.0.0"
 
-"@luma.gl/constants@7.3.0":
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/@luma.gl/constants/-/constants-7.3.0.tgz#b1c45f22ccdd0f2b7064df3d76c44e30d19e3252"
-  integrity sha512-0fpcllcA5xvN+H5Ndro3xIWf8VlEGzY+TMt9OQIUnxKHtlzsU2TvPp5ds1c+25MGB4oiuwcvZrzPnOGrxDzkjg==
+"@luma.gl/constants@7.4.0-alpha.1":
+  version "7.4.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@luma.gl/constants/-/constants-7.4.0-alpha.1.tgz#cc5c98987dfb9b962a79327abfca88a9843d5125"
+  integrity sha512-NeNwcjeSImPHVUTwkMWdyDKZ7jmVQ+eqM5DXPR7MgmQfKwVduNEzFVmIltuTWqQAD+MgUoYuBrBJvrb+eTWUtg==
 
 "@luma.gl/constants@^7.3.0-alpha.1":
   version "7.3.0-alpha.8"
   resolved "https://registry.yarnpkg.com/@luma.gl/constants/-/constants-7.3.0-alpha.8.tgz#900dd18a157e9c9a0886aba6f79fae80006c2bc4"
   integrity sha512-MjEBfWCqYrYREMHh+XQneJlYDK+Z5Uh7cvodUhugaWRKoVbQI884ISAt4+6tWJj5DXQC/k8V1ypa+Hd3hY+oBw==
 
-"@luma.gl/core@^7.3.0":
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/@luma.gl/core/-/core-7.3.0.tgz#9d3c218497abbe23aed63b9195dd7fb9c63b8a8d"
-  integrity sha512-CV4i4hQ54NAv3THvRb6WVjE4ckJL6AlDy59LnNRbGQgrs+QLeoi2f8mH9Wu5IeMPUK16CfvCSUDko3Y/54toRg==
+"@luma.gl/core@^7.4.0-alpha.1":
+  version "7.4.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@luma.gl/core/-/core-7.4.0-alpha.1.tgz#4628465ffc25bf01ba5dfc7cb379747e9db70dbf"
+  integrity sha512-Ttl/IDFWnd3fP7yyRnXwBqXYX0E839rf66Q9CB2Z0eJzDDJhyzlADop4nOgocPJOf4ls7qgGujeDQfazFrljGQ==
   dependencies:
     "@babel/runtime" "^7.0.0"
-    "@luma.gl/constants" "7.3.0"
-    "@luma.gl/shadertools" "7.3.0"
-    "@luma.gl/webgl" "7.3.0"
-    "@luma.gl/webgl-state-tracker" "7.3.0"
-    "@luma.gl/webgl2-polyfill" "7.3.0"
+    "@luma.gl/constants" "7.4.0-alpha.1"
+    "@luma.gl/shadertools" "7.4.0-alpha.1"
+    "@luma.gl/webgl" "7.4.0-alpha.1"
+    "@luma.gl/webgl-state-tracker" "7.4.0-alpha.1"
+    "@luma.gl/webgl2-polyfill" "7.4.0-alpha.1"
     math.gl "^3.0.0"
     probe.gl "^3.1.1"
     seer "^0.2.4"
 
-"@luma.gl/effects@^7.3.0":
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/@luma.gl/effects/-/effects-7.3.0.tgz#d94a716235273de1cd8e2dc852b913e5fc6c96a4"
-  integrity sha512-G0Q8OmVXfzJlWTMew2yaOMJXzalW5R4qaU+8lgldV3NVR39/BI5i+DwpgWcFxR0D5Vx7xgRUWYRr8w1LtwXy+w==
+"@luma.gl/effects@^7.4.0-alpha.1":
+  version "7.4.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@luma.gl/effects/-/effects-7.4.0-alpha.1.tgz#a6bcf28a4d8715fd37743929d3d7ca09ee777a4c"
+  integrity sha512-qmQt+O2Memh7VLBVLgzfIJeL0ehbzdemb1Gabs1sGVopf+qTrZT9hvTmFGttxuCEiR6LcJCZDpJW/KeHTZsezA==
   dependencies:
-    "@luma.gl/constants" "7.3.0"
+    "@luma.gl/constants" "7.4.0-alpha.1"
 
-"@luma.gl/shadertools@7.3.0":
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/@luma.gl/shadertools/-/shadertools-7.3.0.tgz#3063eecad375c778b58bfbff3e5adf2ca98fe648"
-  integrity sha512-2rKmU7YYGOK2vDIMCPcIUQplRRK2HTDxajdyq81YLR8VkI/VdJI9xNinwmhDBnz9thSMcw6+usvZclKQs/Eu5w==
+"@luma.gl/shadertools@7.4.0-alpha.1":
+  version "7.4.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@luma.gl/shadertools/-/shadertools-7.4.0-alpha.1.tgz#8cf969f511549bbdf0d82aeb5f38c615e4b357e1"
+  integrity sha512-3OIS1YFAat43511ulwIJSS1DfGXMPBqNl4kpMLYnR/CkLs9r1GiK9288SNwrf+NBKlS3zvcXsDx8xckuIYKjwg==
   dependencies:
     "@babel/runtime" "^7.0.0"
     math.gl "^3.0.0"
 
-"@luma.gl/webgl-state-tracker@7.3.0":
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/@luma.gl/webgl-state-tracker/-/webgl-state-tracker-7.3.0.tgz#8212ba5d0b495d971fc3bcc5371831dbb72c1dea"
-  integrity sha512-NO/hV68XHMS5oJX62iF0ELJUVcDyleCtvBHmDUKUV1dAWHxpeTd9q27HCLcBcKdhW9l0FQe8g95FfJi3atyRIA==
+"@luma.gl/webgl-state-tracker@7.4.0-alpha.1":
+  version "7.4.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@luma.gl/webgl-state-tracker/-/webgl-state-tracker-7.4.0-alpha.1.tgz#9a9c40cb5cb563caf86a1b85c38831ee21d66db2"
+  integrity sha512-msTGr3aYf0xev9Z/DBzxeCcEaT6YP3EP8SxqxTSrsNGUe+TEfWfAbfoHfwJDkbYTL0lbS4oqSNn6qX6X6la7qg==
   dependencies:
     "@babel/runtime" "^7.0.0"
-    "@luma.gl/constants" "7.3.0"
+    "@luma.gl/constants" "7.4.0-alpha.1"
 
-"@luma.gl/webgl2-polyfill@7.3.0":
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/@luma.gl/webgl2-polyfill/-/webgl2-polyfill-7.3.0.tgz#20042aa451d24fc77c40011dcb8cabf1d4995f4f"
-  integrity sha512-OH+JpwOTIZBd1EKP2TRaoKuNAZKQlEJj69HoeDqukO79PFSz4vmlJwC2kscwdBGVKG+IYQiyxcaIlAJBd0uzhw==
+"@luma.gl/webgl2-polyfill@7.4.0-alpha.1":
+  version "7.4.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@luma.gl/webgl2-polyfill/-/webgl2-polyfill-7.4.0-alpha.1.tgz#7b900f9e413979f09f9fe5af42e6a7808a2cda33"
+  integrity sha512-o2pvBpnLw1rmPzrjWVrY48K+ttfmULs3R5fPoulqFg8QtaMbcBWxczsIBf2km+jTqFTJOjWNjowxhrSaefs1aw==
   dependencies:
     "@babel/runtime" "^7.0.0"
-    "@luma.gl/constants" "7.3.0"
+    "@luma.gl/constants" "7.4.0-alpha.1"
 
-"@luma.gl/webgl@7.3.0":
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/@luma.gl/webgl/-/webgl-7.3.0.tgz#a21ff91b46d8cdc6af7d430c235f0ae5faf68b79"
-  integrity sha512-hgrgiflKKMksSyfSkQft/9NXeBZms8Wv5WPKL9erxhZWZWDRoTGeeRAJ9QN7LRbN9lFIHgmu6SxmGVer2ABm8g==
+"@luma.gl/webgl@7.4.0-alpha.1":
+  version "7.4.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@luma.gl/webgl/-/webgl-7.4.0-alpha.1.tgz#bb397f6ffd6f4e2be8bef21ed80ac9a777b12e6e"
+  integrity sha512-0KOXsoXYvAwna3QSCCxX0VLTay1mI6nzOl2wih9mruILBoN3A8RR4cTZcYIqbGmTw+U0a2VMTSeLX/VwwFg/Uw==
   dependencies:
     "@babel/runtime" "^7.0.0"
-    "@luma.gl/constants" "7.3.0"
-    "@luma.gl/webgl-state-tracker" "7.3.0"
-    "@luma.gl/webgl2-polyfill" "7.3.0"
+    "@luma.gl/constants" "7.4.0-alpha.1"
+    "@luma.gl/webgl-state-tracker" "7.4.0-alpha.1"
+    "@luma.gl/webgl2-polyfill" "7.4.0-alpha.1"
     probe.gl "^3.1.1"
 
 "@mapbox/geojson-area@0.2.2":


### PR DESCRIPTION
For #3719

Requires https://github.com/uber/luma.gl/pull/1268

This PR demonstrates that by adding a new render pass (a variation of the picking pass) we can retrieve the accurate world position of the picked fragment.

The additional pass is performed after the regular picking pass, when the picking info is processed. It draws the picked layer into the picked pixel (a 1x1 framebuffer), using color to encode the world z. After decoding the Z value of the picked pixel, we can unproject the cursor position accurately into the 3D space.

#### Performance

- The new pass is opt-in so that it doesn't affect performance of existing use cases.
- The new pass is cheaper than the picking pass because it
  + disables blending
  + only renders one layer
  + only renders one pixel (regardless of `pickingRadius`)
  + decoding z is very cheap
- Further optimization may be made if we could draw only the picked geometry. This may need to happen at the luma.gl level. There is a draft proposal [WEBGL_draw_instanced_base_vertex_base_instance](https://www.khronos.org/registry/webgl/extensions/WEBGL_draw_instanced_base_vertex_base_instance/) per @tsherif's suggestion.

#### Change List
- Add a `unproject3D` option to `deck.pickObject` and `deck.pickMultipleObjects`
- `picking` shader module can optionally encode world Z instead of object index.
