### PR TITLE
Fix inline versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "deck.gl",
+  "name": "deck.gl-monorepo",
   "description": "A suite of 3D-enabled data visualization overlays, suitable for react-map-gl",
   "license": "MIT",
   "private": "true",


### PR DESCRIPTION
Found the reason root `version` script is not executed by lerna - root package.json cannot use a name that collides with one of the submodules.