### PR TITLE
Add `pass` parameter to layerFilter

### DIFF
--- a/docs/api-reference/deck.md
+++ b/docs/api-reference/deck.md
@@ -75,8 +75,12 @@ Arguments:
 
 - `layer` (Layer) - the layer to be drawn
 - `viewport` (Viewport) - the current viewport
-- `isPicking` (Boolean) - whether this is a picking pass (drawing to offscreen picking buffer)
-- `pass` (String) - the name of the current render pass
+- `isPicking` (Boolean) - whether this is a picking pass
+- `renderPass` (String) - the name of the current render pass. Some standard passes are:
+  + `'screen'` - drawing to screen
+  + `'picking:hover'` - drawing to offscreen picking buffer due to pointer move
+  + `'picking:query'` - drawing to offscreen picking buffer due to user-initiated query, e.g. calling `deck.pickObject`.
+  + `'shadow'` - drawing to shadow map
 
 Returns:
 

--- a/docs/api-reference/deck.md
+++ b/docs/api-reference/deck.md
@@ -49,7 +49,38 @@ The array of deck.gl layers to be rendered. This array is expected to be an arra
 
 ##### `layerFilter` (Function)
 
-Optionally takes a function `({layer, viewport, isPicking}) => Boolean` that is called before a layer is rendered. Gives the application an opportunity to filter out layers from the layer list during either rendering or picking. Filtering can be done per viewport or per layer or both. This enables techniques like adding helper layers that work as masks during picking but do not show up during rendering. All the lifecycle methods are still triggered even a if a layer is filtered out using this prop.
+Default: `null`
+
+If supplied, will be called before a layer is drawn to determine whether it should be rendered. This gives the application an opportunity to filter out layers from the layer list during either rendering or picking. Filtering can be done per viewport or per layer or both. This enables techniques like adding helper layers that work as masks during picking but do not show up during rendering.
+
+```js
+new Deck({
+  // ...
+  layerFilter: ({layer, viewport}) => {
+    if (viewport.id !== 'minimap' && layer.id === 'geofence') {
+      // only display geofence in the minimap
+      return false;
+    }
+    return true;
+  }
+}
+```
+
+Notes:
+
+- `layerFilter` does not override the visibility defined by the layer's `visible` and `pickable` props.
+- All the lifecycle methods are still triggered even a if a layer is filtered out using this prop.
+
+Arguments:
+
+- `layer` (Layer) - the layer to be drawn
+- `viewport` (Viewport) - the current viewport
+- `isPicking` (Boolean) - whether this is a picking pass (drawing to offscreen picking buffer)
+- `pass` (String) - the name of the current render pass
+
+Returns:
+
+`true` if the layer should be drawn.
 
 ##### `getCursor` (Function)
 

--- a/examples/layer-browser/src/map.js
+++ b/examples/layer-browser/src/map.js
@@ -135,7 +135,7 @@ export default class Map extends PureComponent {
   }
 
   // Only show infovis layers in infovis mode and vice versa
-  _layerFilter({layer}) {
+  _layerFilter({layer, renderPass}) {
     const {settings} = this.props;
     const isIdentity = layer.props.coordinateSystem === COORDINATE_SYSTEM.IDENTITY;
     return settings.infovis ? isIdentity : !isIdentity;

--- a/modules/core/src/effects/lighting/lighting-effect.js
+++ b/modules/core/src/effects/lighting/lighting-effect.js
@@ -57,7 +57,7 @@ export default class LightingEffect extends Effect {
     this.shadow = this.directionalLights.some(light => light.shadow);
   }
 
-  prepare(gl, {layers, viewports, onViewportActive, views}) {
+  prepare(gl, {layers, layerFilter, viewports, onViewportActive, views}) {
     if (!this.shadow) return {};
 
     // create light matrix every frame to make sure always updated from light source
@@ -86,7 +86,8 @@ export default class LightingEffect extends Effect {
     for (let i = 0; i < this.shadowPasses.length; i++) {
       const shadowPass = this.shadowPasses[i];
       shadowPass.render({
-        layers: layers.filter(layer => layer.props.shadowEnabled !== false),
+        layers,
+        layerFilter,
         viewports,
         onViewportActive,
         views,

--- a/modules/core/src/lib/deck-picker.js
+++ b/modules/core/src/lib/deck-picker.js
@@ -162,6 +162,7 @@ export default class DeckPicker {
           viewports,
           onViewportActive,
           deviceRect,
+          pass: `picking:${mode}`,
           redrawReason: mode
         });
 
@@ -181,6 +182,7 @@ export default class DeckPicker {
           viewports,
           onViewportActive,
           deviceRect: {x: pickInfo.pickedX, y: pickInfo.pickedY, width: 1, height: 1},
+          pass: `picking:${mode}`,
           redrawReason: 'pick-z',
           pickZ: true
         });
@@ -269,6 +271,7 @@ export default class DeckPicker {
       viewports,
       onViewportActive,
       deviceRect,
+      pass: `picking:${mode}`,
       redrawReason: mode
     });
 
@@ -300,7 +303,7 @@ export default class DeckPicker {
   }
 
   // returns pickedColor or null if no pickable layers found.
-  _drawAndSample({layers, viewports, onViewportActive, deviceRect, redrawReason, pickZ}) {
+  _drawAndSample({layers, viewports, onViewportActive, deviceRect, pass, redrawReason, pickZ}) {
     assert(deviceRect);
     assert(Number.isFinite(deviceRect.width) && deviceRect.width > 0, '`width` must be > 0');
     assert(Number.isFinite(deviceRect.height) && deviceRect.height > 0, '`height` must be > 0');
@@ -322,6 +325,7 @@ export default class DeckPicker {
       onViewportActive,
       pickingFBO,
       deviceRect,
+      pass,
       redrawReason,
       effectProps,
       pickZ

--- a/modules/core/src/lib/deck-renderer.js
+++ b/modules/core/src/lib/deck-renderer.js
@@ -46,6 +46,7 @@ export default class DeckRenderer {
     const layerPass = this.drawPickingColors ? this.pickLayersPass : this.drawLayersPass;
     const effectProps = this._prepareEffects({
       layers,
+      layerFilter: this.layerFilter,
       viewports,
       onViewportActive,
       views,
@@ -61,6 +62,7 @@ export default class DeckRenderer {
       viewports,
       views,
       onViewportActive,
+      pass,
       redrawReason,
       clearCanvas,
       effects,

--- a/modules/core/src/passes/layers-pass.js
+++ b/modules/core/src/passes/layers-pass.js
@@ -73,7 +73,7 @@ export default class LayersPass extends Pass {
     // render layers in normal colors
     layers.forEach((layer, layerIndex) => {
       // Check if we should draw layer
-      const shouldDrawLayer = this.shouldDrawLayer(layer, viewport, layerFilter);
+      const shouldDrawLayer = this.shouldDrawLayer(layer, viewport, layerFilter, pass);
 
       // Calculate stats
       if (shouldDrawLayer && layer.props.pickable) {
@@ -102,11 +102,11 @@ export default class LayersPass extends Pass {
     return renderStatus;
   }
 
-  shouldDrawLayer(layer, viewport, layerFilter) {
+  shouldDrawLayer(layer, viewport, layerFilter, pass) {
     let shouldDrawLayer = !layer.isComposite && layer.props.visible;
 
     if (shouldDrawLayer && layerFilter) {
-      shouldDrawLayer = layerFilter({layer, viewport, isPicking: false});
+      shouldDrawLayer = layerFilter({layer, viewport, isPicking: false, pass});
     }
     return shouldDrawLayer;
   }

--- a/modules/core/src/passes/layers-pass.js
+++ b/modules/core/src/passes/layers-pass.js
@@ -44,7 +44,7 @@ export default class LayersPass extends Pass {
   // intersect with the picking rect
   drawLayersInViewport(
     gl,
-    {layers, layerFilter, viewport, view, parameters, pass = 'draw', effects, effectProps}
+    {layers, layerFilter, viewport, view, parameters, pass = 'unknown', effects, effectProps}
   ) {
     const glViewport = getGLViewport(gl, {viewport});
 
@@ -73,7 +73,7 @@ export default class LayersPass extends Pass {
     // render layers in normal colors
     layers.forEach((layer, layerIndex) => {
       // Check if we should draw layer
-      const shouldDrawLayer = this.shouldDrawLayer(layer, viewport, layerFilter, pass);
+      const shouldDrawLayer = this._shouldDrawLayer(layer, viewport, pass, layerFilter);
 
       // Calculate stats
       if (shouldDrawLayer && layer.props.pickable) {
@@ -102,13 +102,18 @@ export default class LayersPass extends Pass {
     return renderStatus;
   }
 
-  shouldDrawLayer(layer, viewport, layerFilter, pass) {
-    let shouldDrawLayer = !layer.isComposite && layer.props.visible;
+  _shouldDrawLayer(layer, viewport, pass, layerFilter) {
+    let shouldDrawLayer = this.shouldDrawLayer(layer) && !layer.isComposite && layer.props.visible;
 
     if (shouldDrawLayer && layerFilter) {
       shouldDrawLayer = layerFilter({layer, viewport, isPicking: false, renderPass: pass});
     }
     return shouldDrawLayer;
+  }
+
+  /* Methods for subclass overrides */
+  shouldDrawLayer(layer) {
+    return true;
   }
 
   getModuleParameters(layer) {

--- a/modules/core/src/passes/layers-pass.js
+++ b/modules/core/src/passes/layers-pass.js
@@ -106,7 +106,7 @@ export default class LayersPass extends Pass {
     let shouldDrawLayer = !layer.isComposite && layer.props.visible;
 
     if (shouldDrawLayer && layerFilter) {
-      shouldDrawLayer = layerFilter({layer, viewport, isPicking: false, pass});
+      shouldDrawLayer = layerFilter({layer, viewport, isPicking: false, renderPass: pass});
     }
     return shouldDrawLayer;
   }

--- a/modules/core/src/passes/pick-layers-pass.js
+++ b/modules/core/src/passes/pick-layers-pass.js
@@ -21,6 +21,7 @@ export default class PickLayersPass extends LayersPass {
     pickingFBO,
     effectProps,
     deviceRect: {x, y, width, height},
+    pass = 'picking',
     redrawReason,
     pickZ
   }) {
@@ -64,7 +65,7 @@ export default class PickLayersPass extends LayersPass {
           layerFilter,
           viewports,
           onViewportActive,
-          pass: `picking:${redrawReason}`,
+          pass,
           redrawReason,
           effectProps,
           parameters
@@ -74,8 +75,8 @@ export default class PickLayersPass extends LayersPass {
   }
 
   // PRIVATE
-  shouldDrawLayer(layer, viewport, layerFilter, pass) {
-    return layer.props.pickable && super.shouldDrawLayer(layer, viewport, layerFilter, pass);
+  shouldDrawLayer(layer) {
+    return layer.props.pickable;
   }
 
   getModuleParameters(layer, effects, effectProps) {

--- a/modules/core/src/passes/pick-layers-pass.js
+++ b/modules/core/src/passes/pick-layers-pass.js
@@ -75,12 +75,7 @@ export default class PickLayersPass extends LayersPass {
 
   // PRIVATE
   shouldDrawLayer(layer, viewport, layerFilter, pass) {
-    let shouldDrawLayer = !layer.isComposite && layer.props.visible && layer.props.pickable;
-
-    if (shouldDrawLayer && layerFilter) {
-      shouldDrawLayer = layerFilter({layer, viewport, isPicking: true, pass});
-    }
-    return shouldDrawLayer;
+    return layer.props.pickable && super.shouldDrawLayer(layer, viewport, layerFilter, pass);
   }
 
   getModuleParameters(layer, effects, effectProps) {

--- a/modules/core/src/passes/pick-layers-pass.js
+++ b/modules/core/src/passes/pick-layers-pass.js
@@ -64,7 +64,7 @@ export default class PickLayersPass extends LayersPass {
           layerFilter,
           viewports,
           onViewportActive,
-          pass: 'picking',
+          pass: `picking:${redrawReason}`,
           redrawReason,
           effectProps,
           parameters
@@ -74,11 +74,11 @@ export default class PickLayersPass extends LayersPass {
   }
 
   // PRIVATE
-  shouldDrawLayer(layer, viewport, layerFilter) {
+  shouldDrawLayer(layer, viewport, layerFilter, pass) {
     let shouldDrawLayer = !layer.isComposite && layer.props.visible && layer.props.pickable;
 
     if (shouldDrawLayer && layerFilter) {
-      shouldDrawLayer = layerFilter({layer, viewport, isPicking: true});
+      shouldDrawLayer = layerFilter({layer, viewport, isPicking: true, pass});
     }
     return shouldDrawLayer;
   }

--- a/modules/core/src/passes/shadow-pass.js
+++ b/modules/core/src/passes/shadow-pass.js
@@ -66,6 +66,10 @@ export default class ShadowPass extends LayersPass {
     );
   }
 
+  shouldDrawLayer(layer) {
+    return layer.props.shadowEnabled !== false;
+  }
+
   getModuleParameters(layer, effects, effectProps) {
     const moduleParameters = Object.assign(Object.create(layer.props), {
       viewport: layer.context.viewport,

--- a/modules/core/src/passes/shadow-pass.js
+++ b/modules/core/src/passes/shadow-pass.js
@@ -61,7 +61,7 @@ export default class ShadowPass extends LayersPass {
           target.resize({width, height});
         }
 
-        super.render(Object.assign(params, {outputBuffer: target}));
+        super.render(Object.assign(params, {outputBuffer: target, pass: 'shadow'}));
       }
     );
   }


### PR DESCRIPTION
#### Background

Currently, the `pickable` prop is tied to the following features:

- Callbacks such as `onHover` and `onClick`
- Auto highlighting
- Queries such as `pickObjects`

This makes it difficult for applications that need different behaviors in auto-picking on hover (e.g. tooltips, auto-highlight) vs. multi-depth picking on click (e.g. map editing).

This PR introduces an additional `renderPass` field to the `layerFilter` parameters so that applications can control whether a layer is rendered based on which render pass it's in.

Related: https://github.com/uber/streetscape.gl/pull/396

#### Change List
- Add picking mode to `pass` string
- Add `pass` to `layerFilter` parameters
