### PR TITLE
[react] explicitly set deck canvas position

### DIFF
--- a/modules/react/src/deckgl.js
+++ b/modules/react/src/deckgl.js
@@ -29,6 +29,11 @@ const propTypes = Deck.getPropTypes(PropTypes);
 
 const defaultProps = Deck.defaultProps;
 
+const CANVAS_STYLE = {
+  left: 0,
+  top: 0
+};
+
 export default class DeckGL extends React.Component {
   constructor(props) {
     super(props);
@@ -206,7 +211,8 @@ export default class DeckGL extends React.Component {
 
     const canvas = createElement('canvas', {
       key: 'canvas',
-      ref: this._canvasRef
+      ref: this._canvasRef,
+      style: CANVAS_STYLE
     });
 
     // Render deck.gl as the last child


### PR DESCRIPTION
For #4115

The default position of the canvas is not aligned top-left if the parent container has `text-align: center`.

#### Change List
- Explicitly set canvas position
