### PR TITLE
Fix React wrapper z-index

### DIFF
--- a/modules/react/src/deckgl.js
+++ b/modules/react/src/deckgl.js
@@ -193,7 +193,14 @@ export default class DeckGL extends React.Component {
 
     // This styling is enforced for correct positioning with children
     const style = Object.assign(
-      {position: 'absolute', left: 0, top: 0, width: this.props.width, height: this.props.height},
+      {
+        position: 'absolute',
+        zIndex: 0,
+        left: 0,
+        top: 0,
+        width: this.props.width,
+        height: this.props.height
+      },
       this.props.style
     );
 


### PR DESCRIPTION
For #3983 

Fixes a website issue where the map is displayed behind the container div's background

#### Change List
- Set the React wrapper's z-index
