### PR TITLE
Fix gallery examples

### DIFF
--- a/examples/gallery/src/icon-layer.html
+++ b/examples/gallery/src/icon-layer.html
@@ -29,7 +29,7 @@
 
   <script type="text/javascript">
 
-    const {DeckGL, IconLayer, LineLayer, ScatterplotLayer, TextLayer, COORDINATE_SYSTEM} = deck;
+    const {DeckGL, OrthographicView, IconLayer, LineLayer, ScatterplotLayer, TextLayer, COORDINATE_SYSTEM} = deck;
 
     const deckgl =  new DeckGL({
       views: new OrthographicView(),

--- a/examples/gallery/src/point-cloud-layer.html
+++ b/examples/gallery/src/point-cloud-layer.html
@@ -18,7 +18,7 @@
 
   <script type="text/javascript">
 
-    const {DeckGL, PointCloudLayer, COORDINATE_SYSTEM} = deck;
+    const {DeckGL, OrbitView, PointCloudLayer, COORDINATE_SYSTEM} = deck;
 
     // One million points
     const SAMPLE_SIZE = 1e6;
@@ -64,7 +64,7 @@
 
     new DeckGL({
       views: [new OrbitView()],
-      initialViewState: {rotationX: -45, rotationOrbit: -45, zoom: 5},
+      initialViewState: {rotationX: 45, rotationOrbit: -45, zoom: 5},
       controller: true,
       layers: [
         new PointCloudLayer({

--- a/examples/gallery/src/viewport-transition.html
+++ b/examples/gallery/src/viewport-transition.html
@@ -56,12 +56,13 @@
     const deckgl = new DeckGL({
       mapboxApiAccessToken: '<mapbox-access-token>',
       mapStyle: 'mapbox://styles/mapbox/light-v9',
-      initialViewState: {
+      viewState: {
         longitude: CITIES[0].longitude,
         latitude: CITIES[0].latitude,
         zoom: 10
       },
       controller: true,
+      onViewStateChange: ({viewState}) => deckgl.setProps({viewState}),
       layers: [
         new ScatterplotLayer({
           data: CITIES,
@@ -88,7 +89,7 @@
             latitude: d.latitude,
             zoom: 10,
             transitionInterpolator: new FlyToInterpolator(),
-            transitionDuration: 5000
+            transitionDuration: 'auto'
           }
         })
       });


### PR DESCRIPTION

For #3983 

Broken by https://github.com/uber/deck.gl/pull/3992 (no longer exposes all exports globally) and https://github.com/uber/deck.gl/pull/3880 (no longer adds auto controller)