### PR TITLE
Add option to skip normalization in PolygonLayer

### DIFF
--- a/docs/layers/polygon-layer.md
+++ b/docs/layers/polygon-layer.md
@@ -191,6 +191,17 @@ Only works if `getLineDashArray` is specified.
 This is an object that contains material props for [lighting effect](/docs/effects/lighting-effect.md) applied on extruded polygons.
 Check [the lighting guide](/docs/developer-guide/using-lighting.md#constructing-a-material-instance) for configurable settings.
 
+##### `_normalize` (Object, optional)
+
+* Default: `true`
+
+> Note: This prop is experimental
+
+If `false`, will skip normalizing the coordinates returned by `getPolygon`. Disabling normalization improves performance during data update, but makes the layer prone to error in case the data is malformed. It is only recommended when you use this layer with preprocessed static data or validation on the backend.
+
+When normalization is disabled, polygons must be specified in the format of flat array or `{positions, holeIndices}`. Rings must be closed (i.e. the first and last vertices must be identical) and must contain at leat 3 vertices. See `getPolygon` below for details.
+
+
 ### Data Accessors
 
 ##### `getPolygon` ([Function](/docs/developer-guide/using-layers.md#accessors), optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")

--- a/docs/layers/solid-polygon-layer.md
+++ b/docs/layers/solid-polygon-layer.md
@@ -112,7 +112,7 @@ Check [the lighting guide](/docs/developer-guide/using-lighting.md#constructing-
 
 If `false`, will skip normalizing the coordinates returned by `getPolygon`. Disabling normalization improves performance during data update, but makes the layer prone to error in case the data is malformed. It is only recommended when you use this layer with preprocessed static data or validation on the backend.
 
-When normalization is disabled, polygons must be specified in the format of flat array or `{position, holeIndices}`. Rings must be closed (i.e. the first and last vertices must be identical). See `getPolygon` below for details.
+When normalization is disabled, polygons must be specified in the format of flat array or `{positions, holeIndices}`. Rings must be closed (i.e. the first and last vertices must be identical). See `getPolygon` below for details.
 
 ### Data Accessors
 

--- a/modules/geo-layers/src/h3-layers/h3-cluster-layer.js
+++ b/modules/geo-layers/src/h3-layers/h3-cluster-layer.js
@@ -3,32 +3,6 @@ import {h3SetToMultiPolygon} from 'h3-js';
 import {CompositeLayer, createIterable} from '@deck.gl/core';
 import {PolygonLayer} from '@deck.gl/layers';
 
-// Given a nested GeoJSON-style polygon, returns {positions, holeIndices}
-// This function does not validate or normalize
-function flattenPolygon(polygon) {
-  let vertices = 0;
-  for (const ring of polygon) {
-    vertices += ring.length;
-  }
-
-  const positions = new Float64Array(vertices * 2);
-  const numRings = polygon.length;
-  const holeIndices = numRings > 1 && new Array(numRings - 1);
-
-  let i = 0;
-  for (let ringIndex = 0; ringIndex < numRings; ringIndex++) {
-    if (ringIndex > 1) {
-      holeIndices[ringIndex - 1] = i;
-    }
-    for (const point of polygon[ringIndex]) {
-      positions[i++] = point[0];
-      positions[i++] = point[1];
-    }
-  }
-
-  return holeIndices ? {positions, holeIndices} : positions;
-}
-
 const defaultProps = Object.assign(
   {
     getHexagons: {type: 'accessor', value: d => d.hexagons}
@@ -52,9 +26,7 @@ export default class H3ClusterLayer extends CompositeLayer {
         const multiPolygon = h3SetToMultiPolygon(hexagons, true);
 
         for (const polygon of multiPolygon) {
-          polygons.push(
-            this.getSubLayerRow({polygon: flattenPolygon(polygon)}, object, objectInfo.index)
-          );
+          polygons.push(this.getSubLayerRow({polygon}, object, objectInfo.index));
         }
       }
 
@@ -117,8 +89,6 @@ export default class H3ClusterLayer extends CompositeLayer {
       }),
       {
         data: this.state.polygons,
-        _normalize: false,
-        positionFormat: 'XY',
         getPolygon: d => d.polygon
       }
     );

--- a/modules/geo-layers/src/h3-layers/h3-cluster-layer.js
+++ b/modules/geo-layers/src/h3-layers/h3-cluster-layer.js
@@ -3,6 +3,32 @@ import {h3SetToMultiPolygon} from 'h3-js';
 import {CompositeLayer, createIterable} from '@deck.gl/core';
 import {PolygonLayer} from '@deck.gl/layers';
 
+// Given a nested GeoJSON-style polygon, returns {positions, holeIndices}
+// This function does not validate or normalize
+function flattenPolygon(polygon) {
+  let vertices = 0;
+  for (const ring of polygon) {
+    vertices += ring.length;
+  }
+
+  const positions = new Float64Array(vertices * 2);
+  const numRings = polygon.length;
+  const holeIndices = numRings > 1 && new Array(numRings - 1);
+
+  let i = 0;
+  for (let ringIndex = 0; ringIndex < numRings; ringIndex++) {
+    if (ringIndex > 1) {
+      holeIndices[ringIndex - 1] = i;
+    }
+    for (const point of polygon[ringIndex]) {
+      positions[i++] = point[0];
+      positions[i++] = point[1];
+    }
+  }
+
+  return holeIndices ? {positions, holeIndices} : positions;
+}
+
 const defaultProps = Object.assign(
   {
     getHexagons: {type: 'accessor', value: d => d.hexagons}
@@ -26,7 +52,9 @@ export default class H3ClusterLayer extends CompositeLayer {
         const multiPolygon = h3SetToMultiPolygon(hexagons, true);
 
         for (const polygon of multiPolygon) {
-          polygons.push(this.getSubLayerRow({polygon}, object, objectInfo.index));
+          polygons.push(
+            this.getSubLayerRow({polygon: flattenPolygon(polygon)}, object, objectInfo.index)
+          );
         }
       }
 
@@ -89,6 +117,8 @@ export default class H3ClusterLayer extends CompositeLayer {
       }),
       {
         data: this.state.polygons,
+        _normalize: false,
+        positionFormat: 'XY',
         getPolygon: d => d.polygon
       }
     );

--- a/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
+++ b/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
@@ -53,7 +53,7 @@ function getHexagonCentroid(getHexagon, object, objectInfo) {
   return [lng, lat];
 }
 
-function h3ToPolygon(hexId, coverage = 1) {
+function h3ToPolygon(hexId, coverage = 1, flatten) {
   const vertices = h3ToGeoBoundary(hexId, true);
 
   if (coverage !== 1) {
@@ -62,6 +62,16 @@ function h3ToPolygon(hexId, coverage = 1) {
   } else {
     // normalize w.r.t to start vertex
     normalizeLongitudes(vertices);
+  }
+
+  if (flatten) {
+    const positions = new Float64Array(vertices.length * 2);
+    let i = 0;
+    for (const pt of vertices) {
+      positions[i++] = pt[0];
+      positions[i++] = pt[1];
+    }
+    return positions;
   }
 
   return vertices;
@@ -237,9 +247,11 @@ export default class H3HexagonLayer extends CompositeLayer {
       }),
       {
         data,
+        _normalize: false,
+        positionFormat: 'XY',
         getPolygon: (object, objectInfo) => {
           const hexagonId = getHexagon(object, objectInfo);
-          return h3ToPolygon(hexagonId, coverage);
+          return h3ToPolygon(hexagonId, coverage, true);
         }
       }
     );

--- a/modules/geo-layers/src/s2-layer/s2-layer.js
+++ b/modules/geo-layers/src/s2-layer/s2-layer.js
@@ -98,6 +98,8 @@ export default class S2Layer extends CompositeLayer {
       }),
       {
         data,
+        _normalize: false,
+        positionFormat: 'XY',
         getPolygon: (x, objectInfo) => getS2Polygon(getS2Token(x, objectInfo))
       }
     );

--- a/modules/geo-layers/src/s2-layer/s2-utils.js
+++ b/modules/geo-layers/src/s2-layer/s2-utils.js
@@ -26,7 +26,6 @@ function XYZToLngLat([x, y, z]) {
 
 /* Adapted from s2-geometry's S2Cell.getCornerLatLngs */
 function getGeoBounds({face, ij, level}) {
-  const result = [];
   const offsets = [[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]];
 
   // The S2 cell edge is curved: http://s2geometry.io/
@@ -35,6 +34,8 @@ function getGeoBounds({face, ij, level}) {
   // We exponentially reduce resolution as level increases so it doesn't affect perf
   // when there are a large number of cells
   const resolution = Math.max(1, MAX_RESOLUTION * Math.pow(2, -level));
+  const result = new Float64Array(4 * resolution * 2 + 2);
+  let ptIndex = 0;
 
   for (let i = 0; i < 4; i++) {
     const offset = offsets[i].slice(0);
@@ -50,10 +51,15 @@ function getGeoBounds({face, ij, level}) {
       const st = S2.IJToST(ij, level, offset);
       const uv = S2.STToUV(st);
       const xyz = S2.FaceUVToXYZ(face, uv);
+      const lngLat = XYZToLngLat(xyz);
 
-      result.push(XYZToLngLat(xyz));
+      result[ptIndex++] = lngLat[0];
+      result[ptIndex++] = lngLat[1];
     }
   }
+  // close the loop
+  result[ptIndex++] = result[0];
+  result[ptIndex++] = result[1];
   return result;
 }
 

--- a/modules/layers/src/polygon-layer/polygon-layer.js
+++ b/modules/layers/src/polygon-layer/polygon-layer.js
@@ -33,6 +33,7 @@ const defaultProps = {
   extruded: false,
   elevationScale: 1,
   wireframe: false,
+  _normalize: true,
 
   lineWidthUnits: 'meters',
   lineWidthScale: 1,
@@ -91,7 +92,7 @@ export default class PolygonLayer extends CompositeLayer {
   }
 
   _getPaths(dataRange = {}) {
-    const {data, getPolygon, positionFormat} = this.props;
+    const {data, getPolygon, positionFormat, _normalize} = this.props;
     const paths = [];
     const positionSize = positionFormat === 'XY' ? 2 : 3;
     const {startRow, endRow} = dataRange;
@@ -99,7 +100,10 @@ export default class PolygonLayer extends CompositeLayer {
     const {iterable, objectInfo} = createIterable(data, startRow, endRow);
     for (const object of iterable) {
       objectInfo.index++;
-      const polygon = Polygon.normalize(getPolygon(object, objectInfo), positionSize);
+      let polygon = getPolygon(object, objectInfo);
+      if (_normalize) {
+        polygon = Polygon.normalize(polygon, positionSize);
+      }
       const {holeIndices} = polygon;
       const positions = polygon.positions || polygon;
 
@@ -131,6 +135,7 @@ export default class PolygonLayer extends CompositeLayer {
       filled,
       extruded,
       wireframe,
+      _normalize,
       elevationScale,
       transitions,
       positionFormat
@@ -175,6 +180,7 @@ export default class PolygonLayer extends CompositeLayer {
 
           filled,
           wireframe,
+          _normalize,
 
           getElevation,
           getFillColor,
@@ -214,6 +220,7 @@ export default class PolygonLayer extends CompositeLayer {
           rounded: lineJointRounded,
           miterLimit: lineMiterLimit,
           dashJustified: lineDashJustified,
+          _pathType: _normalize ? null : 'loop',
 
           transitions: transitions && {
             getWidth: transitions.getLineWidth,

--- a/modules/layers/src/polygon-layer/polygon-layer.js
+++ b/modules/layers/src/polygon-layer/polygon-layer.js
@@ -220,7 +220,9 @@ export default class PolygonLayer extends CompositeLayer {
           rounded: lineJointRounded,
           miterLimit: lineMiterLimit,
           dashJustified: lineDashJustified,
-          _pathType: _normalize ? null : 'loop',
+
+          // Already normalized
+          _pathType: 'loop',
 
           transitions: transitions && {
             getWidth: transitions.getLineWidth,


### PR DESCRIPTION
Follow up of #3905 

#### Change List
- Add `_normalize` prop to `PolygonLayer`
- Skip normalization in `H3HexagonLayer` and `S2Layer`
- Docs
