### PR TITLE
Port line layer example and web worker data loader to ocular gatsby website  

### DIFF
--- a/website-gatsby/gatsby-config.js
+++ b/website-gatsby/gatsby-config.js
@@ -1,5 +1,9 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
 const {getGatsbyConfig} = require('ocular-gatsby/api');
 
 const config = require('./ocular-config');
 
-module.exports = getGatsbyConfig(config);
+const gatsbyConfig = getGatsbyConfig(config);
+gatsbyConfig.plugins.push('gatsby-plugin-sass');
+
+module.exports = gatsbyConfig;

--- a/website-gatsby/ocular-config.js
+++ b/website-gatsby/ocular-config.js
@@ -32,7 +32,7 @@ module.exports = {
   PROJECT_NAME: 'deck.gl',
   PROJECT_ORG: 'uber',
   PROJECT_URL: 'https://deck.gl',
-  PROJECT_DESC: 'A WebGL-powered framework for visual exploratory analysis of large datasets.',
+  PROJECT_DESC: 'Large-scale WebGL-powered Data Visualization',
   PATH_PREFIX: '/',
 
   FOOTER_LOGO: '',
@@ -51,22 +51,7 @@ module.exports = {
 
   HOME_BULLETS: [
     {
-      text: '',
-      desc: '',
-      img: 'images/icon-high-precision.svg'
-    },
-    {
-      text: 'High-Precision Computations in the GPU',
-      // eslint-disable-next-line
-      desc:
-        'Using polynomial expansions of geospatial projections, \
-and through emulation of 64 bit floating point computations in the GPU, \
-deck.gl renders datasets with unparalleled accuracy and performance.',
-      img: 'images/icon-high-precision.svg'
-    },
-    {
       text: 'A Layered Approach to Data Visualization',
-      // eslint-disable-next-line
       desc:
         'deck.gl allows complex visualizations to be constructed by \
 composing existing layers, and makes it easy to package and \
@@ -75,22 +60,20 @@ a catalog of proven layers and we have many more in the works.',
       img: 'images/icon-layers.svg'
     },
     {
-      text: 'Rich Base Map Support',
-      // eslint-disable-next-line
+      text: 'High-Precision Computations in the GPU',
       desc:
-        'Geospatial visualizations can use vector tile layers to render maps, \
-or use Mapbox GL or Google Maps as base maps with automatically synchronized camera systems. \
-When used with Mapbox GL it automatically coordinates with the Mapbox perspective camera system \
-and the mapbox custom layer API to provide compelling 3D visualizations on top of your \
-Mapbox base maps.',
-      img: 'images/icon-layers.svg'
+        'By emulating 64 bit floating point computations in the GPU, \
+deck.gl renders datasets with unparalleled accuracy and performance.',
+      img: 'images/icon-high-precision.svg'
     },
     {
-      text: 'Deep React Integration',
-      // eslint-disable-next-line
+      text: 'React and Mapbox GL Integrations',
       desc:
-        "The optional React integration provides highly performant WebGL rendering \
-under React's functional programming paradigm.",
+        'deck.gl is a great match with React, supporting efficient WebGL \
+rendering under the Reactive programming paradigm. And when used with \
+Mapbox GL it automatically coordinates with the Mapbox camera system \
+to provide compelling 2D and 3D visualizations on top of your Mapbox \
+based maps.',
       img: 'images/icon-react.svg'
     }
   ],
@@ -118,12 +101,14 @@ under React's functional programming paradigm.",
 
   LINK_TO_GET_STARTED: '/docs',
 
+  INDEX_PAGE_URL: resolve(__dirname, './templates/index.jsx'),
+
   EXAMPLES: [
     {
       title: 'LineLayer',
-      path: 'examples/line',
+      path: 'examples/website/line',
       image: 'images/examples/demo-thumb-line.jpg',
-      componentUrl: resolve(__dirname, '../examples/website/line/app.js')
+      componentUrl: resolve(__dirname, './templates/examples/example-line-layer.jsx')
     },
     {
       title: 'HexagonLayer',

--- a/website-gatsby/package.json
+++ b/website-gatsby/package.json
@@ -21,6 +21,7 @@
     "@luma.gl/core": "^8.0.0-alpha.5",
     "@luma.gl/webgl": "^8.0.0-alpha.5",
     "@probe.gl/stats-widget": "^3.0.1",
+    "d3-color": "^1.4.0",
     "d3-request": "^1.0.6",
     "d3-scale": "^3.0.0",
     "rbush": "^2.0.2",
@@ -30,6 +31,7 @@
   },
   "devDependencies": {
     "gatsby": "^2.3.0",
+    "gatsby-plugin-sass": "^2.1.21",
     "gatsby-plugin-styletron": "^3.0.5",
     "gh-pages": "^2.0.1",
     "ocular-gatsby": "1.0.4",

--- a/website-gatsby/src/components/info-panel.jsx
+++ b/website-gatsby/src/components/info-panel.jsx
@@ -5,9 +5,10 @@ export default class InfoPanel extends PureComponent {
     const { name, controls, sourceLink} = this.props;
 
     return (
-      <div className="options-panel top-right" tabIndex="0">
+      <div className="top-right options-panel" tabIndex="0">
         <h3>{name}</h3>
-        <div className="control-panel" dangerouslySetInnerHTML={{__html: controls}} />
+        <div className="control-panel" />
+        {this.props.children}
 
         {sourceLink && (
           <div className="source-link">

--- a/website-gatsby/src/constants/defaults.js
+++ b/website-gatsby/src/constants/defaults.js
@@ -1,0 +1,12 @@
+export const MAPBOX_STYLES = {
+  LIGHT: 'mapbox://styles/uberdata/cive48w2e001a2imn5mcu2vrs',
+  DARK: 'mapbox://styles/uberdata/cive485h000192imn6c6cc8fc',
+  BLANK: {
+    version: 8,
+    sources: {},
+    layers: []
+  }
+};
+
+export const DATA_URI = 'https://raw.githubusercontent.com/uber-common/deck.gl-data/master/website';
+export const GITHUB_TREE = 'https://github.com/uber/deck.gl/tree/7.3-release';

--- a/website-gatsby/src/utils/data-utils.js
+++ b/website-gatsby/src/utils/data-utils.js
@@ -1,0 +1,32 @@
+import {request, json, text} from 'd3-request';
+
+import {StreamParser} from './worker-utils';
+
+export function loadData(url, worker, onSuccess) {
+  if (worker) {
+    const req = request(url);
+    // use a web worker to parse data
+    const dataParser = new StreamParser(worker, (data, meta) => {
+      onSuccess(data, meta);
+    });
+
+    req
+      .on('progress', dataParser.onProgress)
+      .on('load', dataParser.onLoad)
+      .get();
+  } else if (/\.(json|geojson)$/.test(url)) {
+    // load as json
+    json(url, (error, response) => {
+      if (!error) {
+        onSuccess(response, {});
+      }
+    });
+  } else {
+    // load as plain text
+    text(url, (error, response) => {
+      if (!error) {
+        onSuccess(response, {});
+      }
+    });
+  }
+}

--- a/website-gatsby/src/utils/format-utils.js
+++ b/website-gatsby/src/utils/format-utils.js
@@ -1,0 +1,60 @@
+import {rgb} from 'd3-color';
+
+export const normalizeParam = p => {
+  if (p.type === 'function') {
+    let displayValue = String(p.value);
+    if (Array.isArray(p.value)) {
+      displayValue = `[${displayValue}]`;
+    }
+    if (typeof p.value === 'function') {
+      // pretty print function code:
+      // convert `function funcName(d) {...}` to `d => {...}`
+      displayValue = displayValue.replace(/^function (\w+)?\((\w*?)\)/, '$2 =>');
+      // convert `function funcName(d, i) {...}` to `(d, i) => {...}`
+      displayValue = displayValue.replace(/^function (\w+)?(\(.*?\))/, '$2 =>');
+      // convert `d => {return 1}` to `d => 1`
+      displayValue = displayValue.replace(/\{\s*return\s*(.*?);?\s*\}$/, '$1');
+      return {...p, displayValue};
+    }
+    if (p.altType) {
+      p.type = p.altType;
+    } else {
+      return {...p, displayValue};
+    }
+  }
+  if (p.type === 'json') {
+    return {...p, displayValue: JSON.stringify(p.value)};
+  }
+  if (p.type === 'color') {
+    const value = colorToRGBArray(p.value);
+    return {...p, value, displayValue: rgbToHex(value)};
+  }
+  return {...p, displayValue: String(p.value)};
+};
+
+export const readableInteger = x => {
+  if (!x) {
+    return 0;
+  }
+  if (x < 1000) {
+    return x.toString();
+  }
+  x /= 1000;
+  if (x < 1000) {
+    return `${x.toFixed(1)}K`;
+  }
+  x /= 1000;
+  return `${x.toFixed(1)}M`;
+};
+
+export function rgbToHex(rgbArr) {
+  return rgbArr.slice(0, 3).reduce((acc, v) => `${acc}${v < 16 ? '0' : ''}${v.toString(16)}`, '#');
+}
+
+export function colorToRGBArray(color) {
+  if (Array.isArray(color)) {
+    return color.slice(0, 4);
+  }
+  const c = rgb(color);
+  return [c.r, c.g, c.b, 255];
+}

--- a/website-gatsby/src/utils/worker-utils.js
+++ b/website-gatsby/src/utils/worker-utils.js
@@ -1,0 +1,45 @@
+/* global Worker */
+
+const workers = {};
+
+export function StreamParser(workerUrl, callback) {
+  let parsedLength = 0;
+
+  if (workers[workerUrl]) {
+    workers[workerUrl].terminate();
+  }
+
+  const workerInstance = new Worker(workerUrl);
+  workers[workerUrl] = workerInstance;
+  let streamedData = [];
+
+  workerInstance.onmessage = e => {
+    const {action, data, meta} = e.data;
+    if (action === 'end') {
+      workerInstance.terminate();
+    } else if (action === 'add' && data && data.length) {
+      streamedData = streamedData.concat(data);
+      callback(streamedData, meta); // eslint-disable-line callback-return
+    }
+  };
+
+  this.onProgress = e => {
+    const {responseText} = e.target;
+    const lineBreak = responseText.lastIndexOf('\n') + 1;
+
+    workerInstance.postMessage({
+      event: 'progress',
+      text: responseText.slice(parsedLength, lineBreak)
+    });
+
+    parsedLength = lineBreak;
+  };
+
+  this.onLoad = target => {
+    const {responseText} = target;
+    workerInstance.postMessage({
+      event: 'load',
+      text: responseText.slice(parsedLength)
+    });
+  };
+}

--- a/website-gatsby/static/workers/flight-path-data-decoder.js
+++ b/website-gatsby/static/workers/flight-path-data-decoder.js
@@ -1,0 +1,55 @@
+importScripts('./util.js');
+const FLUSH_LIMIT = 20000;
+let result = [];
+let index = 0;
+let count = 0;
+
+onmessage = function(e) {
+  const lines = e.data.text.split('\n');
+
+  lines.forEach(function(line) {
+
+    if (!line) {
+      return;
+    }
+
+    var parts = line.split('\t');
+    var coords0 = parts[2].split('\x01').map(function(str) { return decodePolyline(str, 5) });
+    var coords1 = parts[3].split('\x01').map(function(str) { return decodePolyline(str, 1) });
+
+    coords0.forEach(function(lineStr, i) {
+      for (var j = 1; j < lineStr.length; j++) {
+        var prevPt0 = coords0[i][j - 1],
+            prevPt1 = coords1[i][j - 1],
+            currPt0 = coords0[i][j],
+            currPt1 = coords1[i][j];
+
+        result.push({
+          name: parts[0],
+          country: parts[1],
+          start: [prevPt0[0], prevPt0[1], prevPt1[0]],
+          end: [currPt0[0], currPt0[1], currPt1[0]]
+        });
+        count++;
+      }
+    });
+
+    if (result.length >= FLUSH_LIMIT) {
+      flush();
+    }
+  });
+
+  if (e.data.event === 'load') {
+    flush();
+    postMessage({action: 'end'});
+  }
+};
+
+function flush() {
+  postMessage({
+    action: 'add',
+    data: result,
+    meta: {count}
+  });
+  result = [];
+}

--- a/website-gatsby/static/workers/util.js
+++ b/website-gatsby/static/workers/util.js
@@ -1,0 +1,80 @@
+function decodeNumberArr(str, b, shift, length) {
+  const result = [];
+  for (let j = 0; j < str.length; j += length) {
+    const token = str.slice(j, j + length);
+    result.push(decodeNumber(token, b, shift));
+  }
+  return result;
+}
+
+function decodeNumber(str, b, shift) {
+  let x = 0;
+  let p = 1;
+  for (let i = str.length; i--;) {
+    x += (str.charCodeAt(i) - shift) * p;
+    p *= b;
+  }
+  return x;
+}
+
+/**
+ * https://github.com/mapbox/polyline
+ *
+ * Decodes to a [longitude, latitude] coordinates array.
+ *
+ * This is adapted from the implementation in Project-OSRM.
+ *
+ * @param {String} str
+ * @param {Number} precision
+ * @returns {Array}
+ *
+ * @see https://github.com/Project-OSRM/osrm-frontend/blob/master/WebContent/routing/OSRM.RoutingGeometry.js
+ */
+function decodePolyline(str, precision) {
+  let index = 0,
+    lat = 0,
+    lng = 0,
+    coordinates = [],
+    shift = 0,
+    result = 0,
+    byte = null,
+    latitude_change,
+    longitude_change,
+    factor = Math.pow(10, precision || 5);
+
+    // Coordinates have variable length when encoded, so just keep
+    // track of whether we've hit the end of the string. In each
+    // loop iteration, a single coordinate is decoded.
+  while (index < str.length) {
+
+        // Reset shift, result, and byte
+    byte = null;
+    shift = 0;
+    result = 0;
+
+    do {
+      byte = str.charCodeAt(index++) - 63;
+      result |= (byte & 0x1f) << shift;
+      shift += 5;
+    } while (byte >= 0x20);
+
+    latitude_change = ((result & 1) ? ~(result >> 1) : (result >> 1));
+
+    shift = result = 0;
+
+    do {
+      byte = str.charCodeAt(index++) - 63;
+      result |= (byte & 0x1f) << shift;
+      shift += 5;
+    } while (byte >= 0x20);
+
+    longitude_change = ((result & 1) ? ~(result >> 1) : (result >> 1));
+
+    lat += latitude_change;
+    lng += longitude_change;
+
+    coordinates.push([lng / factor, lat / factor]);
+  }
+
+  return coordinates;
+}

--- a/website-gatsby/templates/examples/example-line-layer.jsx
+++ b/website-gatsby/templates/examples/example-line-layer.jsx
@@ -1,0 +1,85 @@
+import React, {Component} from 'react';
+import InfoPanel from '../../src/components/info-panel';
+import {MAPBOX_STYLES, DATA_URI, GITHUB_TREE} from '../../src/constants/defaults';
+import {loadData} from '../../src/utils/data-utils';
+import {readableInteger} from '../../src/utils/format-utils';
+import App from '../../../examples/website/line/app';
+
+export default class LineDemo extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      width: 3,
+      airportsData: [],
+      flightData: [],
+      flightDataCount: 0
+    };
+
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  componentDidMount() {
+    loadData(`${DATA_URI}/airports.json`, null, (response, meta) => {
+      this.setState({
+        airportsData: response
+      });
+    });
+    loadData(
+      `${DATA_URI}/flight-path-data.txt`,
+      '/workers/flight-path-data-decoder.js',
+      (response, meta) => {
+        this.setState({
+          flightData: response,
+          flightDataCount: meta.count
+        });
+      }
+    );
+  }
+
+  handleChange(event) {
+    this.setState({width: parseFloat(event.target.value)});
+  }
+
+  render() {
+    const {width, flightData, flightDataCount, airportsData} = this.state;
+
+    return (
+      <div>
+        <App
+          mapStyle={MAPBOX_STYLES.DARK}
+          getWidth={width}
+          flightPaths={flightData}
+          airports={airportsData}
+        />
+        <InfoPanel sourceLink={`${GITHUB_TREE}/${this.props.path}`}>
+          <h3>Flights To And From London Heathrow Airport</h3>
+          <p>Flight paths in a 6-hour window</p>
+          <p>From 08:32:43 GMT to 14:32:43 GMT on March 28th, 2017</p>
+          <p>
+            Flight path data source:
+            <a href="https://opensky-network.org/"> The OpenSky Network</a>
+            <br />
+            Airport location data source:
+            <a href="http://www.naturalearthdata.com/"> Natural Earth</a>
+          </p>
+          <div className="stat">
+            No. of Line Segments<b>{readableInteger(flightDataCount)}</b>
+          </div>
+          <hr />
+          <div className="input">
+            <label>Width</label>
+            <input
+              name="width"
+              type="range"
+              step="0.1"
+              min="0"
+              max="10"
+              value={width}
+              onChange={this.handleChange}
+            />
+          </div>
+        </InfoPanel>
+      </div>
+    );
+  }
+}

--- a/website-gatsby/templates/index.jsx
+++ b/website-gatsby/templates/index.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import {Home} from 'ocular-gatsby/components';
+import './style.scss';
+
+if (typeof window !== 'undefined') {
+  window.website = true;
+}
+
+const HeroExample = require('./examples/example-line-layer').default;
+
+export default class IndexPage extends React.Component {
+  render() {
+    return <Home HeroExample={HeroExample} />;
+  }
+}

--- a/website-gatsby/templates/style.scss
+++ b/website-gatsby/templates/style.scss
@@ -1,0 +1,321 @@
+@import url('https://api.tiles.mapbox.com/mapbox-gl-js/v1.3.1/mapbox-gl.css');
+
+$primary: #00ADE6;
+$secondary: #05E3D5;
+$black: #041725;
+$black-20: #213746;
+$black-40: #5A666D;
+$white: #EDEDED;
+$white-40: #8D9BA3;
+$topbar-height: 64px;
+
+.banner {
+  .container {
+    background: rgba(0, 0, 0, 0);
+  }
+}
+
+.banner .hero .options-panel {
+  display: none;
+}
+
+.stat {
+  text-transform: uppercase;
+  font-size: 0.833em;
+
+  b {
+    display: block;
+    font-size: 3em;
+    font-weight: bold;
+    line-height: 1.833;
+  }
+}
+.tooltip {
+  position: absolute;
+  padding: 4px;
+  background: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  max-width: 300px;
+  font-size: 10px;
+  z-index: 9;
+  pointer-events: none;
+}
+.top-right {
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+.options-panel {
+  width: 344px;
+  background: #fff;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.15);
+  margin: 24px;
+  padding: 12px 24px;
+  max-height: 96%;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overflow-y: overlay;
+  outline: none;
+
+  hr {
+    margin: 12px -24px;
+  }
+  .source-link {
+    text-align: right;
+    margin-top: 8px;
+
+    a {
+      font-weight: bold;
+      color: $black-40;
+      font-size: 11px;
+    }
+  }
+  .input {
+    position: relative;
+    width: 100%;
+
+    &:last-child {
+      margin-bottom: 20px;
+    }
+
+    >* {
+      vertical-align: middle;
+      white-space: nowrap;
+    }
+    label {
+      display: inline-block;
+      width: 40%;
+      margin-right: 10%;
+      color: $black-40;
+      margin-top: 2px;
+      margin-bottom: 2px;
+    }
+    input, a, button {
+      background: #fff;
+      font-size: 0.9em;
+      text-transform: none;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      display: inline-block;
+      padding: 0 4px;
+      margin: 0;
+      width: 50%;
+      height: 20px;
+      line-height: 1.833;
+      text-align: left;
+    }
+    button {
+      color: initial;
+    }
+    button:disabled {
+      color: #aaa;
+      cursor: default;
+      background: #eee;
+    }
+    input {
+      border: solid 1px #ccc;
+
+      &:disabled {
+        background: $white;
+      }
+      &[type="checkbox"] {
+        height: auto;
+      }
+    }
+
+    .tooltip {
+      left: 50%;
+      top: 24px;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 200ms;
+    }
+    &:hover .tooltip {
+      opacity: 1;
+    }
+  }
+  h3 {
+    font-size: 1.2em;
+    font-weight: 500;
+    margin: 8px 0;
+  }
+
+  a {
+    display: inline;
+    color: $primary;
+  }
+
+  p {
+    margin-bottom: 16px;
+  }
+  .legend {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+  }
+  .spinner {
+    height: 18px;
+    line-height: 18px;
+    font-size: 10px;
+
+    >div {
+      white-space: nowrap;
+      left: 0;
+      bottom: 0;
+      position: absolute;
+      height: 18px;
+      padding-left: 20px;
+      transition: width 0.5s;
+    }
+    .spinner--fill {
+      background: $primary;
+      color: $white;
+      overflow: hidden;
+    }
+    .spinner--text {
+      color: $black-40;
+    }
+
+    &.done {
+      height: 0 !important;
+      line-height: 0;
+      font-size: 0;
+      transition: height 0.5s 1s;
+
+      >div {
+        height: 0 !important;
+        transition: height 0.5s 1s;
+      }
+    }
+  }
+}
+code {
+  font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace !important;
+}
+.demo {
+  position: relative;
+  overflow: hidden !important;
+  height: 100vh;
+  transition: height 600ms ease-in;
+}
+.markdown {
+  height: 100%;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+}
+.markdown .demo {
+  height: 80vh;
+
+  >div:first-child {
+    margin-top: 0;
+    transition: margin-top 600ms ease-in;
+  }
+
+  &:not(:hover) {
+    height: 30vh;
+    min-height: 200px;
+    transition: height 300ms;
+
+    >div:first-child {
+      margin-top: -20vh;
+      transition: margin-top 300ms;
+    }
+    .options-panel {
+      overflow-y: hidden;
+    }
+  }
+}
+
+@media (max-width: 768px) {
+  .flexbox--row {
+    display: block;
+  }
+  .toc {
+    position: absolute;
+    width: 100vw;
+    max-width: initial;
+    height: 0;
+    z-index: 9;
+
+    >div {
+      padding-top: 220px;
+    }
+  }
+  .toc.open {
+    height: 100%;
+  }
+  .options-panel {
+    width: 100%;
+    margin: 0;
+  }
+  .options-panel:not(.focus) {
+    cursor: pointer;
+    >div > *, hr, .input {
+      display: none;
+    }
+    &:before {
+      position: absolute;
+      top: 12px;
+      right: 12px;
+      color: $white-40;
+      font-size: 24px;
+      font-family: 'deckgl';
+      content: "\e906";
+    }
+    >.spinner {
+      height: 3px;
+      line-height: 0;
+      font-size: 0;
+
+      .spinner--fill {
+        height: 3px;
+        display: block;
+      }
+    }
+    h3 {
+      display: block;
+    }
+  }
+  .tabs .tip {
+    display: none;
+  }
+  .markdown-body {
+    padding: 40px 12px 96px;
+  }
+  .markdown .demo:not(:hover) .options-panel {
+    .input, hr {
+      display: none;
+    }
+  }
+}
+
+.icon-demo {
+  .tooltip {
+    padding: 4px 12px;
+    max-width: 240px;
+    max-height: 320px;
+    box-sizing: content-box;
+    overflow-y: hidden;
+
+    h5 {
+      font-size: 1em;
+    }
+    p {
+      display: none;
+      text-indent: 4px;
+    }
+  }
+  .tooltip.interactive {
+    border: solid 4px transparent;
+    margin: -4px;
+    background: $white;
+    color: $black;
+    pointer-events: all;
+    width: 240px;
+    overflow-y: auto;
+
+    p {
+      display: block;
+    }
+  }
+}


### PR DESCRIPTION
For #3775, subtask of #3754 

I've ported the LineDemo example from the current website into the ocular gatsby system.  I'm looking for feedback on the port of this single example before I move the rest over in one or more future PRs.

To port the new example, I did the following:
- Reworked the LineDemo component to work without redux
- Moved the use of InfoPanel into the LineDemo component as a direct dependency
- Ported over a minimal set of code for the loading data on web workers
- Added a gatsby SCSS plugin to the website and ported over some minimal styling