### PR TITLE
Icon layer: Use 2D positions to match vertex shader

### DIFF
--- a/modules/layers/src/icon-layer/icon-layer.js
+++ b/modules/layers/src/icon-layer/icon-layer.js
@@ -201,7 +201,9 @@ export default class IconLayer extends Layer {
   }
 
   _getModel(gl) {
-    const positions = [-1, -1, 0, -1, 1, 0, 1, 1, 0, 1, -1, 0];
+    // The icon-layer vertex shader uses 2d positions
+    // specifed via: attribute vec2 positions;
+    const positions = [-1, -1, -1, 1, 1, 1, 1, -1];
 
     return new Model(
       gl,
@@ -210,7 +212,12 @@ export default class IconLayer extends Layer {
         geometry: new Geometry({
           drawMode: GL.TRIANGLE_FAN,
           attributes: {
-            positions: new Float32Array(positions)
+            // The size must be explicitly passed here otherwise luma.gl
+            // will default to assuming that positions are 3D (x,y,z)
+            positions: {
+              size: 2,
+              value: new Float32Array(positions)
+            }
           }
         }),
         isInstanced: true


### PR DESCRIPTION
In IE11, the icon layer was incorrectly rendered. (#2486)

This is because the IE11 webgl engine was interpreting the position list as 2d elements to match the `attribute vec2 positions;` declared in the [shader](https://github.com/uber/deck.gl/blob/master/modules/layers/src/icon-layer/icon-layer-vertex.glsl.js#L24). Other browsers correctly skipped the `z` coordinate.

#### Change List

* Specify icon-layer positions as 2d points
* Specify to the `Geometry()` that the positions have a size of 2 to override the [default](https://github.com/uber/luma.gl/blob/master/modules/core/src/geometry/geometry.js#L90-L92) luma.gl behaviour of assuming a size of 3.
