### PR TITLE
Simplify bundle luma exports

### DIFF
--- a/modules/core/bundle/lumagl.js
+++ b/modules/core/bundle/lumagl.js
@@ -1,40 +1,27 @@
 // Cherry-pick luma core exports that are relevant to deck
 export {
   // Core classes
-  AnimationLoop,
   Model,
   Transform,
-  ClipSpace,
   ProgramManager,
+  Timeline,
   // Context utilities
-  isWebGL,
   isWebGL2,
   FEATURES,
-  hasFeature,
   hasFeatures,
-  getFeatures,
-  getParameter,
   getParameters,
-  setParameter,
   setParameters,
   withParameters,
   // WebGL1 classes
   Buffer,
-  Shader,
-  VertexShader,
-  FragmentShader,
   Program,
   Framebuffer,
   Renderbuffer,
   Texture2D,
   TextureCube,
   // WebGL2 classes
-  Query,
   Texture3D,
   TransformFeedback,
-  VertexArrayObject,
-  VertexArray,
-  UniformBufferLayout,
   // Geometries
   Geometry,
   ConeGeometry,
@@ -45,10 +32,6 @@ export {
   SphereGeometry,
   TruncatedConeGeometry,
   // Shader Modules
-  fp32,
   fp64,
-  project,
-  picking,
-  gouraudLighting,
-  phongLighting
+  pbr
 } from '@luma.gl/core';


### PR DESCRIPTION
#### Change List
- Remove classes that are not needed by custom layers
- Remove utility functions dropped in luma.gl v8
- Remove shader modules that are re-exported by deck
