### PR TITLE
Add option to skip normalization in tesselators

### DIFF
--- a/docs/layers/path-layer.md
+++ b/docs/layers/path-layer.md
@@ -130,6 +130,18 @@ Only works if `rounded` is `false`.
 
 Only effective if `getDashArray` is specified. If `true`, adjust gaps for the dashes to align at both ends.
 
+##### `_pathType` (Object, optional)
+
+* Default: `null`
+
+> Note: This prop is experimental
+
+One of `null`, `'loop'` or `'open'`.
+
+If `'loop'` or `'open'`, will skip normalizing the coordinates returned by `getPath` and instead assume all paths are to be loops or open paths. Disabling normalization improves performance during data update, but makes the layer prone to error in case the data is malformed. It is only recommended when you use this layer with preprocessed static data or validation on the backend.
+
+When normalization is disabled, paths must be specified in the format of flat array. Open paths must contain at least 2 vertices and closed paths must contain at least 3 vertices. See `getPath` below for details.
+
 ### Data Accessors
 
 ##### `getPath` ([Function](/docs/developer-guide/using-layers.md#accessors), optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")

--- a/docs/layers/solid-polygon-layer.md
+++ b/docs/layers/solid-polygon-layer.md
@@ -104,6 +104,16 @@ all elevation without updating the data.
 This is an object that contains material props for [lighting effect](/docs/effects/lighting-effect.md) applied on extruded polygons.
 Check [the lighting guide](/docs/developer-guide/using-lighting.md#constructing-a-material-instance) for configurable settings.
 
+##### `_normalize` (Object, optional)
+
+* Default: `true`
+
+> Note: This prop is experimental
+
+If `false`, will skip normalizing the coordinates returned by `getPolygon`. Disabling normalization improves performance during data update, but makes the layer prone to error in case the data is malformed. It is only recommended when you use this layer with preprocessed static data or validation on the backend.
+
+When normalization is disabled, polygons must be specified in the format of flat array or `{position, holeIndices}`. Rings must be closed (i.e. the first and last vertices must be identical). See `getPolygon` below for details.
+
 ### Data Accessors
 
 ##### `getPolygon` ([Function](/docs/developer-guide/using-layers.md#accessors), optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")

--- a/modules/core/src/utils/tesselator.js
+++ b/modules/core/src/utils/tesselator.js
@@ -38,10 +38,11 @@ export default class Tesselator {
   }
 
   /* Public methods */
-  updateGeometry({data, getGeometry, positionFormat, dataChanged}) {
+  updateGeometry({data, getGeometry, positionFormat, dataChanged, normalize = true}) {
     this.data = data;
     this.getGeometry = getGeometry;
     this.positionSize = positionFormat === 'XY' ? 2 : 3;
+    this.normalize = normalize;
     if (Array.isArray(dataChanged)) {
       // is partial update
       for (const dataRange of dataChanged) {

--- a/modules/core/src/utils/tesselator.js
+++ b/modules/core/src/utils/tesselator.js
@@ -31,6 +31,7 @@ export default class Tesselator {
     this.instanceCount = 0;
     this.attributes = {};
     this._attributeDefs = attributes;
+    this.opts = opts;
 
     this.updateGeometry(opts);
 
@@ -38,11 +39,15 @@ export default class Tesselator {
   }
 
   /* Public methods */
-  updateGeometry({data, getGeometry, positionFormat, dataChanged, normalize = true}) {
+  updateGeometry(opts) {
+    Object.assign(this.opts, opts);
+    const {data, getGeometry, positionFormat, dataChanged, normalize = true} = this.opts;
+
     this.data = data;
     this.getGeometry = getGeometry;
     this.positionSize = positionFormat === 'XY' ? 2 : 3;
     this.normalize = normalize;
+
     if (Array.isArray(dataChanged)) {
       // is partial update
       for (const dataRange of dataChanged) {

--- a/modules/layers/src/path-layer/path-layer.js
+++ b/modules/layers/src/path-layer/path-layer.js
@@ -38,6 +38,7 @@ const defaultProps = {
   miterLimit: {type: 'number', min: 0, value: 4},
   dashJustified: false,
   billboard: false,
+  _normalize: true,
 
   getPath: {type: 'accessor', value: object => object.path},
   getColor: {type: 'accessor', value: DEFAULT_COLOR},
@@ -136,6 +137,7 @@ export default class PathLayer extends Layer {
       const {pathTesselator} = this.state;
       pathTesselator.updateGeometry({
         data: props.data,
+        normalize: props._normalize,
         getGeometry: props.getPath,
         positionFormat: props.positionFormat,
         dataChanged: changeFlags.dataChanged

--- a/modules/layers/src/path-layer/path-layer.js
+++ b/modules/layers/src/path-layer/path-layer.js
@@ -38,7 +38,8 @@ const defaultProps = {
   miterLimit: {type: 'number', min: 0, value: 4},
   dashJustified: false,
   billboard: false,
-  _normalize: true,
+  // `loop` or `open`
+  _pathType: null,
 
   getPath: {type: 'accessor', value: object => object.path},
   getColor: {type: 'accessor', value: DEFAULT_COLOR},
@@ -137,7 +138,8 @@ export default class PathLayer extends Layer {
       const {pathTesselator} = this.state;
       pathTesselator.updateGeometry({
         data: props.data,
-        normalize: props._normalize,
+        normalize: !props._pathType,
+        loop: props._pathType === 'loop',
         getGeometry: props.getPath,
         positionFormat: props.positionFormat,
         dataChanged: changeFlags.dataChanged

--- a/modules/layers/src/path-layer/path-tesselator.js
+++ b/modules/layers/src/path-layer/path-tesselator.js
@@ -27,13 +27,11 @@ const INVALID = 4;
 // This class is set up to allow querying one attribute at a time
 // the way the AttributeManager expects it
 export default class PathTesselator extends Tesselator {
-  constructor({data, getGeometry, positionFormat, fp64}) {
+  constructor(opts) {
     super({
-      data,
-      getGeometry,
-      positionFormat,
+      ...opts,
       attributes: {
-        positions: {size: 3, type: fp64 ? Float64Array : Float32Array},
+        positions: {size: 3, type: opts.fp64 ? Float64Array : Float32Array},
         segmentTypes: {size: 1, type: Uint8ClampedArray}
       }
     });
@@ -46,6 +44,11 @@ export default class PathTesselator extends Tesselator {
 
   /* Implement base Tesselator interface */
   getGeometrySize(path) {
+    if (!this.normalize) {
+      const numPoints = path.length / this.positionSize;
+      return this.opts.loop ? numPoints + 2 : numPoints;
+    }
+
     const numPoints = this.getPathLength(path);
     if (numPoints < 2) {
       // invalid path
@@ -131,7 +134,7 @@ export default class PathTesselator extends Tesselator {
 
   isClosed(path) {
     if (!this.normalize) {
-      return false;
+      return this.opts.loop;
     }
     const numPoints = this.getPathLength(path);
     const firstPoint = this.getPointOnPath(path, 0);

--- a/modules/layers/src/path-layer/path-tesselator.js
+++ b/modules/layers/src/path-layer/path-tesselator.js
@@ -130,6 +130,9 @@ export default class PathTesselator extends Tesselator {
   }
 
   isClosed(path) {
+    if (!this.normalize) {
+      return false;
+    }
     const numPoints = this.getPathLength(path);
     const firstPoint = this.getPointOnPath(path, 0);
     const lastPoint = this.getPointOnPath(path, numPoints - 1);

--- a/modules/layers/src/polygon-layer/polygon-layer.js
+++ b/modules/layers/src/polygon-layer/polygon-layer.js
@@ -99,10 +99,7 @@ export default class PolygonLayer extends CompositeLayer {
     const {iterable, objectInfo} = createIterable(data, startRow, endRow);
     for (const object of iterable) {
       objectInfo.index++;
-      const polygon = Polygon.normalize(
-        getPolygon(object, objectInfo),
-        positionSize
-      );
+      const polygon = Polygon.normalize(getPolygon(object, objectInfo), positionSize);
       const {holeIndices} = polygon;
       const positions = polygon.positions || polygon;
 

--- a/modules/layers/src/polygon-layer/polygon-layer.js
+++ b/modules/layers/src/polygon-layer/polygon-layer.js
@@ -99,10 +99,12 @@ export default class PolygonLayer extends CompositeLayer {
     const {iterable, objectInfo} = createIterable(data, startRow, endRow);
     for (const object of iterable) {
       objectInfo.index++;
-      const {positions, holeIndices} = Polygon.normalize(
+      const polygon = Polygon.normalize(
         getPolygon(object, objectInfo),
         positionSize
       );
+      const {holeIndices} = polygon;
+      const positions = polygon.positions || polygon;
 
       if (holeIndices) {
         // split the positions array into `holeIndices.length + 1` rings

--- a/modules/layers/src/solid-polygon-layer/polygon-tesselator.js
+++ b/modules/layers/src/solid-polygon-layer/polygon-tesselator.js
@@ -30,11 +30,10 @@ const {Tesselator} = experimental;
 // This class is set up to allow querying one attribute at a time
 // the way the AttributeManager expects it
 export default class PolygonTesselator extends Tesselator {
-  constructor({data, getGeometry, fp64, positionFormat, IndexType = Uint32Array}) {
+  constructor(opts) {
+    const {fp64, IndexType = Uint32Array} = opts;
     super({
-      data,
-      getGeometry,
-      positionFormat,
+      ...opts,
       attributes: {
         positions: {size: 3, type: fp64 ? Float64Array : Float32Array},
         vertexValid: {type: Uint8ClampedArray, size: 1},

--- a/modules/layers/src/solid-polygon-layer/polygon-tesselator.js
+++ b/modules/layers/src/solid-polygon-layer/polygon-tesselator.js
@@ -54,11 +54,13 @@ export default class PolygonTesselator extends Tesselator {
 
   /* Implement base Tesselator interface */
   getGeometrySize(polygon) {
-    return Polygon.getVertexCount(polygon, this.positionSize);
+    return Polygon.getVertexCount(polygon, this.positionSize, this.normalize);
   }
 
   updateGeometryAttributes(polygon, context) {
-    polygon = Polygon.normalize(polygon, this.positionSize, context.geometrySize);
+    if (this.normalize) {
+      polygon = Polygon.normalize(polygon, this.positionSize, context.geometrySize);
+    }
 
     this._updateIndices(polygon, context);
     this._updatePositions(polygon, context);
@@ -95,7 +97,7 @@ export default class PolygonTesselator extends Tesselator {
       attributes: {positions},
       positionSize
     } = this;
-    const {positions: polygonPositions} = polygon;
+    const polygonPositions = polygon.positions || polygon;
 
     for (let i = vertexStart, j = 0; j < geometrySize; i++, j++) {
       const x = polygonPositions[j * positionSize];

--- a/modules/layers/src/solid-polygon-layer/polygon.js
+++ b/modules/layers/src/solid-polygon-layer/polygon.js
@@ -168,7 +168,12 @@ function getFlatVertexCount(positions, size, startIndex = 0, endIndex) {
  * @param {Number} positionSize - size of a position, 2 (xy) or 3 (xyz)
  * @returns {Number} vertex count
  */
-export function getVertexCount(polygon, positionSize) {
+export function getVertexCount(polygon, positionSize, normalization = true) {
+  if (!normalization) {
+    polygon = polygon.positions || polygon;
+    return polygon.length / positionSize;
+  }
+
   validate(polygon);
 
   if (polygon.positions) {
@@ -255,7 +260,7 @@ export function normalize(polygon, positionSize, vertexCount) {
   if (Number.isFinite(polygon[0])) {
     // simple flat
     copyFlatRing(positions, 0, polygon, positionSize);
-    return {positions, holeIndices: null};
+    return positions;
   }
   if (!isSimple(polygon)) {
     // complex polygon
@@ -272,7 +277,7 @@ export function normalize(polygon, positionSize, vertexCount) {
   }
   // simple polygon
   copyNestedRing(positions, 0, polygon, positionSize);
-  return {positions, holeIndices: null};
+  return positions;
 }
 /* eslint-enable max-statements */
 
@@ -289,5 +294,5 @@ export function getSurfaceIndices(normalizedPolygon, positionSize) {
     holeIndices = normalizedPolygon.holeIndices.map(positionIndex => positionIndex / positionSize);
   }
   // Let earcut triangulate the polygon
-  return earcut(normalizedPolygon.positions, holeIndices, positionSize);
+  return earcut(normalizedPolygon.positions || normalizedPolygon, holeIndices, positionSize);
 }

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -37,6 +37,7 @@ const defaultProps = {
   extruded: false,
   // Whether to draw a GL.LINES wireframe of the polygon
   wireframe: false,
+  _normalize: true,
 
   // elevation multiplier
   elevationScale: {type: 'number', min: 0, value: 1},
@@ -245,6 +246,7 @@ export default class SolidPolygonLayer extends Layer {
       const {polygonTesselator} = this.state;
       polygonTesselator.updateGeometry({
         data: props.data,
+        normalize: props._normalize,
         getGeometry: props.getPolygon,
         positionFormat: props.positionFormat,
         fp64: this.use64bitPositions(),

--- a/test/modules/layers/path-tesselator.spec.js
+++ b/test/modules/layers/path-tesselator.spec.js
@@ -188,3 +188,34 @@ test('PathTesselator#partial update', t => {
 
   t.end();
 });
+
+test('PathTesselator#normalize', t => {
+  const sampleData = [
+    {path: [1, 1, 2, 2, 3, 3], id: 'A'},
+    {path: [1, 1, 2, 2, 3, 3, 1, 1], id: 'B'}
+  ];
+  const tesselator = new PathTesselator({
+    data: sampleData,
+    loop: false,
+    normalize: false,
+    getGeometry: d => d.path,
+    positionFormat: 'XY'
+  });
+
+  t.is(tesselator.instanceCount, 7, 'Updated instanceCount as open paths');
+
+  tesselator.updateGeometry({
+    loop: true,
+    normalize: false
+  });
+
+  t.is(tesselator.instanceCount, 11, 'Updated instanceCount as closed loops');
+
+  tesselator.updateGeometry({
+    normalize: true
+  });
+
+  t.is(tesselator.instanceCount, 9, 'Updated instanceCount with normalization');
+
+  t.end();
+});

--- a/test/modules/layers/polygon-tesselation.spec.js
+++ b/test/modules/layers/polygon-tesselation.spec.js
@@ -109,7 +109,10 @@ test('polygon#fuctions', t => {
     t.comment(object.name);
 
     const complexPolygon = Polygon.normalize(object.polygon, 2);
-    t.ok(ArrayBuffer.isView(complexPolygon.positions || complexPolygon), 'Polygon.normalize flattens positions');
+    t.ok(
+      ArrayBuffer.isView(complexPolygon.positions || complexPolygon),
+      'Polygon.normalize flattens positions'
+    );
     if (complexPolygon.holeIndices) {
       t.ok(
         Array.isArray(complexPolygon.holeIndices),
@@ -250,6 +253,33 @@ test('PolygonTesselator#partial update', t => {
   ], 'positions');
   t.deepEquals(indices, [1, 3, 2, 7, 4, 5, 5, 6, 7, 10, 12, 11], 'incides');
   t.deepEquals(Array.from(accessorCalled), ['A'], 'Accessor called only on partial data');
+
+  t.end();
+});
+
+test('PolygonTesselator#normalize', t => {
+  const sampleData = [
+    {polygon: [1, 1, 2, 2, 3, 0], id: 'not-closed'},
+    {polygon: [0, 0, 2, 0, 2, 2, 0, 2, 0, 0], id: 'closed'},
+    {
+      polygon: {positions: [0, 0, 3, 0, 3, 3, 0, 3, 1, 1, 2, 1, 1, 2], holeIndices: [8]},
+      id: 'not-closed-with-holes'
+    }
+  ];
+  const tesselator = new PolygonTesselator({
+    data: sampleData,
+    normalize: false,
+    getGeometry: d => d.polygon,
+    positionFormat: 'XY'
+  });
+
+  t.is(tesselator.instanceCount, 15, 'Updated instanceCount without normalization');
+
+  tesselator.updateGeometry({
+    normalize: true
+  });
+
+  t.is(tesselator.instanceCount, 18, 'Updated instanceCount with normalization');
 
   t.end();
 });

--- a/test/modules/layers/polygon-tesselation.spec.js
+++ b/test/modules/layers/polygon-tesselation.spec.js
@@ -109,7 +109,7 @@ test('polygon#fuctions', t => {
     t.comment(object.name);
 
     const complexPolygon = Polygon.normalize(object.polygon, 2);
-    t.ok(ArrayBuffer.isView(complexPolygon.positions), 'Polygon.normalize flattens positions');
+    t.ok(ArrayBuffer.isView(complexPolygon.positions || complexPolygon), 'Polygon.normalize flattens positions');
     if (complexPolygon.holeIndices) {
       t.ok(
         Array.isArray(complexPolygon.holeIndices),


### PR DESCRIPTION
For #3758 

In preparation to (efficiently) accept external position buffers.

See updated documentation in this PR.

#### Change List
- Add option to skip normalization in `Tesselator`
- Add experimental prop `_pathType` to `PathLayer`
- Add experimental prop `_normalize` to `SolidPolygonLayer`
- Docs
- Unit tests