### PR TITLE
Fix trips layer timestamps attribute partial update

### DIFF
--- a/modules/geo-layers/src/trips-layer/trips-layer.js
+++ b/modules/geo-layers/src/trips-layer/trips-layer.js
@@ -109,9 +109,9 @@ if(vTime > currentTime || vTime < currentTime - trailLength) {
     }
 
     const {
-      pathTesselator: {bufferLayout, instanceCount}
+      pathTesselator: {bufferLayout}
     } = this.state;
-    const value = new Float32Array(instanceCount * 2);
+    const {value} = attribute;
 
     const {iterable, objectInfo} = createIterable(data, startRow, endRow);
     let i = 0;
@@ -131,8 +131,8 @@ if(vTime > currentTime || vTime < currentTime - trailLength) {
         value[i++] = timestamps[j + 1];
       }
     }
+    attribute.bufferLayout = bufferLayout;
     attribute.constant = false;
-    attribute.value = value;
   }
 }
 


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/3976

`TripsLayer` was not setting the `bufferLayout` on `instanceTimestamps` which breaks partial update.

(Patching 7.3-release; this method has been removed on master)

#### Change List
- Fix `instanceTimestamps` attribute update
