### PR TITLE
Layer bug fixes

### DIFF
--- a/modules/aggregation-layers/src/grid-aggregation-layer.js
+++ b/modules/aggregation-layers/src/grid-aggregation-layer.js
@@ -153,7 +153,7 @@ export default class GridAggregationLayer extends AggregationLayer {
       case COORDINATE_SYSTEM.LNGLAT_DEPRECATED:
         worldOrigin = [-180, -90]; // Origin used to define grid cell boundaries
         break;
-      case COORDINATE_SYSTEM.IDENTITY:
+      case COORDINATE_SYSTEM.CARTESIAN:
         const {width, height} = this.context.viewport;
         worldOrigin = [-width / 2, -height / 2]; // Origin used to define grid cell boundaries
         break;
@@ -299,7 +299,7 @@ export default class GridAggregationLayer extends AggregationLayer {
 
   _getGridOffset(opts) {
     const {cellSize, boundingBox} = this.state;
-    if (opts.props.coordinateSystem === COORDINATE_SYSTEM.IDENTITY) {
+    if (opts.props.coordinateSystem === COORDINATE_SYSTEM.CARTESIAN) {
       return {xOffset: cellSize, yOffset: cellSize};
     }
     return getGridOffset(boundingBox, cellSize);

--- a/modules/core/src/effects/lighting/point-light.js
+++ b/modules/core/src/effects/lighting/point-light.js
@@ -33,7 +33,7 @@ export class PointLight {
       coordinateOrigin,
       fromCoordinateSystem: viewport.isGeospatial
         ? COORDINATE_SYSTEM.LNGLAT
-        : COORDINATE_SYSTEM.IDENTITY,
+        : COORDINATE_SYSTEM.CARTESIAN,
       fromCoordinateOrigin: [0, 0, 0]
     });
     projectedLight.color = this.color;

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -293,30 +293,6 @@ export default class Layer extends Component {
         attributeManager.invalidateAll();
       }
     }
-
-    // Picking module parameters
-    const {autoHighlight, highlightedObjectIndex, highlightColor} = props;
-    if (
-      oldProps.autoHighlight !== autoHighlight ||
-      oldProps.highlightedObjectIndex !== highlightedObjectIndex ||
-      oldProps.highlightColor !== highlightColor
-    ) {
-      const parameters = {};
-      if (!autoHighlight) {
-        parameters.pickingSelectedColor = null;
-      }
-      // TODO - fix in luma?
-      highlightColor[3] = highlightColor[3] || 255;
-      parameters.pickingHighlightColor = highlightColor;
-
-      // highlightedObjectIndex will overwrite any settings from auto highlighting.
-      if (Number.isInteger(highlightedObjectIndex)) {
-        parameters.pickingSelectedColor =
-          highlightedObjectIndex >= 0 ? this.encodePickingColor(highlightedObjectIndex) : null;
-      }
-
-      this.setModuleParameters(parameters);
-    }
   }
 
   // Called once when layer is no longer matched and state will be discarded
@@ -597,6 +573,7 @@ export default class Layer extends Component {
     for (const extension of this.props.extensions) {
       extension.updateState.call(this, updateParams, extension);
     }
+    this._updateModules(updateParams);
     // End subclass lifecycle methods
 
     if (this.isComposite) {
@@ -756,6 +733,31 @@ export default class Layer extends Component {
   }
 
   // PRIVATE METHODS
+  _updateModules({props, oldProps}) {
+    // Picking module parameters
+    const {autoHighlight, highlightedObjectIndex, highlightColor} = props;
+    if (
+      oldProps.autoHighlight !== autoHighlight ||
+      oldProps.highlightedObjectIndex !== highlightedObjectIndex ||
+      oldProps.highlightColor !== highlightColor
+    ) {
+      const parameters = {};
+      if (!autoHighlight) {
+        parameters.pickingSelectedColor = null;
+      }
+      // TODO - fix in luma?
+      highlightColor[3] = highlightColor[3] || 255;
+      parameters.pickingHighlightColor = highlightColor;
+
+      // highlightedObjectIndex will overwrite any settings from auto highlighting.
+      if (Number.isInteger(highlightedObjectIndex)) {
+        parameters.pickingSelectedColor =
+          highlightedObjectIndex >= 0 ? this.encodePickingColor(highlightedObjectIndex) : null;
+      }
+
+      this.setModuleParameters(parameters);
+    }
+  }
 
   _getUpdateParams() {
     return {

--- a/modules/core/src/shaderlib/project/project-functions.js
+++ b/modules/core/src/shaderlib/project/project-functions.js
@@ -81,7 +81,7 @@ export function getWorldPosition(
         offsetMode
       );
 
-    case COORDINATE_SYSTEM.IDENTITY:
+    case COORDINATE_SYSTEM.CARTESIAN:
     default:
       return viewport.projectPosition([x, y, z]);
   }
@@ -133,7 +133,7 @@ export function projectPosition(position, params) {
 
     case COORDINATE_SYSTEM.LNGLAT:
     case COORDINATE_SYSTEM.LNGLAT_DEPRECATED:
-    case COORDINATE_SYSTEM.IDENTITY:
+    case COORDINATE_SYSTEM.CARTESIAN:
     default:
       return getWorldPosition(position, {
         viewport,

--- a/modules/geo-layers/src/great-circle-layer/great-circle-vertex.glsl.js
+++ b/modules/geo-layers/src/great-circle-layer/great-circle-vertex.glsl.js
@@ -24,8 +24,10 @@ export default `\
 attribute vec3 positions;
 attribute vec4 instanceSourceColors;
 attribute vec4 instanceTargetColors;
-attribute vec4 instancePositions;
-attribute vec4 instancePositions64Low;
+attribute vec3 instanceSourcePositions;
+attribute vec3 instanceSourcePositions64Low;
+attribute vec3 instanceTargetPositions;
+attribute vec3 instanceTargetPositions64Low;
 attribute vec3 instancePickingColors;
 attribute float instanceWidths;
 
@@ -84,8 +86,8 @@ vec2 interpolate (vec2 source, vec2 target, float angularDist, float t) {
 }
 
 void main(void) {
-  geometry.worldPosition = vec3(instancePositions.xy, 0.0);
-  geometry.worldPositionAlt = vec3(instancePositions.zw, 0.0);
+  geometry.worldPosition = instanceSourcePositions;
+  geometry.worldPositionAlt = instanceTargetPositions;
 
   float segmentIndex = positions.x;
   float segmentRatio = getSegmentRatio(segmentIndex);
@@ -98,16 +100,16 @@ void main(void) {
   float indexDir = mix(-1.0, 1.0, step(segmentIndex, 0.0));
   float nextSegmentRatio = getSegmentRatio(segmentIndex + indexDir);
   
-  vec2 source = radians(instancePositions.xy);
-  vec2 target = radians(instancePositions.zw);
+  vec2 source = radians(instanceSourcePositions.xy);
+  vec2 target = radians(instanceTargetPositions.xy);
   
   float angularDist = getAngularDist(source, target);
 
   vec3 currPos = vec3(degrees(interpolate(source, target, angularDist, segmentRatio)), 0.0);
   vec3 nextPos = vec3(degrees(interpolate(source, target, angularDist, nextSegmentRatio)), 0.0);
 
-  vec3 currPos64Low = vec3(mix(instancePositions64Low.xy, instancePositions64Low.zw, segmentRatio), 0.0);
-  vec3 nextPos64Low = vec3(mix(instancePositions64Low.xy, instancePositions64Low.zw, nextSegmentRatio), 0.0);
+  vec3 currPos64Low = mix(instanceSourcePositions64Low, instanceTargetPositions64Low, segmentRatio);
+  vec3 nextPos64Low = mix(instanceSourcePositions64Low, instanceTargetPositions64Low, nextSegmentRatio);
 
   vec4 curr = project_position_to_clipspace(currPos, currPos64Low, vec3(0.0), geometry.position);
   vec4 next = project_position_to_clipspace(nextPos, nextPos64Low, vec3(0.0));

--- a/modules/geo-layers/src/tile-layer/tile-layer.js
+++ b/modules/geo-layers/src/tile-layer/tile-layer.js
@@ -4,12 +4,12 @@ import {GeoJsonLayer} from '@deck.gl/layers';
 import TileCache from './utils/tile-cache';
 
 const defaultProps = {
-  renderSubLayers: {type: 'function', value: props => new GeoJsonLayer(props)},
-  getTileData: {type: 'function', value: ({x, y, z}) => Promise.resolve(null)},
+  renderSubLayers: {type: 'function', value: props => new GeoJsonLayer(props), compare: false},
+  getTileData: {type: 'function', value: ({x, y, z}) => Promise.resolve(null), compare: false},
   // TODO - change to onViewportLoad to align with Tile3DLayer
-  onViewportLoad: {type: 'function', optional: true, value: null},
+  onViewportLoad: {type: 'function', optional: true, value: null, compare: false},
   // eslint-disable-next-line
-  onTileError: {type: 'function', value: err => console.error(err)},
+  onTileError: {type: 'function', value: err => console.error(err), compare: false},
   maxZoom: null,
   minZoom: 0,
   maxCacheSize: null

--- a/modules/geo-layers/src/tile-layer/tile-layer.js
+++ b/modules/geo-layers/src/tile-layer/tile-layer.js
@@ -51,8 +51,8 @@ export default class TileLayer extends CompositeLayer {
         onTileError: this._onTileError.bind(this)
       });
       this.setState({tileCache});
-    } else if (changeFlags.updateTriggersChanged) {
-      // if any updateTriggersChanged (other than getTileData), delete the layer
+    } else if (changeFlags.propsChanged) {
+      // if any props changed, delete the cached layers
       this.state.tileCache.tiles.forEach(tile => {
         tile.layer = null;
       });

--- a/modules/layers/src/bitmap-layer/bitmap-layer-vertex.js
+++ b/modules/layers/src/bitmap-layer/bitmap-layer-vertex.js
@@ -17,5 +17,8 @@ void main(void) {
   DECKGL_FILTER_GL_POSITION(gl_Position, geometry);
 
   vTexCoord = texCoords;
+
+  vec4 color = vec4(0.0);
+  DECKGL_FILTER_COLOR(color, geometry);
 }
 `;

--- a/website/contents/pages.js
+++ b/website/contents/pages.js
@@ -711,10 +711,6 @@ export const docPages = generatePath([
           {
             name: 'JSONConverter',
             content: getDocUrl('api-reference/json/json-converter.md')
-          },
-          {
-            name: 'JSONLayer',
-            content: getDocUrl('api-reference/json/json-layer.md')
           }
         ]
       },

--- a/website/package.json
+++ b/website/package.json
@@ -13,7 +13,6 @@
     "lint": "eslint src --ignore-pattern workers"
   },
   "dependencies": {
-    "@deck.gl/core": "^7.3.6",
     "@loaders.gl/csv": "^2.0.0-beta.5",
     "@loaders.gl/core": "^2.0.0-beta.5",
     "@loaders.gl/draco": "^2.0.0-beta.5",
@@ -32,7 +31,7 @@
     "prop-types": "^15.5.8",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.0",
+    "react-map-gl": "^5.1.0",
     "react-redux": "^4.4.5",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.3.1",


### PR DESCRIPTION
For #3983 

#### Change List
- Remove reference to deprecated `COORDINATE_SYSTEM.IDENTITY` (fixes console warning)
- Move picking highlight related code out of `updateState()`. It depends on `this.getModels()` being populated, but we don't have control over whether or when `super.updateState()` is called by the layer. (fixes `BitmapLayer` autohighlight)
- Add `DECKGL_FILTER_COLOR` hook to `BitmapLayer` vertex shader (fixes picking)
- Update `GreatCircleLayer` vertex shader (base layer changed to use vec3 64low attributes)
- Rerender sublayers when `TileLayer`'s props change