### PR TITLE
pydeck: Add CDN-hosted bundle for standalone HTML rendering

### DIFF
--- a/bindings/python/pydeck/README.md
+++ b/bindings/python/pydeck/README.md
@@ -116,19 +116,9 @@ git clone https://github.com/uber/deck.gl/
 cd deck.gl
 # Build the entire deck.gl project
 yarn bootstrap
-
-# Optional but recommended: Run a hot reloading development server
-cd modules/jupyter-widget
-yarn watch
 ```
 
-If running a non-default URL for webpack's dev server, change the URL in the `PYDECK_DEV_SERVER` environment variable,
-e.g., `export PYDECK_DEV_SERVER=http://localhost:8081`.
-
-Elsewhere, run:
-
 ```bash
-export PYDECK_DEV_SERVER=http://localhost:8080
 cd deck.gl/bindings/python/pydeck
 
 # Create a virtual environment
@@ -140,7 +130,7 @@ pip install -r requirements-dev.txt
 pip install -e .
 ```
 
-To enable develop with Jupyter Lab, run:
+Jupyter Lab is the recommended environment for development testing with pydeck. To enable development with Jupyter Lab, run:
 
 ```bash
 # Execute in deck.gl/modules/jupyter-widget directory
@@ -148,6 +138,7 @@ jupyter labextension install @jupyter-widgets/jupyterlab-manager@1.0.3 --no-buil
 jupyter labextension install . --no-build
 jupyter lab build
 ```
+
 
 ### Tests
 

--- a/bindings/python/pydeck/pydeck/io/html.py
+++ b/bindings/python/pydeck/pydeck/io/html.py
@@ -12,6 +12,7 @@ TEMPLATES_PATH = os.path.join(os.path.dirname(__file__), './templates/')
 j2_env = jinja2.Environment(loader=jinja2.FileSystemLoader(TEMPLATES_PATH),
                             trim_blocks=True)
 
+STANDALONE_LIB = 'https://cdn.jsdelivr.net/npm/@deck.gl/jupyter-widget@8.0.0-alpha.2/dist/standalone-html-bundle.js'
 
 def render_json_to_html(json_input, mapbox_key=None, tooltip=True):
     js = j2_env.get_template('index.j2')
@@ -20,9 +21,8 @@ def render_json_to_html(json_input, mapbox_key=None, tooltip=True):
     html_str = js.render(
         mapbox_key=mapbox_key,
         json_input=json_input,
-        deckgl_jupyter_widget_bundle='https://cdn.jsdelivr.net/npm/@deck.gl/jupyter-widget@8.0.0-alpha.2/dist/index.js',
-        tooltip=tooltip
-    )
+        deckgl_jupyter_widget_bundle=STANDALONE_LIB,
+        tooltip=tooltip)
     return html_str
 
 

--- a/bindings/python/pydeck/pydeck/io/html.py
+++ b/bindings/python/pydeck/pydeck/io/html.py
@@ -20,8 +20,7 @@ def render_json_to_html(json_input, mapbox_key=None, tooltip=True):
     html_str = js.render(
         mapbox_key=mapbox_key,
         json_input=json_input,
-        # TODO change before publication to the NPM-hosted module
-        deckgl_jupyter_widget_bundle='',
+        deckgl_jupyter_widget_bundle='https://cdn.jsdelivr.net/npm/@deck.gl/jupyter-widget@8.0.0-alpha.2/dist/index.js',
         tooltip=tooltip
     )
     return html_str

--- a/bindings/python/pydeck/pydeck/io/html.py
+++ b/bindings/python/pydeck/pydeck/io/html.py
@@ -11,8 +11,7 @@ from IPython.display import IFrame
 TEMPLATES_PATH = os.path.join(os.path.dirname(__file__), './templates/')
 j2_env = jinja2.Environment(loader=jinja2.FileSystemLoader(TEMPLATES_PATH),
                             trim_blocks=True)
-
-STANDALONE_LIB = 'https://cdn.jsdelivr.net/npm/@deck.gl/jupyter-widget@8.0.0-alpha.2/dist/standalone-html-bundle.js'
+CDN_URL = 'https://cdn.jsdelivr.net/npm/@deck.gl/jupyter-widget@^8.0.0/dist/index.min.js'
 
 def render_json_to_html(json_input, mapbox_key=None, tooltip=True):
     js = j2_env.get_template('index.j2')
@@ -21,8 +20,9 @@ def render_json_to_html(json_input, mapbox_key=None, tooltip=True):
     html_str = js.render(
         mapbox_key=mapbox_key,
         json_input=json_input,
-        deckgl_jupyter_widget_bundle=STANDALONE_LIB,
-        tooltip=tooltip)
+        deckgl_jupyter_widget_bundle=CDN_URL,
+        tooltip=tooltip
+    )
     return html_str
 
 

--- a/bindings/python/pydeck/pydeck/io/html.py
+++ b/bindings/python/pydeck/pydeck/io/html.py
@@ -11,7 +11,7 @@ from IPython.display import IFrame
 TEMPLATES_PATH = os.path.join(os.path.dirname(__file__), './templates/')
 j2_env = jinja2.Environment(loader=jinja2.FileSystemLoader(TEMPLATES_PATH),
                             trim_blocks=True)
-CDN_URL = 'https://cdn.jsdelivr.net/npm/@deck.gl/jupyter-widget@^8.0.0/dist/index.min.js'
+CDN_URL = 'https://cdn.jsdelivr.net/npm/@deck.gl/jupyter-widget@^8.0.0/dist/index.js'
 
 def render_json_to_html(json_input, mapbox_key=None, tooltip=True):
     js = j2_env.get_template('index.j2')

--- a/modules/jupyter-widget/package.json
+++ b/modules/jupyter-widget/package.json
@@ -18,6 +18,8 @@
   "files": [
     "dist/index.js",
     "dist/index.js.map",
+    "dist/standalone-html-bundle.js",
+    "dist/standalone-html-bundle.js.map",
     "src",
     "README.md"
   ],

--- a/modules/jupyter-widget/package.json
+++ b/modules/jupyter-widget/package.json
@@ -18,8 +18,6 @@
   "files": [
     "dist/index.js",
     "dist/index.js.map",
-    "dist/standalone-html-bundle.js",
-    "dist/standalone-html-bundle.js.map",
     "src",
     "README.md"
   ],


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #3640

The standalone HTML renderer needs to download a built version of @deck.gl/jupyter-widget from a CDN to work. Blocking for pydeck 0.2.0.