### PR TITLE
Fix support for luma.gl buffers as external attributes

### DIFF
--- a/docs/api-reference/layer.md
+++ b/docs/api-reference/layer.md
@@ -75,9 +75,11 @@ Each value in `data.attributes` may be one of the following formats:
 - An object containing the following optional fields. For more information, see [WebGL vertex attribute API](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/vertexAttribPointer).
   + `buffer` ([Buffer](https://luma.gl/docs/api-reference/webgl/buffer))
   + `value` (TypedArray)
+  + `type` (GLenum) - A WebGL data type, see [vertexAttribPointer](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/vertexAttribPointer#Parameters).
   + `size` (Number) - the number of elements per vertex attribute.
   + `offset` (Number) - offset of the first vertex attribute into the buffer, in bytes
   + `stride` (Number) - the offset between the beginning of consecutive vertex attributes, in bytes
+  + `normalized` (Boolean) - whether data values should be normalized. Note that all color attributes in deck.gl layers are normalized by default.
 
 **Remarks**
 

--- a/modules/core/src/lib/attribute/attribute.js
+++ b/modules/core/src/lib/attribute/attribute.js
@@ -246,10 +246,10 @@ export default class Attribute extends DataColumn {
     if (ArrayBuffer.isView(buffer)) {
       buffer = {value: buffer};
     }
-    assert(ArrayBuffer.isView(buffer.value), `invalid ${settings.accessor}`);
     const needsUpdate = settings.transform || startIndices !== this.startIndices;
 
     if (needsUpdate) {
+      assert(ArrayBuffer.isView(buffer.value), `invalid ${settings.accessor}`);
       const needsNormalize = buffer.size && buffer.size !== this.size;
 
       state.binaryAccessor = getAccessorFromBuffer(buffer.value, {

--- a/modules/core/src/lib/attribute/data-column.js
+++ b/modules/core/src/lib/attribute/data-column.js
@@ -216,7 +216,7 @@ export default class DataColumn {
       this.value = opts.value;
 
       // Copy the type of the buffer into the accessor
-      accessor.type = buffer.accessor.type;
+      accessor.type = opts.type || buffer.accessor.type;
       accessor.bytesPerElement = buffer.accessor.BYTES_PER_ELEMENT;
       accessor.stride = getStride(accessor);
     } else if (opts.value) {
@@ -243,7 +243,7 @@ export default class DataColumn {
       // Hack: force Buffer to infer data type
       buffer.setAccessor(null);
       buffer.subData({data: value, offset: byteOffset});
-      accessor.type = buffer.accessor.type;
+      accessor.type = opts.type || buffer.accessor.type;
     }
 
     return true;

--- a/modules/layers/src/solid-polygon-layer/polygon-tesselator.js
+++ b/modules/layers/src/solid-polygon-layer/polygon-tesselator.js
@@ -66,9 +66,8 @@ export default class PolygonTesselator extends Tesselator {
   }
 
   getGeometryFromBuffer(buffer) {
-    const getGeometry = super.getGeometryFromBuffer(buffer);
     if (this.normalize || !this.buffers.indices) {
-      return getGeometry;
+      return super.getGeometryFromBuffer(buffer);
     }
     // we don't need to read the positions if no normalization/tesselation
     return () => null;

--- a/test/modules/core/lib/attribute/attribute.spec.js
+++ b/test/modules/core/lib/attribute/attribute.spec.js
@@ -726,11 +726,23 @@ test('Attribute#setExternalBuffer', t => {
     }),
     'should set external buffer to attribute descriptor'
   );
-  const attributeAccessor = attribute.getAccessor();
+  let attributeAccessor = attribute.getAccessor();
   t.is(attributeAccessor.offset, 4, 'attribute accessor is updated');
   t.is(attributeAccessor.stride, 8, 'attribute accessor is updated');
   t.is(attribute.value, value1, 'external value is set');
   t.is(attributeAccessor.type, GL.FLOAT, 'attribute type is set correctly');
+
+  t.ok(
+    attribute.setExternalBuffer({
+      offset: 4,
+      stride: 8,
+      value: value1,
+      type: GL.UNSIGNED_BYTE
+    }),
+    'should set external buffer to attribute descriptor'
+  );
+  attributeAccessor = attribute.getAccessor();
+  t.is(attributeAccessor.type, GL.UNSIGNED_BYTE, 'attribute type is set correctly');
 
   buffer.delete();
   attribute.delete();
@@ -831,11 +843,6 @@ test('Attribute#setBinaryValue', t => {
   t.is(spy.callCount, 1, 'setData is called only once on the same data');
   t.notOk(attribute.needsUpdate(), 'attribute is updated');
 
-  t.throws(
-    () => attribute.setBinaryValue([0, 1, 2, 3]),
-    'should throw if external value is invalid'
-  );
-
   spy.reset();
   attribute.delete();
 
@@ -864,6 +871,11 @@ test('Attribute#setBinaryValue', t => {
   t.notOk(attribute.setBinaryValue(value), 'should require update');
   t.ok(attribute.state.binaryAccessor, 'binaryAccessor is assigned');
   t.ok(attribute.needsUpdate(), 'attribute still needs update');
+
+  t.throws(
+    () => attribute.setBinaryValue([0, 1, 2, 3]),
+    'should throw if external value is invalid'
+  );
 
   attribute.delete();
   t.end();


### PR DESCRIPTION

For #4114 

#### Change List
- Do not throw (in most cases) when `value` is missing from external buffer
- Allow external buffer to override the `type` accessor
