### PR TITLE
React module fixes

### DIFF
--- a/docs/api-reference/react/deckgl.md
+++ b/docs/api-reference/react/deckgl.md
@@ -69,41 +69,6 @@ import {_MapContext as MapContext, NavigationControl} from 'react-map-gl';
 </DeckGL>
 ```
 
-### View State Properties
-
-For backwards compatibility, the `DeckGL` component can be used without the `viewState` prop. If a `viewState` prop is not supplied, `DeckGL` will attempt to autocreate a geospatial view state from the following props.
-
-##### `latitude` (Number, optional)
-
-Current latitude - used to define a mercator projection if `viewState` is not supplied.
-
-##### `longitude` (Number, optional)
-
-Current longitude - used to define a mercator projection if `viewState` is not supplied.
-
-##### `zoom` (Number, optional)
-
-Current zoom - used to define a mercator projection if `viewState` is not supplied.
-
-##### `bearing` (Number, optional)
-
-Current bearing - used to define a mercator projection if `viewState` is not supplied.
-
-##### `pitch` (Number, optional)
-
-Current pitch - used to define a mercator projection if `viewState` is not supplied.
-
-##### `controller` (Function | Boolean | Object, optional)
-
-Options for viewport interactivity.
-
-* `null` or `false`: this view is not interactive.
-* `true`: initiates the default controller with default options.
-* `Controller` class: initiates the provided controller with default options.
-* `Object`: controller options. This will be merged with the default controller options. 
-  - `controller.type`: the controller class
-  - For other options, consult the documentation of each Controller class.
-
 
 ### Children
 
@@ -136,7 +101,7 @@ It is possible to use JSX syntax to create deck.gl views as React children of th
   <DeckGL />
 ```
 
-If a certain view id is used in both JSX views and the `views` prop, the view instance in the `views` prop has priority. This makes it possible to use the pure-JS `views` API while positioning child components in JSX:
+If a certain view id is used in both JSX views and the `views` prop, the view instance in the `views` prop has priority.
 
 ```jsx
   const views = [
@@ -152,26 +117,20 @@ If a certain view id is used in both JSX views and the `views` prop, the view in
 ```
 
 
-#### Position Children in Viewport
+#### Position Children in Views
 
 To make it easy to use React components in combination with deck.gl views (e.g. to place a base map under a view, or add a label on top of a view), deck.gl can make such components automatically adjust as that view is added, removed or resized.
 
-`DeckGL` injects its child elements with the following props:
+Each child element of `DeckGL` is positioned inside a view. All children of a view is wrapped in a DOM container that:
 
-* `x` - the left offset of the current view, in pixels
-* `y` - the top offset of the current view, in pixels
-* `width` - the width of the current view, in pixels
-* `height` - the height of the current view, in pixels
-* `viewState` - the view state of the current view
-* `viewport` - the `Viewport` instance of the current view
-
-If the element is a direct child of `DeckGL`, the current view is the default (first) view.
-If the element is nested under a `<View>` tag, the current view is the one corresponding to the containing View's `id` prop.
-
-Each element is wrapped in a DOM container that:
-
-* is offset to be relative to the deck.gl view with the corresponding view id.
+* is offset to be relative to the deck.gl view that it corresponds to.
 * is resized to match the extent of the deck.gl view with the corresponding view id.
+* is hidden if the view id is missing from `DeckGL`'s `views` prop.
+
+The containing view of each element is determined as follows:
+
+- If the element is a direct child of `DeckGL`, it is positioned inside the default (first) view.
+- If the element is nested under a `<View id={id}>` tag, it is positioned inside the view corresponding to the `id` prop. 
 
 
 #### Render callbacks

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -45,6 +45,18 @@
   + `METERS`: use `METER_OFFSETS`
 
 
+##### React
+
+- `DeckGL` no longer injects its children with view props (`width`, `height`, `viewState` etc.). If your custom component needs these props, consider using the [ContextProvider](/docs/api-reference/react/deckgl.md#react-context) or a render callback:
+
+  ```jsx
+  <DeckGL>
+    {({width, height, viewState}) => (...)}
+  </DeckGL>
+  ```
+
+- The children of `DeckGL` are now placed above the canvas by default (except the react-map-gl base map). Wrap them in e.g. `<div style={{zIndex: -1}}>` if they are intended to be placed behind the canvas.
+
 ##### Debugging
 
 deck.gl now removes most logging when bundling under `NODE_ENV=production`.

--- a/examples/layer-browser/src/map.js
+++ b/examples/layer-browser/src/map.js
@@ -17,17 +17,16 @@ const MapboxAccessToken =
 
 const NAVIGATION_CONTROL_STYLES = {
   margin: 10,
-  position: 'absolute',
-  zIndex: 1
+  position: 'absolute'
 };
 
 const VIEW_LABEL_STYLES = {
-  zIndex: 10,
   padding: 5,
   margin: 20,
   fontSize: 12,
   backgroundColor: '#282727',
-  color: '#FFFFFF'
+  color: '#FFFFFF',
+  position: 'absolute'
 };
 
 const INITIAL_VIEW_STATES = {
@@ -47,11 +46,7 @@ const INITIAL_VIEW_STATES = {
   }
 };
 
-const ViewportLabel = props => (
-  <div style={{position: 'absolute'}}>
-    <div style={{...VIEW_LABEL_STYLES, display: ''}}>{props.children}</div>
-  </div>
-);
+const ViewportLabel = props => <div style={VIEW_LABEL_STYLES}>{props.children}</div>;
 
 export default class Map extends PureComponent {
   constructor(props) {

--- a/modules/core/src/controllers/transition-manager.js
+++ b/modules/core/src/controllers/transition-manager.js
@@ -115,7 +115,9 @@ export default class TransitionManager {
 
     // update transitionDuration for 'auto' mode
     const {transitionInterpolator} = endProps;
-    const duration = transitionInterpolator.getDuration(startProps, endProps);
+    const duration = transitionInterpolator.getDuration
+      ? transitionInterpolator.getDuration(startProps, endProps)
+      : endProps.transitionDuration;
 
     const initialProps = endProps.transitionInterpolator.initializeProps(
       startProps,

--- a/modules/react/src/deckgl.js
+++ b/modules/react/src/deckgl.js
@@ -41,6 +41,7 @@ export default class DeckGL extends React.Component {
 
     // Refs
     this._containerRef = React.createRef();
+    this._canvasRef = React.createRef();
 
     // Bind public methods
     this.pickObject = this.pickObject.bind(this);
@@ -63,6 +64,7 @@ export default class DeckGL extends React.Component {
       new DeckClass(
         Object.assign({}, this.props, {
           parent: this._containerRef.current,
+          canvas: this._canvasRef.current,
           style: null,
           width: '100%',
           height: '100%',
@@ -195,8 +197,16 @@ export default class DeckGL extends React.Component {
       this.props.style
     );
 
+    const canvas = createElement('canvas', {
+      key: 'canvas',
+      ref: this._canvasRef
+    });
+
     // Render deck.gl as the last child
-    return createElement('div', {id: 'deckgl-wrapper', ref: this._containerRef, style}, children);
+    return createElement('div', {id: 'deckgl-wrapper', ref: this._containerRef, style}, [
+      canvas,
+      children
+    ]);
   }
 }
 

--- a/modules/react/src/utils/evaluate-children.js
+++ b/modules/react/src/utils/evaluate-children.js
@@ -1,5 +1,7 @@
 import {cloneElement} from 'react';
 
+const MAP_STYLE = {position: 'absolute', zIndex: -1};
+
 export default function evaluateChildren(children, childProps) {
   if (!children) {
     return children;
@@ -10,5 +12,19 @@ export default function evaluateChildren(children, childProps) {
   if (Array.isArray(children)) {
     return children.map(child => evaluateChildren(child, childProps));
   }
-  return cloneElement(children, childProps);
+
+  // Special treatment for react-map-gl's Map component
+  // to support shorthand use case <DeckGL><StaticMap /></DeckGL>
+  if (isReactMap(children)) {
+    // Place map under the canvas
+    childProps.style = MAP_STYLE;
+    return cloneElement(children, childProps);
+  }
+  return children;
+}
+
+function isReactMap(child) {
+  const componentClass = child && child.type;
+  const componentProps = componentClass && componentClass.defaultProps;
+  return componentProps && componentProps.mapStyle;
 }

--- a/modules/react/src/utils/position-children-under-views.js
+++ b/modules/react/src/utils/position-children-under-views.js
@@ -1,5 +1,5 @@
 import {createElement} from 'react';
-import {View, log} from '@deck.gl/core';
+import {View} from '@deck.gl/core';
 import {inheritsFrom} from './inherits-from';
 import evaluateChildren from './evaluate-children';
 
@@ -12,16 +12,11 @@ export default function positionChildrenUnderViews({children, viewports, deck, C
     return [];
   }
 
+  const views = {};
   const defaultViewId = viewManager.views[0].id;
 
-  return children.map((child, i) => {
-    if (child.props.viewportId) {
-      log.removed('viewportId', '<View>')();
-    }
-    if (child.props.viewId) {
-      log.removed('viewId', '<View>')();
-    }
-
+  // Sort children by view id
+  for (const child of children) {
     // Unless child is a View, position / render as part of the default view
     let viewId = defaultViewId;
     let viewChildren = child;
@@ -30,38 +25,46 @@ export default function positionChildrenUnderViews({children, viewports, deck, C
       viewId = child.props.id || defaultViewId;
       viewChildren = child.props.children;
     }
-    const childStyle = viewChildren && viewChildren.props && viewChildren.props.style;
 
     const viewport = viewManager.getViewport(viewId);
     const viewState = viewManager.getViewState(viewId);
 
     // Drop (auto-hide) elements with viewId that are not matched by any current view
-    if (!viewport) {
-      return null;
+    if (viewport) {
+      const {x, y, width, height} = viewport;
+      // Resolve potentially relative dimensions using the deck.gl container size
+      viewChildren = evaluateChildren(viewChildren, {
+        x,
+        y,
+        width,
+        height,
+        viewport,
+        viewState
+      });
+
+      if (!views[viewId]) {
+        views[viewId] = {
+          viewport,
+          children: []
+        };
+      }
+      views[viewId].children.push(viewChildren);
     }
+  }
 
-    // Resolve potentially relative dimensions using the deck.gl container size
-    const {x, y, width, height} = viewport;
-
-    viewChildren = evaluateChildren(viewChildren, {
-      x,
-      y,
-      width,
-      height,
-      viewport,
-      viewState
-    });
-
+  // Render views
+  return Object.keys(views).map(viewId => {
+    const {viewport: {x, y, width, height}} = views[viewId];
+    let viewChildren = views[viewId].children;
     const style = {
       position: 'absolute',
-      // Use child's z-index for ordering
-      zIndex: childStyle ? childStyle.zIndex : -1,
       left: x,
       top: y,
       width,
       height
     };
-    const key = `view-child-${viewId}-${i}`;
+
+    const key = `view-${viewId}`;
 
     if (ContextProvider) {
       const contextValue = {

--- a/modules/react/src/utils/position-children-under-views.js
+++ b/modules/react/src/utils/position-children-under-views.js
@@ -54,7 +54,8 @@ export default function positionChildrenUnderViews({children, viewports, deck, C
 
   // Render views
   return Object.keys(views).map(viewId => {
-    const {viewport: {x, y, width, height}} = views[viewId];
+    const {viewport} = views[viewId];
+    const {x, y, width, height} = viewport;
     let viewChildren = views[viewId].children;
     const style = {
       position: 'absolute',

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "raw-loader": "^0.5.1",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "react-map-gl": "^4.1.2",
+    "react-map-gl": "^5.1.0",
     "reify": "^0.18.1"
   },
   "pre-commit": [

--- a/test/modules/react/utils/evaluate-children.spec.js
+++ b/test/modules/react/utils/evaluate-children.spec.js
@@ -1,6 +1,7 @@
 import test from 'tape-catch';
 import evaluateChildren from '@deck.gl/react/utils/evaluate-children';
 import React, {createElement} from 'react';
+import {StaticMap} from 'react-map-gl';
 
 const TEST_CHILD_PROPS = {zIndex: 1};
 
@@ -29,6 +30,14 @@ const TEST_CASES = [
     count: 2,
     expected: {
       className: 'test',
+      zIndex: undefined
+    }
+  },
+  {
+    title: 'react-map-gl Map',
+    input: createElement(StaticMap),
+    count: 1,
+    expected: {
       zIndex: 1
     }
   }

--- a/test/modules/react/utils/position-children-under-views.spec.js
+++ b/test/modules/react/utils/position-children-under-views.spec.js
@@ -62,30 +62,21 @@ test('positionChildrenUnderViews', t => {
     children: TEST_CHILDREN,
     deck: {viewManager: dummyViewManager}
   });
-  t.is(children.length, 4, 'Returns wrapped children');
+  t.is(children.length, 2, 'Returns wrapped children');
 
-  t.notOk(children[0], 'Invisible view');
-  t.ok(children[1].key && children[2].key && children[3].key, 'Wrapper components have keys');
-  t.is(children[1].props.style.left, 0, 'Wrapper component has x position');
-  t.is(children[2].props.style.left, 400, 'Wrapper component has x position');
-  t.is(children[2].props.style.zIndex, 1, 'Wrapper component has z-index');
-  t.is(children[3].props.style.zIndex, 2, 'Wrapper component has z-index');
+  t.is(children[0].key, 'view-map', 'Has map view');
+  t.is(children[1].key, 'view-ortho', 'Has orthographic view');
+  t.is(children[0].props.style.left, 0, 'Wrapper component has x position');
+  t.is(children[1].props.style.left, 400, 'Wrapper component has x position');
 
-  let wrappedChild = children[1].props.children;
-  t.is(wrappedChild.props.id, 'function-under-view', 'function child preserves id');
-  t.is(wrappedChild.props.width, 400, 'function child has width');
-  t.is(wrappedChild.props.viewState, TEST_VIEW_STATES.map, 'function child has viewState');
+  let wrappedChild = children[0].props.children;
+  t.is(wrappedChild[0].props.id, 'function-under-view', 'function child preserves id');
+  t.is(wrappedChild[0].props.width, 400, 'function child has width');
+  t.is(wrappedChild[0].props.viewState, TEST_VIEW_STATES.map, 'function child has viewState');
+  t.is(wrappedChild[1].props.id, 'element-without-view', 'element child preserves id');
 
-  wrappedChild = children[2].props.children;
-  t.is(wrappedChild.props.id, 'element-under-view', 'element child preserves id');
-  t.is(wrappedChild.props.width, 400, 'element child has width');
-  t.is(wrappedChild.props.viewState, TEST_VIEW_STATES.ortho, 'element child has viewState');
-
-  wrappedChild = children[3].props.children;
-  t.is(wrappedChild.props.id, 'element-without-view', 'element child preserves id');
-  t.is(wrappedChild.props.width, 400, 'element child has width');
-  t.is(wrappedChild.props.viewState, TEST_VIEW_STATES.map, 'element child has viewState');
-
+  wrappedChild = children[1].props.children;
+  t.is(wrappedChild[0].props.id, 'element-under-view', 'element child preserves id');
   t.end();
 });
 
@@ -101,13 +92,13 @@ test('positionChildrenUnderViews#ContextProvider', t => {
     ContextProvider: context.Provider
   });
 
-  t.notOk(children[0], 'Invisible view');
+  t.is(children.length, 2, 'Returns wrapped children');
 
-  let wrappedChild = children[1].props.children;
+  let wrappedChild = children[0].props.children;
   t.is(wrappedChild.type, context.Provider, 'child is wrapped in ContextProvider');
   t.is(wrappedChild.props.value.viewport, TEST_VIEWPORTS.map, 'Context has viewport');
 
-  wrappedChild = children[2].props.children;
+  wrappedChild = children[1].props.children;
   t.is(wrappedChild.type, context.Provider, 'child is wrapped in ContextProvider');
   t.is(wrappedChild.props.value.viewport, TEST_VIEWPORTS.ortho, 'Context has viewport');
   t.end();


### PR DESCRIPTION

For #3983 

#### Change List
- Fix a crash when used with older versions of react-map-gl (missing `transitionInterpolator.getDuration`)
- Behavioral change: (except the base map) all child elements default to render above the canvas. This removes the dependency on `child.props.style.zIndex` to position children.
- Behavioral change: (except the base map) no longer overwrites `child.props` with information from the current viewport (viewState, width, height, etc.). This removes React warning about unsupported div props. Components can still use `ContextProvider` or functional child to listen to viewport change.
- Only create one wrapper for each view. This improves performance when a lot of child elements are used.
- Unit tests
- Docs
