### PR TITLE
Support initialViewState updates

### DIFF
--- a/docs/api-reference/deck.md
+++ b/docs/api-reference/deck.md
@@ -127,8 +127,7 @@ Notes:
 
 * The `props.onViewStateChange` callback will still be called, if provided.
 * If `props.viewState` is supplied by the application, the supplied `viewState` will always be used, "shadowing" the `Deck` component's internal `viewState`.
-* In simple applications, use of the `initialViewState` prop can avoid the need track the view state in the application.
-* Any new `initialViewState` value is compared shallowly with the previous value. Therefore, it is especially important for React applications to use a constant or component state as the `initialViewState` value, in order to avoid any unexpected "reset" of the camera.
+* In simple applications, use of the `initialViewState` prop can avoid the need to track the view state in the application.
 * One drawback of using `initialViewState` for reactive/functional applications is that the `Deck` component becomes more stateful.
 
 ##### `controller` (Function | Boolean | Object)

--- a/docs/api-reference/deck.md
+++ b/docs/api-reference/deck.md
@@ -121,11 +121,14 @@ Transitions between two viewState objects can also be achieved by providing set 
 
 If `initialViewState` is provided, the `Deck` component will track view state changes from any attached `controller` using internal state, with `initialViewState` as its initial view state.
 
+If the `initialViewState` prop changes, the internally tracked view state will be updated to match the new "initial" view state.
+
 Notes:
 
 * The `props.onViewStateChange` callback will still be called, if provided.
 * If `props.viewState` is supplied by the application, the supplied `viewState` will always be used, "shadowing" the `Deck` component's internal `viewState`.
-* In simple applications, use of the `initialViewState` prop can avoid the need track the view state in the application .
+* In simple applications, use of the `initialViewState` prop can avoid the need track the view state in the application.
+* Any new `initialViewState` value is compared shallowly with the previous value. Therefore, it is especially important for React applications to use a constant or component state as the `initialViewState` value, in order to avoid any unexpected "reset" of the camera.
 * One drawback of using `initialViewState` for reactive/functional applications is that the `Deck` component becomes more stateful.
 
 ##### `controller` (Function | Boolean | Object)

--- a/examples/gallery/src/viewport-transition.html
+++ b/examples/gallery/src/viewport-transition.html
@@ -56,13 +56,12 @@
     const deckgl = new DeckGL({
       mapboxApiAccessToken: '<mapbox-access-token>',
       mapStyle: 'mapbox://styles/mapbox/light-v9',
-      viewState: {
+      initialViewState: {
         longitude: CITIES[0].longitude,
         latitude: CITIES[0].latitude,
         zoom: 10
       },
       controller: true,
-      onViewStateChange: ({viewState}) => deckgl.setProps({viewState}),
       layers: [
         new ScatterplotLayer({
           data: CITIES,
@@ -84,11 +83,11 @@
       .attr('id', (d, i) => 'city-' + i)
       .on('change', d => {
         deckgl.setProps({
-          viewState: {
+          initialViewState: {
             longitude: d.longitude,
             latitude: d.latitude,
             zoom: 10,
-            transitionInterpolator: new FlyToInterpolator(),
+            transitionInterpolator: new FlyToInterpolator({speed: 1.5}),
             transitionDuration: 'auto'
           }
         })

--- a/examples/playground/src/deck-with-maps.js
+++ b/examples/playground/src/deck-with-maps.js
@@ -3,31 +3,7 @@ import DeckGL from '@deck.gl/react';
 import {View} from '@deck.gl/core';
 
 export default class DeckWithMaps extends Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      // NOTE: viewState is re-initialized from jsonProps when those change,
-      // but can be updated independently by the user "panning".
-      viewState: props.initialViewState
-    };
-
-    this._onViewStateChange = this._onViewStateChange.bind(this);
-  }
-
-  componentDidUpdate(prevProps) {
-    if (this.props.initialViewState !== prevProps.initialViewState) {
-      this.setState({viewState: this.props.initialViewState});
-    }
-  }
-
-  _onViewStateChange({viewState}) {
-    // TODO - It would be cool to update the viewState here!
-    this.setState({viewState});
-  }
-
   render() {
-    const {viewState} = this.state;
     const {views = []} = this.props;
 
     const maps = [];
@@ -46,12 +22,7 @@ export default class DeckWithMaps extends Component {
     }
 
     return (
-      <DeckGL
-        id="json-deck"
-        {...this.props}
-        viewState={viewState}
-        onViewStateChange={this._onViewStateChange}
-      >
+      <DeckGL id="json-deck" {...this.props}>
         {maps}
       </DeckGL>
     );

--- a/examples/website/3d-tiles/app.js
+++ b/examples/website/3d-tiles/app.js
@@ -30,7 +30,7 @@ export default class App extends PureComponent {
     super(props);
 
     this.state = {
-      viewState: INITIAL_VIEW_STATE,
+      initialViewState: INITIAL_VIEW_STATE,
       attributions: []
     };
 
@@ -50,8 +50,8 @@ export default class App extends PureComponent {
   _centerViewOnTileset(tileset) {
     const {cartographicCenter, zoom} = tileset;
     this.setState({
-      viewState: {
-        ...this.state.viewState,
+      initialViewState: {
+        ...INITIAL_VIEW_STATE,
 
         // Update deck.gl viewState, moving the camera to the new tileset
         longitude: cartographicCenter[0],
@@ -61,11 +61,6 @@ export default class App extends PureComponent {
         pitch: INITIAL_VIEW_STATE.pitch
       }
     });
-  }
-
-  // Called by DeckGL when user interacts with the map
-  _onViewStateChange({viewState}) {
-    this.setState({viewState});
   }
 
   _renderTile3DLayer() {
@@ -79,19 +74,13 @@ export default class App extends PureComponent {
   }
 
   render() {
-    const {viewState} = this.state;
+    const {initialViewState} = this.state;
     const tile3DLayer = this._renderTile3DLayer();
     const {mapStyle = 'mapbox://styles/uberdata/cive485h000192imn6c6cc8fc'} = this.props;
 
     return (
       <div>
-        <DeckGL
-          layers={[tile3DLayer]}
-          initialViewState={INITIAL_VIEW_STATE}
-          viewState={viewState}
-          onViewStateChange={this._onViewStateChange.bind(this)}
-          controller={true}
-        >
+        <DeckGL layers={[tile3DLayer]} initialViewState={initialViewState} controller={true}>
           <StaticMap mapStyle={mapStyle} mapboxApiAccessToken={MAPBOX_TOKEN} preventStyleDiffing />
         </DeckGL>
       </div>

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -146,7 +146,7 @@ export default class Deck {
     // This object is reused for subsequent `onClick` and `onDrag*` callbacks.
     this._lastPointerDownInfo = null;
 
-    this.viewState = props.initialViewState || null; // Internal view state if no callback is supplied
+    this.viewState = null; // Internal view state if no callback is supplied
     this.interactiveState = {
       isDragging: false // Whether the cursor is down
     };
@@ -237,6 +237,7 @@ export default class Deck {
     }
   }
 
+  /* eslint-disable complexity */
   setProps(props) {
     this.stats.get('setProps Time').timeStart();
 
@@ -245,6 +246,10 @@ export default class Deck {
     }
     if ('onLayerClick' in props) {
       log.removed('onLayerClick', 'onClick')();
+    }
+    if (props.initialViewState && this.props.initialViewState !== props.initialViewState) {
+      // Overwrite internal view state
+      this.viewState = props.initialViewState;
     }
 
     // Merge with existing props
@@ -276,6 +281,7 @@ export default class Deck {
 
     this.stats.get('setProps Time').timeEnd();
   }
+  /* eslint-enable complexity */
 
   // Public API
   // Check if a redraw is needed

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -27,6 +27,7 @@ import DeckRenderer from './deck-renderer';
 import DeckPicker from './deck-picker';
 import Tooltip from './tooltip';
 import log from '../utils/log';
+import {deepEqual} from '../utils/deep-equal';
 import deckGlobal from './init';
 
 import {getBrowser} from 'probe.gl/env';
@@ -237,7 +238,6 @@ export default class Deck {
     }
   }
 
-  /* eslint-disable complexity */
   setProps(props) {
     this.stats.get('setProps Time').timeStart();
 
@@ -247,7 +247,7 @@ export default class Deck {
     if ('onLayerClick' in props) {
       log.removed('onLayerClick', 'onClick')();
     }
-    if (props.initialViewState && this.props.initialViewState !== props.initialViewState) {
+    if (props.initialViewState && !deepEqual(this.props.initialViewState, props.initialViewState)) {
       // Overwrite internal view state
       this.viewState = props.initialViewState;
     }
@@ -281,7 +281,6 @@ export default class Deck {
 
     this.stats.get('setProps Time').timeEnd();
   }
-  /* eslint-enable complexity */
 
   // Public API
   // Check if a redraw is needed

--- a/modules/core/src/utils/deep-equal.js
+++ b/modules/core/src/utils/deep-equal.js
@@ -1,13 +1,20 @@
-// Compare two objects, partial deep equal
+// Partial deep equal (only recursive on arrays)
 export function deepEqual(a, b) {
   if (a === b) {
     return true;
   }
-  // TODO - implement deep equal on view descriptors
-  return Object.keys(a).every(key => {
-    if (Array.isArray(a[key]) && Array.isArray(b[key])) {
-      return deepEqual(a[key], b[key]);
+  if (!a || !b) {
+    return false;
+  }
+  for (const key in a) {
+    const aValue = a[key];
+    const bValue = b[key];
+    const equals =
+      aValue === bValue ||
+      (Array.isArray(aValue) && Array.isArray(bValue) && deepEqual(aValue, bValue));
+    if (!equals) {
+      return false;
     }
-    return a[key] === b[key];
-  });
+  }
+  return true;
 }


### PR DESCRIPTION
#### Background

We currently have two models of view state management:

- Stateless:

  ```jsx
  <DeckGL controller={true}
      viewState={this.state.viewState}
      onViewStateChange={({viewState}) => this.setState({viewState})} />
  ```

- Stateful

  ```jsx
  <DeckGL controller={true}
      internalViewState={INITIAL_VIEWSTATE} />
  ```

Currently, if the user wants to manipulate the view state outside of the controller at any time (e.g. click a button and fly to another city), they have to use the stateless model.

The main concern is that this breaks the reactive paradigm (potentially modifying props outside of the React render cycle). Maybe we don't expose this method on the React component?

Related: [Imperative API RFC](https://github.com/uber/deck.gl/blob/master/dev-docs/RFCs/v7.x/imperative-api-rfc.md)

#### Change List
- Add `deck.setViewState` and `DeckGL.setViewState`
- Docs
- Update tile-3d and playground examples to use the new API
