### PR TITLE
Secretly expose props symbols

### DIFF
--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "webpack-dev-server --progress --hot --open",
     "start-local": "webpack-dev-server --env.local --progress --hot --open",
-    "build": "rm -rf dist && mkdir dist && cp index.html dist/ && webpack --env.production=true"
+    "build": "rm -rf dist && mkdir dist && cp index.html dist/ && webpack --env.local --env.production=true"
   },
   "dependencies": {
     "deck.gl": "^7.3.6",

--- a/modules/core/src/lifecycle/constants.js
+++ b/modules/core/src/lifecycle/constants.js
@@ -12,8 +12,8 @@ export const LIFECYCLE = {
 // but are copied with Object.assign ¯\_(ツ)_/¯
 // Supported everywhere except IE11, can be polyfilled with core-js
 export const PROP_SYMBOLS = {
-  COMPONENT: Symbol('component'),
-  ASYNC_DEFAULTS: Symbol('asyncPropDefaults'),
-  ASYNC_ORIGINAL: Symbol('asyncPropOriginal'),
-  ASYNC_RESOLVED: Symbol('asyncPropResolved')
+  COMPONENT: Symbol.for('component'),
+  ASYNC_DEFAULTS: Symbol.for('asyncPropDefaults'),
+  ASYNC_ORIGINAL: Symbol.for('asyncPropOriginal'),
+  ASYNC_RESOLVED: Symbol.for('asyncPropResolved')
 };

--- a/website/src/utils/layer-params.js
+++ b/website/src/utils/layer-params.js
@@ -1,5 +1,7 @@
 const blackList = ['coordinateSystem', 'modelMatrix'];
 
+const ASYNC_ORIGINAL = Symbol.for('asyncPropOriginal');
+
 /* eslint-disable complexity */
 /*
  * infer parameter type from a prop
@@ -76,7 +78,7 @@ export function getLayerParams(layer, propParameters = {}) {
       const param = propToParam(
         key,
         LAYER_PROPTYPES,
-        layer.props._asyncPropOriginalValues[key] || layer.props[key]
+        layer.props[ASYNC_ORIGINAL][key] || layer.props[key]
       );
       if (param) {
         paramsArray.push(param);


### PR DESCRIPTION

For #3983 

#### Change List
- Use `Symbol.for` instead of `Symbol` to take advantage of the global registry
- Fix a crash in website embedded demos when try to access original async values
