### PR TITLE
Bump dependency versions in modules, examples and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,12 @@ const scatterplotLayer = new ScatterplotLayer({
 ```js
 import DeckGL from 'deck.gl';
 
-<DeckGL width="100%" height="100%" longitude={-122.4} latitude={37.78} zoom={8} controller={true} layers={[scatterplotLayer]} />
+<DeckGL
+  width="100%"
+  height="100%"
+  initialViewState={{longitude: -122.4, latitude: 37.78, zoom: 8}}
+  controller={true}
+  layers={[scatterplotLayer]} />
 ```
 
 ## Using deck.gl with Pure JS
@@ -68,12 +73,13 @@ import DeckGL from 'deck.gl';
 import {Deck} from '@deck.gl/core';
 
 const deck = new Deck({
-  container: document.body,
   width: '100vw',
   height: '100vh',
-  longitude: -122.4,
-  latitude: 37.78,
-  zoom: 8,
+  initialViewState: {
+    longitude: -122.4,
+    latitude: 37.78,
+    zoom: 8
+  },
   controller: true,
   layers: [scatterplotLayer]
 });
@@ -84,7 +90,7 @@ Minimum setups of end-to-end deck.gl usage is also showcased in the [hello-world
 To learn how to use deck.gl through the many examples that come with the deck.gl repo, please clone the latest **release** branch:
 
 ```
-git clone -b 6.2-release --single-branch https://github.com/uber/deck.gl.git
+git clone -b 7.3-release --single-branch https://github.com/uber/deck.gl.git
 ```
 
 For the most up-to-date information, see our [API documentations](http://deck.gl/#/documentation)

--- a/docs/layers/arc-layer.md
+++ b/docs/layers/arc-layer.md
@@ -70,10 +70,10 @@ new ArcLayer({});
 To use pre-bundled scripts:
 
 ```html
-<script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 <!-- or -->
-<script src="https://unpkg.com/@deck.gl/core@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/layers@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/core@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/layers@^8.0.0/dist.min.js"></script>
 ```
 
 ```js

--- a/docs/layers/bitmap-layer.md
+++ b/docs/layers/bitmap-layer.md
@@ -43,10 +43,10 @@ new BitmapLayer({});
 To use pre-bundled scripts:
 
 ```html
-<script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 <!-- or -->
-<script src="https://unpkg.com/@deck.gl/core@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/layers@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/core@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/layers@^8.0.0/dist.min.js"></script>
 ```
 
 ```js

--- a/docs/layers/column-layer.md
+++ b/docs/layers/column-layer.md
@@ -67,10 +67,10 @@ new ColumnLayer({});
 To use pre-bundled scripts:
 
 ```html
-<script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 <!-- or -->
-<script src="https://unpkg.com/@deck.gl/core@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/layers@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/core@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/layers@^8.0.0/dist.min.js"></script>
 ```
 
 ```js

--- a/docs/layers/contour-layer.md
+++ b/docs/layers/contour-layer.md
@@ -60,11 +60,11 @@ new ContourLayer({});
 To use pre-bundled scripts:
 
 ```html
-<script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 <!-- or -->
-<script src="https://unpkg.com/@deck.gl/core@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/layers@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/aggregation-layers@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/core@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/layers@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/aggregation-layers@^8.0.0/dist.min.js"></script>
 ```
 
 ```js

--- a/docs/layers/cpu-grid-layer.md
+++ b/docs/layers/cpu-grid-layer.md
@@ -69,11 +69,11 @@ new CPUGridLayer({});
 To use pre-bundled scripts:
 
 ```html
-<script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 <!-- or -->
-<script src="https://unpkg.com/@deck.gl/core@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/layers@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/aggregation-layers@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/core@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/layers@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/aggregation-layers@^8.0.0/dist.min.js"></script>
 ```
 
 ```js

--- a/docs/layers/geojson-layer.md
+++ b/docs/layers/geojson-layer.md
@@ -68,10 +68,10 @@ new GeoJsonLayer({});
 To use pre-bundled scripts:
 
 ```html
-<script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 <!-- or -->
-<script src="https://unpkg.com/@deck.gl/core@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/layers@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/core@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/layers@^8.0.0/dist.min.js"></script>
 ```
 
 ```js

--- a/docs/layers/gpu-grid-layer.md
+++ b/docs/layers/gpu-grid-layer.md
@@ -73,11 +73,11 @@ new GPUGridLayer({});
 To use pre-bundled scripts:
 
 ```html
-<script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 <!-- or -->
-<script src="https://unpkg.com/@deck.gl/core@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/layers@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/aggregation-layers@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/core@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/layers@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/aggregation-layers@^8.0.0/dist.min.js"></script>
 ```
 
 ```js

--- a/docs/layers/grid-cell-layer.md
+++ b/docs/layers/grid-cell-layer.md
@@ -69,10 +69,10 @@ new GridCellLayer({});
 To use pre-bundled scripts:
 
 ```html
-<script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 <!-- or -->
-<script src="https://unpkg.com/@deck.gl/core@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/layers@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/core@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/layers@^8.0.0/dist.min.js"></script>
 ```
 
 ```js

--- a/docs/layers/grid-layer.md
+++ b/docs/layers/grid-layer.md
@@ -68,11 +68,11 @@ new GridLayer({});
 To use pre-bundled scripts:
 
 ```html
-<script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 <!-- or -->
-<script src="https://unpkg.com/@deck.gl/core@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/layers@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/aggregation-layers@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/core@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/layers@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/aggregation-layers@^8.0.0/dist.min.js"></script>
 ```
 
 ```js

--- a/docs/layers/h3-cluster-layer.md
+++ b/docs/layers/h3-cluster-layer.md
@@ -78,11 +78,11 @@ To use pre-bundled scripts:
 
 ```html
 <script src="https://unpkg.com/h3-js"></script>
-<script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 <!-- or -->
-<script src="https://unpkg.com/@deck.gl/core@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/layers@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/geo-layers@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/core@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/layers@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/geo-layers@^8.0.0/dist.min.js"></script>
 ```
 
 ```js

--- a/docs/layers/h3-hexagon-layer.md
+++ b/docs/layers/h3-hexagon-layer.md
@@ -70,11 +70,11 @@ To use pre-bundled scripts:
 
 ```html
 <script src="https://unpkg.com/h3-js"></script>
-<script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 <!-- or -->
-<script src="https://unpkg.com/@deck.gl/core@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/layers@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/geo-layers@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/core@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/layers@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/geo-layers@^8.0.0/dist.min.js"></script>
 ```
 
 ```js

--- a/docs/layers/heatmap-layer.md
+++ b/docs/layers/heatmap-layer.md
@@ -51,11 +51,11 @@ new HeatmapLayer({});
 To use pre-bundled scripts:
 
 ```html
-<script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 <!-- or -->
-<script src="https://unpkg.com/@deck.gl/core@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/layers@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/aggregation-layers@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/core@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/layers@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/aggregation-layers@^8.0.0/dist.min.js"></script>
 ```
 
 ```js

--- a/docs/layers/hexagon-layer.md
+++ b/docs/layers/hexagon-layer.md
@@ -65,11 +65,11 @@ new HexagonLayer({});
 To use pre-bundled scripts:
 
 ```html
-<script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 <!-- or -->
-<script src="https://unpkg.com/@deck.gl/core@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/layers@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/aggregation-layers@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/core@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/layers@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/aggregation-layers@^8.0.0/dist.min.js"></script>
 ```
 
 ```js

--- a/docs/layers/icon-layer.md
+++ b/docs/layers/icon-layer.md
@@ -138,10 +138,10 @@ new IconLayer({});
 To use pre-bundled scripts:
 
 ```html
-<script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 <!-- or -->
-<script src="https://unpkg.com/@deck.gl/core@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/layers@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/core@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/layers@^8.0.0/dist.min.js"></script>
 ```
 
 ```js

--- a/docs/layers/line-layer.md
+++ b/docs/layers/line-layer.md
@@ -70,10 +70,10 @@ new LineLayer({});
 To use pre-bundled scripts:
 
 ```html
-<script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 <!-- or -->
-<script src="https://unpkg.com/@deck.gl/core@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/layers@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/core@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/layers@^8.0.0/dist.min.js"></script>
 ```
 
 ```js

--- a/docs/layers/path-layer.md
+++ b/docs/layers/path-layer.md
@@ -64,10 +64,10 @@ new PathLayer({});
 To use pre-bundled scripts:
 
 ```html
-<script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 <!-- or -->
-<script src="https://unpkg.com/@deck.gl/core@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/layers@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/core@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/layers@^8.0.0/dist.min.js"></script>
 ```
 
 ```js

--- a/docs/layers/point-cloud-layer.md
+++ b/docs/layers/point-cloud-layer.md
@@ -63,10 +63,10 @@ new PointCloudLayer({});
 To use pre-bundled scripts:
 
 ```html
-<script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 <!-- or -->
-<script src="https://unpkg.com/@deck.gl/core@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/layers@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/core@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/layers@^8.0.0/dist.min.js"></script>
 ```
 
 ```js

--- a/docs/layers/polygon-layer.md
+++ b/docs/layers/polygon-layer.md
@@ -83,10 +83,10 @@ new PolygonLayer({});
 To use pre-bundled scripts:
 
 ```html
-<script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 <!-- or -->
-<script src="https://unpkg.com/@deck.gl/core@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/layers@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/core@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/layers@^8.0.0/dist.min.js"></script>
 ```
 
 ```js

--- a/docs/layers/s2-layer.md
+++ b/docs/layers/s2-layer.md
@@ -75,11 +75,11 @@ To use pre-bundled scripts:
 
 ```html
 <script src="https://bundle.run/s2-geometry@1.2.10"></script>
-<script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 <!-- or -->
-<script src="https://unpkg.com/@deck.gl/core@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/layers@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/geo-layers@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/core@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/layers@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/geo-layers@^8.0.0/dist.min.js"></script>
 ```
 
 ```js

--- a/docs/layers/scatterplot-layer.md
+++ b/docs/layers/scatterplot-layer.md
@@ -67,10 +67,10 @@ new ScatterplotLayer({});
 To use pre-bundled scripts:
 
 ```html
-<script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 <!-- or -->
-<script src="https://unpkg.com/@deck.gl/core@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/layers@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/core@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/layers@^8.0.0/dist.min.js"></script>
 ```
 
 ```js

--- a/docs/layers/screen-grid-layer.md
+++ b/docs/layers/screen-grid-layer.md
@@ -76,11 +76,11 @@ new ScreenGridLayer({});
 To use pre-bundled scripts:
 
 ```html
-<script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 <!-- or -->
-<script src="https://unpkg.com/@deck.gl/core@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/layers@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/aggregation-layers@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/core@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/layers@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/aggregation-layers@^8.0.0/dist.min.js"></script>
 ```
 
 ```js

--- a/docs/layers/simple-mesh-layer.md
+++ b/docs/layers/simple-mesh-layer.md
@@ -59,10 +59,10 @@ new SimpleMeshLayer({});
 To use pre-bundled scripts:
 
 ```html
-<script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 <!-- or -->
-<script src="https://unpkg.com/@deck.gl/core@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/mesh-layers@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/core@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/mesh-layers@^8.0.0/dist.min.js"></script>
 ```
 
 ```js

--- a/docs/layers/solid-polygon-layer.md
+++ b/docs/layers/solid-polygon-layer.md
@@ -44,10 +44,10 @@ new SolidPolygonLayer({});
 To use pre-bundled scripts:
 
 ```html
-<script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 <!-- or -->
-<script src="https://unpkg.com/@deck.gl/core@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/layers@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/core@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/layers@^8.0.0/dist.min.js"></script>
 ```
 
 ```js

--- a/docs/layers/text-layer.md
+++ b/docs/layers/text-layer.md
@@ -67,10 +67,10 @@ new TextLayer({});
 To use pre-bundled scripts:
 
 ```html
-<script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 <!-- or -->
-<script src="https://unpkg.com/@deck.gl/core@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/layers@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/core@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/layers@^8.0.0/dist.min.js"></script>
 ```
 
 ```js

--- a/docs/layers/tile-3d-layer.md
+++ b/docs/layers/tile-3d-layer.md
@@ -60,10 +60,10 @@ new Tile3DLayer({});
 To use pre-bundled scripts:
 
 ```html
-<script src="https://unpkg.com/deck.gl@~7.3.0/dist.min.js"></script>
+<script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 <!-- or -->
-<script src="https://unpkg.com/@deck.gl/core@~7.3.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/layers@~7.3.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/core@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/layers@^8.0.0/dist.min.js"></script>
 ```
 
 ```js

--- a/docs/layers/tile-layer.md
+++ b/docs/layers/tile-layer.md
@@ -80,11 +80,11 @@ new TileLayer({});
 To use pre-bundled scripts:
 
 ```html
-<script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 <!-- or -->
-<script src="https://unpkg.com/@deck.gl/core@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/layers@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/geo-layers@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/core@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/layers@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/geo-layers@^8.0.0/dist.min.js"></script>
 ```
 
 ```js

--- a/docs/layers/trips-layer.md
+++ b/docs/layers/trips-layer.md
@@ -57,11 +57,11 @@ const App = ({data, viewport}) => {
 To use pre-bundled scripts:
 
 ```html
-<script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 <!-- or -->
-<script src="https://unpkg.com/@deck.gl/core@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/layers@^7.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/geo-layers@^7.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/core@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/layers@^8.0.0/dist.min.js"></script>
+<script src="https://unpkg.com/@deck.gl/geo-layers@^8.0.0/dist.min.js"></script>
 ```
 
 ```js

--- a/examples/experimental/bezier/package.json
+++ b/examples/experimental/bezier/package.json
@@ -7,7 +7,7 @@
     "start": "webpack-dev-server --progress --hot --open"
   },
   "dependencies": {
-    "deck.gl": "^7.3.0-beta",
+    "deck.gl": "^8.0.0-beta",
     "react": "^16.3.0",
     "react-dom": "^16.3.0"
   },

--- a/examples/experimental/sun/package.json
+++ b/examples/experimental/sun/package.json
@@ -7,7 +7,7 @@
     "start": "webpack-dev-server --progress --hot --open"
   },
   "dependencies": {
-    "deck.gl": "^7.3.0-beta",
+    "deck.gl": "^8.0.0-beta",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
     "react-map-gl": "^5.0.0"

--- a/examples/gallery/src/arc-layer.html
+++ b/examples/gallery/src/arc-layer.html
@@ -2,7 +2,7 @@
   <head>
     <title>deck.gl ArcLayer Example</title>
 
-    <script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+    <script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
     <script src="https://d3js.org/d3.v5.min.js"></script>
 
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.4.0/mapbox-gl.js"></script>

--- a/examples/gallery/src/bitmap-layer.html
+++ b/examples/gallery/src/bitmap-layer.html
@@ -2,7 +2,7 @@
   <head>
     <title>deck.gl BitmapLayer Example</title>
 
-    <script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+    <script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.4.0/mapbox-gl.js"></script>
 
     <style type="text/css">

--- a/examples/gallery/src/boiler-plate.html
+++ b/examples/gallery/src/boiler-plate.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <title>Get Started with deck.gl</title>
-    <script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+    <script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.4.0/mapbox-gl.js"></script>
   </head>
 

--- a/examples/gallery/src/column-layer.html
+++ b/examples/gallery/src/column-layer.html
@@ -2,7 +2,7 @@
   <head>
     <title>deck.gl ColumnLayer Example</title>
 
-    <script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+    <script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.4.0/mapbox-gl.js"></script>
 
     <style type="text/css">

--- a/examples/gallery/src/contour-layer.html
+++ b/examples/gallery/src/contour-layer.html
@@ -2,7 +2,7 @@
   <head>
     <title>deck.gl ContourLayer Example</title>
 
-    <script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+    <script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.4.0/mapbox-gl.js"></script>
 

--- a/examples/gallery/src/geojson-layer.html
+++ b/examples/gallery/src/geojson-layer.html
@@ -2,7 +2,7 @@
   <head>
     <title>deck.gl GeoJsonLayer (Polygon) Example</title>
 
-    <script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+    <script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.4.0/mapbox-gl.js"></script>
 
     <style type="text/css">

--- a/examples/gallery/src/great-circle-layer.html
+++ b/examples/gallery/src/great-circle-layer.html
@@ -2,7 +2,7 @@
   <head>
     <title>deck.gl GreatCircleLayer Example</title>
 
-    <script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+    <script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.4.0/mapbox-gl.js"></script>
 

--- a/examples/gallery/src/hexagon-layer.html
+++ b/examples/gallery/src/hexagon-layer.html
@@ -2,7 +2,7 @@
   <head>
     <title>deck.gl HexagonLayer Example</title>
 
-    <script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+    <script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
     <script src="https://d3js.org/d3.v5.min.js"></script>
 
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.4.0/mapbox-gl.js"></script>

--- a/examples/gallery/src/highway.html
+++ b/examples/gallery/src/highway.html
@@ -2,7 +2,7 @@
   <head>
     <title>deck.gl GeoJsonLayer (Path) Example</title>
 
-    <script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+    <script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
     <script src="https://d3js.org/d3.v5.min.js"></script>
 
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.4.0/mapbox-gl.js"></script>

--- a/examples/gallery/src/icon-layer.html
+++ b/examples/gallery/src/icon-layer.html
@@ -2,7 +2,7 @@
   <head>
     <title>deck.gl IconLayer Example</title>
 
-    <script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+    <script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/rest.js/15.2.6/octokit-rest.min.js"></script>
 
     <style type="text/css">

--- a/examples/gallery/src/line-layer.html
+++ b/examples/gallery/src/line-layer.html
@@ -2,7 +2,7 @@
   <head>
     <title>deck.gl LineLayer Example</title>
 
-    <script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+    <script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.4.0/mapbox-gl.js"></script>
 
     <style type="text/css">

--- a/examples/gallery/src/mapbox-layer.html
+++ b/examples/gallery/src/mapbox-layer.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <title>Interleaving deck.gl with Mapbox Layers</title>
-    <script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+    <script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.4.0/mapbox-gl.js"></script>
   </head>
 

--- a/examples/gallery/src/point-cloud-layer.html
+++ b/examples/gallery/src/point-cloud-layer.html
@@ -2,7 +2,7 @@
   <head>
     <title>deck.gl PointCloudLayer Example</title>
 
-    <script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+    <script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 
     <style type="text/css">
       body {

--- a/examples/gallery/src/scatterplot-layer.html
+++ b/examples/gallery/src/scatterplot-layer.html
@@ -2,7 +2,7 @@
   <head>
     <title>deck.gl ScatterplotLayer Example</title>
 
-    <script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+    <script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.4.0/mapbox-gl.js"></script>
 

--- a/examples/gallery/src/screengrid-layer.html
+++ b/examples/gallery/src/screengrid-layer.html
@@ -2,7 +2,7 @@
   <head>
     <title>deck.gl ScreenGridLayer Example</title>
 
-    <script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+    <script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.4.0/mapbox-gl.js"></script>
 

--- a/examples/gallery/src/text-layer.html
+++ b/examples/gallery/src/text-layer.html
@@ -2,7 +2,7 @@
   <head>
     <title>deck.gl TextLayer Example</title>
 
-    <script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+    <script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.4.0/mapbox-gl.js"></script>
 

--- a/examples/gallery/src/viewport-transition.html
+++ b/examples/gallery/src/viewport-transition.html
@@ -2,7 +2,7 @@
   <head>
     <title>deck.gl Viewport Transition Example</title>
 
-    <script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+    <script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
     <script src="https://d3js.org/d3.v5.min.js"></script>
 
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.4.0/mapbox-gl.js"></script>

--- a/examples/get-started/pure-js/basic/package.json
+++ b/examples/get-started/pure-js/basic/package.json
@@ -8,8 +8,8 @@
     "build": "webpack -p"
   },
   "dependencies": {
-    "@deck.gl/core": "^7.3.0-beta",
-    "@deck.gl/layers": "^7.3.0-beta"
+    "@deck.gl/core": "^8.0.0-beta",
+    "@deck.gl/layers": "^8.0.0-beta"
   },
   "devDependencies": {
     "html-webpack-plugin": "^3.0.7",

--- a/examples/get-started/pure-js/google-maps/package.json
+++ b/examples/get-started/pure-js/google-maps/package.json
@@ -8,9 +8,9 @@
     "build": "webpack -p"
   },
   "dependencies": {
-    "@deck.gl/core": "^7.3.0-beta",
-    "@deck.gl/google-maps": "^7.3.0-beta",
-    "@deck.gl/layers": "^7.3.0-beta"
+    "@deck.gl/core": "^8.0.0-beta",
+    "@deck.gl/google-maps": "^8.0.0-beta",
+    "@deck.gl/layers": "^8.0.0-beta"
   },
   "devDependencies": {
     "webpack": "^4.20.2",

--- a/examples/get-started/pure-js/mapbox/package.json
+++ b/examples/get-started/pure-js/mapbox/package.json
@@ -8,8 +8,8 @@
     "build": "webpack -p"
   },
   "dependencies": {
-    "@deck.gl/core": "^7.3.0-beta",
-    "@deck.gl/layers": "^7.3.0-beta",
+    "@deck.gl/core": "^8.0.0-beta",
+    "@deck.gl/layers": "^8.0.0-beta",
     "mapbox-gl": "^1.0.0"
   },
   "devDependencies": {

--- a/examples/get-started/react/basic/package.json
+++ b/examples/get-started/react/basic/package.json
@@ -8,7 +8,7 @@
     "build": "webpack -p"
   },
   "dependencies": {
-    "deck.gl": "^7.3.0-beta",
+    "deck.gl": "^8.0.0-beta",
     "react": "^16.3.0",
     "react-dom": "^16.3.0"
   },

--- a/examples/get-started/react/mapbox-browserify/package.json
+++ b/examples/get-started/react/mapbox-browserify/package.json
@@ -7,7 +7,7 @@
     "build": "browserify ./app.js -o dist/app.js -t babelify -t envify"
   },
   "dependencies": {
-    "deck.gl": "^7.3.0-beta",
+    "deck.gl": "^8.0.0-beta",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
     "react-map-gl": "^5.0.0"

--- a/examples/get-started/react/mapbox/package.json
+++ b/examples/get-started/react/mapbox/package.json
@@ -8,7 +8,7 @@
     "build": "webpack -p"
   },
   "dependencies": {
-    "deck.gl": "^7.3.0-beta",
+    "deck.gl": "^8.0.0-beta",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
     "react-map-gl": "^5.0.0"

--- a/examples/get-started/scripting/basic/index.html
+++ b/examples/get-started/scripting/basic/index.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <!-- deck.gl standalone bundle -->
-    <script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+    <script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 
     <style type="text/css">
       body {margin: 0; padding: 0;}

--- a/examples/get-started/scripting/google-maps/index.html
+++ b/examples/get-started/scripting/google-maps/index.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <!-- deck.gl standalone bundle -->
-    <script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+    <script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 
     <!-- Google Maps dependencies -->
     <!-- Replace google_maps_api_key with your API key! -->

--- a/examples/get-started/scripting/mapbox/index.html
+++ b/examples/get-started/scripting/mapbox/index.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <!-- deck.gl standalone bundle -->
-    <script src="https://unpkg.com/deck.gl@^7.0.0/dist.min.js"></script>
+    <script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 
     <!-- Mapbox dependencies -->
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.4.0/mapbox-gl.js"></script>

--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -8,7 +8,7 @@
     "build": "rm -rf dist && mkdir dist && cp index.html dist/ && webpack --env.production=true"
   },
   "dependencies": {
-    "deck.gl": "^7.3.6",
+    "deck.gl": "^8.0.0-beta",
     "@loaders.gl/csv": "^2.0.0-beta.5",
     "@loaders.gl/core": "^2.0.0-beta.5",
     "@loaders.gl/draco": "^2.0.0-beta.5",

--- a/examples/website/3d-heatmap/package.json
+++ b/examples/website/3d-heatmap/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "d3-request": "^1.0.5",
-    "deck.gl": "^7.3.0-beta",
+    "deck.gl": "^8.0.0-beta",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
     "react-map-gl": "^5.0.0"

--- a/examples/website/3d-tiles/package.json
+++ b/examples/website/3d-tiles/package.json
@@ -5,7 +5,7 @@
     "start-local": "webpack-dev-server --env.local --progress --hot --open"
   },
   "dependencies": {
-    "deck.gl": "^7.3.0-beta",
+    "deck.gl": "^8.0.0-beta",
     "@loaders.gl/draco": "^2.0.0-beta.5",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",

--- a/examples/website/arc/package.json
+++ b/examples/website/arc/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "d3-scale": "^2.0.0",
-    "deck.gl": "^7.3.0-beta",
+    "deck.gl": "^8.0.0-beta",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
     "react-map-gl": "^5.0.0"

--- a/examples/website/brushing/package.json
+++ b/examples/website/brushing/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "d3-scale": "^2.0.0",
-    "deck.gl": "^7.3.0-beta",
+    "deck.gl": "^8.0.0-beta",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
     "react-map-gl": "^5.0.0"

--- a/examples/website/data-filter/package.json
+++ b/examples/website/data-filter/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "baseui": "^8.5.1",
     "d3-request": "^1.0.5",
-    "deck.gl": "^7.3.0-beta",
+    "deck.gl": "^8.0.0-beta",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
     "react-map-gl": "^5.0.0",

--- a/examples/website/geojson/package.json
+++ b/examples/website/geojson/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "d3-scale": "^2.0.0",
-    "deck.gl": "^7.3.0-beta",
+    "deck.gl": "^8.0.0-beta",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
     "react-map-gl": "^5.0.0"

--- a/examples/website/heatmap/package.json
+++ b/examples/website/heatmap/package.json
@@ -4,7 +4,7 @@
     "start-local": "webpack-dev-server --env.local --progress --hot --port 3000 --open"
   },
   "dependencies": {
-    "deck.gl": "^7.3.0-beta",
+    "deck.gl": "^8.0.0-beta",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-map-gl": "^5.0.0"

--- a/examples/website/highway/package.json
+++ b/examples/website/highway/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "d3-request": "^1.0.5",
     "d3-scale": "^2.0.0",
-    "deck.gl": "^7.3.0-beta",
+    "deck.gl": "^8.0.0-beta",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
     "react-map-gl": "^5.0.0"

--- a/examples/website/icon/package.json
+++ b/examples/website/icon/package.json
@@ -7,7 +7,7 @@
     "start": "webpack-dev-server --progress --hot --open"
   },
   "dependencies": {
-    "deck.gl": "^7.3.0-beta",
+    "deck.gl": "^8.0.0-beta",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
     "react-map-gl": "^5.0.0",

--- a/examples/website/line/package.json
+++ b/examples/website/line/package.json
@@ -7,7 +7,7 @@
     "start": "webpack-dev-server --progress --hot --open"
   },
   "dependencies": {
-    "deck.gl": "^7.3.0-beta",
+    "deck.gl": "^8.0.0-beta",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
     "react-map-gl": "^5.0.0"

--- a/examples/website/map-tile/package.json
+++ b/examples/website/map-tile/package.json
@@ -7,7 +7,7 @@
     "start": "webpack-dev-server --progress --hot --open"
   },
   "dependencies": {
-    "deck.gl": "^7.3.0-beta",
+    "deck.gl": "^8.0.0-beta",
     "react": "^16.3.0",
     "react-dom": "^16.3.0"
   },

--- a/examples/website/mesh/package.json
+++ b/examples/website/mesh/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@loaders.gl/obj": "^2.0.0-beta.5",
-    "deck.gl": "^7.3.0-beta",
+    "deck.gl": "^8.0.0-beta",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
     "math.gl": "^3.0.0"

--- a/examples/website/plot/package.json
+++ b/examples/website/plot/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "d3-scale": "^2.0.0",
-    "deck.gl": "^7.3.0-beta",
+    "deck.gl": "^8.0.0-beta",
     "react": "^16.3.0",
     "react-dom": "^16.3.0"
   },

--- a/examples/website/point-cloud/package.json
+++ b/examples/website/point-cloud/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@loaders.gl/las": "^2.0.0-beta.5",
     "@loaders.gl/ply": "^2.0.0-beta.5",
-    "deck.gl": "^7.3.0-beta",
+    "deck.gl": "^8.0.0-beta",
     "react": "^16.3.0",
     "react-dom": "^16.3.0"
   },

--- a/examples/website/scatterplot/package.json
+++ b/examples/website/scatterplot/package.json
@@ -7,7 +7,7 @@
     "start": "webpack-dev-server --progress --hot --open"
   },
   "dependencies": {
-    "deck.gl": "^7.3.0-beta",
+    "deck.gl": "^8.0.0-beta",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
     "react-map-gl": "^5.0.0"

--- a/examples/website/scenegraph-layer/package.json
+++ b/examples/website/scenegraph-layer/package.json
@@ -7,8 +7,7 @@
     "start": "webpack-dev-server --progress --hot --open"
   },
   "dependencies": {
-    "@deck.gl/mesh-layers": "^7.3.0-beta",
-    "@deck.gl/react": "^7.3.0-beta",
+    "deck.gl": "^8.0.0-beta",
     "@loaders.gl/gltf": "^2.0.0-beta.5",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",

--- a/examples/website/screen-grid/package.json
+++ b/examples/website/screen-grid/package.json
@@ -7,7 +7,7 @@
     "start": "webpack-dev-server --progress --hot --open"
   },
   "dependencies": {
-    "deck.gl": "^7.3.0-beta",
+    "deck.gl": "^8.0.0-beta",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
     "react-map-gl": "^5.0.0"

--- a/examples/website/tagmap/package.json
+++ b/examples/website/tagmap/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "d3-scale": "^2.0.0",
-    "deck.gl": "^7.3.0-beta",
+    "deck.gl": "^8.0.0-beta",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
     "react-map-gl": "^5.0.0",

--- a/examples/website/text-layer/package.json
+++ b/examples/website/text-layer/package.json
@@ -7,7 +7,7 @@
     "start": "webpack-dev-server --progress --hot --open"
   },
   "dependencies": {
-    "deck.gl": "^7.3.0-beta",
+    "deck.gl": "^8.0.0-beta",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
     "react-map-gl": "^5.0.0"

--- a/examples/website/trips/package.json
+++ b/examples/website/trips/package.json
@@ -7,7 +7,7 @@
     "start": "webpack-dev-server --progress --hot --open"
   },
   "dependencies": {
-    "deck.gl": "^7.3.0-beta",
+    "deck.gl": "^8.0.0-beta",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
     "react-map-gl": "^5.0.0"

--- a/modules/aggregation-layers/package.json
+++ b/modules/aggregation-layers/package.json
@@ -35,7 +35,7 @@
     "d3-hexbin": "^0.2.1"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^7.3.0-beta",
-    "@deck.gl/layers": "^7.3.0-beta"
+    "@deck.gl/core": "^8.0.0-beta",
+    "@deck.gl/layers": "^8.0.0-beta"
   }
 }

--- a/modules/extensions/package.json
+++ b/modules/extensions/package.json
@@ -30,6 +30,6 @@
     "prepublishOnly": "npm run build-bundle && npm run build-bundle -- --env.dev"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^7.3.0-beta"
+    "@deck.gl/core": "^8.0.0-beta"
   }
 }

--- a/modules/geo-layers/package.json
+++ b/modules/geo-layers/package.json
@@ -41,8 +41,8 @@
     "s2-geometry": "^1.2.10"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^7.3.0-beta",
-    "@deck.gl/layers": "^7.3.0-beta",
-    "@deck.gl/mesh-layers": "^7.3.0-beta"
+    "@deck.gl/core": "^8.0.0-beta",
+    "@deck.gl/layers": "^8.0.0-beta",
+    "@deck.gl/mesh-layers": "^8.0.0-beta"
   }
 }

--- a/modules/google-maps/package.json
+++ b/modules/google-maps/package.json
@@ -30,6 +30,6 @@
     "prepublishOnly": "npm run build-bundle && npm run build-bundle -- --env.dev"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^7.3.0-beta"
+    "@deck.gl/core": "^8.0.0-beta"
   }
 }

--- a/modules/json/package.json
+++ b/modules/json/package.json
@@ -34,6 +34,6 @@
     "expression-eval": "^2.0.0"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^7.3.0-beta"
+    "@deck.gl/core": "^8.0.0-beta"
   }
 }

--- a/modules/layers/package.json
+++ b/modules/layers/package.json
@@ -34,6 +34,6 @@
     "earcut": "^2.0.6"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^7.3.0-beta"
+    "@deck.gl/core": "^8.0.0-beta"
   }
 }

--- a/modules/mapbox/package.json
+++ b/modules/mapbox/package.json
@@ -30,6 +30,6 @@
     "prepublishOnly": "npm run build-bundle && npm run build-bundle -- --env.dev"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^7.3.0-beta"
+    "@deck.gl/core": "^8.0.0-beta"
   }
 }

--- a/modules/mesh-layers/package.json
+++ b/modules/mesh-layers/package.json
@@ -30,7 +30,7 @@
     "prepublishOnly": "npm run build-bundle && npm run build-bundle -- --env.dev"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^7.3.0-beta"
+    "@deck.gl/core": "^8.0.0-beta"
   },
   "dependencies": {
     "@luma.gl/experimental": "^8.0.0-beta.3"

--- a/modules/react/package.json
+++ b/modules/react/package.json
@@ -29,8 +29,8 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^7.3.0-beta",
-    "react": "0.14.x - 16.x",
-    "react-dom": "0.14.x - 16.x"
+    "@deck.gl/core": "^8.0.0-beta",
+    "react": ">=16.3",
+    "react-dom": ">=16.3"
   }
 }

--- a/modules/test-utils/package.json
+++ b/modules/test-utils/package.json
@@ -24,10 +24,10 @@
     "src"
   ],
   "peerDependencies": {
-    "@deck.gl/core": "^7.3.0-beta",
+    "@deck.gl/core": "^8.0.0-beta",
     "@luma.gl/test-utils": "^8.0.0-beta.3",
     "@luma.gl/webgl": "^8.0.0-beta.3",
-    "@probe.gl/test-utils": "^3.1.0"
+    "@probe.gl/test-utils": "^3.2.0-beta"
   },
   "scripts": {}
 }


### PR DESCRIPTION

For #3983 

#### Change List
- Update module peerDependencies to 8.0.0-beta
- Update example dependencies to 8.0.0-beta
- Update CDN links in docs
- Update readme to match the latest API
