### PR TITLE
Clean up hover handling

### DIFF
--- a/modules/core/src/lib/deck-picker.js
+++ b/modules/core/src/lib/deck-picker.js
@@ -30,7 +30,7 @@ import GL from '@luma.gl/constants';
 import assert from '../utils/assert';
 import PickLayersPass from '../passes/pick-layers-pass';
 import {getClosestObject, getUniqueObjects} from './picking/query-object';
-import {processPickInfo, callLayerPickingCallbacks, getLayerPickingInfo} from './picking/pick-info';
+import {processPickInfo, getLayerPickingInfo} from './picking/pick-info';
 
 export default class DeckPicker {
   constructor(gl) {
@@ -125,7 +125,6 @@ export default class DeckPicker {
     radius = 0,
     depth = 1,
     mode = 'query',
-    event,
     unproject3D,
     onViewportActive
   }) {
@@ -213,10 +212,10 @@ export default class DeckPicker {
         pixelRatio
       });
 
-      const processedPickInfos = callLayerPickingCallbacks(infos, mode, event);
-
-      if (processedPickInfos) {
-        processedPickInfos.forEach(info => result.push(info));
+      for (const info of infos.values()) {
+        if (info.layer) {
+          result.push(info);
+        }
       }
 
       // If no object is picked stop.

--- a/modules/core/src/lib/picking/pick-info.js
+++ b/modules/core/src/lib/picking/pick-info.js
@@ -149,35 +149,3 @@ function getViewportFromCoordinates({viewports}) {
   const viewport = viewports[0];
   return viewport;
 }
-
-// Per-layer event handlers (e.g. onClick, onHover) are provided by the
-// user and out of deck.gl's control. It's very much possible that
-// the user calls React lifecycle methods in these function, such as
-// ReactComponent.setState(). React lifecycle methods sometimes induce
-// a re-render and re-generation of props of deck.gl and its layers,
-// which invalidates all layers currently passed to this very function.
-
-// Therefore, per-layer event handlers must be invoked at the end
-// of the picking operation. NO operation that relies on the states of current
-// layers should be called after this code.
-export function callLayerPickingCallbacks(infos, mode, event) {
-  const unhandledPickInfos = [];
-
-  infos.forEach(info => {
-    if (!info.layer) {
-      return;
-    }
-
-    switch (mode) {
-      case 'hover':
-        info.handled = info.layer.onHover(info, event);
-        break;
-      case 'query':
-      default:
-    }
-
-    unhandledPickInfos.push(info);
-  });
-
-  return unhandledPickInfos;
-}


### PR DESCRIPTION
Move calling layer callbacks outside of `DeckPicker`. This makes the handling of hover events consistent with click, drag etc.
