### PR TITLE
Audit assert usages

### DIFF
--- a/modules/core/src/controllers/map-controller.js
+++ b/modules/core/src/controllers/map-controller.js
@@ -226,8 +226,6 @@ class MapState extends ViewState {
    *   relative scale.
    */
   zoom({pos, startPos, scale}) {
-    assert(scale > 0, '`scale` must be a positive number');
-
     // Make sure we zoom around the current mouse position rather than map center
     let {startZoom, startZoomLngLat} = this._interactiveState;
 
@@ -241,13 +239,6 @@ class MapState extends ViewState {
       startZoom = this._viewportProps.zoom;
       startZoomLngLat = this._unproject(startPos) || this._unproject(pos);
     }
-
-    // take the start lnglat and put it where the mouse is down.
-    assert(
-      startZoomLngLat,
-      '`startZoomLngLat` prop is required ' +
-        'for zoom behavior to calculate where to position the map.'
-    );
 
     const zoom = this._calculateNewZoom({scale, startZoom});
 

--- a/modules/core/src/controllers/transition-manager.js
+++ b/modules/core/src/controllers/transition-manager.js
@@ -1,6 +1,5 @@
 import LinearInterpolator from '../transitions/linear-interpolator';
 import Transition from '../transitions/transition';
-import assert from '../utils/assert';
 
 const noop = () => {};
 
@@ -22,7 +21,6 @@ const DEFAULT_PROPS = {
 
 export default class TransitionManager {
   constructor(ControllerState, props = {}) {
-    assert(ControllerState);
     this.ControllerState = ControllerState;
     this.props = Object.assign({}, DEFAULT_PROPS, props);
     this.propsInTransition = null;
@@ -112,8 +110,6 @@ export default class TransitionManager {
   }
 
   _triggerTransition(startProps, endProps) {
-    assert(this._isTransitionEnabled(endProps), 'Transition is not enabled');
-
     const startViewstate = new this.ControllerState(startProps);
     const endViewStateProps = new this.ControllerState(endProps).shortestPathFrom(startViewstate);
 

--- a/modules/core/src/lib/deck-picker.js
+++ b/modules/core/src/lib/deck-picker.js
@@ -305,9 +305,7 @@ export default class DeckPicker {
 
   // returns pickedColor or null if no pickable layers found.
   _drawAndSample({layers, viewports, onViewportActive, deviceRect, pass, redrawReason, pickZ}) {
-    assert(deviceRect);
-    assert(Number.isFinite(deviceRect.width) && deviceRect.width > 0, '`width` must be > 0');
-    assert(Number.isFinite(deviceRect.height) && deviceRect.height > 0, '`height` must be > 0');
+    assert(deviceRect.width > 0 && deviceRect.height > 0);
 
     const pickableLayers = layers.filter(layer => layer.isPickable());
     if (pickableLayers.length < 1) {

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -617,7 +617,6 @@ export default class Deck {
 
     // viewManager must be initialized before layerManager
     // layerManager depends on viewport created by viewManager.
-    assert(this.viewManager);
     const viewport = this.viewManager.getViewports()[0];
 
     // Note: avoid React setState due GL animation loop / setState timing issue

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -193,13 +193,10 @@ export default class Layer extends Component {
   // Always unprojects to the viewport's coordinate system
   unproject(xy) {
     const {viewport} = this.context;
-    assert(Array.isArray(xy));
     return viewport.unproject(xy);
   }
 
   projectPosition(xyz) {
-    assert(Array.isArray(xyz));
-
     return projectPosition(xyz, {
       viewport: this.context.viewport,
       modelMatrix: this.props.modelMatrix,
@@ -242,7 +239,6 @@ export default class Layer extends Component {
   // Returns the picking color that doesn't match any subfeature
   // Use if some graphics do not belong to any pickable subfeature
   encodePickingColor(i, target = []) {
-    assert(i < 16777215, 'index out of picking color range');
     target[0] = (i + 1) & 255;
     target[1] = ((i + 1) >> 8) & 255;
     target[2] = (((i + 1) >> 8) >> 8) & 255;
@@ -446,6 +442,7 @@ export default class Layer extends Component {
       // If the attribute is larger than the cache, resize the cache and populate the missing chunk
       const newCacheSize = pickingColorCache.length / 3;
       const pickingColor = [];
+      assert(newCacheSize < 16777215, 'index out of picking color range');
 
       for (let i = cacheSize; i < newCacheSize; i++) {
         this.encodePickingColor(i, pickingColor);

--- a/modules/core/src/lifecycle/props.js
+++ b/modules/core/src/lifecycle/props.js
@@ -1,4 +1,3 @@
-import assert from '../utils/assert';
 import {PROP_SYMBOLS} from './constants';
 
 const {COMPONENT} = PROP_SYMBOLS;
@@ -84,8 +83,6 @@ export function compareProps({
   propTypes = {},
   triggerName = 'props'
 } = {}) {
-  assert(oldProps !== undefined && newProps !== undefined, 'compareProps args');
-
   // shallow equality => deep equality
   if (oldProps === newProps) {
     return null;

--- a/modules/core/src/shaderlib/project/viewport-uniforms.js
+++ b/modules/core/src/shaderlib/project/viewport-uniforms.js
@@ -159,8 +159,6 @@ function calculateViewportUniforms({
     viewport
   });
 
-  assert(viewProjectionMatrix, 'Viewport missing modelViewProjectionMatrix');
-
   // Calculate projection pixels per unit
   const distanceScales = viewport.getDistanceScales();
 

--- a/modules/core/src/transitions/transition-interpolator.js
+++ b/modules/core/src/transitions/transition-interpolator.js
@@ -80,7 +80,7 @@ export default class TransitionInterpolator {
    * @returns {object} - a list of interpolated viewport props
    */
   interpolateProps(startProps, endProps, t) {
-    assert(false, 'interpolateProps is not implemented');
+    return endProps;
   }
 
   /**

--- a/modules/core/src/viewports/viewport.js
+++ b/modules/core/src/viewports/viewport.js
@@ -35,8 +35,6 @@ import {
 
 import {PROJECTION_MODE} from '../lib/constants';
 
-import assert from '../utils/assert';
-
 const DEGREES_TO_RADIANS = Math.PI / 180;
 
 const IDENTITY = createMat4();
@@ -274,7 +272,6 @@ export default class Viewport {
   // INTERNAL METHODS
 
   _createProjectionMatrix({orthographic, fovyRadians, aspect, focalDistance, near, far}) {
-    assert(Number.isFinite(fovyRadians));
     return orthographic
       ? new Matrix4().orthographic({fovy: fovyRadians, aspect, focalDistance, near, far})
       : new Matrix4().perspective({fovy: fovyRadians, aspect, near, far});
@@ -371,18 +368,15 @@ export default class Viewport {
       // Projection matrix parameters, used if projectionMatrix not supplied
       orthographic = false,
       fovyRadians,
-      fovyDegrees,
-      fovy,
+      fovy = 75,
       near = 0.1, // Distance of near clipping plane
       far = 1000, // Distance of far clipping plane
       focalDistance = 1
     } = opts;
 
-    const radians = fovyRadians || (fovyDegrees || fovy || 75) * DEGREES_TO_RADIANS;
-
     this.projectionProps = {
       orthographic,
-      fovyRadians: radians,
+      fovyRadians: fovyRadians || fovy * DEGREES_TO_RADIANS,
       aspect: this.width / this.height,
       focalDistance,
       near,

--- a/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.js
+++ b/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.js
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {Layer, project32, phongLighting, picking, COORDINATE_SYSTEM} from '@deck.gl/core';
+import {Layer, project32, phongLighting, picking, COORDINATE_SYSTEM, log} from '@deck.gl/core';
 import GL from '@luma.gl/constants';
 import {Model, Geometry, Texture2D, isWebGL2} from '@luma.gl/core';
 
@@ -33,13 +33,6 @@ import vs1 from './simple-mesh-layer-vertex.glsl1';
 import fs1 from './simple-mesh-layer-fragment.glsl1';
 import vs3 from './simple-mesh-layer-vertex.glsl';
 import fs3 from './simple-mesh-layer-fragment.glsl';
-
-// Replacement for the external assert method to reduce bundle size
-function assert(condition, message) {
-  if (!condition) {
-    throw new Error(`deck.gl: ${message}`);
-  }
-}
 
 /*
  * Convert image data into texture
@@ -53,7 +46,7 @@ function getTextureFromData(gl, data, opts) {
 }
 
 function validateGeometryAttributes(attributes) {
-  assert(
+  log.assert(
     attributes.positions || attributes.POSITION,
     'SimpleMeshLayer requires "postions" or "POSITION" attribute in mesh property.'
   );


### PR DESCRIPTION
Generally speaking, `assert` should only be used for sanity checking user-provided parameters and be helpful in debugging.

#### Change List
- Remove `assert` on parameters passed between internal code
- Remove `assert` where it's impossible to fail (e.g. a crash would happen before the assertion is reached)
- Avoid `assert` in performance critical functions
