### PR TITLE
Handle offset in DataColumn

### DIFF
--- a/modules/core/src/lib/attribute/attribute-transition-utils.js
+++ b/modules/core/src/lib/attribute/attribute-transition-utils.js
@@ -96,7 +96,7 @@ export function padBuffer({
   // its `size` and `elementOffset`?
   const precisionMultiplier = attribute.doublePrecision ? 2 : 1;
   const size = attribute.size * precisionMultiplier;
-  const offset = attribute.elementOffset * precisionMultiplier;
+  const byteOffset = attribute.byteOffset;
   const toStartIndices = attribute.startIndices;
   const hasStartIndices = fromStartIndices && toStartIndices;
   const toLength = getAttributeBufferLength(attribute, numInstances);
@@ -107,7 +107,9 @@ export function padBuffer({
     return;
   }
 
-  const toData = isConstant ? attribute.value : attribute.getBuffer().getData({});
+  const toData = isConstant
+    ? attribute.value
+    : attribute.getBuffer().getData({srcByteOffset: byteOffset});
   if (attribute.settings.normalized) {
     const getter = getData;
     getData = (value, chunk) => attribute._normalizeConstant(getter(value, chunk));
@@ -124,10 +126,12 @@ export function padBuffer({
     target: data,
     sourceStartIndices: fromStartIndices,
     targetStartIndices: toStartIndices,
-    offset,
     size,
     getData: getMissingData
   });
 
-  buffer.setData({data});
+  if (buffer.byteLength < data.byteLength + byteOffset) {
+    buffer.reallocate(data.byteLength + byteOffset);
+  }
+  buffer.subData({data, offset: byteOffset});
 }

--- a/modules/core/src/lib/attribute/attribute-transition-utils.js
+++ b/modules/core/src/lib/attribute/attribute-transition-utils.js
@@ -130,6 +130,7 @@ export function padBuffer({
     getData: getMissingData
   });
 
+  // TODO: support offset in buffer.setData?
   if (buffer.byteLength < data.byteLength + byteOffset) {
     buffer.reallocate(data.byteLength + byteOffset);
   }

--- a/modules/core/src/lib/attribute/attribute.js
+++ b/modules/core/src/lib/attribute/attribute.js
@@ -1,5 +1,4 @@
 /* eslint-disable complexity */
-import {_Accessor as Accessor} from '@luma.gl/core';
 import DataColumn from './data-column';
 import assert from '../../utils/assert';
 import {createIterable} from '../../utils/iterable-utils';
@@ -13,7 +12,6 @@ export default class Attribute extends DataColumn {
 
     const {
       // deck.gl fields
-      offset = 0,
       transition = false,
       noAlloc = false,
       update = null,
@@ -27,7 +25,6 @@ export default class Attribute extends DataColumn {
       noAlloc,
       update: update || (accessor && this._standardAccessor),
       accessor,
-      elementOffset: offset / Accessor.getBytesPerElement(this.settings),
       transform
     });
 
@@ -223,7 +220,7 @@ export default class Attribute extends DataColumn {
 
   getVertexOffset(row, startIndices = this.startIndices) {
     const vertexIndex = startIndices ? startIndices[row] : row;
-    return this.settings.elementOffset + vertexIndex * this.size;
+    return vertexIndex * this.size;
   }
 
   getShaderAttributes() {

--- a/modules/core/src/utils/array-utils.js
+++ b/modules/core/src/utils/array-utils.js
@@ -61,15 +61,7 @@ function padArrayChunk({source, target, start = 0, end, getData}) {
  * @params {Array<Number>} [sourceStartIndices] - subdivision of the original data in [object0StartIndex, object1StartIndex, ...]
  * @params {Array<Number>} [targetStartIndices] - subdivision of the output data in [object0StartIndex, object1StartIndex, ...]
  */
-export function padArray({
-  source,
-  target,
-  size,
-  offset = 0,
-  getData,
-  sourceStartIndices,
-  targetStartIndices
-}) {
+export function padArray({source, target, size, getData, sourceStartIndices, targetStartIndices}) {
   if (!Array.isArray(targetStartIndices)) {
     // Flat arrays
     padArrayChunk({
@@ -81,15 +73,15 @@ export function padArray({
   }
 
   // Arrays have internal structure
-  let sourceIndex = offset;
-  let targetIndex = offset;
+  let sourceIndex = 0;
+  let targetIndex = 0;
   const getChunkData = getData && ((i, chunk) => getData(i + targetIndex, chunk));
 
   const n = Math.min(sourceStartIndices.length, targetStartIndices.length);
 
   for (let i = 1; i < n; i++) {
-    const nextSourceIndex = sourceStartIndices[i] * size + offset;
-    const nextTargetIndex = targetStartIndices[i] * size + offset;
+    const nextSourceIndex = sourceStartIndices[i] * size;
+    const nextTargetIndex = targetStartIndices[i] * size;
 
     padArrayChunk({
       source: source.subarray(sourceIndex, nextSourceIndex),

--- a/modules/layers/src/path-layer/path-layer.js
+++ b/modules/layers/src/path-layer/path-layer.js
@@ -63,8 +63,7 @@ export default class PathLayer extends Layer {
     attributeManager.addInstanced({
       positions: {
         size: 3,
-        // Hack - Attribute class needs this to properly apply partial update
-        // The first 3 numbers of the value is just padding
+        // Start filling buffer from 3 elements in
         offset: 12,
         type: GL.DOUBLE,
         fp64: this.use64bitPositions(),

--- a/modules/layers/src/path-layer/path-tesselator.js
+++ b/modules/layers/src/path-layer/path-tesselator.js
@@ -33,7 +33,7 @@ export default class PathTesselator extends Tesselator {
       getGeometry,
       positionFormat,
       attributes: {
-        positions: {size: 3, padding: 3, type: fp64 ? Float64Array : Float32Array},
+        positions: {size: 3, type: fp64 ? Float64Array : Float32Array},
         segmentTypes: {size: 1, type: Uint8ClampedArray}
       }
     });
@@ -92,9 +92,9 @@ export default class PathTesselator extends Tesselator {
     // segmentTypes     3  4  4  0  0  0  0  4  4
     for (let i = vertexStart, ptIndex = 0; ptIndex < geometrySize; i++, ptIndex++) {
       const p = this.getPointOnPath(path, ptIndex);
-      positions[i * 3 + 3] = p[0];
-      positions[i * 3 + 4] = p[1];
-      positions[i * 3 + 5] = p[2] || 0;
+      positions[i * 3] = p[0];
+      positions[i * 3 + 1] = p[1];
+      positions[i * 3 + 2] = p[2] || 0;
     }
   }
 

--- a/test/modules/core/lib/attribute/attribute.spec.js
+++ b/test/modules/core/lib/attribute/attribute.spec.js
@@ -710,7 +710,6 @@ test('Attribute#setExternalBuffer', t => {
   t.is(attribute.getAccessor().type, GL.FLOAT, 'attribute type is set correctly');
 
   t.ok(attribute.setExternalBuffer(value2), 'should set external buffer to typed array');
-  t.is(attribute.getBuffer().debugData.constructor.name, 'Uint8Array', 'external value is set');
   t.is(attribute.getAccessor().type, GL.UNSIGNED_BYTE, 'attribute type is set correctly');
 
   t.ok(attribute2.setExternalBuffer(value2), 'external value is set');
@@ -797,11 +796,6 @@ test('Attribute#doublePrecision', t0 => {
 
     attribute.setExternalBuffer(new Uint32Array([3, 4, 5, 4, 4, 5]));
     t.ok(attribute.value instanceof Uint32Array, 'Attribute is Uint32Array');
-    t.deepEqual(
-      attribute.buffer.debugData.slice(0, 6),
-      [3, 4, 5, 4, 4, 5],
-      'Attribute value is set'
-    );
     validateShaderAttributes(t, attribute, false);
 
     t.throws(
@@ -811,11 +805,6 @@ test('Attribute#doublePrecision', t0 => {
 
     attribute.setExternalBuffer(new Float64Array([3, 4, 5, 4, 4, 5]));
     t.ok(attribute.value instanceof Float64Array, 'Attribute is Float64Array');
-    t.deepEqual(
-      attribute.buffer.debugData.slice(0, 6),
-      [3, 4, 5, 0, 0, 0],
-      'Attribute value is set'
-    );
     validateShaderAttributes(t, attribute, true);
 
     const buffer = new Buffer(gl, 12);
@@ -850,11 +839,6 @@ test('Attribute#doublePrecision', t0 => {
 
     attribute.setExternalBuffer(new Uint32Array([3, 4, 5, 4, 4, 5]));
     t.ok(attribute.value instanceof Uint32Array, 'Attribute is Uint32Array');
-    t.deepEqual(
-      attribute.buffer.debugData.slice(0, 6),
-      [3, 4, 5, 4, 4, 5],
-      'Attribute value is set'
-    );
     validateShaderAttributes(t, attribute, false);
 
     t.throws(
@@ -864,11 +848,6 @@ test('Attribute#doublePrecision', t0 => {
 
     attribute.setExternalBuffer(new Float64Array([3, 4, 5, 4, 4, 5]));
     t.ok(attribute.value instanceof Float64Array, 'Attribute is Float64Array');
-    t.deepEqual(
-      attribute.buffer.debugData.slice(0, 6),
-      [3, 4, 5, 0, 0, 0],
-      'Attribute value is set'
-    );
     validateShaderAttributes(t, attribute, true);
 
     const buffer = new Buffer(gl, 12);

--- a/test/modules/layers/path-tesselator.spec.js
+++ b/test/modules/layers/path-tesselator.spec.js
@@ -84,13 +84,13 @@ test('PathTesselator#constructor', t => {
 
       t.ok(ArrayBuffer.isView(tesselator.get('positions')), 'PathTesselator.get positions');
       t.deepEquals(
-        tesselator.get('positions').slice(0, 12),
-        [0, 0, 0, 1, 1, 0, 2, 2, 0, 3, 3, 0],
+        tesselator.get('positions').slice(0, 9),
+        [1, 1, 0, 2, 2, 0, 3, 3, 0],
         'positions are filled'
       );
 
       t.deepEquals(
-        tesselator.get('positions').slice(24, 33),
+        tesselator.get('positions').slice(21, 30),
         [2, 2, 0, 3, 3, 0, 1, 1, 0],
         'positions is handling loop correctly'
       );
@@ -119,8 +119,8 @@ test('PathTesselator#partial update', t => {
   let positions = tesselator.get('positions').slice(0, 21);
   t.is(tesselator.instanceCount, 9, 'Initial instance count');
   t.deepEquals(
-    positions,
-    [0, 0, 0, 1, 1, 0, 2, 2, 0, 3, 3, 0, 1, 1, 0, 2, 2, 0, 3, 3, 0],
+    positions.slice(0, 18),
+    [1, 1, 0, 2, 2, 0, 3, 3, 0, 1, 1, 0, 2, 2, 0, 3, 3, 0],
     'positions'
   );
   t.deepEquals(Array.from(accessorCalled), ['A', 'B'], 'Accessor called on all data');
@@ -128,14 +128,11 @@ test('PathTesselator#partial update', t => {
   sampleData[2] = {path: [[4, 4], [5, 5], [6, 6]], id: 'C'};
   accessorCalled.clear();
   tesselator.updatePartialGeometry({startRow: 2});
-  positions = tesselator.get('positions').slice(0, 39);
+  positions = tesselator.get('positions').slice(0, 36);
   t.is(tesselator.instanceCount, 12, 'Updated instance count');
   t.deepEquals(
     positions,
     [
-      0,
-      0,
-      0,
       1,
       1,
       0,
@@ -180,11 +177,11 @@ test('PathTesselator#partial update', t => {
   sampleData[0] = {path: [[6, 6], [5, 5], [4, 4]], id: 'A'};
   accessorCalled.clear();
   tesselator.updatePartialGeometry({startRow: 0, endRow: 1});
-  positions = tesselator.get('positions').slice(0, 30);
+  positions = tesselator.get('positions').slice(0, 27);
   t.is(tesselator.instanceCount, 12, 'Updated instance count');
   t.deepEquals(
     positions,
-    [0, 0, 0, 6, 6, 0, 5, 5, 0, 4, 4, 0, 1, 1, 0, 2, 2, 0, 3, 3, 0, 1, 1, 0, 2, 2, 0, 3, 3, 0],
+    [6, 6, 0, 5, 5, 0, 4, 4, 0, 1, 1, 0, 2, 2, 0, 3, 3, 0, 1, 1, 0, 2, 2, 0, 3, 3, 0],
     'positions'
   );
   t.deepEquals(Array.from(accessorCalled), ['A'], 'Accessor called only on partial data');


### PR DESCRIPTION
For #3758 

This change moves the handling of attribute offset from typed array generation to the buffer management. Layers and application no longer have to consider the buffer layout when dealing with attributes.

#### Change List
- `DataColumn` can upload value to WebGL buffer at an offset
- Remove `Attribute.elementOffset`
- `PathTesselator` no longer adds padding to the positions array
