### PR TITLE
Change bufferLayout to startIndices

### DIFF
--- a/modules/core/src/lib/attribute/attribute-manager.js
+++ b/modules/core/src/lib/attribute/attribute-manager.js
@@ -216,7 +216,7 @@ export default class AttributeManager {
   update({
     data,
     numInstances,
-    bufferLayout,
+    vertexStarts,
     transitions,
     props = {},
     buffers = {},
@@ -246,7 +246,7 @@ export default class AttributeManager {
         this._updateAttribute({
           attribute,
           numInstances,
-          bufferLayout,
+          vertexStarts,
           data,
           props,
           context

--- a/modules/core/src/lib/attribute/attribute-manager.js
+++ b/modules/core/src/lib/attribute/attribute-manager.js
@@ -216,7 +216,7 @@ export default class AttributeManager {
   update({
     data,
     numInstances,
-    vertexStarts,
+    startIndices,
     transitions,
     props = {},
     buffers = {},
@@ -246,7 +246,7 @@ export default class AttributeManager {
         this._updateAttribute({
           attribute,
           numInstances,
-          vertexStarts,
+          startIndices,
           data,
           props,
           context

--- a/modules/core/src/lib/attribute/attribute-transition-manager.js
+++ b/modules/core/src/lib/attribute/attribute-transition-manager.js
@@ -116,7 +116,7 @@ export default class AttributeTransitionManager {
     // an attribute can change transition type when it updates
     // let's remove the transition when that happens so we can create the new transition type
     // TODO: when switching transition types, make sure to carry over the attribute's
-    // previous buffers, currentLength, bufferLayout, etc, to be used as the starting point
+    // previous buffers, currentLength, vertexStarts, etc, to be used as the starting point
     // for the next transition
     let isNew = !transition || transition.type !== settings.type;
     if (isNew) {

--- a/modules/core/src/lib/attribute/attribute-transition-manager.js
+++ b/modules/core/src/lib/attribute/attribute-transition-manager.js
@@ -116,7 +116,7 @@ export default class AttributeTransitionManager {
     // an attribute can change transition type when it updates
     // let's remove the transition when that happens so we can create the new transition type
     // TODO: when switching transition types, make sure to carry over the attribute's
-    // previous buffers, currentLength, vertexStarts, etc, to be used as the starting point
+    // previous buffers, currentLength, startIndices, etc, to be used as the starting point
     // for the next transition
     let isNew = !transition || transition.type !== settings.type;
     if (isNew) {

--- a/modules/core/src/lib/attribute/attribute-transition-utils.js
+++ b/modules/core/src/lib/attribute/attribute-transition-utils.js
@@ -89,7 +89,7 @@ export function padBuffer({
   numInstances,
   attribute,
   fromLength,
-  fromVertexStarts,
+  fromStartIndices,
   getData = x => x
 }) {
   // TODO: move the precisionMultiplier logic to the attribute when retrieving
@@ -97,13 +97,13 @@ export function padBuffer({
   const precisionMultiplier = attribute.doublePrecision ? 2 : 1;
   const size = attribute.size * precisionMultiplier;
   const offset = attribute.elementOffset * precisionMultiplier;
-  const toVertexStarts = attribute.vertexStarts;
-  const hasVertexStarts = fromVertexStarts && toVertexStarts;
+  const toStartIndices = attribute.startIndices;
+  const hasStartIndices = fromStartIndices && toStartIndices;
   const toLength = getAttributeBufferLength(attribute, numInstances);
   const isConstant = attribute.state.constant;
 
   // check if buffer needs to be padded
-  if (!hasVertexStarts && fromLength >= toLength) {
+  if (!hasStartIndices && fromLength >= toLength) {
     return;
   }
 
@@ -122,8 +122,8 @@ export function padBuffer({
   padArray({
     source,
     target: data,
-    sourceVertexStarts: fromVertexStarts,
-    targetVertexStarts: toVertexStarts,
+    sourceStartIndices: fromStartIndices,
+    targetStartIndices: toStartIndices,
     offset,
     size,
     getData: getMissingData

--- a/modules/core/src/lib/attribute/attribute-transition-utils.js
+++ b/modules/core/src/lib/attribute/attribute-transition-utils.js
@@ -89,7 +89,7 @@ export function padBuffer({
   numInstances,
   attribute,
   fromLength,
-  fromBufferLayout,
+  fromVertexStarts,
   getData = x => x
 }) {
   // TODO: move the precisionMultiplier logic to the attribute when retrieving
@@ -97,13 +97,13 @@ export function padBuffer({
   const precisionMultiplier = attribute.doublePrecision ? 2 : 1;
   const size = attribute.size * precisionMultiplier;
   const offset = attribute.elementOffset * precisionMultiplier;
-  const toBufferLayout = attribute.bufferLayout;
-  const hasBufferLayout = fromBufferLayout && toBufferLayout;
+  const toVertexStarts = attribute.vertexStarts;
+  const hasVertexStarts = fromVertexStarts && toVertexStarts;
   const toLength = getAttributeBufferLength(attribute, numInstances);
   const isConstant = attribute.state.constant;
 
   // check if buffer needs to be padded
-  if (!hasBufferLayout && fromLength >= toLength) {
+  if (!hasVertexStarts && fromLength >= toLength) {
     return;
   }
 
@@ -122,8 +122,8 @@ export function padBuffer({
   padArray({
     source,
     target: data,
-    sourceLayout: fromBufferLayout,
-    targetLayout: toBufferLayout,
+    sourceVertexStarts: fromVertexStarts,
+    targetVertexStarts: toVertexStarts,
     offset,
     size,
     getData: getMissingData

--- a/modules/core/src/lib/attribute/attribute.js
+++ b/modules/core/src/lib/attribute/attribute.js
@@ -262,7 +262,8 @@ export default class Attribute extends DataColumn {
 
       if (vertexStarts) {
         attribute._normalizeValue(objectValue, objectInfo.target);
-        const numVertices = (vertexStarts[objectInfo.index + 1] || numInstances) - vertexStarts[objectInfo.index];
+        const numVertices =
+          (vertexStarts[objectInfo.index + 1] || numInstances) - vertexStarts[objectInfo.index];
         fillArray({
           target: attribute.value,
           source: objectInfo.target,

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -425,12 +425,12 @@ export default class Layer extends Component {
 
     // Figure out data length
     const numInstances = this.getNumInstances(props);
-    const vertexStarts = this.getVertexStarts(props);
+    const startIndices = this.getStartIndices(props);
 
     attributeManager.update({
       data: props.data,
       numInstances,
-      vertexStarts,
+      startIndices,
       props,
       transitions: props.transitions,
       buffers: props,
@@ -554,17 +554,17 @@ export default class Layer extends Component {
   // The default (null) is one value each object.
   // Some data formats (e.g. paths, polygons) have various length. Their buffer layout
   //  is in the form of [L0, L1, L2, ...]
-  getVertexStarts(props) {
+  getStartIndices(props) {
     props = props || this.props;
 
-    // First Check if vertexStarts is provided as an explicit value
-    if (props.vertexStarts !== undefined) {
-      return props.vertexStarts;
+    // First Check if startIndices is provided as an explicit value
+    if (props.startIndices !== undefined) {
+      return props.startIndices;
     }
 
     // Second check if the layer has set its own value
-    if (this.state && this.state.vertexStarts) {
-      return this.state.vertexStarts;
+    if (this.state && this.state.startIndices) {
+      return this.state.startIndices;
     }
 
     return null;

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -425,12 +425,12 @@ export default class Layer extends Component {
 
     // Figure out data length
     const numInstances = this.getNumInstances(props);
-    const bufferLayout = this.getBufferLayout(props);
+    const vertexStarts = this.getVertexStarts(props);
 
     attributeManager.update({
       data: props.data,
       numInstances,
-      bufferLayout,
+      vertexStarts,
       props,
       transitions: props.transitions,
       buffers: props,
@@ -554,17 +554,17 @@ export default class Layer extends Component {
   // The default (null) is one value each object.
   // Some data formats (e.g. paths, polygons) have various length. Their buffer layout
   //  is in the form of [L0, L1, L2, ...]
-  getBufferLayout(props) {
+  getVertexStarts(props) {
     props = props || this.props;
 
-    // First Check if bufferLayout is provided as an explicit value
-    if (props.bufferLayout !== undefined) {
-      return props.bufferLayout;
+    // First Check if vertexStarts is provided as an explicit value
+    if (props.vertexStarts !== undefined) {
+      return props.vertexStarts;
     }
 
     // Second check if the layer has set its own value
-    if (this.state && this.state.bufferLayout !== undefined) {
-      return this.state.bufferLayout;
+    if (this.state && this.state.vertexStarts) {
+      return this.state.vertexStarts;
     }
 
     return null;

--- a/modules/core/src/transitions/gpu-interpolation-transition.js
+++ b/modules/core/src/transitions/gpu-interpolation-transition.js
@@ -21,7 +21,7 @@ export default class GPUInterpolationTransition {
     // `attribute.userData` is the original options passed when constructing the attribute.
     // This ensures that we set the proper `doublePrecision` flag and shader attributes.
     this.attributeInTransition = new Attribute(gl, attribute.settings);
-    this.currentBufferLayout = attribute.bufferLayout;
+    this.currentVertexStarts = attribute.vertexStarts;
     // storing currentLength because this.buffer may be larger than the actual length we want to use
     // this is because we only reallocate buffers when they grow, not when they shrink,
     // due to performance costs
@@ -45,7 +45,7 @@ export default class GPUInterpolationTransition {
   // we need to start animating towards the new values
   // this also correctly resizes / pads the transform's buffers
   // in case the attribute's buffer has changed in length or in
-  // bufferLayout
+  // vertexStarts
   start(transitionSettings, numInstances) {
     if (transitionSettings.duration <= 0) {
       this.transition.cancel();
@@ -62,7 +62,7 @@ export default class GPUInterpolationTransition {
       numInstances,
       attribute,
       fromLength: this.currentLength,
-      fromBufferLayout: this.currentBufferLayout,
+      fromVertexStarts: this.currentVertexStarts,
       getData: transitionSettings.enter
     };
 
@@ -70,7 +70,7 @@ export default class GPUInterpolationTransition {
       padBuffer({buffer, ...padBufferOpts});
     }
 
-    this.currentBufferLayout = attribute.bufferLayout;
+    this.currentVertexStarts = attribute.vertexStarts;
     this.currentLength = getAttributeBufferLength(attribute, numInstances);
     this.attributeInTransition.update({
       buffer: buffers[1],

--- a/modules/core/src/transitions/gpu-interpolation-transition.js
+++ b/modules/core/src/transitions/gpu-interpolation-transition.js
@@ -21,7 +21,7 @@ export default class GPUInterpolationTransition {
     // `attribute.userData` is the original options passed when constructing the attribute.
     // This ensures that we set the proper `doublePrecision` flag and shader attributes.
     this.attributeInTransition = new Attribute(gl, attribute.settings);
-    this.currentVertexStarts = attribute.vertexStarts;
+    this.currentStartIndices = attribute.startIndices;
     // storing currentLength because this.buffer may be larger than the actual length we want to use
     // this is because we only reallocate buffers when they grow, not when they shrink,
     // due to performance costs
@@ -45,7 +45,7 @@ export default class GPUInterpolationTransition {
   // we need to start animating towards the new values
   // this also correctly resizes / pads the transform's buffers
   // in case the attribute's buffer has changed in length or in
-  // vertexStarts
+  // startIndices
   start(transitionSettings, numInstances) {
     if (transitionSettings.duration <= 0) {
       this.transition.cancel();
@@ -62,7 +62,7 @@ export default class GPUInterpolationTransition {
       numInstances,
       attribute,
       fromLength: this.currentLength,
-      fromVertexStarts: this.currentVertexStarts,
+      fromStartIndices: this.currentStartIndices,
       getData: transitionSettings.enter
     };
 
@@ -70,7 +70,7 @@ export default class GPUInterpolationTransition {
       padBuffer({buffer, ...padBufferOpts});
     }
 
-    this.currentVertexStarts = attribute.vertexStarts;
+    this.currentStartIndices = attribute.startIndices;
     this.currentLength = getAttributeBufferLength(attribute, numInstances);
     this.attributeInTransition.update({
       buffer: buffers[1],

--- a/modules/core/src/transitions/gpu-spring-transition.js
+++ b/modules/core/src/transitions/gpu-spring-transition.js
@@ -25,7 +25,7 @@ export default class GPUSpringTransition {
       gl,
       Object.assign({}, attribute.settings, {normalized: false})
     );
-    this.currentBufferLayout = attribute.bufferLayout;
+    this.currentVertexStarts = attribute.vertexStarts;
     // storing currentLength because this.buffer may be larger than the actual length we want to use
     // this is because we only reallocate buffers when they grow, not when they shrink,
     // due to performance costs
@@ -52,14 +52,14 @@ export default class GPUSpringTransition {
   // we need to start animating towards the new values
   // this also correctly resizes / pads the transform's buffers
   // in case the attribute's buffer has changed in length or in
-  // bufferLayout
+  // vertexStarts
   start(transitionSettings, numInstances) {
     const {gl, buffers, attribute} = this;
     const padBufferOpts = {
       numInstances,
       attribute,
       fromLength: this.currentLength,
-      fromBufferLayout: this.currentBufferLayout,
+      fromVertexStarts: this.currentVertexStarts,
       getData: transitionSettings.enter
     };
 
@@ -67,7 +67,7 @@ export default class GPUSpringTransition {
       padBuffer({buffer, ...padBufferOpts});
     }
 
-    this.currentBufferLayout = attribute.bufferLayout;
+    this.currentVertexStarts = attribute.vertexStarts;
     this.currentLength = getAttributeBufferLength(attribute, numInstances);
     this.attributeInTransition.update({
       buffer: buffers[1],

--- a/modules/core/src/transitions/gpu-spring-transition.js
+++ b/modules/core/src/transitions/gpu-spring-transition.js
@@ -25,7 +25,7 @@ export default class GPUSpringTransition {
       gl,
       Object.assign({}, attribute.settings, {normalized: false})
     );
-    this.currentVertexStarts = attribute.vertexStarts;
+    this.currentStartIndices = attribute.startIndices;
     // storing currentLength because this.buffer may be larger than the actual length we want to use
     // this is because we only reallocate buffers when they grow, not when they shrink,
     // due to performance costs
@@ -52,14 +52,14 @@ export default class GPUSpringTransition {
   // we need to start animating towards the new values
   // this also correctly resizes / pads the transform's buffers
   // in case the attribute's buffer has changed in length or in
-  // vertexStarts
+  // startIndices
   start(transitionSettings, numInstances) {
     const {gl, buffers, attribute} = this;
     const padBufferOpts = {
       numInstances,
       attribute,
       fromLength: this.currentLength,
-      fromVertexStarts: this.currentVertexStarts,
+      fromStartIndices: this.currentStartIndices,
       getData: transitionSettings.enter
     };
 
@@ -67,7 +67,7 @@ export default class GPUSpringTransition {
       padBuffer({buffer, ...padBufferOpts});
     }
 
-    this.currentVertexStarts = attribute.vertexStarts;
+    this.currentStartIndices = attribute.startIndices;
     this.currentLength = getAttributeBufferLength(attribute, numInstances);
     this.attributeInTransition.update({
       buffer: buffers[1],

--- a/modules/core/src/utils/array-utils.js
+++ b/modules/core/src/utils/array-utils.js
@@ -52,17 +52,17 @@ function padArrayChunk({source, target, start = 0, end, getData}) {
 /*
  * The padArray function stretches a source array to the size of a target array.
    The arrays can have internal structures (like the attributes of PathLayer and
-   SolidPolygonLayer), defined by the optional sourceLayout and targetLayout parameters.
+   SolidPolygonLayer), defined by the optional sourceVertexStarts and targetVertexStarts parameters.
    If the target array is larger, the getData callback is used to fill in the blanks.
  * @params {TypedArray} source - original data
  * @params {TypedArray} target - output data
  * @params {Number} size - length per datum
  * @params {Function} getData - callback to get new data when source is short
- * @params {Array<Number>} [sourceLayout] - subdivision of the original data in [chunkSize0, chunkSize1, ...]
- * @params {Array<Number>} [targetLayout] - subdivision of the output data in [chunkSize0, chunkSize1, ...]
+ * @params {Array<Number>} [sourceVertexStarts] - subdivision of the original data in [object0StartIndex, object1StartIndex, ...]
+ * @params {Array<Number>} [targetVertexStarts] - subdivision of the output data in [object0StartIndex, object1StartIndex, ...]
  */
-export function padArray({source, target, size, offset = 0, getData, sourceLayout, targetLayout}) {
-  if (!Array.isArray(targetLayout)) {
+export function padArray({source, target, size, offset = 0, getData, sourceVertexStarts, targetVertexStarts}) {
+  if (!Array.isArray(targetVertexStarts)) {
     // Flat arrays
     padArrayChunk({
       source,
@@ -77,22 +77,22 @@ export function padArray({source, target, size, offset = 0, getData, sourceLayou
   let targetIndex = offset;
   const getChunkData = getData && ((i, chunk) => getData(i + targetIndex, chunk));
 
-  const n = Math.min(sourceLayout.length, targetLayout.length);
+  const n = Math.min(sourceVertexStarts.length, targetVertexStarts.length);
 
-  for (let i = 0; i < n; i++) {
-    const sourceChunkLength = sourceLayout[i] * size;
-    const targetChunkLength = targetLayout[i] * size;
+  for (let i = 1; i < n; i++) {
+    const nextSourceIndex = sourceVertexStarts[i] * size + offset;
+    const nextTargetIndex = targetVertexStarts[i] * size + offset;
 
     padArrayChunk({
-      source: source.subarray(sourceIndex, sourceIndex + sourceChunkLength),
+      source: source.subarray(sourceIndex, nextSourceIndex),
       target,
       start: targetIndex,
-      end: targetIndex + targetChunkLength,
+      end: nextTargetIndex,
       getData: getChunkData
     });
 
-    sourceIndex += sourceChunkLength;
-    targetIndex += targetChunkLength;
+    sourceIndex = nextSourceIndex;
+    targetIndex = nextTargetIndex;
   }
 
   if (targetIndex < target.length) {

--- a/modules/core/src/utils/array-utils.js
+++ b/modules/core/src/utils/array-utils.js
@@ -52,14 +52,14 @@ function padArrayChunk({source, target, start = 0, end, getData}) {
 /*
  * The padArray function stretches a source array to the size of a target array.
    The arrays can have internal structures (like the attributes of PathLayer and
-   SolidPolygonLayer), defined by the optional sourceVertexStarts and targetVertexStarts parameters.
+   SolidPolygonLayer), defined by the optional sourceStartIndices and targetStartIndices parameters.
    If the target array is larger, the getData callback is used to fill in the blanks.
  * @params {TypedArray} source - original data
  * @params {TypedArray} target - output data
  * @params {Number} size - length per datum
  * @params {Function} getData - callback to get new data when source is short
- * @params {Array<Number>} [sourceVertexStarts] - subdivision of the original data in [object0StartIndex, object1StartIndex, ...]
- * @params {Array<Number>} [targetVertexStarts] - subdivision of the output data in [object0StartIndex, object1StartIndex, ...]
+ * @params {Array<Number>} [sourceStartIndices] - subdivision of the original data in [object0StartIndex, object1StartIndex, ...]
+ * @params {Array<Number>} [targetStartIndices] - subdivision of the output data in [object0StartIndex, object1StartIndex, ...]
  */
 export function padArray({
   source,
@@ -67,10 +67,10 @@ export function padArray({
   size,
   offset = 0,
   getData,
-  sourceVertexStarts,
-  targetVertexStarts
+  sourceStartIndices,
+  targetStartIndices
 }) {
-  if (!Array.isArray(targetVertexStarts)) {
+  if (!Array.isArray(targetStartIndices)) {
     // Flat arrays
     padArrayChunk({
       source,
@@ -85,11 +85,11 @@ export function padArray({
   let targetIndex = offset;
   const getChunkData = getData && ((i, chunk) => getData(i + targetIndex, chunk));
 
-  const n = Math.min(sourceVertexStarts.length, targetVertexStarts.length);
+  const n = Math.min(sourceStartIndices.length, targetStartIndices.length);
 
   for (let i = 1; i < n; i++) {
-    const nextSourceIndex = sourceVertexStarts[i] * size + offset;
-    const nextTargetIndex = targetVertexStarts[i] * size + offset;
+    const nextSourceIndex = sourceStartIndices[i] * size + offset;
+    const nextTargetIndex = targetStartIndices[i] * size + offset;
 
     padArrayChunk({
       source: source.subarray(sourceIndex, nextSourceIndex),

--- a/modules/core/src/utils/array-utils.js
+++ b/modules/core/src/utils/array-utils.js
@@ -61,7 +61,15 @@ function padArrayChunk({source, target, start = 0, end, getData}) {
  * @params {Array<Number>} [sourceVertexStarts] - subdivision of the original data in [object0StartIndex, object1StartIndex, ...]
  * @params {Array<Number>} [targetVertexStarts] - subdivision of the output data in [object0StartIndex, object1StartIndex, ...]
  */
-export function padArray({source, target, size, offset = 0, getData, sourceVertexStarts, targetVertexStarts}) {
+export function padArray({
+  source,
+  target,
+  size,
+  offset = 0,
+  getData,
+  sourceVertexStarts,
+  targetVertexStarts
+}) {
   if (!Array.isArray(targetVertexStarts)) {
     // Flat arrays
     padArrayChunk({

--- a/modules/geo-layers/src/trips-layer/trips-layer.js
+++ b/modules/geo-layers/src/trips-layer/trips-layer.js
@@ -84,21 +84,17 @@ if(vTime > currentTime || vTime < currentTime - trailLength) {
     const {data, getTimestamps} = this.props;
 
     const {
-      pathTesselator: {bufferLayout, instanceCount}
+      pathTesselator: {vertexStarts, instanceCount}
     } = this.state;
     const value = new Float32Array(instanceCount * 2);
 
     const {iterable, objectInfo} = createIterable(data, startRow, endRow);
-    let i = 0;
-
-    for (let objectIndex = 0; objectIndex < startRow; objectIndex++) {
-      i += bufferLayout[objectIndex] * 2;
-    }
+    let i = vertexStarts[startRow] * 2;
 
     for (const object of iterable) {
       objectInfo.index++;
 
-      const geometrySize = bufferLayout[objectInfo.index];
+      const maxI = (vertexStarts[objectInfo.index + 1] || instanceCount) * 2;
       const timestamps = getTimestamps(object, objectInfo);
 
       // Support for legacy use case is removed in v8.0
@@ -106,7 +102,7 @@ if(vTime > currentTime || vTime < currentTime - trailLength) {
       log.assert(timestamps, 'TrisLayer: invalid timestamps');
 
       // For each line segment, we have [startTimestamp, endTimestamp]
-      for (let j = 0; j < geometrySize; j++) {
+      for (let j = 0; i < maxI; j++) {
         value[i++] = timestamps[j];
         value[i++] = timestamps[j + 1];
       }

--- a/modules/layers/src/path-layer/path-layer.js
+++ b/modules/layers/src/path-layer/path-layer.js
@@ -143,7 +143,7 @@ export default class PathLayer extends Layer {
       });
       this.setState({
         numInstances: pathTesselator.instanceCount,
-        vertexStarts: pathTesselator.vertexStarts
+        startIndices: pathTesselator.vertexStarts
       });
       if (!changeFlags.dataChanged) {
         // Base `layer.updateState` only invalidates all attributes on data change
@@ -275,14 +275,14 @@ export default class PathLayer extends Layer {
   calculatePositions(attribute) {
     const {pathTesselator} = this.state;
 
-    attribute.vertexStarts = pathTesselator.vertexStarts;
+    attribute.startIndices = pathTesselator.vertexStarts;
     attribute.value = pathTesselator.get('positions');
   }
 
   calculateSegmentTypes(attribute) {
     const {pathTesselator} = this.state;
 
-    attribute.vertexStarts = pathTesselator.vertexStarts;
+    attribute.startIndices = pathTesselator.vertexStarts;
     attribute.value = pathTesselator.get('segmentTypes');
   }
 }

--- a/modules/layers/src/path-layer/path-layer.js
+++ b/modules/layers/src/path-layer/path-layer.js
@@ -143,7 +143,7 @@ export default class PathLayer extends Layer {
       });
       this.setState({
         numInstances: pathTesselator.instanceCount,
-        bufferLayout: pathTesselator.bufferLayout
+        vertexStarts: pathTesselator.vertexStarts
       });
       if (!changeFlags.dataChanged) {
         // Base `layer.updateState` only invalidates all attributes on data change
@@ -275,14 +275,14 @@ export default class PathLayer extends Layer {
   calculatePositions(attribute) {
     const {pathTesselator} = this.state;
 
-    attribute.bufferLayout = pathTesselator.bufferLayout;
+    attribute.vertexStarts = pathTesselator.vertexStarts;
     attribute.value = pathTesselator.get('positions');
   }
 
   calculateSegmentTypes(attribute) {
     const {pathTesselator} = this.state;
 
-    attribute.bufferLayout = pathTesselator.bufferLayout;
+    attribute.vertexStarts = pathTesselator.vertexStarts;
     attribute.value = pathTesselator.get('segmentTypes');
   }
 }

--- a/modules/layers/src/solid-polygon-layer/polygon-tesselator.js
+++ b/modules/layers/src/solid-polygon-layer/polygon-tesselator.js
@@ -66,7 +66,7 @@ export default class PolygonTesselator extends Tesselator {
 
   // Flatten the indices array
   _updateIndices(polygon, {geometryIndex, vertexStart: offset, indexStart}) {
-    const {attributes, indexLayout, typedArrayManager} = this;
+    const {attributes, indexStarts, typedArrayManager} = this;
 
     let target = attributes.indices;
     let i = indexStart;
@@ -84,7 +84,7 @@ export default class PolygonTesselator extends Tesselator {
       target[i++] = indices[j] + offset;
     }
 
-    indexLayout[geometryIndex] = indices.length;
+    indexStarts[geometryIndex + 1] = indexStart + indices.length;
     attributes.indices = target;
   }
 

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -253,7 +253,7 @@ export default class SolidPolygonLayer extends Layer {
 
       this.setState({
         numInstances: polygonTesselator.instanceCount,
-        bufferLayout: polygonTesselator.bufferLayout
+        vertexStarts: polygonTesselator.vertexStarts
       });
 
       if (!changeFlags.dataChanged) {
@@ -324,13 +324,13 @@ export default class SolidPolygonLayer extends Layer {
 
   calculateIndices(attribute) {
     const {polygonTesselator} = this.state;
-    attribute.bufferLayout = polygonTesselator.indexLayout;
+    attribute.vertexStarts = polygonTesselator.indexStarts;
     attribute.value = polygonTesselator.get('indices');
   }
 
   calculatePositions(attribute) {
     const {polygonTesselator} = this.state;
-    attribute.bufferLayout = polygonTesselator.bufferLayout;
+    attribute.vertexStarts = polygonTesselator.vertexStarts;
     attribute.value = polygonTesselator.get('positions');
   }
 

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -253,7 +253,7 @@ export default class SolidPolygonLayer extends Layer {
 
       this.setState({
         numInstances: polygonTesselator.instanceCount,
-        vertexStarts: polygonTesselator.vertexStarts
+        startIndices: polygonTesselator.vertexStarts
       });
 
       if (!changeFlags.dataChanged) {
@@ -324,13 +324,13 @@ export default class SolidPolygonLayer extends Layer {
 
   calculateIndices(attribute) {
     const {polygonTesselator} = this.state;
-    attribute.vertexStarts = polygonTesselator.indexStarts;
+    attribute.startIndices = polygonTesselator.indexStarts;
     attribute.value = polygonTesselator.get('indices');
   }
 
   calculatePositions(attribute) {
     const {polygonTesselator} = this.state;
-    attribute.vertexStarts = polygonTesselator.vertexStarts;
+    attribute.startIndices = polygonTesselator.vertexStarts;
     attribute.value = polygonTesselator.get('positions');
   }
 

--- a/test/modules/core/lib/attribute/attribute.spec.js
+++ b/test/modules/core/lib/attribute/attribute.spec.js
@@ -308,7 +308,7 @@ test('Attribute#updateBuffer', t => {
     {
       title: 'variable size',
       numInstances: 10,
-      bufferLayout: [2, 1, 4, 3]
+      vertexStarts: [0, 2, 3, 7]
     }
   ];
 
@@ -404,7 +404,7 @@ test('Attribute#updateBuffer', t => {
       attribute.allocate(param.numInstances);
       attribute.updateBuffer({
         numInstances: param.numInstances,
-        bufferLayout: param.bufferLayout,
+        vertexStarts: param.vertexStarts,
         data: TEST_PROPS.data,
         props: TEST_PROPS
       });
@@ -504,7 +504,7 @@ test('Attribute#updateBuffer - partial', t => {
       attribute: ATTRIBUTE_2,
       params: {
         numInstances: 10,
-        bufferLayout: [2, 1, 4, 3, 1]
+        vertexStarts: [0, 2, 3, 7]
       },
       value: [0, 0, 11, 22, 22, 22, 22, 33, 33, 33]
     },
@@ -518,7 +518,7 @@ test('Attribute#updateBuffer - partial', t => {
       ],
       params: {
         numInstances: 10,
-        bufferLayout: [2, 1, 4, 3]
+        vertexStarts: [0, 2, 3, 7]
       },
       value: [0, 0, 11, 22, 22, 22, 22, 30, 30, 30]
     },
@@ -533,7 +533,7 @@ test('Attribute#updateBuffer - partial', t => {
       ],
       params: {
         numInstances: 10,
-        bufferLayout: [2, 1, 4, 3]
+        vertexStarts: [0, 2, 3, 7]
       },
       value: [0, 0, 10, 21, 21, 21, 21, 30, 30, 30]
     },
@@ -551,7 +551,7 @@ test('Attribute#updateBuffer - partial', t => {
       ],
       params: {
         numInstances: 13,
-        bufferLayout: [2, 1, 4, 3, 1, 2]
+        vertexStarts: [0, 2, 3, 7, 10, 11]
       },
       value: [0, 0, 10, 20, 20, 20, 20, 30, 30, 30, 41, 52, 52]
     }

--- a/test/modules/core/lib/attribute/attribute.spec.js
+++ b/test/modules/core/lib/attribute/attribute.spec.js
@@ -308,7 +308,7 @@ test('Attribute#updateBuffer', t => {
     {
       title: 'variable size',
       numInstances: 10,
-      vertexStarts: [0, 2, 3, 7]
+      startIndices: [0, 2, 3, 7]
     }
   ];
 
@@ -404,7 +404,7 @@ test('Attribute#updateBuffer', t => {
       attribute.allocate(param.numInstances);
       attribute.updateBuffer({
         numInstances: param.numInstances,
-        vertexStarts: param.vertexStarts,
+        startIndices: param.startIndices,
         data: TEST_PROPS.data,
         props: TEST_PROPS
       });
@@ -504,7 +504,7 @@ test('Attribute#updateBuffer - partial', t => {
       attribute: ATTRIBUTE_2,
       params: {
         numInstances: 10,
-        vertexStarts: [0, 2, 3, 7]
+        startIndices: [0, 2, 3, 7]
       },
       value: [0, 0, 11, 22, 22, 22, 22, 33, 33, 33]
     },
@@ -518,7 +518,7 @@ test('Attribute#updateBuffer - partial', t => {
       ],
       params: {
         numInstances: 10,
-        vertexStarts: [0, 2, 3, 7]
+        startIndices: [0, 2, 3, 7]
       },
       value: [0, 0, 11, 22, 22, 22, 22, 30, 30, 30]
     },
@@ -533,7 +533,7 @@ test('Attribute#updateBuffer - partial', t => {
       ],
       params: {
         numInstances: 10,
-        vertexStarts: [0, 2, 3, 7]
+        startIndices: [0, 2, 3, 7]
       },
       value: [0, 0, 10, 21, 21, 21, 21, 30, 30, 30]
     },
@@ -551,7 +551,7 @@ test('Attribute#updateBuffer - partial', t => {
       ],
       params: {
         numInstances: 13,
-        vertexStarts: [0, 2, 3, 7, 10, 11]
+        startIndices: [0, 2, 3, 7, 10, 11]
       },
       value: [0, 0, 10, 20, 20, 20, 20, 30, 30, 30, 41, 52, 52]
     }

--- a/test/modules/core/utils/array-utils.spec.js
+++ b/test/modules/core/utils/array-utils.spec.js
@@ -56,8 +56,8 @@ const PAD_ARRAY_TEST_CASES = [
       target: new Float32Array(4),
       source: new Float32Array([0, 1, 2, 3, 4, 5]),
       size: 2,
-      targetLayout: [1, 1],
-      sourceLayout: [1, 2],
+      targetVertexStarts: [0, 1, 2],
+      sourceVertexStarts: [0, 1, 3],
       getData: i => [-1, i]
     },
     result: new Float32Array([0, 1, 2, 3])
@@ -68,8 +68,8 @@ const PAD_ARRAY_TEST_CASES = [
       target: new Float32Array(10),
       source: new Float32Array([0, 1, 2, 3, 4, 5]),
       size: 2,
-      targetLayout: [2, 1, 2],
-      sourceLayout: [1, 2],
+      targetVertexStarts: [0, 2, 3, 5],
+      sourceVertexStarts: [0, 1, 3],
       getData: i => [-1, i]
     },
     result: new Float32Array([0, 1, -1, 2, 2, 3, -1, 6, -1, 8])

--- a/test/modules/core/utils/array-utils.spec.js
+++ b/test/modules/core/utils/array-utils.spec.js
@@ -56,8 +56,8 @@ const PAD_ARRAY_TEST_CASES = [
       target: new Float32Array(4),
       source: new Float32Array([0, 1, 2, 3, 4, 5]),
       size: 2,
-      targetVertexStarts: [0, 1, 2],
-      sourceVertexStarts: [0, 1, 3],
+      targetStartIndices: [0, 1, 2],
+      sourceStartIndices: [0, 1, 3],
       getData: i => [-1, i]
     },
     result: new Float32Array([0, 1, 2, 3])
@@ -68,8 +68,8 @@ const PAD_ARRAY_TEST_CASES = [
       target: new Float32Array(10),
       source: new Float32Array([0, 1, 2, 3, 4, 5]),
       size: 2,
-      targetVertexStarts: [0, 2, 3, 5],
-      sourceVertexStarts: [0, 1, 3],
+      targetStartIndices: [0, 2, 3, 5],
+      sourceStartIndices: [0, 1, 3],
       getData: i => [-1, i]
     },
     result: new Float32Array([0, 1, -1, 2, 2, 3, -1, 6, -1, 8])

--- a/test/modules/layers/core-layers.spec.js
+++ b/test/modules/layers/core-layers.spec.js
@@ -219,7 +219,7 @@ test('PathLayer', t => {
         layer.props.widthMinPixels,
         'should update widthMinPixels'
       );
-      t.ok(layer.getVertexStarts(), 'should have vertex layout');
+      t.ok(layer.getStartIndices(), 'should have vertex layout');
     }
   });
 

--- a/test/modules/layers/core-layers.spec.js
+++ b/test/modules/layers/core-layers.spec.js
@@ -219,7 +219,7 @@ test('PathLayer', t => {
         layer.props.widthMinPixels,
         'should update widthMinPixels'
       );
-      t.ok(layer.getBufferLayout(), 'should have buffer layout');
+      t.ok(layer.getVertexStarts(), 'should have vertex layout');
     }
   });
 

--- a/test/modules/layers/polygon-tesselation.spec.js
+++ b/test/modules/layers/polygon-tesselation.spec.js
@@ -150,7 +150,7 @@ test('PolygonTesselator#constructor', t => {
 
       t.is(tesselator.instanceCount, 73, 'PolygonTesselator counts points correctly');
       t.is(tesselator.vertexCount, 135, 'PolygonTesselator counts indices correctly');
-      t.ok(Array.isArray(tesselator.bufferLayout), 'PolygonTesselator.bufferLayout');
+      t.ok(Array.isArray(tesselator.vertexStarts), 'PolygonTesselator.vertexStarts');
 
       t.ok(ArrayBuffer.isView(tesselator.get('indices')), 'PolygonTesselator.get indices');
       t.ok(ArrayBuffer.isView(tesselator.get('positions')), 'PolygonTesselator.get positions');


### PR DESCRIPTION
For #3758

#### Background

Variable-width attributes (e.g. those of the `PathLayer` or the `PolygonLayer`) contain a `bufferLayout` member that stores the vertex count of each object as `[chunk0Length, chunk1Length, ...]`.

This PR replaces the member with `vertexStarts` which stores the staring indices of each object as `[chunk0Start, chunk1Start, ...]`. This allows us to access arbitrary positions in the data without having to loop from the start.

This is in preparation for RFC #3884 -- if an application wants to supply a flat positions buffer for paths/polygons, they need to also supply a `vertexStarts` array, making the previously private API public.

I'm not happy with the name `vertexStarts`. Any suggestions?

#### Change List
- `Attribute` class
- `Tesselator` classes
- Attribute transition utils
- Unit tests

Verified with the layer browser and the attribute transition test app.
