### PR TITLE
Support binary logical attributes

### DIFF
--- a/modules/core/src/lib/attribute/attribute-manager.js
+++ b/modules/core/src/lib/attribute/attribute-manager.js
@@ -241,8 +241,8 @@ export default class AttributeManager {
 
       if (attribute.setExternalBuffer(buffers[attributeName])) {
         // Step 1: try update attribute directly from external buffers
-      } else if (attribute.setLogicalValue(buffers[accessorName], data.startIndices)) {
-        // Step 2: try set logical value from external buffers
+      } else if (attribute.setBinaryValue(buffers[accessorName], data.startIndices)) {
+        // Step 2: try set packed value from external typed array
       } else if (attribute.setConstantValue(props[accessorName])) {
         // Step 3: try set constant value from props
       } else if (attribute.needsUpdate()) {

--- a/modules/core/src/lib/attribute/attribute-manager.js
+++ b/modules/core/src/lib/attribute/attribute-manager.js
@@ -235,10 +235,14 @@ export default class AttributeManager {
       const accessorName = attribute.settings.accessor;
       attribute.startIndices = startIndices;
 
-      if (attribute.setVirtualBuffer(buffers[attributeName])) {
-        // Step 1: try set virtual attribute from external buffers
-      } else if (attribute.setLogicalBuffer(buffers[accessorName], data.startIndices)) {
-        // Step 2: try set logical attribute from external buffers
+      if (props[attributeName]) {
+        log.removed(`props.${attributeName}`, `data.attributes.${attributeName}`)();
+      }
+
+      if (attribute.setExternalBuffer(buffers[attributeName])) {
+        // Step 1: try update attribute directly from external buffers
+      } else if (attribute.setLogicalValue(buffers[accessorName], data.startIndices)) {
+        // Step 2: try set logical value from external buffers
       } else if (attribute.setConstantValue(props[accessorName])) {
         // Step 3: try set constant value from props
       } else if (attribute.needsUpdate()) {

--- a/modules/core/src/lib/attribute/attribute.js
+++ b/modules/core/src/lib/attribute/attribute.js
@@ -30,8 +30,8 @@ export default class Attribute extends DataColumn {
 
     Object.assign(this.state, {
       lastExternalBuffer: null,
-      logicalValue: null,
-      logicalAccessor: null,
+      binaryValue: null,
+      binaryAccessor: null,
       needsUpdate: true,
       needsRedraw: false,
       updateRanges: range.FULL,
@@ -219,15 +219,15 @@ export default class Attribute extends DataColumn {
     return true;
   }
 
-  // Logical value is a typed array packed from mapping the source data with the accessor
-  // If the logical value is the same as the attribute value, set it directly
+  // Binary value is a typed array packed from mapping the source data with the accessor
+  // If the returned value from the accessor is the same as the attribute value, set it directly
   // Otherwise use the auto updater for transform/normalization
-  setLogicalValue(buffer, startIndices = null) {
+  setBinaryValue(buffer, startIndices = null) {
     const {state, settings} = this;
 
     if (!buffer) {
-      state.logicalValue = null;
-      state.logicalAccessor = null;
+      state.binaryValue = null;
+      state.binaryAccessor = null;
       return false;
     }
 
@@ -236,11 +236,11 @@ export default class Attribute extends DataColumn {
       return false;
     }
 
-    if (state.logicalValue === buffer) {
+    if (state.binaryValue === buffer) {
       this.clearNeedsUpdate();
       return true;
     }
-    state.logicalValue = buffer;
+    state.binaryValue = buffer;
     this.setNeedsRedraw();
 
     if (ArrayBuffer.isView(buffer)) {
@@ -252,7 +252,7 @@ export default class Attribute extends DataColumn {
     if (needsUpdate) {
       const needsNormalize = buffer.size && buffer.size !== this.size;
 
-      state.logicalAccessor = getAccessorFromBuffer(buffer.value, {
+      state.binaryAccessor = getAccessorFromBuffer(buffer.value, {
         size: buffer.size || this.size,
         stride: buffer.stride,
         offset: buffer.offset,
@@ -294,7 +294,7 @@ export default class Attribute extends DataColumn {
 
     const {accessor, transform} = settings;
     const accessorFunc =
-      state.logicalAccessor || (typeof accessor === 'function' ? accessor : props[accessor]);
+      state.binaryAccessor || (typeof accessor === 'function' ? accessor : props[accessor]);
 
     assert(typeof accessorFunc === 'function', `accessor "${accessor}" is not a function`);
 

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -433,7 +433,7 @@ export default class Layer extends Component {
       startIndices,
       props,
       transitions: props.transitions,
-      buffers: props,
+      buffers: props.data.attributes,
       context: this,
       // Don't worry about non-attribute props
       ignoreUnknownAttributes: true

--- a/modules/core/src/utils/iterable-utils.js
+++ b/modules/core/src/utils/iterable-utils.js
@@ -92,6 +92,11 @@ export function getAccessorFromBuffer(typedArray, {size, stride, offset, startIn
         }
         result[i - startIndex] = target;
       }
+    } else if (elementStride === size) {
+      result = typedArray.subarray(
+        startIndex * size + elementOffset,
+        endIndex * size + elementOffset
+      );
     } else {
       result = new typedArray.constructor((endIndex - startIndex) * size);
       let targetIndex = 0;

--- a/modules/core/src/utils/iterable-utils.js
+++ b/modules/core/src/utils/iterable-utils.js
@@ -60,3 +60,49 @@ export function createIterable(data, startRow = 0, endRow = Infinity) {
 export function isAsyncIterable(data) {
   return data && data[Symbol.asyncIterator];
 }
+
+/*
+ * Create an accessor function from a flat buffer that yields the value at each object index
+ */
+export function getAccessorFromBuffer(typedArray, {size, stride, offset, startIndices, nested}) {
+  const bytesPerElement = typedArray.BYTES_PER_ELEMENT;
+  const elementStride = stride ? stride / bytesPerElement : size;
+  const elementOffset = offset ? offset / bytesPerElement : 0;
+  const vertexCount = Math.floor((typedArray.length - elementOffset) / elementStride);
+
+  return (_, {index, target}) => {
+    if (!startIndices) {
+      const sourceIndex = index * elementStride + elementOffset;
+      for (let j = 0; j < size; j++) {
+        target[j] = typedArray[sourceIndex + j];
+      }
+      return target;
+    }
+    const startIndex = startIndices[index];
+    const endIndex = startIndices[index + 1] || vertexCount;
+    let result;
+
+    if (nested) {
+      result = new Array(endIndex - startIndex);
+      for (let i = startIndex; i < endIndex; i++) {
+        const sourceIndex = i * elementStride + elementOffset;
+        target = new Array(size);
+        for (let j = 0; j < size; j++) {
+          target[j] = typedArray[sourceIndex + j];
+        }
+        result[i - startIndex] = target;
+      }
+    } else {
+      result = new typedArray.constructor((endIndex - startIndex) * size);
+      let targetIndex = 0;
+      for (let i = startIndex; i < endIndex; i++) {
+        const sourceIndex = i * elementStride + elementOffset;
+        for (let j = 0; j < size; j++) {
+          result[targetIndex++] = typedArray[sourceIndex + j];
+        }
+      }
+    }
+
+    return result;
+  };
+}

--- a/test/modules/core/lib/attribute/attribute.spec.js
+++ b/test/modules/core/lib/attribute/attribute.spec.js
@@ -689,7 +689,10 @@ test('Attribute#setExternalBuffer', t => {
   const value2 = new Uint8Array(4);
 
   attribute.setNeedsUpdate();
-  t.notOk(attribute.setExternalBuffer(null), 'should do nothing if setting external buffer to null');
+  t.notOk(
+    attribute.setExternalBuffer(null),
+    'should do nothing if setting external buffer to null'
+  );
   t.ok(attribute.needsUpdate(), 'attribute still needs update');
 
   t.ok(attribute.setExternalBuffer(buffer), 'should set external buffer to Buffer object');
@@ -763,7 +766,10 @@ test('Attribute#setLogicalValue', t => {
   t.is(spy.callCount, 1, 'setData is called only once on the same data');
   t.notOk(attribute.needsUpdate(), 'attribute is updated');
 
-  t.throws(() => attribute.setLogicalValue([0, 1, 2, 3]), 'should throw if external value is invalid');
+  t.throws(
+    () => attribute.setLogicalValue([0, 1, 2, 3]),
+    'should throw if external value is invalid'
+  );
 
   spy.reset();
   attribute.delete();

--- a/test/modules/core/lib/attribute/attribute.spec.js
+++ b/test/modules/core/lib/attribute/attribute.spec.js
@@ -743,7 +743,7 @@ test('Attribute#setExternalBuffer', t => {
   t.end();
 });
 
-test('Attribute#setLogicalValue', t => {
+test('Attribute#setBinaryValue', t => {
   let attribute = new Attribute(gl, {
     id: 'test-attribute',
     type: GL.FLOAT,
@@ -753,21 +753,21 @@ test('Attribute#setLogicalValue', t => {
   let value = new Float32Array(12);
 
   attribute.setNeedsUpdate();
-  t.notOk(attribute.setLogicalValue(null), 'should do nothing if setting external buffer to null');
+  t.notOk(attribute.setBinaryValue(null), 'should do nothing if setting external buffer to null');
   t.ok(attribute.needsUpdate(), 'attribute still needs update');
 
   const spy = makeSpy(attribute, 'setData');
-  t.ok(attribute.setLogicalValue(value), 'should use external logical value');
+  t.ok(attribute.setBinaryValue(value), 'should use external binary value');
   t.is(spy.callCount, 1, 'setData is called');
   t.notOk(attribute.needsUpdate(), 'attribute is updated');
 
   attribute.setNeedsUpdate();
-  t.ok(attribute.setLogicalValue(value), 'should use external logical value');
+  t.ok(attribute.setBinaryValue(value), 'should use external binary value');
   t.is(spy.callCount, 1, 'setData is called only once on the same data');
   t.notOk(attribute.needsUpdate(), 'attribute is updated');
 
   t.throws(
-    () => attribute.setLogicalValue([0, 1, 2, 3]),
+    () => attribute.setBinaryValue([0, 1, 2, 3]),
     'should throw if external value is invalid'
   );
 
@@ -782,7 +782,7 @@ test('Attribute#setLogicalValue', t => {
     update: () => {}
   });
   attribute.setNeedsUpdate();
-  t.notOk(attribute.setLogicalValue(value), 'should do nothing if noAlloc');
+  t.notOk(attribute.setBinaryValue(value), 'should do nothing if noAlloc');
   t.ok(attribute.needsUpdate(), 'attribute still needs update');
 
   attribute = new Attribute(gl, {
@@ -796,8 +796,8 @@ test('Attribute#setLogicalValue', t => {
   value = {value: new Uint8Array(12), size: 3};
 
   attribute.setNeedsUpdate();
-  t.notOk(attribute.setLogicalValue(value), 'should require update');
-  t.ok(attribute.state.logicalAccessor, 'logicalAccessor is assigned');
+  t.notOk(attribute.setBinaryValue(value), 'should require update');
+  t.ok(attribute.state.binaryAccessor, 'binaryAccessor is assigned');
   t.ok(attribute.needsUpdate(), 'attribute still needs update');
 
   attribute.delete();

--- a/test/modules/core/utils/iterable-utils.spec.js
+++ b/test/modules/core/utils/iterable-utils.spec.js
@@ -138,6 +138,16 @@ test('getAccessorFromBuffer', t => {
       output: [[1, 1, 0, 2, 2, 0], [3, 3, 0]]
     },
     {
+      title: 'variable-width buffer with offset',
+      input: {
+        value: new Float32Array([0, 0, 0, 1, 1, 0, 2, 2, 0, 3, 3, 0]),
+        size: 3,
+        offset: 12,
+        startIndices: [0, 2]
+      },
+      output: [[1, 1, 0, 2, 2, 0], [3, 3, 0]]
+    },
+    {
       title: 'variable-width buffer with stride and offset',
       input: {
         value: new Float32Array([0, 0, 0, 1, 1, 0, 2, 2, 0, 3, 3, 0]),

--- a/test/modules/core/utils/iterable-utils.spec.js
+++ b/test/modules/core/utils/iterable-utils.spec.js
@@ -1,86 +1,86 @@
 import test from 'tape-catch';
-import {createIterable} from '@deck.gl/core/utils/iterable-utils';
-
-const TEST_CASES = [
-  {
-    title: 'empty data',
-    input: {
-      data: null
-    },
-    count: 0
-  },
-  {
-    title: 'array data',
-    input: {
-      data: [1, 2, 3]
-    },
-    count: 3,
-    firstObject: 1,
-    firstIndex: 0
-  },
-  {
-    title: 'iterable data',
-    input: {
-      data: new Map([['x', 1], ['y', 2], ['z', 3]])
-    },
-    count: 3,
-    firstObject: ['x', 1],
-    firstIndex: 0
-  },
-  {
-    title: 'non-iterable data',
-    input: {
-      data: {length: 3}
-    },
-    count: 3,
-    firstObject: undefined,
-    firstIndex: 0
-  },
-  {
-    title: 'array data with range',
-    input: {
-      data: [1, 2, 3],
-      startIndex: 0,
-      endIndex: 1
-    },
-    count: 1,
-    firstObject: 1,
-    firstIndex: 0
-  },
-  {
-    title: 'array data with range',
-    input: {
-      data: [1, 2, 3],
-      startIndex: 1
-    },
-    count: 2,
-    firstObject: 2,
-    firstIndex: 1
-  },
-  {
-    title: 'iterable data with range',
-    input: {
-      data: new Map([['x', 1], ['y', 2], ['z', 3]]),
-      startIndex: 1,
-      endIndex: 4
-    },
-    count: 2,
-    firstObject: ['y', 2],
-    firstIndex: 1
-  },
-  {
-    title: 'non-iterable data with range',
-    input: {
-      data: {length: 3},
-      startIndex: 2
-    },
-    count: 1,
-    firstObject: undefined,
-    firstIndex: 2
-  }
-];
+import {createIterable, getAccessorFromBuffer} from '@deck.gl/core/utils/iterable-utils';
 
 test('createIterable', t => {
+  const TEST_CASES = [
+    {
+      title: 'empty data',
+      input: {
+        data: null
+      },
+      count: 0
+    },
+    {
+      title: 'array data',
+      input: {
+        data: [1, 2, 3]
+      },
+      count: 3,
+      firstObject: 1,
+      firstIndex: 0
+    },
+    {
+      title: 'iterable data',
+      input: {
+        data: new Map([['x', 1], ['y', 2], ['z', 3]])
+      },
+      count: 3,
+      firstObject: ['x', 1],
+      firstIndex: 0
+    },
+    {
+      title: 'non-iterable data',
+      input: {
+        data: {length: 3}
+      },
+      count: 3,
+      firstObject: undefined,
+      firstIndex: 0
+    },
+    {
+      title: 'array data with range',
+      input: {
+        data: [1, 2, 3],
+        startIndex: 0,
+        endIndex: 1
+      },
+      count: 1,
+      firstObject: 1,
+      firstIndex: 0
+    },
+    {
+      title: 'array data with range',
+      input: {
+        data: [1, 2, 3],
+        startIndex: 1
+      },
+      count: 2,
+      firstObject: 2,
+      firstIndex: 1
+    },
+    {
+      title: 'iterable data with range',
+      input: {
+        data: new Map([['x', 1], ['y', 2], ['z', 3]]),
+        startIndex: 1,
+        endIndex: 4
+      },
+      count: 2,
+      firstObject: ['y', 2],
+      firstIndex: 1
+    },
+    {
+      title: 'non-iterable data with range',
+      input: {
+        data: {length: 3},
+        startIndex: 2
+      },
+      count: 1,
+      firstObject: undefined,
+      firstIndex: 2
+    }
+  ];
+
   for (const testCase of TEST_CASES) {
     const {iterable, objectInfo} = createIterable(
       testCase.input.data,
@@ -103,6 +103,71 @@ test('createIterable', t => {
     t.is(count, testCase.count, `${testCase.title} yields correct object count`);
     t.deepEqual(firstObject, testCase.firstObject, `${testCase.title} yields correct first object`);
     t.is(firstIndex, testCase.firstIndex, `${testCase.title} yields correct first index`);
+  }
+
+  t.end();
+});
+
+test('getAccessorFromBuffer', t => {
+  const TEST_CASES = [
+    {
+      title: 'plain buffer',
+      input: {
+        value: new Float32Array([1, 1, 0, 2, 2, 0, 3, 3, 0]),
+        size: 3
+      },
+      output: [[1, 1, 0], [2, 2, 0], [3, 3, 0]]
+    },
+    {
+      title: 'buffer with stride and offset',
+      input: {
+        value: new Float32Array([0, 0, 0, 1, 1, 0, 2, 2, 0, 3, 3, 0]),
+        size: 2,
+        stride: 12,
+        offset: 12
+      },
+      output: [[1, 1], [2, 2], [3, 3]]
+    },
+    {
+      title: 'variable-width buffer',
+      input: {
+        value: new Float32Array([1, 1, 0, 2, 2, 0, 3, 3, 0]),
+        size: 3,
+        startIndices: [0, 2]
+      },
+      output: [[1, 1, 0, 2, 2, 0], [3, 3, 0]]
+    },
+    {
+      title: 'variable-width buffer with stride and offset',
+      input: {
+        value: new Float32Array([0, 0, 0, 1, 1, 0, 2, 2, 0, 3, 3, 0]),
+        size: 2,
+        stride: 12,
+        offset: 12,
+        startIndices: [0, 2]
+      },
+      output: [[1, 1, 2, 2], [3, 3]]
+    },
+    {
+      title: 'variable-width buffer nested',
+      input: {
+        value: new Float32Array([1, 1, 0, 2, 2, 0, 3, 3, 0]),
+        size: 3,
+        startIndices: [0, 2],
+        nested: true
+      },
+      output: [[[1, 1, 0], [2, 2, 0]], [[3, 3, 0]]]
+    }
+  ];
+
+  for (const testCase of TEST_CASES) {
+    t.comment(testCase.title);
+    const accessor = getAccessorFromBuffer(testCase.input.value, testCase.input);
+    const context = {index: -1, target: []};
+    for (const result of testCase.output) {
+      context.index++;
+      t.deepEqual(accessor(null, context), result, `accessor at index ${context.index}`);
+    }
   }
 
   t.end();


### PR DESCRIPTION
For #3758, implements the RFC in #3884 

#### Change List
- Drops support for external attributes in top-level props
- Add `attribute.setBinaryValue`, support auto-packed attributes
- Unit tests

#### TODO (follow-up PRs)
- `PathLayer`
- `SolidPolygonLayer`