### PR TITLE
Remove dependency on `registerShaderModule`

### DIFF
--- a/docs/developer-guide/custom-layers/picking.md
+++ b/docs/developer-guide/custom-layers/picking.md
@@ -103,12 +103,13 @@ If your layer creates its own [Model](https://github.com/uber/luma.gl/blob/maste
 
 ```js
 import {Model} from '@luma.gl/core';
+import {picking} from '@deck.gl/core';
 
 new Model(gl, {
   ...
   vs: CUSTOM_VS,
   fs: CUSTOM_FS,
-  modules: ['picking', ...]
+  modules: [picking]
 });
 ```
 

--- a/docs/developer-guide/custom-layers/writing-shaders.md
+++ b/docs/developer-guide/custom-layers/writing-shaders.md
@@ -3,10 +3,12 @@
 A shader library facilitates creating shaders that work seamlessly with deck.gl. The `modules` parameter passed to the [Model](https://github.com/uber/luma.gl/blob/master/docs/api-reference/core/model.md) class can dynamically include parts from this library into your own GLSL code:
 
 ```js
+import {picking, project32, gouraudLighting} from '@deck.gl/core';
+
 const model = new Model(gl, {
   vs: '// vertex shader GLSL source'
   fs: '// fragment shader GLSL source',
-  modules: ['picking', 'project', 'lighting'] // list of optional module names
+  modules: [picking, project32, gouraudLighting] // list of optional module names
 });
 ```
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -32,6 +32,29 @@
   + `pixelsPerMeter` -> `unitsPerMeter`
   + `metersPerPixel` -> `metersPerUnit`
 
+##### Shader modules
+
+This change affects custom layers. deck.gl is no longer registering shaders by default. This means any `modules` array defined in `layer.getShaders()` or `new Model()` must now use the full shader module objects, instead of just their names. All supported shader modules can be imported from `@deck.gl/core`.
+
+```js
+/// OLD
+new Model({
+  // ...
+  modules: ['picking', 'project32', 'gouraud-lighting']
+});
+```
+
+Should now become
+
+```js
+import {picking, project32, gouraudLighting} from '@deck.gl/core';
+/// NEW
+new Model({
+  // ...
+  modules: [picking, project32, gouraudLighting]
+});
+```
+
 
 ## Upgrading from deck.gl v7.2 to v7.3
 

--- a/examples/experimental/bezier/src/bezier-curve-layer/bezier-curve-layer.js
+++ b/examples/experimental/bezier/src/bezier-curve-layer/bezier-curve-layer.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {Layer, fp64LowPart} from '@deck.gl/core';
+import {Layer, fp64LowPart, picking} from '@deck.gl/core';
 import GL from '@luma.gl/constants';
 import {Model, Geometry} from '@luma.gl/core';
 
@@ -38,7 +38,7 @@ const defaultProps = {
 
 export default class BezierCurveLayer extends Layer {
   getShaders() {
-    return {vs, fs, modules: ['picking']};
+    return {vs, fs, modules: [picking]};
   }
 
   initializeState() {

--- a/examples/website/plot/plot-layer/surface-layer.js
+++ b/examples/website/plot/plot-layer/surface-layer.js
@@ -1,4 +1,4 @@
-import {Layer} from '@deck.gl/core';
+import {Layer, picking} from '@deck.gl/core';
 import GL from '@luma.gl/constants';
 import {Model} from '@luma.gl/core';
 
@@ -81,7 +81,7 @@ export default class SurfaceLayer extends Layer {
       id: `${this.props.id}-surface`,
       vs: surfaceVertex,
       fs: fragmentShader,
-      modules: ['picking'],
+      modules: [picking],
       drawMode: GL.TRIANGLES,
       vertexCount: 0,
       isIndexed: true

--- a/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-cell-layer.js
+++ b/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-cell-layer.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {Layer, fp64LowPart} from '@deck.gl/core';
+import {Layer, fp64LowPart, project32, gouraudLighting, picking} from '@deck.gl/core';
 import GL from '@luma.gl/constants';
 import {Model, CubeGeometry, PhongMaterial, fp64 as fp64ShaderModule} from '@luma.gl/core';
 const defaultMaterial = new PhongMaterial();
@@ -58,7 +58,7 @@ export default class GPUGridCellLayer extends Layer {
     return super.getShaders({
       vs,
       fs,
-      modules: ['project32', 'gouraud-lighting', 'picking', fp64ShaderModule]
+      modules: [project32, gouraudLighting, picking, fp64ShaderModule]
     });
   }
 

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
@@ -37,7 +37,7 @@ import {
   hasFeatures,
   isWebGL2
 } from '@luma.gl/core';
-import {AttributeManager, COORDINATE_SYSTEM, log, mergeShaders} from '@deck.gl/core';
+import {AttributeManager, COORDINATE_SYSTEM, log, mergeShaders, project32} from '@deck.gl/core';
 import TriangleLayer from './triangle-layer';
 import AggregationLayer from '../aggregation-layer';
 import {defaultColorRange, colorRangeToFlatArray} from '../utils/color-utils';
@@ -287,7 +287,7 @@ export default class HeatmapLayer extends AggregationLayer {
       {
         vs: weights_vs,
         _fs: weights_fs,
-        modules: ['project32']
+        modules: [project32]
       },
       shaderOptions
     );

--- a/modules/aggregation-layers/src/heatmap-layer/triangle-layer.js
+++ b/modules/aggregation-layers/src/heatmap-layer/triangle-layer.js
@@ -20,7 +20,7 @@
 
 import GL from '@luma.gl/constants';
 import {Model, Geometry} from '@luma.gl/core';
-import {Layer} from '@deck.gl/core';
+import {Layer, project32} from '@deck.gl/core';
 import vs from './triangle-layer-vertex.glsl';
 import fs from './triangle-layer-fragment.glsl';
 
@@ -31,7 +31,7 @@ const defaultProps = {
 
 export default class TriangleLayer extends Layer {
   getShaders() {
-    return {vs, fs, modules: ['project32']};
+    return {vs, fs, modules: [project32]};
   }
 
   initializeState() {

--- a/modules/aggregation-layers/src/screen-grid-layer/screen-grid-cell-layer.js
+++ b/modules/aggregation-layers/src/screen-grid-layer/screen-grid-cell-layer.js
@@ -20,7 +20,7 @@
 
 import GL from '@luma.gl/constants';
 import {Model, Geometry, FEATURES, hasFeatures} from '@luma.gl/core';
-import {Layer, log} from '@deck.gl/core';
+import {Layer, log, picking} from '@deck.gl/core';
 import {defaultColorRange, colorRangeToFlatArray} from '../utils/color-utils';
 import vs from './screen-grid-layer-vertex.glsl';
 import fs from './screen-grid-layer-fragment.glsl';
@@ -43,7 +43,7 @@ export default class ScreenGridCellLayer extends Layer {
   }
 
   getShaders() {
-    return {vs, fs, modules: ['picking']};
+    return {vs, fs, modules: [picking]};
   }
 
   initializeState() {

--- a/modules/aggregation-layers/src/utils/gpu-grid-aggregation/gpu-grid-aggregator.js
+++ b/modules/aggregation-layers/src/utils/gpu-grid-aggregation/gpu-grid-aggregator.js
@@ -30,7 +30,7 @@ import {
   fp64 as fp64ShaderModule,
   withParameters
 } from '@luma.gl/core';
-import {log, project64, mergeShaders} from '@deck.gl/core';
+import {log, project32, project64, mergeShaders} from '@deck.gl/core';
 import {worldToPixels} from '@math.gl/web-mercator';
 const {fp64ifyMatrix4} = fp64ShaderModule;
 
@@ -1008,7 +1008,7 @@ function getAggregationModel(gl, shaderOptions, fp64 = false) {
     {
       vs: fp64 ? AGGREGATE_TO_GRID_VS_FP64 : AGGREGATE_TO_GRID_VS,
       fs: AGGREGATE_TO_GRID_FS,
-      modules: fp64 ? [project64] : ['project32']
+      modules: fp64 ? [project64] : [project32]
     },
     shaderOptions
   );

--- a/modules/core/src/index.js
+++ b/modules/core/src/index.js
@@ -53,8 +53,15 @@ export {default as Viewport} from './viewports/viewport';
 export {default as WebMercatorViewport} from './viewports/web-mercator-viewport';
 
 // Shader modules
-export {default as project} from './shaderlib/project/project';
-export {default as project64} from './shaderlib/project64/project64';
+export {
+  picking,
+  project,
+  project32,
+  project64,
+  gouraudLighting,
+  phongLighting,
+  shadow
+} from './shaderlib';
 
 export {default as View} from './views/view';
 export {default as MapView} from './views/map-view';

--- a/modules/core/src/lib/init.js
+++ b/modules/core/src/lib/init.js
@@ -24,7 +24,6 @@ import {HTMLImageLoader} from '@loaders.gl/images';
 import {global} from '../utils/globals';
 import log from '../utils/log';
 import jsonLoader from '../utils/json-loader';
-import {initializeShaderModules} from '../shaderlib';
 
 // Version detection using babel plugin
 // Fallback for tests and SSR since global variable is defined by Webpack.
@@ -48,8 +47,6 @@ if (!global.deck) {
   };
 
   registerLoaders([jsonLoader, HTMLImageLoader]);
-
-  initializeShaderModules();
 }
 
 export default global.deck;

--- a/modules/core/src/shaderlib/index.js
+++ b/modules/core/src/shaderlib/index.js
@@ -19,11 +19,7 @@
 // THE SOFTWARE.
 
 import {ProgramManager} from '@luma.gl/core';
-import {
-  fp32,
-  gouraudlighting as gouraudLighting,
-  phonglighting as phongLighting
-} from '@luma.gl/core';
+import {gouraudlighting as gouraudLighting, phonglighting as phongLighting} from '@luma.gl/core';
 import geometry from './misc/geometry';
 import project from './project/project';
 import project32 from './project32/project32';

--- a/modules/core/src/shaderlib/index.js
+++ b/modules/core/src/shaderlib/index.js
@@ -18,8 +18,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {registerShaderModules, ProgramManager} from '@luma.gl/core';
-import {fp32, gouraudlighting, phonglighting} from '@luma.gl/core';
+import {ProgramManager} from '@luma.gl/core';
+import {
+  fp32,
+  gouraudlighting as gouraudLighting,
+  phonglighting as phongLighting
+} from '@luma.gl/core';
 import geometry from './misc/geometry';
 import project from './project/project';
 import project32 from './project32/project32';
@@ -36,10 +40,6 @@ const SHADER_HOOKS = [
   'fs:DECKGL_FILTER_COLOR(inout vec4 color, FragmentGeometry geometry)'
 ];
 
-export function initializeShaderModules() {
-  registerShaderModules([fp32, project, project32, gouraudlighting, phonglighting, picking]);
-}
-
 export function createProgramManager(gl) {
   const programManager = ProgramManager.getDefaultProgramManager(gl);
 
@@ -53,4 +53,4 @@ export function createProgramManager(gl) {
   return programManager;
 }
 
-export {picking, project, project64, gouraudlighting, phonglighting, shadow};
+export {picking, project, project32, project64, gouraudLighting, phongLighting, shadow};

--- a/modules/geo-layers/src/great-circle-layer/great-circle-layer.js
+++ b/modules/geo-layers/src/great-circle-layer/great-circle-layer.js
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+import {picking, project32} from '@deck.gl/core';
 import {ArcLayer} from '@deck.gl/layers';
 import vs from './great-circle-vertex.glsl';
 
@@ -25,7 +26,7 @@ export default class GreatCircleLayer extends ArcLayer {
   getShaders() {
     const shaders = Object.assign({}, super.getShaders(), {
       vs,
-      modules: ['picking', 'project32']
+      modules: [picking, project32]
     });
     return shaders;
   }

--- a/modules/layers/src/arc-layer/arc-layer.js
+++ b/modules/layers/src/arc-layer/arc-layer.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {Layer, createIterable} from '@deck.gl/core';
+import {Layer, createIterable, picking} from '@deck.gl/core';
 
 import GL from '@luma.gl/constants';
 import {Model, Geometry} from '@luma.gl/core';
@@ -45,7 +45,7 @@ const defaultProps = {
 
 export default class ArcLayer extends Layer {
   getShaders() {
-    return super.getShaders({vs, fs, modules: ['picking']}); // 'project' module added by default.
+    return super.getShaders({vs, fs, modules: [picking]}); // 'project' module added by default.
   }
 
   initializeState() {

--- a/modules/layers/src/bitmap-layer/bitmap-layer.js
+++ b/modules/layers/src/bitmap-layer/bitmap-layer.js
@@ -20,7 +20,7 @@
 
 /* global HTMLVideoElement */
 import GL from '@luma.gl/constants';
-import {Layer} from '@deck.gl/core';
+import {Layer, project32, picking} from '@deck.gl/core';
 import {Model, Geometry, Texture2D} from '@luma.gl/core';
 
 import vs from './bitmap-layer-vertex';
@@ -53,7 +53,7 @@ const defaultProps = {
  */
 export default class BitmapLayer extends Layer {
   getShaders() {
-    return super.getShaders({vs, fs, modules: ['project32', 'picking']});
+    return super.getShaders({vs, fs, modules: [project32, picking]});
   }
 
   initializeState() {

--- a/modules/layers/src/column-layer/column-layer.js
+++ b/modules/layers/src/column-layer/column-layer.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {Layer} from '@deck.gl/core';
+import {Layer, project32, gouraudLighting, picking} from '@deck.gl/core';
 import GL from '@luma.gl/constants';
 import {Model, PhongMaterial} from '@luma.gl/core';
 import ColumnGeometry from './column-geometry';
@@ -59,7 +59,7 @@ const defaultProps = {
 
 export default class ColumnLayer extends Layer {
   getShaders() {
-    return super.getShaders({vs, fs, modules: ['project32', 'gouraud-lighting', 'picking']});
+    return super.getShaders({vs, fs, modules: [project32, gouraudLighting, picking]});
   }
 
   /**

--- a/modules/layers/src/icon-layer/icon-layer.js
+++ b/modules/layers/src/icon-layer/icon-layer.js
@@ -17,7 +17,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-import {Layer} from '@deck.gl/core';
+import {Layer, project32, picking} from '@deck.gl/core';
 import GL from '@luma.gl/constants';
 import {Model, Geometry} from '@luma.gl/core';
 
@@ -68,7 +68,7 @@ const defaultProps = {
 
 export default class IconLayer extends Layer {
   getShaders() {
-    return super.getShaders({vs, fs, modules: ['project32', 'picking']});
+    return super.getShaders({vs, fs, modules: [project32, picking]});
   }
 
   initializeState() {

--- a/modules/layers/src/line-layer/line-layer.js
+++ b/modules/layers/src/line-layer/line-layer.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {Layer} from '@deck.gl/core';
+import {Layer, project32, picking} from '@deck.gl/core';
 import GL from '@luma.gl/constants';
 import {Model, Geometry} from '@luma.gl/core';
 
@@ -41,7 +41,7 @@ const defaultProps = {
 
 export default class LineLayer extends Layer {
   getShaders() {
-    return super.getShaders({vs, fs, modules: ['project32', 'picking']});
+    return super.getShaders({vs, fs, modules: [project32, picking]});
   }
 
   initializeState() {

--- a/modules/layers/src/path-layer/path-layer.js
+++ b/modules/layers/src/path-layer/path-layer.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {Layer} from '@deck.gl/core';
+import {Layer, project32, picking} from '@deck.gl/core';
 import GL from '@luma.gl/constants';
 import {Model, Geometry} from '@luma.gl/core';
 
@@ -53,7 +53,7 @@ const ATTRIBUTE_TRANSITION = {
 
 export default class PathLayer extends Layer {
   getShaders() {
-    return super.getShaders({vs, fs, modules: ['project32', 'picking']}); // 'project' module added by default.
+    return super.getShaders({vs, fs, modules: [project32, picking]}); // 'project' module added by default.
   }
 
   initializeState() {

--- a/modules/layers/src/point-cloud-layer/point-cloud-layer.js
+++ b/modules/layers/src/point-cloud-layer/point-cloud-layer.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {Layer} from '@deck.gl/core';
+import {Layer, project32, gouraudLighting, picking} from '@deck.gl/core';
 import GL from '@luma.gl/constants';
 import {Model, Geometry, PhongMaterial} from '@luma.gl/core';
 
@@ -65,7 +65,7 @@ function normalizeData(data) {
 
 export default class PointCloudLayer extends Layer {
   getShaders(id) {
-    return super.getShaders({vs, fs, modules: ['project32', 'gouraud-lighting', 'picking']});
+    return super.getShaders({vs, fs, modules: [project32, gouraudLighting, picking]});
   }
 
   initializeState() {

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer.js
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {Layer} from '@deck.gl/core';
+import {Layer, project32, picking} from '@deck.gl/core';
 import GL from '@luma.gl/constants';
 import {Model, Geometry} from '@luma.gl/core';
 
@@ -54,7 +54,7 @@ const defaultProps = {
 
 export default class ScatterplotLayer extends Layer {
   getShaders(id) {
-    return super.getShaders({vs, fs, modules: ['project32', 'picking']});
+    return super.getShaders({vs, fs, modules: [project32, picking]});
   }
 
   initializeState() {

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {Layer} from '@deck.gl/core';
+import {Layer, project32, gouraudLighting, picking} from '@deck.gl/core';
 import GL from '@luma.gl/constants';
 import {Model, Geometry, hasFeature, FEATURES, PhongMaterial} from '@luma.gl/core';
 
@@ -66,7 +66,7 @@ export default class SolidPolygonLayer extends Layer {
       vs,
       fs,
       defines: {},
-      modules: ['project32', 'gouraud-lighting', 'picking']
+      modules: [project32, gouraudLighting, picking]
     });
   }
 

--- a/modules/main/src/index.js
+++ b/modules/main/src/index.js
@@ -50,8 +50,13 @@ export {
   // For custom layers
   AttributeManager,
   // Shader modules
+  picking,
   project,
+  project32,
   project64,
+  gouraudLighting,
+  phongLighting,
+  shadow,
   // Internal classes
   LayerManager,
   DeckRenderer,

--- a/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.js
+++ b/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {Layer} from '@deck.gl/core';
+import {Layer, project32, picking} from '@deck.gl/core';
 import {ScenegraphNode, isWebGL2, pbr, log} from '@luma.gl/core';
 import {createGLTFObjects} from '@luma.gl/addons';
 import GL from '@luma.gl/constants';
@@ -206,7 +206,7 @@ export default class ScenegraphLayer extends Layer {
   }
 
   getLoadOptions() {
-    const modules = ['project32', 'picking'];
+    const modules = [project32, picking];
     const {_lighting, _imageBasedLightingEnvironment} = this.props;
 
     if (_lighting === 'pbr') {

--- a/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.js
+++ b/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.js
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {Layer} from '@deck.gl/core';
+import {Layer, project32, phongLighting, picking} from '@deck.gl/core';
 import GL from '@luma.gl/constants';
 import {Model, Geometry, Texture2D, PhongMaterial, isWebGL2} from '@luma.gl/core';
 
@@ -119,7 +119,7 @@ export default class SimpleMeshLayer extends Layer {
     const vs = gl2 ? vs3 : vs1;
     const fs = gl2 ? fs3 : fs1;
 
-    return super.getShaders({vs, fs, modules: ['project32', 'phong-lighting', 'picking']});
+    return super.getShaders({vs, fs, modules: [project32, phongLighting, picking]});
   }
 
   initializeState() {

--- a/test/modules/aggregation-layers/gpu-grid-layer/gpu-grid-cell-layer-vertex.spec.js
+++ b/test/modules/aggregation-layers/gpu-grid-layer/gpu-grid-cell-layer-vertex.spec.js
@@ -1,6 +1,7 @@
 import test from 'tape-catch';
 // import VS from '@deck.gl/aggregation-layers/gpu-grid-layer/gpu-grid-cell-layer-vertex.glsl';
 import {getQuantizeScale} from '@deck.gl/aggregation-layers/utils/scale-utils';
+import {project32, gouraudLighting, picking} from '@deck.gl/core';
 import {gl} from '@deck.gl/test-utils';
 import {Transform, Buffer} from '@luma.gl/core';
 import {equals, config} from 'math.gl';
@@ -80,7 +81,7 @@ void main(void) {
       inValue: valueBuffer
     },
     vs,
-    modules: ['project32', 'gouraud-lighting', 'picking'],
+    modules: [project32, gouraudLighting, picking],
     // inject,
     feedbackBuffers: {
       outColor: outBuffer

--- a/test/modules/aggregation-layers/gpu-grid-layer/webgl1-spies-utils.js
+++ b/test/modules/aggregation-layers/gpu-grid-layer/webgl1-spies-utils.js
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 
 import {isWebGL2, fp64 as fp64ShaderModule} from '@luma.gl/core';
+import {project32, gouraudLighting, picking} from '@deck.gl/core';
 import {_GPUGridAggregator as GPUGridAggregator} from '@deck.gl/aggregation-layers';
 import GPUGridCellLayer from '@deck.gl/aggregation-layers/gpu-grid-layer/gpu-grid-cell-layer';
 import {makeSpy} from '@probe.gl/test-utils';
@@ -42,7 +43,7 @@ export function setupSpysForWebGL1(gl) {
     getShadersSpy.returns({
       vs: VS,
       fs: FS,
-      modules: ['project32', 'gouraud-lighting', 'picking', fp64ShaderModule]
+      modules: [project32, gouraudLighting, picking, fp64ShaderModule]
     });
     isSupportedSpy.returns(true);
     setupUniformBufferSpy.returns(null);

--- a/test/modules/core/utils/shader.spec.js
+++ b/test/modules/core/utils/shader.spec.js
@@ -1,4 +1,5 @@
 import test from 'tape-catch';
+import {project, phongLighting} from '@deck.gl/core';
 import {mergeShaders} from '@deck.gl/core/utils/shader';
 
 const TEST_SHADERS = {vs: 'vs', fs: 'fs'};
@@ -13,14 +14,14 @@ const TEST_CASES = [
     title: 'missing target fields',
     input: {
       defines: {DRAW: 1},
-      modules: ['project'],
+      modules: [project],
       inject: {'fs#main-start': 'discard;'}
     },
     output: {
       vs: 'vs',
       fs: 'fs',
       defines: {DRAW: 1},
-      modules: ['project'],
+      modules: [project],
       inject: {'fs#main-start': 'discard;'}
     }
   },
@@ -29,14 +30,14 @@ const TEST_CASES = [
     input: {
       vs: 'vs-v2',
       defines: {DRAW: 0, EXTRUDE: 1},
-      modules: ['phong-lighting'],
+      modules: [phongLighting],
       inject: {'fs#main-end': 'filter_pickingColor(gl_FragColor);'}
     },
     output: {
       vs: 'vs-v2',
       fs: 'fs',
       defines: {DRAW: 0, EXTRUDE: 1},
-      modules: ['project', 'phong-lighting'],
+      modules: [project, phongLighting],
       inject: {'fs#main-start': 'discard;', 'fs#main-end': 'filter_pickingColor(gl_FragColor);'}
     }
   }

--- a/test/modules/layers/path-layer/path-layer-vertex.spec.js
+++ b/test/modules/layers/path-layer/path-layer-vertex.spec.js
@@ -2,6 +2,7 @@ import test from 'tape-catch';
 
 // import {COORDINATE_SYSTEM, Viewport, WebMercatorViewport} from 'deck.gl';
 import {gl} from '@deck.gl/test-utils';
+import {picking, project32} from '@deck.gl/core';
 import {Transform, Buffer} from '@luma.gl/core';
 import VS from '../../../../modules/layers/src/path-layer/path-layer-vertex.glsl';
 
@@ -27,7 +28,7 @@ varying float result;
       inFlag
     },
     vs: VS,
-    modules: ['picking', 'project32'],
+    modules: [picking, project32],
     inject,
     feedbackMap: {
       inFlag: 'result'

--- a/test/modules/layers/scenegraph-layer.spec.js
+++ b/test/modules/layers/scenegraph-layer.spec.js
@@ -21,6 +21,7 @@
 import test from 'tape-catch';
 import {testLayer, generateLayerTests} from '@deck.gl/test-utils';
 
+import {project32} from '@deck.gl/core';
 import {ScenegraphLayer} from '@deck.gl/mesh-layers';
 import {GroupNode, ModelNode, CubeGeometry} from '@luma.gl/core';
 
@@ -101,7 +102,7 @@ test('ScenegraphLayer#tests', t => {
             geometry: new CubeGeometry(),
             vs,
             fs,
-            modules: ['project32'],
+            modules: [project32],
             isInstanced: true
           })
         ]);


### PR DESCRIPTION
For #3869

#### Change List
- Remove shader initialization
- Layers
- Tests
- Docs
- Upgrade guide

#### TODO
We don't have documentations for all available shader modules.