### PR TITLE
Warn if initialViewState and viewState are both present

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -113,7 +113,9 @@ new Model({
 });
 ```
 
-##### Multi-view state handling
+##### Auto view state update
+
+A bug was fixed where initial view state tracking could sometimes overwrite user-provided `viewState` prop. Apps that rely on auto view state update by specifying `initialViewState` should make sure that `viewState` is never assigned. If manual view state update is desired, use `viewState` and `onViewStateChange` instead. See [developer guide](/docs/developer-guide/views.md#using-a-view-class-with-view-state) for examples.
 
 We have fixed a bug when using `initialViewState` with multiple views. In the past, the state change in one view is unintendedly propagated to all views. As a result of this fix, multiple views (e.g. mini map) are no longer synchronized by default. To synchronize them, define the views with an explicit `viewState.id`:
 

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -29,6 +29,7 @@ import Tooltip from './tooltip';
 import log from '../utils/log';
 import deckGlobal from './init';
 
+import {getBrowser} from 'probe.gl/env';
 import GL from '@luma.gl/constants';
 import {
   AnimationLoop,
@@ -43,7 +44,7 @@ import {EventManager} from 'mjolnir.js';
 
 import assert from '../utils/assert';
 import {EVENTS} from './constants';
-/* global window, document */
+/* global document */
 
 function noop() {}
 
@@ -159,7 +160,12 @@ export default class Deck {
     this._onViewStateChange = this._onViewStateChange.bind(this);
     this._onInteractiveStateChange = this._onInteractiveStateChange.bind(this);
 
-    if (isIE11()) {
+    if (props.viewState && props.initialViewState) {
+      log.warn(
+        'View state tracking is disabled. Use either `initialViewState` for auto update or `viewState` for manual update.'
+      )();
+    }
+    if (getBrowser() === 'IE') {
       log.warn('IE 11 support will be deprecated in v8.0')();
     }
 
@@ -807,15 +813,6 @@ export default class Deck {
     metrics.renderbufferMemory = memoryStats.get('Renderbuffer Memory').count;
     metrics.gpuMemory = memoryStats.get('GPU Memory').count;
   }
-}
-
-function isIE11() {
-  if (typeof window === undefined) {
-    return false;
-  }
-  const navigator = window.navigator || {};
-  const userAgent = navigator.userAgent || '';
-  return userAgent.indexOf('Trident/') !== -1;
 }
 
 Deck.getPropTypes = getPropTypes;


### PR DESCRIPTION
For #4075 

#### Change List
- Log warning if both `initialViewState` and `viewState` are both specified
- Add explanation to the upgrade guide
