### PR TITLE
Effects system clean up

### DIFF
--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -8,7 +8,8 @@ import {
   OrbitView,
   AmbientLight,
   DirectionalLight,
-  LightingEffect
+  LightingEffect,
+  PostProcessEffect
 } from '@deck.gl/core';
 import {SolidPolygonLayer} from '@deck.gl/layers';
 
@@ -22,6 +23,8 @@ import LayerControls from './components/layer-controls';
 
 import LAYER_CATEGORIES from './examples';
 import Map from './map';
+
+import {ink} from '@luma.gl/effects';
 
 const AMBIENT_LIGHT = new AmbientLight({
   color: [255, 255, 255],
@@ -51,6 +54,8 @@ const GLOBAL_LIGHTING_WITH_SHADOW = new LightingEffect({
   DIRECTIONAL_LIGHT_SHADOW
 });
 
+const POST_PROCESS = new PostProcessEffect(ink, {strength: 0.5});
+
 const LAND_COVER = [[[-122.3, 37.7], [-122.3, 37.9], [-122.6, 37.9], [-122.6, 37.7]]];
 
 // ---- View ---- //
@@ -65,6 +70,7 @@ export default class App extends PureComponent {
       },
       settings: {
         shadow: false,
+        postProcessing: false,
         orthographic: false,
         multiview: false,
         infovis: false,
@@ -239,9 +245,12 @@ export default class App extends PureComponent {
 
   _getEffects() {
     // TODO
-    const {shadow} = this.state.settings;
+    const {shadow, postProcessing} = this.state.settings;
 
-    return [shadow ? GLOBAL_LIGHTING_WITH_SHADOW : GLOBAL_LIGHTING];
+    return [
+      shadow ? GLOBAL_LIGHTING_WITH_SHADOW : GLOBAL_LIGHTING,
+      postProcessing && POST_PROCESS
+    ].filter(Boolean);
   }
 
   render() {

--- a/modules/core/src/effects/lighting/camera-light.js
+++ b/modules/core/src/effects/lighting/camera-light.js
@@ -3,6 +3,7 @@ import {getUniformsFromViewport} from '../../shaderlib/project/viewport-uniforms
 
 export default class CameraLight extends PointLight {
   getProjectedLight({layer}) {
+    const {projectedLight} = this;
     const viewport = layer.context.viewport;
     const {coordinateSystem, coordinateOrigin, modelMatrix} = layer.props;
     const {project_uCameraPosition} = getUniformsFromViewport({
@@ -11,9 +12,9 @@ export default class CameraLight extends PointLight {
       coordinateSystem,
       coordinateOrigin
     });
-    this.projectedLight.color = this.color;
-    this.projectedLight.intensity = this.intensity;
-    this.projectedLight.position = project_uCameraPosition;
-    return this.projectedLight;
+    projectedLight.color = this.color;
+    projectedLight.intensity = this.intensity;
+    projectedLight.position = project_uCameraPosition;
+    return projectedLight;
   }
 }

--- a/modules/core/src/effects/lighting/point-light.js
+++ b/modules/core/src/effects/lighting/point-light.js
@@ -9,6 +9,7 @@ export default class PointLight extends BasePointLight {
   }
 
   getProjectedLight({layer}) {
+    const {projectedLight} = this;
     const viewport = layer.context.viewport;
     const {coordinateSystem, coordinateOrigin} = layer.props;
     const position = projectPosition(this.position, {
@@ -20,9 +21,9 @@ export default class PointLight extends BasePointLight {
         : COORDINATE_SYSTEM.IDENTITY,
       fromCoordinateOrigin: [0, 0, 0]
     });
-    this.projectedLight.color = this.color;
-    this.projectedLight.intensity = this.intensity;
-    this.projectedLight.position = position;
-    return this.projectedLight;
+    projectedLight.color = this.color;
+    projectedLight.intensity = this.intensity;
+    projectedLight.position = position;
+    return projectedLight;
   }
 }

--- a/modules/core/src/effects/post-process-effect.js
+++ b/modules/core/src/effects/post-process-effect.js
@@ -11,28 +11,25 @@ export default class PostProcessEffect extends Effect {
     this.module = module;
   }
 
-  prepare(gl) {
+  postRender(gl, params) {
     if (!this.passes) {
       this.passes = createPasses(gl, this.module, this.id, this.props);
     }
-  }
 
-  render(params) {
-    const {target = null} = params;
-    let switchBuffer = false;
+    const {target} = params;
+    let inputBuffer = params.inputBuffer;
+    let outputBuffer = params.swapBuffer;
+
     for (let index = 0; index < this.passes.length; index++) {
-      const inputBuffer = switchBuffer ? params.outputBuffer : params.inputBuffer;
-      let outputBuffer = switchBuffer ? params.inputBuffer : params.outputBuffer;
       if (target && index === this.passes.length - 1) {
         outputBuffer = target;
       }
       this.passes[index].render({inputBuffer, outputBuffer});
-      switchBuffer = !switchBuffer;
+      const switchBuffer = outputBuffer;
+      outputBuffer = inputBuffer;
+      inputBuffer = switchBuffer;
     }
-    return {
-      inputBuffer: switchBuffer ? params.outputBuffer : params.inputBuffer,
-      outputBuffer: switchBuffer ? params.inputBuffer : params.outputBuffer
-    };
+    return inputBuffer;
   }
 
   cleanup() {

--- a/modules/core/src/lib/effect.js
+++ b/modules/core/src/lib/effect.js
@@ -6,9 +6,9 @@ export default class Effect {
     Object.assign(this.props, props);
   }
 
-  prepare() {}
+  preRender() {}
 
-  getParameters() {}
+  getModuleParameters() {}
 
   cleanup() {}
 }

--- a/modules/core/src/passes/draw-layers-pass.js
+++ b/modules/core/src/passes/draw-layers-pass.js
@@ -1,12 +1,3 @@
 import LayersPass from './layers-pass';
 
-export default class DrawLayersPass extends LayersPass {
-  // PRIVATE
-  getModuleParameters(layer, effects) {
-    const moduleParameters = {};
-    for (const effect of effects) {
-      Object.assign(moduleParameters, effect.getParameters(layer));
-    }
-    return moduleParameters;
-  }
-}
+export default class DrawLayersPass extends LayersPass {}

--- a/test/modules/core/effects/post-process-effect.spec.js
+++ b/test/modules/core/effects/post-process-effect.spec.js
@@ -25,41 +25,25 @@ test('PostProcessEffect#constructor', t => {
   t.end();
 });
 
-test('PostProcessEffect#prepare', t => {
+test('PostProcessEffect#postRender', t => {
   const effect = new PostProcessEffect(testModule);
-  effect.prepare(gl);
-  t.ok(effect.passes, 'post-processing pass created');
-  t.equal(effect.passes.length, 1, 'post-processing pass length is right');
-  effect.cleanup();
-
-  t.end();
-});
-
-test('PostProcessEffect#render', t => {
-  const effect = new PostProcessEffect(testModule);
-  effect.prepare(gl);
+  effect.preRender(gl);
   const inputBuffer = new Framebuffer(gl);
   const outputBuffer = new Framebuffer(gl);
 
-  const params1 = effect.render({inputBuffer, outputBuffer});
-  t.ok(params1, 'post-processing effect rendered without throwing');
-  t.deepEqual(
-    params1,
-    {inputBuffer: outputBuffer, outputBuffer: inputBuffer},
-    'post-processing effect buffer swapped'
-  );
+  const buffer1 = effect.postRender(gl, {inputBuffer, swapBuffer: outputBuffer});
+  t.ok(effect.passes, 'post-processing pass created');
 
-  const params2 = effect.render({
+  t.ok(buffer1, 'post-processing effect rendered without throwing');
+  t.is(buffer1, outputBuffer, 'post-processing effect buffer swapped');
+
+  const buffer2 = effect.postRender(gl, {
     inputBuffer,
-    outputBuffer,
+    swapBuffer: outputBuffer,
     target: Framebuffer.getDefaultFramebuffer(gl)
   });
-  t.ok(params2, 'post-processing effect rendered without throwing');
-  t.deepEqual(
-    params2,
-    {inputBuffer: outputBuffer, outputBuffer: inputBuffer},
-    'post-processing effect buffer swapped'
-  );
+  t.ok(buffer2, 'post-processing effect rendered without throwing');
+  t.is(buffer2, Framebuffer.getDefaultFramebuffer(gl), 'post-processing effect rendered to target');
 
   effect.cleanup();
   inputBuffer.delete();

--- a/test/modules/core/lib/effect-manager.spec.js
+++ b/test/modules/core/lib/effect-manager.spec.js
@@ -78,7 +78,7 @@ test('EffectManager#cleanup resource', t => {
   const effectManager = new EffectManager({gl, layerManager});
   effectManager.setEffects([effect]);
   const resBegin = getResourceCounts();
-  effect.prepare(gl);
+  effect.preRender(gl);
   effectManager.setEffects([]);
   const resEnd = getResourceCounts();
 
@@ -91,7 +91,7 @@ test('EffectManager#finalize', t => {
   const effectManager = new EffectManager({gl, layerManager});
   effectManager.setEffects([effect]);
   const resBegin = getResourceCounts();
-  effect.prepare(gl);
+  effect.preRender(gl);
   effectManager.finalize();
   const resEnd = getResourceCounts();
 

--- a/test/modules/core/passes/pick-layers-pass.spec.js
+++ b/test/modules/core/passes/pick-layers-pass.spec.js
@@ -34,8 +34,7 @@ test('PickLayersPass#drawPickingBuffer', t => {
     layers: layerManager.getLayers(),
     onViewportActive: layerManager.activateViewport,
     pickingFBO,
-    deviceRect: {x: 0, y: 0, width: 100, height: 100},
-    effectProps: {lightSources: {}}
+    deviceRect: {x: 0, y: 0, width: 100, height: 100}
   });
 
   const subLayers = layer.getSubLayers();


### PR DESCRIPTION

#### Change List
- Rename: `effect.prepare` -> `effect.preRender`, no longer returns object
- Rename: `effect.render` -> `effect.postRender`, returns the last output buffer
- Rename: `effect.getParameters` -> `effect.getModuleParameters`
- Remove `DeckRenderer`'s dependency on `PostProcessEffect`, allow custom effects to have `postRender` lifecycle
- Remove `effectProps` from layer pass, use `moduleParameters`