### PR TITLE
Support variable-width values in auto update

### DIFF
--- a/modules/core/src/lib/attribute/attribute.js
+++ b/modules/core/src/lib/attribute/attribute.js
@@ -240,6 +240,7 @@ export default class Attribute extends DataColumn {
     return shaderAttributes;
   }
 
+  /* eslint-disable max-depth, max-statements */
   _standardAccessor(attribute, {data, startRow, endRow, props, numInstances, startIndices}) {
     const {settings, value, size} = attribute;
 
@@ -263,12 +264,18 @@ export default class Attribute extends DataColumn {
       if (startIndices) {
         const numVertices =
           (startIndices[objectInfo.index + 1] || numInstances) - startIndices[objectInfo.index];
-        if (objectValue && objectValue.length > size) {
-          attribute.value.set(objectValue, i);
+        if (objectValue && Array.isArray(objectValue[0])) {
+          let startIndex = i;
+          for (const item of objectValue) {
+            attribute._normalizeValue(item, value, startIndex);
+            startIndex += size;
+          }
+        } else if (objectValue && objectValue.length > size) {
+          value.set(objectValue, i);
         } else {
           attribute._normalizeValue(objectValue, objectInfo.target);
           fillArray({
-            target: attribute.value,
+            target: value,
             source: objectInfo.target,
             start: i,
             count: numVertices
@@ -283,6 +290,7 @@ export default class Attribute extends DataColumn {
     attribute.constant = false;
     attribute.startIndices = startIndices;
   }
+  /* eslint-enable max-depth, max-statements */
 
   // Validate deck.gl level fields
   _validateAttributeUpdaters() {

--- a/modules/core/src/lib/attribute/attribute.js
+++ b/modules/core/src/lib/attribute/attribute.js
@@ -261,15 +261,19 @@ export default class Attribute extends DataColumn {
       }
 
       if (startIndices) {
-        attribute._normalizeValue(objectValue, objectInfo.target);
         const numVertices =
           (startIndices[objectInfo.index + 1] || numInstances) - startIndices[objectInfo.index];
-        fillArray({
-          target: attribute.value,
-          source: objectInfo.target,
-          start: i,
-          count: numVertices
-        });
+        if (objectValue && objectValue.length > size) {
+          attribute.value.set(objectValue, i);
+        } else {
+          attribute._normalizeValue(objectValue, objectInfo.target);
+          fillArray({
+            target: attribute.value,
+            source: objectInfo.target,
+            start: i,
+            count: numVertices
+          });
+        }
         i += numVertices * size;
       } else {
         attribute._normalizeValue(objectValue, value, i);

--- a/modules/geo-layers/src/trips-layer/trips-layer.js
+++ b/modules/geo-layers/src/trips-layer/trips-layer.js
@@ -87,7 +87,6 @@ if(vTime > currentTime || vTime < currentTime - trailLength) {
 
     super.draw(params);
   }
-
 }
 
 TripsLayer.layerName = 'TripsLayer';

--- a/modules/geo-layers/src/trips-layer/trips-layer.js
+++ b/modules/geo-layers/src/trips-layer/trips-layer.js
@@ -19,7 +19,6 @@
 // THE SOFTWARE.
 
 import {PathLayer} from '@deck.gl/layers';
-import {createIterable, log} from '@deck.gl/core';
 
 const defaultProps = {
   trailLength: {type: 'number', value: 120, min: 0},
@@ -33,12 +32,13 @@ export default class TripsLayer extends PathLayer {
     shaders.inject = {
       'vs:#decl': `\
 uniform float trailLength;
-attribute vec2 instanceTimestamps;
+attribute float instanceTimestamps;
+attribute float instanceNextTimestamps;
 varying float vTime;
 `,
       // Timestamp of the vertex
       'vs:#main-end': `\
-vTime = instanceTimestamps.x + (instanceTimestamps.y - instanceTimestamps.x) * vPathPosition.y / vPathLength;
+vTime = instanceTimestamps + (instanceNextTimestamps - instanceTimestamps) * vPathPosition.y / vPathLength;
 `,
       'fs:#decl': `\
 uniform float trailLength;
@@ -62,9 +62,17 @@ if(vTime > currentTime || vTime < currentTime - trailLength) {
 
     const attributeManager = this.getAttributeManager();
     attributeManager.addInstanced({
-      instanceTimestamps: {
-        size: 2,
-        update: this.calculateInstanceTimestamps
+      timestamps: {
+        size: 1,
+        accessor: 'getTimestamps',
+        shaderAttributes: {
+          instanceTimestamps: {
+            offset: 0
+          },
+          instanceNextTimestamps: {
+            offset: 4
+          }
+        }
       }
     });
   }
@@ -80,36 +88,6 @@ if(vTime > currentTime || vTime < currentTime - trailLength) {
     super.draw(params);
   }
 
-  calculateInstanceTimestamps(attribute, {startRow, endRow}) {
-    const {data, getTimestamps} = this.props;
-
-    const {
-      pathTesselator: {vertexStarts, instanceCount}
-    } = this.state;
-    const value = new Float32Array(instanceCount * 2);
-
-    const {iterable, objectInfo} = createIterable(data, startRow, endRow);
-    let i = vertexStarts[startRow] * 2;
-
-    for (const object of iterable) {
-      objectInfo.index++;
-
-      const maxI = (vertexStarts[objectInfo.index + 1] || instanceCount) * 2;
-      const timestamps = getTimestamps(object, objectInfo);
-
-      // Support for legacy use case is removed in v8.0
-      // TODO - remove when all apps are updated
-      log.assert(timestamps, 'TrisLayer: invalid timestamps');
-
-      // For each line segment, we have [startTimestamp, endTimestamp]
-      for (let j = 0; i < maxI; j++) {
-        value[i++] = timestamps[j];
-        value[i++] = timestamps[j + 1];
-      }
-    }
-    attribute.constant = false;
-    attribute.value = value;
-  }
 }
 
 TripsLayer.layerName = 'TripsLayer';

--- a/test/modules/core/lib/attribute/attribute.spec.js
+++ b/test/modules/core/lib/attribute/attribute.spec.js
@@ -422,6 +422,55 @@ test('Attribute#updateBuffer', t => {
   t.end();
 });
 
+test('Attribute#standard accessor - variable width', t => {
+  const TEST_PROPS = {
+    data: [
+      {id: 'A', value: [10, 11], color: [255, 0, 0, 255, 255, 0]},
+      {id: 'B', value: [20], color: [128, 128, 128, 128, 128, 128]},
+      {id: 'C', value: [30, 31, 32], color: [255, 255, 255]}
+    ],
+    getColor: d => d.color,
+    getValue: d => d.value
+  };
+
+  const TEST_CASES = [
+    {
+      attribute: new Attribute(gl, {
+        id: 'values',
+        type: GL.FLOAT,
+        size: 1,
+        accessor: 'getValue'
+      }),
+      result: [10, 11, 20, 30, 31, 32]
+    },
+    {
+      attribute: new Attribute(gl, {
+        id: 'colors',
+        type: GL.UNSIGNED_BYTE,
+        size: 3,
+        accessor: 'getColor'
+      }),
+      result: [255, 0, 0, 255, 255, 0, 128, 128, 128, 255, 255, 255, 255, 255, 255, 255, 255, 255]
+    }
+  ];
+
+  for (const testCase of TEST_CASES) {
+    const {attribute, result} = testCase;
+    attribute.setNeedsUpdate(true);
+    attribute.allocate(10);
+    attribute.updateBuffer({
+      numInstances: 6,
+      startIndices: [0, 2, 3],
+      data: TEST_PROPS.data,
+      props: TEST_PROPS
+    });
+
+    t.deepEqual(attribute.value.slice(0, result.length), result, 'attribute buffer is updated');
+  }
+
+  t.end();
+});
+
 test('Attribute#updateBuffer - partial', t => {
   let accessorCalled = 0;
 

--- a/test/modules/core/lib/attribute/attribute.spec.js
+++ b/test/modules/core/lib/attribute/attribute.spec.js
@@ -425,8 +425,8 @@ test('Attribute#updateBuffer', t => {
 test('Attribute#standard accessor - variable width', t => {
   const TEST_PROPS = {
     data: [
-      {id: 'A', value: [10, 11], color: [255, 0, 0, 255, 255, 0]},
-      {id: 'B', value: [20], color: [128, 128, 128, 128, 128, 128]},
+      {id: 'A', value: [10, 11], color: [[255, 0, 0], [255, 255, 0]]},
+      {id: 'B', value: [20], color: [[128, 128, 128], [128, 128, 128]]},
       {id: 'C', value: [30, 31, 32], color: [255, 255, 255]}
     ],
     getColor: d => d.color,
@@ -447,10 +447,36 @@ test('Attribute#standard accessor - variable width', t => {
       attribute: new Attribute(gl, {
         id: 'colors',
         type: GL.UNSIGNED_BYTE,
-        size: 3,
+        size: 4,
+        defaultValue: [0, 0, 0, 255],
         accessor: 'getColor'
       }),
-      result: [255, 0, 0, 255, 255, 0, 128, 128, 128, 255, 255, 255, 255, 255, 255, 255, 255, 255]
+      result: [
+        255,
+        0,
+        0,
+        255,
+        255,
+        255,
+        0,
+        255,
+        128,
+        128,
+        128,
+        255,
+        255,
+        255,
+        255,
+        255,
+        255,
+        255,
+        255,
+        255,
+        255,
+        255,
+        255,
+        255
+      ]
     }
   ];
 


### PR DESCRIPTION
For #3758 

#### Change List
- Attribute auto updater allows assigning each vertex in a tesselated object different values.
- Simplify `TripsLayer`
- Tests