### PR TITLE
Fix bundle transpilation

### DIFF
--- a/modules/core/bundle/deckgl.js
+++ b/modules/core/bundle/deckgl.js
@@ -1,6 +1,6 @@
 /* global window, document */
 /* eslint-disable max-statements */
-import Mapbox from 'react-map-gl/dist/es6/mapbox/mapbox';
+import Mapbox from 'react-map-gl/dist/esm/mapbox/mapbox';
 
 import {Deck} from '../src';
 

--- a/modules/main/bundle.js
+++ b/modules/main/bundle.js
@@ -8,8 +8,7 @@ Object.assign(
   require('@deck.gl/geo-layers'),
   require('@deck.gl/google-maps'),
   require('@deck.gl/mesh-layers'),
-  require('@deck.gl/mapbox'),
-  require('@deck.gl/json')
+  require('@deck.gl/mapbox')
 );
 
 module.exports = deck;

--- a/website/package.json
+++ b/website/package.json
@@ -21,6 +21,7 @@
     "@tweenjs/tween.js": "^16.7.0",
     "autobind-decorator": "^1.3.3",
     "baseui": "^8.5.1",
+    "core-js": "^3.0.0",
     "d3-color": "^1.0.1",
     "d3-request": "^1.0.2",
     "d3-scale": "^1.0.6",

--- a/website/webpack.config.js
+++ b/website/webpack.config.js
@@ -15,7 +15,7 @@ const ALIASES = require('ocular-dev-tools/config/ocular.config')({
 // https://github.com/babel/babel-loader/issues/149#issuecomment-191991686
 const BABEL_CONFIG = {
   // https://babeljs.io/docs/en/babel-polyfill#size
-  presets: [['@babel/preset-env', {useBuiltIns: 'usage'}], '@babel/preset-react'],
+  presets: [['@babel/preset-env', {useBuiltIns: 'usage', corejs: 3}], '@babel/preset-react'],
   plugins: [
     ['@babel/plugin-proposal-decorators', {legacy: true}],
     ['@babel/plugin-proposal-class-properties', {loose: true}],


### PR DESCRIPTION

For #3983 

#### Change List
- Replace imported es6 code with esm
- Drop unused `@deck.gl/json` from the main bundle (jupyter-widget is building its own bundle), dependency expression-eval is causing issues
- Fix website build warnings
