### PR TITLE
fix cursor style in React

### DIFF
--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -544,8 +544,9 @@ export default class Deck {
   }
 
   _updateCursor() {
-    if (this.canvas) {
-      this.canvas.style.cursor = this.props.getCursor(this.interactiveState);
+    const container = this.props.parent || this.canvas;
+    if (container) {
+      container.style.cursor = this.props.getCursor(this.interactiveState);
     }
   }
 


### PR DESCRIPTION
For #4116

`canvas` is behind view containers in v8.0.

#### Change List
- Assign cursor style to container element
