### PR TITLE
Simplify PathLayer tesselation

### DIFF
--- a/modules/layers/src/path-layer/path-layer.js
+++ b/modules/layers/src/path-layer/path-layer.js
@@ -61,7 +61,7 @@ export default class PathLayer extends Layer {
     const attributeManager = this.getAttributeManager();
     /* eslint-disable max-len */
     attributeManager.addInstanced({
-      startPositions: {
+      positions: {
         size: 3,
         // Hack - Attribute class needs this to properly apply partial update
         // The first 3 numbers of the value is just padding
@@ -70,7 +70,7 @@ export default class PathLayer extends Layer {
         fp64: this.use64bitPositions(),
         transition: ATTRIBUTE_TRANSITION,
         accessor: 'getPath',
-        update: this.calculateStartPositions,
+        update: this.calculatePositions,
         noAlloc,
         shaderAttributes: {
           instanceLeftPositions: {
@@ -78,23 +78,12 @@ export default class PathLayer extends Layer {
           },
           instanceStartPositions: {
             offset: 12
-          }
-        }
-      },
-      endPositions: {
-        size: 3,
-        type: GL.DOUBLE,
-        fp64: this.use64bitPositions(),
-        transition: ATTRIBUTE_TRANSITION,
-        accessor: 'getPath',
-        update: this.calculateEndPositions,
-        noAlloc,
-        shaderAttributes: {
+          },
           instanceEndPositions: {
-            offset: 0
+            offset: 24
           },
           instanceRightPositions: {
-            offset: 12
+            offset: 36
           }
         }
       },
@@ -283,18 +272,11 @@ export default class PathLayer extends Layer {
     );
   }
 
-  calculateStartPositions(attribute) {
+  calculatePositions(attribute) {
     const {pathTesselator} = this.state;
 
     attribute.bufferLayout = pathTesselator.bufferLayout;
-    attribute.value = pathTesselator.get('startPositions');
-  }
-
-  calculateEndPositions(attribute) {
-    const {pathTesselator} = this.state;
-
-    attribute.bufferLayout = pathTesselator.bufferLayout;
-    attribute.value = pathTesselator.get('endPositions');
+    attribute.value = pathTesselator.get('positions');
   }
 
   calculateSegmentTypes(attribute) {

--- a/test/modules/layers/path-tesselator.spec.js
+++ b/test/modules/layers/path-tesselator.spec.js
@@ -30,7 +30,7 @@ const SAMPLE_DATA = [
   {path: new Float64Array([1, 1, 2, 2, 3, 3]), width: 1, dashArray: [0, 0], color: [0, 0, 0]},
   {path: [[1, 1], [2, 2], [3, 3], [1, 1]], width: 3, dashArray: [2, 1], color: [0, 0, 255]}
 ];
-const INSTANCE_COUNT = 9;
+const INSTANCE_COUNT = 12;
 
 const TEST_DATA = [
   {
@@ -82,26 +82,17 @@ test('PathTesselator#constructor', t => {
       t.comment(`  ${testCase.title}`);
       const tesselator = new PathTesselator(Object.assign({}, testData, testCase.params));
 
-      t.ok(
-        ArrayBuffer.isView(tesselator.get('startPositions')),
-        'PathTesselator.get startPositions'
-      );
+      t.ok(ArrayBuffer.isView(tesselator.get('positions')), 'PathTesselator.get positions');
       t.deepEquals(
-        tesselator.get('startPositions').slice(0, 9),
-        [0, 0, 0, 1, 1, 0, 2, 2, 0],
-        'startPositions are filled'
+        tesselator.get('positions').slice(0, 12),
+        [0, 0, 0, 1, 1, 0, 2, 2, 0, 3, 3, 0],
+        'positions are filled'
       );
 
-      t.ok(ArrayBuffer.isView(tesselator.get('endPositions')), 'PathTesselator.get endPositions');
       t.deepEquals(
-        tesselator.get('endPositions').slice(0, 9),
-        [2, 2, 0, 3, 3, 0, 2, 2, 0],
-        'endPositions are filled'
-      );
-      t.deepEquals(
-        tesselator.get('endPositions').slice(21, 30),
-        [2, 2, 0, 3, 3, 0, 0, 0, 0],
-        'endPositions is handling loop correctly'
+        tesselator.get('positions').slice(24, 33),
+        [2, 2, 0, 3, 3, 0, 1, 1, 0],
+        'positions is handling loop correctly'
       );
     });
   });
@@ -125,36 +116,76 @@ test('PathTesselator#partial update', t => {
     positionFormat: 'XY'
   });
 
-  let startPositions = tesselator.get('startPositions').slice(0, 18);
-  t.is(tesselator.instanceCount, 7, 'Initial instance count');
+  let positions = tesselator.get('positions').slice(0, 21);
+  t.is(tesselator.instanceCount, 9, 'Initial instance count');
   t.deepEquals(
-    startPositions,
-    [0, 0, 0, 1, 1, 0, 2, 2, 0, 1, 1, 0, 2, 2, 0, 3, 3, 0],
-    'startPositions'
+    positions,
+    [0, 0, 0, 1, 1, 0, 2, 2, 0, 3, 3, 0, 1, 1, 0, 2, 2, 0, 3, 3, 0],
+    'positions'
   );
   t.deepEquals(Array.from(accessorCalled), ['A', 'B'], 'Accessor called on all data');
 
   sampleData[2] = {path: [[4, 4], [5, 5], [6, 6]], id: 'C'};
   accessorCalled.clear();
   tesselator.updatePartialGeometry({startRow: 2});
-  startPositions = tesselator.get('startPositions').slice(0, 30);
-  t.is(tesselator.instanceCount, 9, 'Updated instance count');
+  positions = tesselator.get('positions').slice(0, 39);
+  t.is(tesselator.instanceCount, 12, 'Updated instance count');
   t.deepEquals(
-    startPositions,
-    [0, 0, 0, 1, 1, 0, 2, 2, 0, 1, 1, 0, 2, 2, 0, 3, 3, 0, 1, 1, 0, 2, 2, 0, 4, 4, 0, 5, 5, 0],
-    'startPositions'
+    positions,
+    [
+      0,
+      0,
+      0,
+      1,
+      1,
+      0,
+      2,
+      2,
+      0,
+      3,
+      3,
+      0,
+      1,
+      1,
+      0,
+      2,
+      2,
+      0,
+      3,
+      3,
+      0,
+      1,
+      1,
+      0,
+      2,
+      2,
+      0,
+      3,
+      3,
+      0,
+      4,
+      4,
+      0,
+      5,
+      5,
+      0,
+      6,
+      6,
+      0
+    ],
+    'positions'
   );
   t.deepEquals(Array.from(accessorCalled), ['C'], 'Accessor called only on partial data');
 
   sampleData[0] = {path: [[6, 6], [5, 5], [4, 4]], id: 'A'};
   accessorCalled.clear();
   tesselator.updatePartialGeometry({startRow: 0, endRow: 1});
-  startPositions = tesselator.get('startPositions').slice(0, 30);
-  t.is(tesselator.instanceCount, 9, 'Updated instance count');
+  positions = tesselator.get('positions').slice(0, 30);
+  t.is(tesselator.instanceCount, 12, 'Updated instance count');
   t.deepEquals(
-    startPositions,
-    [0, 0, 0, 6, 6, 0, 5, 5, 0, 1, 1, 0, 2, 2, 0, 3, 3, 0, 1, 1, 0, 2, 2, 0, 4, 4, 0, 5, 5, 0],
-    'startPositions'
+    positions,
+    [0, 0, 0, 6, 6, 0, 5, 5, 0, 4, 4, 0, 1, 1, 0, 2, 2, 0, 3, 3, 0, 1, 1, 0, 2, 2, 0, 3, 3, 0],
+    'positions'
   );
   t.deepEquals(Array.from(accessorCalled), ['A'], 'Accessor called only on partial data');
 


### PR DESCRIPTION
For #3758 

#### Background

This change simplifies the layout of the position attributes, saves a little bit of memory, and prepares `PathTesselator` for accepting external buffers.

In this new format, loops are padded with 2 additional vertices, and paths without loops no longer require tesselation. We may expose it later as an option for use cases where performance is more important than visual quality. @twojtasz 

#### Change List
- Use a single positions buffer in `PathLayer`
- Unit tests