### PR TITLE
Clean up picking code

### DIFF
--- a/modules/core/src/lib/picking/pick-info.js
+++ b/modules/core/src/lib/picking/pick-info.js
@@ -152,3 +152,38 @@ function getViewportFromCoordinates({viewports}) {
   const viewport = viewports[0];
   return viewport;
 }
+
+// Per-layer event handlers (e.g. onClick, onHover) are provided by the
+// user and out of deck.gl's control. It's very much possible that
+// the user calls React lifecycle methods in these function, such as
+// ReactComponent.setState(). React lifecycle methods sometimes induce
+// a re-render and re-generation of props of deck.gl and its layers,
+// which invalidates all layers currently passed to this very function.
+
+// Therefore, per-layer event handlers must be invoked at the end
+// of the picking operation. NO operation that relies on the states of current
+// layers should be called after this code.
+export function callLayerPickingCallbacks(infos, mode, event) {
+  const unhandledPickInfos = [];
+
+  infos.forEach(info => {
+    if (!info.layer) {
+      return;
+    }
+
+    let handled = false;
+    switch (mode) {
+      case 'hover':
+        handled = info.layer.onHover(info, event);
+        break;
+      case 'query':
+      default:
+    }
+
+    if (!handled) {
+      unhandledPickInfos.push(info);
+    }
+  });
+
+  return unhandledPickInfos;
+}

--- a/test/modules/core/lib/deck-picker.spec.js
+++ b/test/modules/core/lib/deck-picker.spec.js
@@ -35,7 +35,7 @@ test('DeckPicker#getPickingRect', t => {
 
   for (const testCase of DEVICE_RECT_TEST_CASES) {
     t.deepEqual(
-      deckPicker.getPickingRect(testCase.input),
+      deckPicker._getPickingRect(testCase.input),
       testCase.output,
       `${testCase.title}: returns correct result`
     );


### PR DESCRIPTION
#### Change List

- Private methods naming convention
- Avoid unnecessarily deconstructing and reconstructing objects
