### PR TITLE
Clean up render passes

### DIFF
--- a/modules/core/src/lib/deck-picker.js
+++ b/modules/core/src/lib/deck-picker.js
@@ -50,9 +50,6 @@ export default class DeckPicker {
     if ('layerFilter' in props) {
       this.layerFilter = props.layerFilter;
     }
-    this.pickLayersPass.setProps({
-      layerFilter: this.layerFilter
-    });
   }
 
   finalize() {
@@ -320,6 +317,7 @@ export default class DeckPicker {
 
     this.pickLayersPass.render({
       layers,
+      layerFilter: this.layerFilter,
       viewports,
       onViewportActive,
       pickingFBO,

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -645,15 +645,12 @@ export default class Deck {
 
     this.props.onBeforeRender({gl});
 
-    const layers = this.layerManager.getLayers();
-    const activateViewport = this.layerManager.activateViewport;
-
     this.deckRenderer.renderLayers(
       Object.assign(
         {
-          layers,
+          layers: this.layerManager.getLayers(),
           viewports: this.viewManager.getViewports(),
-          activateViewport,
+          onViewportActive: this.layerManager.activateViewport,
           views: this.viewManager.getViews(),
           pass: 'screen',
           redrawReason,

--- a/modules/test-utils/src/lifecycle-test.js
+++ b/modules/test-utils/src/lifecycle-test.js
@@ -90,7 +90,7 @@ export function testDrawLayer({
       deckRenderer.renderLayers({
         viewports: [viewport],
         layers: layerManager.getLayers(),
-        activateViewport: layerManager.activateViewport
+        onViewportActive: layerManager.activateViewport
       });
     },
     onError
@@ -209,7 +209,7 @@ function runLayerTests(layerManager, deckRenderer, layer, testCases, spies, onEr
         deckRenderer.renderLayers({
           viewports: [viewport],
           layers: layerManager.getLayers(),
-          activateViewport: layerManager.activateViewport
+          onViewportActive: layerManager.activateViewport
         }),
       onError
     );


### PR DESCRIPTION
#### Change List
- Private method naming convention
- Avoid unnecessary breaking/reconstructing parameter objects

