### PR TITLE
Move substantial data operation inside unit tests

### DIFF
--- a/test/data/grid-aggregation-data.js
+++ b/test/data/grid-aggregation-data.js
@@ -366,8 +366,6 @@ const fixtureWorldSpace = {
   }
 };
 
-Object.assign(fixtureWorldSpace, buildAttributes(fixtureWorldSpace));
-
 export const GridAggregationData = {
   viewport,
   fixture,

--- a/test/modules/aggregation-layers/utils/gpu-grid-aggregator.spec.js
+++ b/test/modules/aggregation-layers/utils/gpu-grid-aggregator.spec.js
@@ -162,6 +162,8 @@ test('GPUGridAggregator#CompareCPUandGPU', t => {
 });
 
 test('GPUGridAggregator worldspace aggregation #CompareCPUandGPU', t => {
+  Object.assign(fixtureWorldSpace, GridAggregationData.buildAttributes(fixtureWorldSpace));
+
   const sa = new GPUGridAggregator(gl);
   let results = sa.run(Object.assign({}, fixtureWorldSpace, {useGPU: false}));
   const cpuResults = {


### PR DESCRIPTION
Otherwise we can't skip them when debugging with `test.only`.