### PR TITLE
Clean up layer internal state

### DIFF
--- a/examples/experimental/bezier/src/bezier-curve-layer/bezier-curve-layer.js
+++ b/examples/experimental/bezier/src/bezier-curve-layer/bezier-curve-layer.js
@@ -42,7 +42,7 @@ export default class BezierCurveLayer extends Layer {
   }
 
   initializeState() {
-    const {attributeManager} = this.state;
+    const attributeManager = this.getAttributeManager();
 
     /* eslint-disable max-len */
     attributeManager.addInstanced({

--- a/examples/website/plot/plot-layer/surface-layer.js
+++ b/examples/website/plot/plot-layer/surface-layer.js
@@ -70,7 +70,7 @@ export default class SurfaceLayer extends Layer {
         this.setState({
           vertexCount: uCount * vCount
         });
-        this.state.attributeManager.invalidateAll();
+        this.getAttributeManager().invalidateAll();
       }
     }
   }
@@ -207,7 +207,8 @@ export default class SurfaceLayer extends Layer {
   /* eslint-enable max-statements */
 
   calculateColors(attribute) {
-    const {vertexCount, attributeManager} = this.state;
+    const {vertexCount} = this.state;
+    const attributeManager = this.getAttributeManager();
 
     // reuse the calculated [x, y, z] in positions
     const positions = attributeManager.attributes.positions.value;

--- a/modules/core/src/lib/layer-manager.js
+++ b/modules/core/src/lib/layer-manager.js
@@ -347,15 +347,6 @@ export default class LayerManager {
       // TODO - what should the lifecycle state be here? LIFECYCLE.INITIALIZATION_FAILED?
     }
 
-    // Set back pointer (used in picking)
-    layer.internalState.layer = layer;
-
-    // Save layer on model for picking purposes
-    // store on model.userData rather than directly on model
-    for (const model of layer.getModels()) {
-      model.userData.layer = layer;
-    }
-
     return error;
   }
 

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -865,8 +865,18 @@ ${flags.viewportChanged ? 'viewport' : ''}\
     });
 
     this.state = {};
-    // TODO deprecated, for backwards compatibility with older layers
-    this.state.attributeManager = attributeManager;
+    // for backwards compatibility with older layers
+    // TODO - remove in next release
+    /* eslint-disable accessor-pairs */
+    Object.defineProperty(this.state, 'attributeManager', {
+      get: () => {
+        log.deprecated('layer.state.attributeManager', 'layer.getAttributeManager()');
+        return attributeManager;
+      }
+    });
+    /* eslint-enable accessor-pairs */
+
+    this.internalState.layer = this;
     this.internalState.uniformTransitions = new UniformTransitionManager(this.context.timeline);
     this.internalState.onAsyncPropUpdated = this._onAsyncPropUpdated.bind(this);
 
@@ -885,22 +895,15 @@ ${flags.viewportChanged ? 'viewport' : ''}\
 
     // Move internalState
     this.internalState = internalState;
-    this.internalState.component = this;
+    this.internalState.layer = this;
 
     // Move state
     this.state = state;
-    // Deprecated: layer references on `state`
-    state.layer = this;
     // We keep the state ref on old layers to support async actions
     // oldLayer.state = null;
 
     // Ensure any async props are updated
     this.internalState.setAsyncProps(this.props);
-
-    // Update model layer reference
-    for (const model of this.getModels()) {
-      model.userData.layer = this;
-    }
 
     this.diffProps(this.props, this.internalState.getOldProps());
   }

--- a/test/apps/carto-wip/time-sliced-scatterplot-layer/time-sliced-scatterplot-layer.js
+++ b/test/apps/carto-wip/time-sliced-scatterplot-layer/time-sliced-scatterplot-layer.js
@@ -33,7 +33,7 @@ export default class TimeSlicedScatterplotLayer extends ScatterplotLayer {
   initializeState() {
     super.initializeState();
 
-    this.state.attributeManager.addInstanced({
+    this.getAttributeManager().addInstanced({
       time: {size: 1, accessor: 'getTime', defaultValue: 0, update: this.calculateTime}
     });
     /* eslint-enable max-len */


### PR DESCRIPTION
For #3869 

#### Change List
- Avoid referencing `layer.internalState` from `LayerManager`
- Remove unused `model.userData.layer`
- Remove unused `layer.state.layer`
- Deprecate `layer.state.attributeManager`
