### PR TITLE
GPUGridAggregator: enforce point size to workaround ANGLE bug

### DIFF
--- a/modules/aggregation-layers/src/utils/gpu-grid-aggregation/aggregate-all-vs-64.glsl.js
+++ b/modules/aggregation-layers/src/utils/gpu-grid-aggregation/aggregate-all-vs-64.glsl.js
@@ -48,5 +48,7 @@ void main(void) {
   vec2 texCoordYFP64 = div_fp64(xIndexFP64, gridSizeXFP64);
 
   vTextureCoord = vec2(texCoordYFP64.x, texCoordXFP64.x);
+  // Enforce default value for ANGLE issue (https://bugs.chromium.org/p/angleproject/issues/detail?id=3941)
+  gl_PointSize = 1.0;
 }
 `;


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
Applying work around for an ANGLE bug similar to HeatmapLayer
More details: #3732 
ANGLE bug: https://bugs.chromium.org/p/angleproject/issues/detail?id=3941&can=8&q=&colspec=ID%20Type%20Status%20Priority%20Feature%20Owner%20Summary
<!-- For all the PRs -->
#### Change List
- GPUGridAggregator: enforce point size to workaround ANGLE bug
