### PR TITLE
[v8.0] Change layer opacity default to 1

### DIFF
--- a/docs/api-reference/layer.md
+++ b/docs/api-reference/layer.md
@@ -95,7 +95,7 @@ In the second example (conditional rendering) the layer state will be destroyed 
 
 ##### `opacity` (Number, optional)
 
-* Default: `0.8`
+* Default: `1`
 
 The opacity of the layer.
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -4,6 +4,10 @@
 
 ### Breaking Changes
 
+##### Defaults
+
+- The `opacity` prop of all layers is now default to `1` (used to be `0.8`).
+
 ##### Removed
 
 - `project` shader module

--- a/examples/experimental/sun/src/app.js
+++ b/examples/experimental/sun/src/app.js
@@ -67,7 +67,6 @@ export class App extends Component {
       new SolidPolygonLayer({
         id: 'buildings',
         data,
-        opacity: 1,
         extruded: true,
         getPolygon: f => f.polygon,
         getElevation: f => f.height,
@@ -77,7 +76,6 @@ export class App extends Component {
       new SolidPolygonLayer({
         id: 'land',
         data: landCover,
-        opacity: 1,
         extruded: false,
         getPolygon: f => f,
         getFillColor: [0, 0, 0, 0]

--- a/examples/gallery/src/contour-layer.html
+++ b/examples/gallery/src/contour-layer.html
@@ -33,7 +33,6 @@
           data:
             'https://raw.githubusercontent.com/uber-common/deck.gl-data/master/examples/screen-grid/ca-transit-stops.json',
           getPosition: d => d,
-          opacity: 1,
           contours: [
             {threshold: 1, color: [255, 0, 0], strokeWidth: 4},
             {threshold: 5, color: [0, 255, 0], strokeWidth: 2},

--- a/examples/gallery/src/hexagon-layer.html
+++ b/examples/gallery/src/hexagon-layer.html
@@ -104,7 +104,6 @@
         elevationScale: 250,
         extruded: true,
         getPosition: d => d,
-        opacity: 1,
         ...options
       });
 

--- a/examples/gallery/src/highway.html
+++ b/examples/gallery/src/highway.html
@@ -112,7 +112,6 @@
       new GeoJsonLayer({
         id: 'geojson',
         data: 'https://raw.githubusercontent.com/uber-common/deck.gl-data/master/examples/highway/roads.json',
-        opacity: 1,
         stroked: false,
         filled: false,
         lineWidthMinPixels: 1,

--- a/examples/gallery/src/icon-layer.html
+++ b/examples/gallery/src/icon-layer.html
@@ -74,8 +74,7 @@
         getPosition: d => d.position,
         getFillColor: [23, 38, 42],
         getRadius: 12,
-        radiusMaxPixels: 60,
-        opacity: 1
+        radiusMaxPixels: 60
       });
 
       const textLayer = new TextLayer({

--- a/examples/gallery/src/line-layer.html
+++ b/examples/gallery/src/line-layer.html
@@ -43,6 +43,7 @@
         new LineLayer({
           id: 'line',
           data: 'https://raw.githubusercontent.com/uber-common/deck.gl-data/master/examples/line/heathrow-flights.json',
+          opacity: 0.8,
           pickable: true,
           getSourcePosition: d => d.start,
           getTargetPosition: d => d.end,

--- a/examples/gallery/src/point-cloud-layer.html
+++ b/examples/gallery/src/point-cloud-layer.html
@@ -69,7 +69,6 @@
         new PointCloudLayer({
           id: 'pointCloud',
           coordinateSystem: COORDINATE_SYSTEM.IDENTITY,
-          opacity: 1,
           data: points,
           getPosition: d => d.position,
           getNormal: d => d.normal,

--- a/examples/gallery/src/screengrid-layer.html
+++ b/examples/gallery/src/screengrid-layer.html
@@ -32,6 +32,7 @@
         new ScreenGridLayer({
           id: 'grid',
           data: 'https://raw.githubusercontent.com/uber-common/deck.gl-data/master/examples/screen-grid/ca-transit-stops.json',
+          opacity: 0.8,
           minColor: [0, 0, 0, 0],
           getPosition: d => d,
           cellSizePixels: 20

--- a/examples/get-started/pure-js/basic/app.js
+++ b/examples/get-started/pure-js/basic/app.js
@@ -37,7 +37,6 @@ export const deck = new Deck({
       // Styles
       filled: true,
       pointRadiusMinPixels: 2,
-      opacity: 1,
       pointRadiusScale: 2000,
       getRadius: f => 11 - f.properties.scalerank,
       getFillColor: [200, 0, 80, 180],

--- a/examples/get-started/pure-js/google-maps/app.js
+++ b/examples/get-started/pure-js/google-maps/app.js
@@ -35,7 +35,6 @@ loadScript(GOOGLE_MAPS_API_URL).then(() => {
         // Styles
         filled: true,
         pointRadiusMinPixels: 2,
-        opacity: 1,
         pointRadiusScale: 2000,
         getRadius: f => 11 - f.properties.scalerank,
         getFillColor: [200, 0, 80, 180],

--- a/examples/get-started/pure-js/mapbox/app.js
+++ b/examples/get-started/pure-js/mapbox/app.js
@@ -49,7 +49,6 @@ export const deck = new Deck({
       // Styles
       filled: true,
       pointRadiusMinPixels: 2,
-      opacity: 1,
       pointRadiusScale: 2000,
       getRadius: f => 11 - f.properties.scalerank,
       getFillColor: [200, 0, 80, 180],

--- a/examples/get-started/react/basic/app.js
+++ b/examples/get-started/react/basic/app.js
@@ -43,7 +43,6 @@ class Root extends Component {
           data={AIR_PORTS}
           filled={true}
           pointRadiusMinPixels={2}
-          opacity={1}
           pointRadiusScale={2000}
           getRadius={f => 11 - f.properties.scalerank}
           getFillColor={[200, 0, 80, 180]}

--- a/examples/get-started/react/mapbox-browserify/app.js
+++ b/examples/get-started/react/mapbox-browserify/app.js
@@ -34,7 +34,6 @@ class Root extends Component {
         // Styles
         filled: true,
         pointRadiusMinPixels: 2,
-        opacity: 1,
         pointRadiusScale: 2000,
         getRadius: f => 11 - f.properties.scalerank,
         getFillColor: [200, 0, 80, 180],

--- a/examples/get-started/react/mapbox/app.js
+++ b/examples/get-started/react/mapbox/app.js
@@ -34,7 +34,6 @@ class Root extends Component {
         // Styles
         filled: true,
         pointRadiusMinPixels: 2,
-        opacity: 1,
         pointRadiusScale: 2000,
         getRadius: f => 11 - f.properties.scalerank,
         getFillColor: [200, 0, 80, 180],

--- a/examples/get-started/scripting/basic/index.html
+++ b/examples/get-started/scripting/basic/index.html
@@ -49,7 +49,6 @@ const deckgl = new deck.DeckGL({
       // Styles
       filled: true,
       pointRadiusMinPixels: 2,
-      opacity: 1,
       pointRadiusScale: 2000,
       getRadius: f => (11 - f.properties.scalerank),
       getFillColor: [200, 0, 80, 180],

--- a/examples/get-started/scripting/google-maps/index.html
+++ b/examples/get-started/scripting/google-maps/index.html
@@ -36,7 +36,6 @@ const deckOverlay = new deck.GoogleMapsOverlay({
       // Styles
       filled: true,
       pointRadiusMinPixels: 2,
-      opacity: 1,
       pointRadiusScale: 2000,
       getRadius: f => (11 - f.properties.scalerank),
       getFillColor: [200, 0, 80, 180],

--- a/examples/get-started/scripting/mapbox/index.html
+++ b/examples/get-started/scripting/mapbox/index.html
@@ -41,7 +41,6 @@ const deckgl = new deck.DeckGL({
       // Styles
       filled: true,
       pointRadiusMinPixels: 2,
-      opacity: 1,
       pointRadiusScale: 2000,
       getRadius: f => (11 - f.properties.scalerank),
       getFillColor: [200, 0, 80, 180],

--- a/examples/playground/json-examples/3d-heatmap-minimap.json
+++ b/examples/playground/json-examples/3d-heatmap-minimap.json
@@ -49,7 +49,6 @@
       "elevationScale": 50,
       "extruded": true,
       "getPosition": "-",
-      "opacity": 1,
       "radius": 1000,
       "upperPercentile": 100,
 

--- a/examples/playground/json-examples/3d-heatmap.json
+++ b/examples/playground/json-examples/3d-heatmap.json
@@ -32,7 +32,6 @@
       "elevationScale": 50,
       "extruded": true,
       "getPosition": "-",
-      "opacity": 1,
       "radius": 1000,
       "upperPercentile": 100,
 

--- a/examples/playground/json-examples/line.json
+++ b/examples/playground/json-examples/line.json
@@ -32,6 +32,7 @@
       "type": "LineLayer",
       "id": "flight-paths",
       "data": "https://raw.githubusercontent.com/uber-common/deck.gl-data/master/examples/line/heathrow-flights.json",
+      "opacity": 0.8,
       "strokeWidth": 3,
       "getSourcePosition": "start",
       "getTargetPosition": "end",

--- a/examples/playground/json-examples/screen-grid.json
+++ b/examples/playground/json-examples/screen-grid.json
@@ -22,6 +22,7 @@
     	"type": "ScreenGridLayer",
       "id": "grid",
       "data": "https://raw.githubusercontent.com/uber-common/deck.gl-data/master/examples/screen-grid/ca-transit-stops.json",
+      "opacity": 0.8,
       "cellSizePixels": 20,
       "colorRange": [
         [255, 255, 178, 25],

--- a/examples/website/3d-heatmap/app.js
+++ b/examples/website/3d-heatmap/app.js
@@ -87,7 +87,6 @@ export default class App extends Component {
         extruded: true,
         getPosition: d => d,
         onHover: this.props.onHover,
-        opacity: 1,
         pickable: Boolean(this.props.onHover),
         radius,
         upperPercentile,

--- a/examples/website/brushing/app.js
+++ b/examples/website/brushing/app.js
@@ -172,7 +172,6 @@ export default class App extends Component {
         id: 'sources',
         data: sources,
         brushingRadius: brushRadius,
-        opacity: 1,
         brushingEnabled: enableBrushing,
         pickable: false,
         // only show source points when brushing
@@ -187,7 +186,6 @@ export default class App extends Component {
         lineWidthMinPixels: 2,
         stroked: true,
         filled: false,
-        opacity: 1,
         brushingEnabled: enableBrushing,
         // only show rings when brushing
         radiusScale: enableBrushing ? 4000 : 0,
@@ -198,7 +196,6 @@ export default class App extends Component {
         id: 'targets',
         data: targets,
         brushingRadius: brushRadius,
-        opacity: 1,
         brushingEnabled: enableBrushing,
         pickable: true,
         radiusScale: 3000,

--- a/examples/website/heatmap/app.js
+++ b/examples/website/heatmap/app.js
@@ -26,7 +26,6 @@ export default class App extends PureComponent {
       new HeatmapLayer({
         data,
         id: 'heatmp-layer',
-        opacity: 1,
         pickable: false,
         getPosition: d => [d[0], d[1]],
         getWeight: d => d[2],

--- a/examples/website/highway/app.js
+++ b/examples/website/highway/app.js
@@ -114,7 +114,6 @@ export default class App extends Component {
       new GeoJsonLayer({
         id: 'geojson',
         data: roads,
-        opacity: 1,
         stroked: false,
         filled: false,
         lineWidthMinPixels: 0.5,

--- a/examples/website/line/app.js
+++ b/examples/website/line/app.js
@@ -90,6 +90,7 @@ export default class App extends Component {
       new LineLayer({
         id: 'flight-paths',
         data: flightPaths,
+        opacity: 0.8,
         getSourcePosition: d => d.start,
         getTargetPosition: d => d.end,
         getColor,

--- a/examples/website/map-tile/app.js
+++ b/examples/website/map-tile/app.js
@@ -51,7 +51,6 @@ export default class App extends PureComponent {
         onHover: this._onHover,
         autoHighlight,
         highlightColor,
-        opacity: 1,
         // https://wiki.openstreetmap.org/wiki/Zoom_levels
         minZoom: 0,
         maxZoom: 19,

--- a/examples/website/mesh/app.js
+++ b/examples/website/mesh/app.js
@@ -77,7 +77,6 @@ export default class App extends PureComponent {
       new SolidPolygonLayer({
         id: 'background',
         data: background,
-        opacity: 1,
         extruded: false,
         coordinateSystem: COORDINATE_SYSTEM.IDENTITY,
         getPolygon: f => f,

--- a/examples/website/plot/app.js
+++ b/examples/website/plot/app.js
@@ -72,7 +72,6 @@ export default class App extends Component {
           drawAxes: showAxis,
           axesPadding: 0.25,
           axesColor: [0, 0, 0, 128],
-          opacity: 1,
           pickable: true,
           onHover: this._onHover,
           updateTriggers: {

--- a/examples/website/screen-grid/app.js
+++ b/examples/website/screen-grid/app.js
@@ -38,6 +38,7 @@ export default class App extends Component {
       new ScreenGridLayer({
         id: 'grid',
         data,
+        opacity: 0.8,
         getPosition: d => [d[0], d[1]],
         getWeight: d => d[2],
         cellSizePixels: cellSize,

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -62,7 +62,7 @@ const defaultProps = {
 
   visible: true,
   pickable: false,
-  opacity: {type: 'number', min: 0, max: 1, value: 0.8},
+  opacity: {type: 'number', min: 0, max: 1, value: 1},
 
   onHover: {type: 'function', value: null, compare: false, optional: true},
   onClick: {type: 'function', value: null, compare: false, optional: true},

--- a/modules/geo-layers/src/tile-3d-layer/tile-3d-layer.js
+++ b/modules/geo-layers/src/tile-3d-layer/tile-3d-layer.js
@@ -11,7 +11,6 @@ import {getFrameState} from './get-frame-state';
 const defaultProps = {
   getPointColor: [0, 0, 0],
   pointSize: 1.0,
-  opacity: 1.0,
 
   data: null,
   _ionAssetId: null,

--- a/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.js
+++ b/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.js
@@ -46,7 +46,6 @@ const defaultProps = {
   sizeScale: {type: 'number', value: 1, min: 0},
   getPosition: {type: 'accessor', value: x => x.position},
   getColor: {type: 'accessor', value: DEFAULT_COLOR},
-  opacity: {type: 'number', min: 0, max: 1, value: 1.0},
 
   // flat or pbr
   _lighting: 'flat',

--- a/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.js
+++ b/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.js
@@ -92,7 +92,6 @@ const defaultProps = {
     depthTest: true,
     depthFunc: GL.LEQUAL
   },
-  opacity: 1.0,
 
   // NOTE(Tarek): Quick and dirty wireframe. Just draws
   // the same mesh with LINE_STRIPS. Won't follow edges

--- a/test/render/test-cases.js
+++ b/test/render/test-cases.js
@@ -70,7 +70,6 @@ const GRID_LAYER_INFO = {
   props: {
     data: dataSamples.points,
     cellSize: 200,
-    opacity: 1,
     extruded: true,
     pickable: true,
     getPosition: d => d.COORDINATES
@@ -91,7 +90,6 @@ const HEXAGON_LAYER_INFO = {
     extruded: true,
     pickable: true,
     radius: 1000,
-    opacity: 1,
     elevationScale: 1,
     elevationRange: [0, 3000],
     coverage: 1,
@@ -175,6 +173,7 @@ export const TEST_CASES = [
       new GeoJsonLayer({
         id: 'geojson-lnglat',
         data: dataSamples.geojson,
+        opacity: 0.8,
         getRadius: f => MARKER_SIZE_MAP[f.properties['marker-size']],
         getFillColor: f => parseColor(f.properties.fill || f.properties['marker-color']),
         getLineColor: f => parseColor(f.properties.stroke),
@@ -224,6 +223,7 @@ export const TEST_CASES = [
       new PointCloudLayer({
         id: 'pointcloud-identity',
         data: [{position: [0, 100, 0]}, {position: [-100, -100, 0]}, {position: [100, -100, 0]}],
+        opacity: 0.8,
         coordinateSystem: COORDINATE_SYSTEM.IDENTITY,
         getPosition: d => d.position,
         getNormal: d => [0, 0.5, 0.2],
@@ -247,6 +247,7 @@ export const TEST_CASES = [
         id: 'screengrid-infoviz',
         data: screenSpaceData,
         coordinateSystem: COORDINATE_SYSTEM.IDENTITY,
+        opacity: 0.8,
         getPosition: d => d,
         cellSizePixels: 40,
         pickable: false
@@ -271,7 +272,6 @@ export const TEST_CASES = [
         getPosition: d => d,
         coordinateSystem: COORDINATE_SYSTEM.IDENTITY,
         cellSize: 40,
-        opacity: 1,
         contours: [
           {threshold: 1, color: [50, 50, 50]},
           {threshold: 2, color: [100, 100, 100]},
@@ -298,7 +298,6 @@ export const TEST_CASES = [
         getPosition: d => d,
         coordinateSystem: COORDINATE_SYSTEM.IDENTITY,
         cellSize: 40,
-        opacity: 1,
         contours: [
           {threshold: [1, 2], color: [150, 0, 0]},
           {threshold: [2, 5], color: [0, 150, 0]}
@@ -423,7 +422,6 @@ export const TEST_CASES = [
         getPosition: d => d.COORDINATES,
         getFillColor: d => [255, 128, 0],
         getRadius: d => d.SPACES,
-        opacity: 1,
         pickable: true,
         radiusScale: 30,
         radiusMinPixels: 1,
@@ -449,7 +447,6 @@ export const TEST_CASES = [
         getPosition: d => d.COORDINATES,
         getFillColor: d => [255, 128, 0],
         getRadius: d => d.SPACES,
-        opacity: 1,
         pickable: true,
         radiusScale: 30,
         radiusMinPixels: 1,
@@ -472,6 +469,7 @@ export const TEST_CASES = [
       new ArcLayer({
         id: 'arc-lnglat',
         data: dataSamples.routes,
+        opacity: 0.8,
         strokeWidth: 2,
         getSourcePosition: d => d.START,
         getTargetPosition: d => d.END,
@@ -498,6 +496,7 @@ export const TEST_CASES = [
       new LineLayer({
         id: 'line-lnglat',
         data: dataSamples.routes,
+        opacity: 0.8,
         getWidth: 0,
         widthMinPixels: 2,
         getSourcePosition: d => d.START,
@@ -627,6 +626,7 @@ export const TEST_CASES = [
       new IconLayer({
         id: 'icon-lnglat-auto',
         data: dataSamples.points,
+        opacity: 0.8,
         updateTriggers: {
           getIcon: 2
         },
@@ -703,6 +703,7 @@ export const TEST_CASES = [
       new GeoJsonLayer({
         id: 'geojson-lnglat',
         data: dataSamples.geojson,
+        opacity: 0.8,
         getRadius: f => MARKER_SIZE_MAP[f.properties['marker-size']],
         getFillColor: f => {
           const color = parseColor(f.properties.fill || f.properties['marker-color']);
@@ -736,6 +737,7 @@ export const TEST_CASES = [
       new GeoJsonLayer({
         id: 'geojson-extruded-lnglat',
         data: dataSamples.geojson,
+        opacity: 0.8,
         extruded: true,
         wireframe: true,
         getRadius: f => MARKER_SIZE_MAP[f.properties['marker-size']],
@@ -774,7 +776,6 @@ export const TEST_CASES = [
         cellSize: dataSamples.worldGrid.cellSize,
         extruded: true,
         pickable: true,
-        opacity: 1,
         getFillColor: g => [245, 166, g.value * 255, 255],
         getElevation: h => h.value * 5000
       })
@@ -888,6 +889,7 @@ export const TEST_CASES = [
       new ScreenGridLayer({
         id: 'screengrid-lnglat-cpu-aggregation',
         data: dataSamples.points,
+        opacity: 0.8,
         getPosition: d => d.COORDINATES,
         cellSizePixels: 40,
         pickable: false,
@@ -909,6 +911,7 @@ export const TEST_CASES = [
       new ScreenGridLayer({
         id: 'screengrid-lnglat-colorRange',
         data: dataSamples.points,
+        opacity: 0.8,
         getPosition: d => d.COORDINATES,
         cellSizePixels: 40,
         pickable: false
@@ -935,7 +938,6 @@ export const TEST_CASES = [
         coverage: 1,
         extruded: true,
         pickable: true,
-        opacity: 1,
         getPosition: h => h.centroid,
         getFillColor: h => [48, 128, h.value * 255, 255],
         getElevation: h => h.value * 5000
@@ -976,7 +978,6 @@ export const TEST_CASES = [
         coverage: 1,
         extruded: true,
         pickable: true,
-        opacity: 1,
         shadowEnabled: false,
         getPosition: h => h.centroid,
         getFillColor: h => [48, 128, h.value * 255, 255],
@@ -1012,7 +1013,6 @@ export const TEST_CASES = [
         extruded: false,
         stroked: true,
         pickable: true,
-        opacity: 1,
         lineWidthUnits: 'pixels',
         getPosition: h => h.centroid,
         getFillColor: h => [48, 128, h.value * 255, 255],
@@ -1065,6 +1065,7 @@ export const TEST_CASES = [
       new HeatmapLayer({
         id: 'heatmap-lnglat',
         data: dataSamples.points,
+        opacity: 0.8,
         pickable: false,
         getPosition: d => d.COORDINATES,
         radiusPixels: 35,
@@ -1091,7 +1092,6 @@ export const TEST_CASES = [
         getPosition: d => [d.position[0] * 1e-5, d.position[1] * 1e-5, d.position[2]],
         getNormal: d => d.normal,
         getColor: d => d.color,
-        opacity: 1,
         pointSize: 2,
         pickable: true
       })
@@ -1116,7 +1116,6 @@ export const TEST_CASES = [
         getPosition: d => d.position,
         getNormal: d => d.normal,
         getColor: d => d.color,
-        opacity: 1,
         pointSize: 2,
         pickable: true
       })
@@ -1136,7 +1135,6 @@ export const TEST_CASES = [
       new PathLayer({
         id: 'path-meter',
         data: dataSamples.meterPaths,
-        opacity: 1.0,
         getColor: f => [255, 0, 0],
         getWidth: f => 10,
         widthMinPixels: 1,
@@ -1167,6 +1165,7 @@ export const TEST_CASES = [
       new TextLayer({
         id: 'text-layer',
         data: dataSamples.points.slice(0, 50),
+        opacity: 0.8,
         fontFamily: 'Arial',
         getText: x => `${x.PLACEMENT}-${x.YR_INSTALLED}`,
         getPosition: x => x.COORDINATES,
@@ -1194,6 +1193,7 @@ export const TEST_CASES = [
       new TextLayer({
         id: 'text-layer',
         data: dataSamples.points.slice(0, 50),
+        opacity: 0.8,
         fontFamily: 'Arial',
         getText: x => `${x.PLACEMENT}-${x.YR_INSTALLED}`,
         getPosition: x => x.COORDINATES,
@@ -1222,6 +1222,7 @@ export const TEST_CASES = [
       new TextLayer({
         id: 'text-layer',
         data: dataSamples.points.slice(0, 10),
+        opacity: 0.8,
         fontFamily: 'Arial',
         getText: x => `${x.PLACEMENT}\n${x.YR_INSTALLED}`,
         getPosition: x => x.COORDINATES,
@@ -1249,6 +1250,7 @@ export const TEST_CASES = [
       new TextLayer({
         id: 'text-layer',
         data: dataSamples.points.slice(0, 3),
+        opacity: 0.8,
         fontFamily: 'Arial',
         wordBreak: 'break-word',
         width: 1000,
@@ -1305,7 +1307,6 @@ export const TEST_CASES = [
         id: 'contour-lnglat-cpu-aggregation',
         data: dataSamples.points,
         cellSize: 200,
-        opacity: 1,
         getPosition: d => d.COORDINATES,
         contours: [
           {threshold: 1, color: [255, 0, 0], strokeWidth: 6},
@@ -1331,7 +1332,6 @@ export const TEST_CASES = [
         id: 'contour-lnglat',
         data: dataSamples.points,
         cellSize: 200,
-        opacity: 1,
         getPosition: d => d.COORDINATES,
         contours: [
           {threshold: 1, color: [255, 0, 0], strokeWidth: 6},
@@ -1357,7 +1357,6 @@ export const TEST_CASES = [
         id: 'contour-isobands-lnglat',
         data: dataSamples.points,
         cellSize: 200,
-        opacity: 1,
         getPosition: d => d.COORDINATES,
         contours: [
           {threshold: [1, 5], color: [255, 0, 0], strokeWidth: 6},
@@ -1381,6 +1380,7 @@ export const TEST_CASES = [
     layers: [
       new H3HexagonLayer({
         data: h3.kRing('882830829bfffff', 4),
+        opacity: 0.8,
         getHexagon: d => d,
         getFillColor: (d, {index}) => [255, index * 5, 0],
         getElevation: (d, {index}) => index * 100
@@ -1400,6 +1400,7 @@ export const TEST_CASES = [
     layers: [
       new H3HexagonLayer({
         data: h3.kRing('891c0000003ffff', 4),
+        opacity: 0.8,
         getHexagon: d => d,
         getFillColor: (d, {index}) => [255, index * 5, 0],
         getElevation: (d, {index}) => index * 10
@@ -1419,6 +1420,7 @@ export const TEST_CASES = [
     layers: [
       new H3HexagonLayer({
         data: h3.kRing('882830829bfffff', 4),
+        opacity: 0.8,
         getHexagon: d => d,
         extruded: false,
         stroked: true,
@@ -1441,6 +1443,7 @@ export const TEST_CASES = [
     layers: [
       new H3HexagonLayer({
         data: h3.kRing('882830829bfffff', 4),
+        opacity: 0.8,
         getHexagon: d => d,
         extruded: false,
         stroked: true,
@@ -1466,6 +1469,7 @@ export const TEST_CASES = [
         data: h3
           .polyfill([[-90, -180], [90, -180], [90, 0], [-90, 0]], 0)
           .concat(h3.polyfill([[-90, 180], [90, 180], [90, 0], [-90, 0]], 0)),
+        opacity: 0.8,
         getHexagon: d => d,
         extruded: false,
         filled: false,
@@ -1488,6 +1492,7 @@ export const TEST_CASES = [
     layers: [
       new H3ClusterLayer({
         data: ['882830829bfffff'],
+        opacity: 0.8,
         getHexagons: d => h3.kRing(d, 6),
         getLineWidth: 100,
         stroked: true,
@@ -1507,6 +1512,7 @@ export const TEST_CASES = [
     },
     layers: [
       new BitmapLayer({
+        opacity: 0.8,
         bounds: [-122.45, 37.7, -122.35, 37.8],
         image: ICON_ATLAS
       })
@@ -1526,6 +1532,7 @@ export const TEST_CASES = [
       new TripsLayer({
         id: 'trips-3d',
         data: dataSamples.trips,
+        opacity: 0.8,
         getPath: d => [d[0].begin_shape].concat(d.map(leg => leg.end_shape)),
         getTimestamps: d => [d[0].begin_time].concat(d.map(leg => leg.end_time)),
         getColor: [253, 128, 93],
@@ -1554,7 +1561,6 @@ export const TEST_CASES = [
         getPosition: d => d.COORDINATES,
         getFillColor: d => [255, 128, 0],
         getRadius: d => d.SPACES,
-        opacity: 1,
         pickable: true,
         radiusScale: 30,
         radiusMinPixels: 1,
@@ -1575,6 +1581,7 @@ export const TEST_CASES = [
     layers: [
       new S2Layer({
         data: dataSamples.s2cells,
+        opacity: 0.8,
         filled: true,
         stroked: false,
         getS2Token: f => f.token,

--- a/website/src/components/demos/geo-layer-demos.js
+++ b/website/src/components/demos/geo-layer-demos.js
@@ -74,7 +74,6 @@ export const TileLayerDemo = createLayerDemoClass({
   allowMissingData: true,
   props: {
     stroked: false,
-    opacity: 1,
 
     getLineColor: [192, 192, 192],
     getFillColor: [140, 170, 180],


### PR DESCRIPTION
For #3869 

#### Change List
- `opacity` is now default to `1`
- Remove override in `Tile3DLayer`, `SimpleMeshLayer` and `ScenegraphLayer`
- Update examples and render tests

cc @heshan0131 @georgios-uber @ibgreen @jcready @supersonicclay for visibility