### PR TITLE
Abstract tooltip DOM tests into a separate class

### DIFF
--- a/test/modules/core/lib/tooltip.spec.js
+++ b/test/modules/core/lib/tooltip.spec.js
@@ -1,32 +1,9 @@
-/* global window */
-import Tooltip from '@deck.gl/core/lib/tooltip';
 import test from 'tape-catch';
 
-let document;
-if (typeof window === undefined || !window.document) {
-  const {JSDOM} = require('jsdom');
-  const dom = new JSDOM(`<!DOCTYPE html>`);
-  document = dom.window.document;
-} else {
-  document = window.document;
-}
+import Tooltip from '@deck.gl/core/lib/tooltip';
+import DocumentTest from 'deck.gl-test/utils/document';
 
-const CANVAS_PARENT_CLASS_NAME = 'tooltip-canvas-parent';
 const pickedInfo = {object: {elevationValue: 10}, x: 0, y: 0};
-
-function setup() {
-  const canvas = document.createElement('canvas');
-  const canvasParent = document.createElement('div');
-  canvasParent.className = 'tooltip-canvas-parent';
-  canvasParent.appendChild(canvas);
-  document.body.appendChild(canvasParent);
-  return new Tooltip(canvas);
-}
-
-function teardown() {
-  const el = document.getElementsByClassName(CANVAS_PARENT_CLASS_NAME)[0];
-  el.remove();
-}
 
 function getTooltipFunc(pickedValue) {
   return {
@@ -45,60 +22,75 @@ function getTooltipFuncDefault(pickedValue) {
 }
 
 test('Tooltip#constructor', t => {
-  const tooltip = setup(); // eslint-disable-line
-  t.ok(document.getElementsByClassName('deck-tooltip'), 'Tooltip exists in document');
-  t.equals(document.getElementsByClassName('deck-tooltip')[0].style.top, '0px');
-  teardown();
+  const documentTest = new DocumentTest(Tooltip);
+  documentTest.setup();
+  t.ok(documentTest.document.getElementsByClassName('deck-tooltip'), 'Tooltip exists in document');
+  t.equals(documentTest.document.getElementsByClassName('deck-tooltip')[0].style.top, '0px');
+  documentTest.teardown();
   t.end();
 });
 
 test('Tooltip#setTooltip', t => {
-  const tooltip = setup();
+  const documentTest = new DocumentTest(Tooltip);
+  documentTest.setup();
+  const tooltip = documentTest.testObject;
   tooltip.setTooltip(getTooltipFunc(pickedInfo), pickedInfo.x, pickedInfo.y);
   t.equals(tooltip.el.style.backgroundColor, 'lemonchiffon');
   t.equals(tooltip.el.innerHTML, '<strong>Number of points:</strong> 10');
   t.equals(tooltip.el.className, 'coolTooltip');
-  teardown();
+  documentTest.teardown();
   t.end();
 });
 
 test('Tooltip#setTooltipWithString', t => {
-  const tooltip = setup();
+  const documentTest = new DocumentTest(Tooltip);
+  documentTest.setup();
+  const tooltip = documentTest.testObject;
   const pickedInfoFunc = info => `Number of points: ${info.object.elevationValue}`;
   tooltip.setTooltip(pickedInfoFunc(pickedInfo), pickedInfo.x, pickedInfo.y);
   t.equals(tooltip.el.innerText, 'Number of points: 10');
   t.equals(tooltip.el.className, 'deck-tooltip');
-  teardown();
+  documentTest.teardown();
   t.end();
 });
 
 test('Tooltip#setTooltipDefaults', t => {
-  const tooltip = setup();
+  const documentTest = new DocumentTest(Tooltip);
+  documentTest.setup();
+  const tooltip = documentTest.testObject;
   const tooltipResult = getTooltipFuncDefault(pickedInfo);
   tooltip.setTooltip(tooltipResult, pickedInfo.x, pickedInfo.y);
   t.equals(tooltip.el.innerText, 'Number of points: 10');
   t.equals(tooltip.el.className, 'deck-tooltip');
-  teardown();
+  documentTest.teardown();
   t.end();
 });
 
 test('Tooltip#setTooltipNullCase', t => {
-  const tooltip = setup();
+  const documentTest = new DocumentTest(Tooltip);
+  documentTest.setup();
+  const tooltip = documentTest.testObject;
   tooltip.setTooltip(null, pickedInfo.x, pickedInfo.y);
   t.equals(tooltip.el.style.display, 'none');
-  teardown();
+  documentTest.teardown();
   t.end();
 });
 
 test('Tooltip#remove', t => {
-  const tooltip = setup();
-  t.equals(document.getElementsByClassName('deck-tooltip').length, 1, 'Tooltip element present');
+  const documentTest = new DocumentTest(Tooltip);
+  documentTest.setup();
+  const tooltip = documentTest.testObject;
+  t.equals(
+    documentTest.document.getElementsByClassName('deck-tooltip').length,
+    1,
+    'Tooltip element present'
+  );
   tooltip.remove();
   t.equals(
-    document.getElementsByClassName('deck-tooltip').length,
+    documentTest.document.getElementsByClassName('deck-tooltip').length,
     0,
     'Tooltip element successfully removed'
   );
-  teardown();
+  documentTest.teardown();
   t.end();
 });

--- a/test/utils/document.js
+++ b/test/utils/document.js
@@ -1,0 +1,47 @@
+/* global window */
+
+function applyConstructorOrFunction(functionOrConstructor, ...args) {
+  try {
+    return new functionOrConstructor(...args); // eslint-disable-line new-cap
+  } catch (err) {
+    return functionOrConstructor(...args);
+  }
+}
+
+export default class DocumentTest {
+  // Simplify the testing of deck.gl work that requires a document and canvas
+  constructor(canvasCallback) {
+    this.document = this._createDocument();
+    this.canvasParent = null;
+    this.testObject = null;
+    this.canvasCallback = canvasCallback;
+  }
+
+  _createDocument() {
+    // Creates a global document object via JSDOM or a deep clone of the browser one if available
+    if (typeof window === undefined || !window.document) {
+      const {JSDOM} = require('jsdom');
+      const dom = new JSDOM(`<!DOCTYPE html>`);
+      return dom.window.document;
+    }
+    const documentClone = window.document.cloneNode(true);
+    return documentClone;
+  }
+
+  setup() {
+    // Creates a canvas which can be passed to canvasCallback
+    // to add a node to
+    const canvas = this.document.createElement('canvas');
+    const canvasParent = this.document.createElement('div');
+    canvasParent.className = 'canvas-parent';
+    canvasParent.appendChild(canvas);
+    this.canvasParent = canvasParent;
+    this.document.body.appendChild(canvasParent);
+    this.testObject = applyConstructorOrFunction(this.canvasCallback, canvas);
+  }
+
+  teardown() {
+    this.testObject.remove();
+    this.canvasParent.remove();
+  }
+}


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Supports increasing the test coverage on @deck.gl/jupyter-widget, where
many components of the module assumes DOM access.
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
- Create a helper class for document testing
- Refactor deck.gl core's tooltip to use this helper class