### PR TITLE
Remove `experimental` export, use underscores

### DIFF
--- a/examples/layer-browser/src/examples/core-layers.js
+++ b/examples/layer-browser/src/examples/core-layers.js
@@ -1,5 +1,3 @@
-import {experimental} from '@deck.gl/core';
-
 import {
   ScatterplotLayer,
   ArcLayer,
@@ -16,11 +14,10 @@ import {
 
 import {PathStyleExtension} from '@deck.gl/extensions';
 
-const {flattenVertices} = experimental;
-
 // Demonstrate immutable support
 import * as dataSamples from '../data-samples';
 import {parseColor, setOpacity} from '../utils/color';
+import flattenVertices from '../utils/flatten-vertices';
 
 const MARKER_SIZE_MAP = {
   small: 200,

--- a/examples/layer-browser/src/utils/flatten-vertices.js
+++ b/examples/layer-browser/src/utils/flatten-vertices.js
@@ -1,0 +1,22 @@
+// Flattens nested array of vertices, padding third coordinate as needed
+export default function flattenVertices(nestedArray, {result = [], dimensions = 3} = {}) {
+  let index = -1;
+  let vertexLength = 0;
+  while (++index < nestedArray.length) {
+    const value = nestedArray[index];
+    if (Array.isArray(value) || ArrayBuffer.isView(value)) {
+      flattenVertices(value, {result, dimensions});
+    } else {
+      // eslint-disable-next-line
+      if (vertexLength < dimensions) {
+        result.push(value);
+        vertexLength++;
+      }
+    }
+  }
+  // Add a third coordinate if needed
+  if (vertexLength > 0 && vertexLength < dimensions) {
+    result.push(0);
+  }
+  return result;
+}

--- a/modules/aggregation-layers/bundle.js
+++ b/modules/aggregation-layers/bundle.js
@@ -8,7 +8,5 @@ const deck = _global.deck || {};
 if (!deck.LineLayer) {
   throw new Error('@deck.gl/layers is not found');
 }
-// Merge experimental exports
-Object.assign(deckGLLayers.experimental, deck.experimental);
 
 module.exports = Object.assign(deck, deckGLLayers);

--- a/modules/aggregation-layers/src/aggregation-layer.js
+++ b/modules/aggregation-layers/src/aggregation-layer.js
@@ -18,9 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {CompositeLayer, AttributeManager, experimental} from '@deck.gl/core';
+import {CompositeLayer, AttributeManager, _compareProps as compareProps} from '@deck.gl/core';
 import {cssToDeviceRatio} from '@luma.gl/core';
-const {compareProps} = experimental;
 
 // props when changed results in new uniforms that requires re-aggregation
 const UNIFORM_PROPS = [

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
@@ -37,7 +37,13 @@ import {
   hasFeatures,
   isWebGL2
 } from '@luma.gl/core';
-import {AttributeManager, COORDINATE_SYSTEM, log, mergeShaders, project32} from '@deck.gl/core';
+import {
+  AttributeManager,
+  COORDINATE_SYSTEM,
+  log,
+  _mergeShaders as mergeShaders,
+  project32
+} from '@deck.gl/core';
 import TriangleLayer from './triangle-layer';
 import AggregationLayer from '../aggregation-layer';
 import {defaultColorRange, colorRangeToFlatArray} from '../utils/color-utils';

--- a/modules/aggregation-layers/src/index.js
+++ b/modules/aggregation-layers/src/index.js
@@ -32,29 +32,15 @@ export {default as HeatmapLayer} from './heatmap-layer/heatmap-layer';
 export {default as _GPUGridAggregator} from './utils/gpu-grid-aggregation/gpu-grid-aggregator';
 export {default as _CPUAggregator} from './utils/cpu-aggregator';
 
-import {default as BinSorter} from './utils/bin-sorter';
-import {
-  linearScale,
-  getLinearScale,
-  quantizeScale,
-  getQuantizeScale,
-  getQuantileScale,
-  getOrdinalScale,
-  getScaleFunctionByScaleType,
-  getScaleDomain
+export {default as _BinSorter} from './utils/bin-sorter';
+export {
+  linearScale as _linearScale,
+  getLinearScale as _getLinearScale,
+  quantizeScale as _quantizeScale,
+  getQuantizeScale as _getQuantizeScale,
+  getQuantileScale as _getQuantileScale,
+  getOrdinalScale as _getOrdinalScale,
+  getScaleFunctionByScaleType as _getScaleFunctionByScaleType,
+  getScaleDomain as _getScaleDomain
 } from './utils/scale-utils';
-import {defaultColorRange} from './utils/color-utils';
-
-export const experimental = {
-  BinSorter,
-
-  linearScale,
-  getLinearScale,
-  quantizeScale,
-  getQuantizeScale,
-  getQuantileScale,
-  getOrdinalScale,
-  getScaleFunctionByScaleType,
-  getScaleDomain,
-  defaultColorRange
-};
+export {defaultColorRange as _defaultColorRange} from './utils/color-utils';

--- a/modules/aggregation-layers/src/index.js
+++ b/modules/aggregation-layers/src/index.js
@@ -33,14 +33,3 @@ export {default as _GPUGridAggregator} from './utils/gpu-grid-aggregation/gpu-gr
 export {default as _CPUAggregator} from './utils/cpu-aggregator';
 
 export {default as _BinSorter} from './utils/bin-sorter';
-export {
-  linearScale as _linearScale,
-  getLinearScale as _getLinearScale,
-  quantizeScale as _quantizeScale,
-  getQuantizeScale as _getQuantizeScale,
-  getQuantileScale as _getQuantileScale,
-  getOrdinalScale as _getOrdinalScale,
-  getScaleFunctionByScaleType as _getScaleFunctionByScaleType,
-  getScaleDomain as _getScaleDomain
-} from './utils/scale-utils';
-export {defaultColorRange as _defaultColorRange} from './utils/color-utils';

--- a/modules/aggregation-layers/src/utils/gpu-grid-aggregation/gpu-grid-aggregator.js
+++ b/modules/aggregation-layers/src/utils/gpu-grid-aggregation/gpu-grid-aggregator.js
@@ -29,7 +29,7 @@ import {
   withParameters
 } from '@luma.gl/core';
 import {fp64arithmetic} from '@luma.gl/shadertools';
-import {log, project32, mergeShaders} from '@deck.gl/core';
+import {log, project32, _mergeShaders as mergeShaders} from '@deck.gl/core';
 
 import {
   DEFAULT_RUN_PARAMS,

--- a/modules/core/src/index.js
+++ b/modules/core/src/index.js
@@ -69,39 +69,24 @@ export {default as FirstPersonController} from './controllers/first-person-contr
 export {default as OrbitController} from './controllers/orbit-controller';
 export {default as OrthographicController} from './controllers/orthographic-controller';
 
-// EXPERIMENTAL EXPORTS
-
-// Experimental Effects (non-React) bindings
+// Extensions interface
 export {default as Effect} from './lib/effect';
+export {default as LayerExtension} from './lib/layer-extension';
 
-// Eperimental Transitions
+// Transitions
 export {TRANSITION_EVENTS} from './controllers/transition-manager';
 export {default as LinearInterpolator} from './transitions/linear-interpolator';
 export {default as FlyToInterpolator} from './transitions/viewport-fly-to-interpolator';
 
 // Layer utilities
 export {default as log} from './utils/log';
-import {flattenVertices, fillArray} from './utils/flatten'; // Export? move to luma.gl or math.gl?
-
 export {createIterable} from './utils/iterable-utils';
 export {fp64LowPart} from './utils/math-utils';
-import Tesselator from './utils/tesselator'; // Export? move to luma.gl or math.gl?
-import {count} from './utils/count';
-import memoize from './utils/memoize';
-export {mergeShaders} from './utils/shader';
+export {default as Tesselator} from './utils/tesselator'; // Export? move to luma.gl or math.gl?
 
-export {default as LayerExtension} from './lib/layer-extension';
-
-// props
-import {compareProps} from './lifecycle/props';
-
-// Exports for layers
-// Experimental Features may change in minor version bumps, use at your own risk)
-export const experimental = {
-  Tesselator,
-  flattenVertices,
-  fillArray,
-  count,
-  memoize,
-  compareProps
-};
+// Experimental utilities
+export {fillArray as _fillArray} from './utils/flatten'; // Export? move to luma.gl or math.gl?
+export {count as _count} from './utils/count';
+export {default as _memoize} from './utils/memoize';
+export {mergeShaders as _mergeShaders} from './utils/shader';
+export {compareProps as _compareProps} from './lifecycle/props';

--- a/modules/core/src/utils/flatten.js
+++ b/modules/core/src/utils/flatten.js
@@ -53,29 +53,6 @@ function flattenArray(array, filter, map, result) {
   return result;
 }
 
-// Flattens nested array of vertices, padding third coordinate as needed
-export function flattenVertices(nestedArray, {result = [], dimensions = 3} = {}) {
-  let index = -1;
-  let vertexLength = 0;
-  while (++index < nestedArray.length) {
-    const value = nestedArray[index];
-    if (Array.isArray(value) || ArrayBuffer.isView(value)) {
-      flattenVertices(value, {result, dimensions});
-    } else {
-      // eslint-disable-next-line
-      if (vertexLength < dimensions) {
-        result.push(value);
-        vertexLength++;
-      }
-    }
-  }
-  // Add a third coordinate if needed
-  if (vertexLength > 0 && vertexLength < dimensions) {
-    result.push(0);
-  }
-  return result;
-}
-
 // Uses copyWithin to significantly speed up typed array value filling
 export function fillArray({target, source, start = 0, count = 1}) {
   const length = source.length;

--- a/modules/extensions/src/fp64/project64.js
+++ b/modules/extensions/src/fp64/project64.js
@@ -20,8 +20,7 @@
 
 import {fp64} from '@luma.gl/core';
 const {fp64ify, fp64ifyMatrix4} = fp64;
-import {project, experimental} from '@deck.gl/core';
-const {memoize} = experimental;
+import {project, _memoize as memoize} from '@deck.gl/core';
 
 import project64Shader from './project64.glsl';
 

--- a/modules/extensions/src/path-style/path-style.js
+++ b/modules/extensions/src/path-style/path-style.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {LayerExtension, mergeShaders} from '@deck.gl/core';
+import {LayerExtension, _mergeShaders as mergeShaders} from '@deck.gl/core';
 import {dashShaders} from './shaders.glsl';
 
 const defaultProps = {

--- a/modules/jupyter-widget/src/deck-bundle.js
+++ b/modules/jupyter-widget/src/deck-bundle.js
@@ -4,8 +4,6 @@
  */
 const deck = require('../../core/bundle');
 
-const {experimental} = deck;
-
 Object.assign(
   deck,
   require('@deck.gl/layers'),
@@ -14,7 +12,5 @@ Object.assign(
   require('@deck.gl/mesh-layers'),
   require('@deck.gl/json')
 );
-
-Object.assign(deck.experimental, experimental);
 
 module.exports = deck;

--- a/modules/layers/src/path-layer/path-tesselator.js
+++ b/modules/layers/src/path-layer/path-tesselator.js
@@ -17,8 +17,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-import {experimental} from '@deck.gl/core';
-const {Tesselator} = experimental;
+import {Tesselator} from '@deck.gl/core';
 
 const START_CAP = 1;
 const END_CAP = 2;

--- a/modules/layers/src/solid-polygon-layer/polygon-tesselator.js
+++ b/modules/layers/src/solid-polygon-layer/polygon-tesselator.js
@@ -24,8 +24,7 @@
 // - 3D surfaces (top and sides only)
 // - 3D wireframes (not yet)
 import * as Polygon from './polygon';
-import {experimental} from '@deck.gl/core';
-const {Tesselator} = experimental;
+import {Tesselator} from '@deck.gl/core';
 
 // This class is set up to allow querying one attribute at a time
 // the way the AttributeManager expects it

--- a/modules/main/bundle.js
+++ b/modules/main/bundle.js
@@ -1,5 +1,4 @@
 const deck = require('../core/bundle');
-const {experimental} = deck;
 
 Object.assign(
   deck,
@@ -12,8 +11,5 @@ Object.assign(
   require('@deck.gl/mapbox'),
   require('@deck.gl/json')
 );
-
-// Make sure core exports are preserved
-Object.assign(deck.experimental, experimental);
 
 module.exports = deck;

--- a/modules/main/src/index.js
+++ b/modules/main/src/index.js
@@ -19,8 +19,6 @@
 // THE SOFTWARE.
 /* eslint-disable max-len */
 
-const experimental = {};
-
 //
 // CORE LIBRARY
 //
@@ -77,45 +75,10 @@ export {
   // Extension
   LayerExtension,
   // Utilities
+  Tesselator,
   fp64LowPart,
-  createIterable,
-  mergeShaders
+  createIterable
 } from '@deck.gl/core';
-
-// EXPERIMENTAL CORE LIB CLASSES (May change in minor version bumps, use at your own risk)
-import {experimental as CoreExperimental} from '@deck.gl/core';
-import {experimental as AggregationExperimental} from '@deck.gl/aggregation-layers';
-
-// Experimental Data Accessor Helpers
-// INTERNAL - TODO remove from experimental exports
-const {
-  // For layers
-  count,
-  flattenVertices,
-  fillArray
-} = CoreExperimental;
-
-const {
-  BinSorter,
-  linearScale,
-  getLinearScale,
-  quantizeScale,
-  getQuantizeScale,
-  defaultColorRange
-} = AggregationExperimental;
-
-Object.assign(experimental, {
-  // For layers
-  BinSorter,
-  linearScale,
-  getLinearScale,
-  quantizeScale,
-  getQuantizeScale,
-  defaultColorRange,
-  count,
-  flattenVertices,
-  fillArray
-});
 
 //
 // LAYERS PACKAGES
@@ -165,9 +128,3 @@ export {SimpleMeshLayer, ScenegraphLayer} from '@deck.gl/mesh-layers';
 //
 
 export {default, DeckGL} from '@deck.gl/react';
-
-//
-// EXPERIMENTAL EXPORTS
-//
-
-export {experimental};

--- a/modules/react/src/deckgl.js
+++ b/modules/react/src/deckgl.js
@@ -20,8 +20,7 @@
 
 import React, {createElement} from 'react';
 import PropTypes from 'prop-types';
-import {Deck, experimental} from '@deck.gl/core';
-const {memoize} = experimental;
+import {Deck, _memoize as memoize} from '@deck.gl/core';
 
 import extractJSXLayers from './utils/extract-jsx-layers';
 import positionChildrenUnderViews from './utils/position-children-under-views';

--- a/modules/test-utils/src/generate-layer-tests.js
+++ b/modules/test-utils/src/generate-layer-tests.js
@@ -17,8 +17,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-import {experimental} from '@deck.gl/core';
-const {count} = experimental;
+import {_count as count} from '@deck.gl/core';
 
 function noop() {}
 

--- a/test/modules/core/utils/flatten.spec.js
+++ b/test/modules/core/utils/flatten.spec.js
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 import test from 'tape-catch';
-import {flatten, flattenVertices, fillArray} from '@deck.gl/core/utils/flatten';
+import {flatten, fillArray} from '@deck.gl/core/utils/flatten';
 
 const FLATTEN_TEST_CASES = [
   {
@@ -57,22 +57,6 @@ const FLATTEN_TEST_CASES = [
   }
 ];
 
-const FLATTEN_VERTICES_TEST_CASES = [
-  {
-    title: 'test array',
-    argument: [[1, 0], [[2, 0], [2, 1, 0, 0]], [[[3, 0, 0], [3, 0, 1]]]],
-    result: [1, 0, 0, 2, 0, 0, 2, 1, 0, 3, 0, 0, 3, 0, 1]
-  },
-  {
-    title: 'test array of typed array',
-    argument: [new Float32Array([1, 0, 0]), new Float32Array([1, 1, 0])],
-    opts: {
-      dimensions: 2
-    },
-    result: [1, 0, 1, 1]
-  }
-];
-
 const FILL_ARRAY_TEST_CASES = [
   {
     title: 'test array',
@@ -86,14 +70,6 @@ test('flatten', t => {
     t.comment(tc.title + JSON.stringify(tc.opts));
     const result = tc.opts ? flatten(tc.argument, tc.opts) : flatten(tc.argument);
     t.deepEqual(result, tc.result, `flatten ${tc.title} returned expected result`);
-  }
-  t.end();
-});
-
-test('flattenVertices', t => {
-  for (const tc of FLATTEN_VERTICES_TEST_CASES) {
-    const result = flattenVertices(tc.argument, tc.opts);
-    t.deepEqual(result, tc.result, `flattenVertices ${tc.title} returned expected result`);
   }
   t.end();
 });

--- a/test/modules/geo-layers/h3-layers.spec.js
+++ b/test/modules/geo-layers/h3-layers.spec.js
@@ -20,8 +20,7 @@
 
 import test from 'tape-catch';
 import {h3ToGeoBoundary, h3ToGeo} from 'h3-js';
-import {experimental} from '@deck.gl/core';
-const {count} = experimental;
+import {_count as count} from '@deck.gl/core';
 import {testLayer, generateLayerTests} from '@deck.gl/test-utils';
 import {H3HexagonLayer, H3ClusterLayer} from '@deck.gl/geo-layers';
 import {scalePolygon, normalizeLongitudes} from '@deck.gl/geo-layers/h3-layers/h3-hexagon-layer';

--- a/test/modules/imports-spec.js
+++ b/test/modules/imports-spec.js
@@ -48,9 +48,7 @@ test('Top-level imports', t0 => {
 
   test('import "deck.gl"', t => {
     t.notOk(hasEmptyExports(deck), 'No empty top-level export in deck.gl');
-    t.notOk(hasEmptyExports(deck.experimental), 'No empty experimental export in deck.gl');
     t.notOk(hasEmptyExports(core), 'No empty top-level export in @deck.gl/core');
-    t.notOk(hasEmptyExports(core.experimental), 'No empty experimental export in @deck.gl/core');
     t.end();
   });
 


### PR DESCRIPTION
For #3869 

#### Change List
- Remove `experimental` object from core and aggregation-layers, use underscore names for experimental exports
- Remove unused `flattenVertices` util

cc @heshan0131 