### PR TITLE
Fix 3d picking projection with camera offset

### DIFF
--- a/modules/core/src/lib/deck-picker.js
+++ b/modules/core/src/lib/deck-picker.js
@@ -186,7 +186,8 @@ export default class DeckPicker {
           redrawReason: 'pick-z',
           pickZ: true
         });
-        // picked value is in common space (pixels)
+        // picked value is in common space (pixels) from the camera target (viewport.position)
+        // convert it to meters from the ground
         z = zValues[0] * viewports[0].distanceScales.metersPerPixel[2] + viewports[0].position[2];
       }
 

--- a/modules/core/src/lib/deck-picker.js
+++ b/modules/core/src/lib/deck-picker.js
@@ -187,7 +187,7 @@ export default class DeckPicker {
           pickZ: true
         });
         // picked value is in common space (pixels)
-        z = zValues[0] * viewports[0].distanceScales.metersPerPixel[2];
+        z = zValues[0] * viewports[0].distanceScales.metersPerPixel[2] + viewports[0].position[2];
       }
 
       // Only exclude if we need to run picking again.


### PR DESCRIPTION

#### Change List
- When the camera is not pointing to the ground, common space z must compensate for the offset.
