### PR TITLE
@deck.gl/jupyter-widget: Change version variable for JupyterLab installation

### DIFF
--- a/modules/jupyter-widget/src/version.js
+++ b/modules/jupyter-widget/src/version.js
@@ -5,5 +5,16 @@
  * The html widget manager assumes that this is the same as the npm package
  * version number.
  */
-export const MODULE_VERSION = __VERSION__;
+let version;
+
+// JupyterLab path
+if (typeof __VERSION__ === 'undefined') {
+  const deck = require('../dist/index');
+  version = deck.version;
+} else {
+  // Standard build
+  version = __VERSION__;
+}
+
+export const MODULE_VERSION = version;
 export const MODULE_NAME = '@deck.gl/jupyter-widget';


### PR DESCRIPTION
The `version` variable needs to be defined in a way that it can be used by JupyterLab (which installs from the source code).

<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #3640
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
- Define `version` from the distribution bundle
