### PR TITLE
[JupyterLab support] Remove RequireJS from JS jupyter-widget notebook module

### DIFF
--- a/test/modules/jupyter-widget/index.spec.js
+++ b/test/modules/jupyter-widget/index.spec.js
@@ -1,15 +1,20 @@
 import test from 'tape-catch';
 
-const moduleAlias = require('module-alias');
-moduleAlias.addAlias('@jupyter-widgets/base', (fromPath, request, alias) => {
-  return `${__dirname}/mock-widget-base.js`;
-});
+// eslint-disable-next-line
+const isBrowser = new Function('try {return this===window;}catch(e){ return false;}');
+
+if (!isBrowser) {
+  const moduleAlias = require('module-alias');
+  moduleAlias.addAlias('@jupyter-widgets/base', (fromPath, request, alias) => {
+    return `${__dirname}/mock-widget-base.js`;
+  });
+}
 
 function getDeckModel(state) {
   // Require at runtime, after the environment is polyfilled
   try {
     const {DeckGLModel} = require('@deck.gl/jupyter-widget');
-    const {createTestModel} = require('./mock-widget-base');
+    const {createTestModel} = !isBrowser ? require('./mock-widget-base') : require('./utils.spec');
 
     const model = createTestModel(DeckGLModel, state);
     return model;

--- a/test/modules/jupyter-widget/utils.spec.js
+++ b/test/modules/jupyter-widget/utils.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/namespace */
 /* global window, console */
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.

--- a/test/modules/jupyter-widget/utils.spec.js
+++ b/test/modules/jupyter-widget/utils.spec.js
@@ -1,0 +1,93 @@
+/* global window, console */
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import * as widgets from '@jupyter-widgets/base';
+
+let numComms = 0;
+
+/**
+ * Creates a mock connection to a Jupyter notebook
+ */
+export class MockComm {
+  constructor() {
+    this.comm_id = `mock-comm-id-${numComms}`;
+    numComms += 1;
+  }
+  on_close(fn) {
+    this._on_close = fn;
+  }
+  on_msg(fn) {
+    this._on_msg = fn;
+  }
+  _process_msg(msg) {
+    if (this._on_msg) {
+      return this._on_msg(msg);
+    }
+    return Promise.resolve();
+  }
+  close() {
+    if (this._on_close) {
+      this._on_close();
+    }
+    return 'dummy';
+  }
+  send() {
+    return 'dummy';
+  }
+
+  open() {
+    return 'dummy';
+  }
+}
+
+export class DummyManager extends widgets.ManagerBase {
+  constructor() {
+    super();
+    this.el = window.document.createElement('div');
+  }
+
+  display_view(msg, view, options) {
+    // TODO: make this a spy
+    // TODO: return an html element
+    return Promise.resolve(view).then(v => {
+      this.el.appendChild(v.el);
+      v.on('remove', () => console.log('view removed', v)); //eslint-disable-line
+      return v.el;
+    });
+  }
+
+  loadClass(className, moduleName, moduleVersion) {
+    if (moduleName === '@jupyter-widgets/base') {
+      if (widgets[className]) {
+        return Promise.resolve(widgets[className]);
+      }
+      return Promise.reject(`Cannot find class ${className}`);
+    } else if (moduleName === 'jupyter-datawidgets') {
+      if (this.testClasses[className]) {
+        return Promise.resolve(this.testClasses[className]);
+      }
+      return Promise.reject(`Cannot find class ${className}`);
+    }
+    return Promise.reject(`Cannot find module ${moduleName}`);
+  }
+
+  _get_comm_info() {
+    return Promise.resolve({});
+  }
+
+  _create_comm() {
+    return Promise.resolve(new MockComm());
+  }
+}
+
+export function createTestModel(constructor, attributes) {
+  const id = widgets.uuid();
+  const widget_manager = new DummyManager();
+  const modelOptions = {
+    widget_manager,
+    model_id: id
+  };
+
+  return new constructor(attributes, modelOptions);
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,5 +4,6 @@ module.exports = env => {
   const config = getWebpackConfig(env);
   // Unfortunately, ocular-dev-tool swallows logs...
   require('fs').writeFileSync('/tmp/ocular.log', JSON.stringify(config, null, 2));
+  config.node.module = 'empty';
   return config;
 };


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
RequireJS makes our build process fairly complex. This PR removes RequireJS from the @deck.gl/jupyter-widget module. An additional set of PRs is still needed to address pydeck's expectation that RequireJS is present.
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
-
