### PR TITLE
Attribute update perf

### DIFF
--- a/modules/core/src/lib/attribute/attribute.js
+++ b/modules/core/src/lib/attribute/attribute.js
@@ -322,7 +322,7 @@ export default class Attribute extends DataColumn {
         } else if (objectValue && objectValue.length > size) {
           value.set(objectValue, i);
         } else {
-          attribute._normalizeValue(objectValue, objectInfo.target);
+          attribute._normalizeValue(objectValue, objectInfo.target, 0);
           fillArray({
             target: value,
             source: objectInfo.target,

--- a/test/bench/index.js
+++ b/test/bench/index.js
@@ -34,7 +34,7 @@ import attributeUpdateBench from './attribute-update.bench';
 import comparePropsBench from './compare-props.bench';
 import textAutoWrappingBench from './text-auto-wrapping.bench';
 
-const suite = new Bench({});
+const suite = new Bench({minIterations: 10});
 
 // add tests
 layerBench(suite);

--- a/test/bench/layer.bench.js
+++ b/test/bench/layer.bench.js
@@ -21,18 +21,64 @@
 /* eslint-disable no-console, no-invalid-this */
 import * as data from 'deck.gl-test/data';
 
-import {ScatterplotLayer} from 'deck.gl';
+import {LayerManager, MapView, DeckRenderer} from '@deck.gl/core';
+import {ScatterplotLayer} from '@deck.gl/layers';
+import {gl} from '@deck.gl/test-utils';
 
 // import {testInitializeLayer} from '@deck.gl/test-utils';
 
 let testIdx = 0;
 const testLayer = new ScatterplotLayer({data: data.points});
 
+const testViewport = new MapView().makeViewport({
+  width: 100,
+  height: 100,
+  viewState: {longitude: 0, latitude: 0, zoom: 1}
+});
+
+const layerManager = new LayerManager(gl, {viewport: testViewport});
+const deckRenderer = new DeckRenderer(gl);
+
 // add tests
 
 export default function layerBench(suite) {
   return suite
     .group('LAYER UTILS')
+
+    .add('initialize layers', () => {
+      testIdx++;
+      layerManager.setLayers(
+        Array.from(
+          {length: 100},
+          (_, i) =>
+            new ScatterplotLayer({
+              id: `test-${testIdx}-layer-${i}`
+            })
+        )
+      );
+    })
+    .add('update layers', () => {
+      const newData = new Array(1000).fill({position: [0, 0], color: [0, 0, 0]});
+      layerManager.setLayers(
+        Array.from(
+          {length: 100},
+          (_, i) =>
+            new ScatterplotLayer({
+              id: `test-${testIdx}-layer-${i}`,
+              data: newData,
+              getPosition: d => d.position,
+              getFillColor: d => d.color
+            })
+        )
+      );
+    })
+    .add('draw layers', () => {
+      deckRenderer.renderLayers({
+        viewports: [testViewport],
+        layers: layerManager.getLayers(),
+        onViewportActive: layerManager.activateViewport
+      });
+    })
     .add('encoding picking color', () => {
       testIdx++;
       if ((testIdx + 1) >> 24) {


### PR DESCRIPTION
A fix we made in `attribute._normalizeValue` from 7.3 to 8.0 is showing up in profiling. This PR restores the old implementation for size<=4 use cases for performance.

Before:

├─ initialize layers: 34.3 iterations/s ±20.04%
├─ update layers: 13.5 iterations/s ±6.94%

After:

├─ initialize layers: 37.5 iterations/s ±20.41%
├─ update layers: 39.4 iterations/s ±6.43%


#### Change List
- Improve `attribute._normalizeValue` perf
- Bench tests

