### PR TITLE
Error handling

### DIFF
--- a/docs/api-reference/deck.md
+++ b/docs/api-reference/deck.md
@@ -387,7 +387,7 @@ Callback arguments:
 
 ##### `onError` (Function, optional)
 
-Called if deck.gl encounters an error. If supplied, deck will attempt to render the rest of the scene instead of crashing.
+Called if deck.gl encounters an error. By default, deck logs the error to console and attempt to continue rendering the rest of the scene.
 
 Callback arguments:
 

--- a/docs/api-reference/deck.md
+++ b/docs/api-reference/deck.md
@@ -384,6 +384,17 @@ Callback arguments:
 * `gl` - the WebGL context.
 
 
+
+##### `onError` (Function, optional)
+
+Called if deck.gl encounters an error. If supplied, deck will attempt to render the rest of the scene instead of crashing.
+
+Callback arguments:
+
+* `error` ([Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error))
+* `source` - the source of the error, likely a Layer instance
+
+
 ##### `_onMetrics` (Function, optional) **Experimental**
 
 Called once every second with performance metrics.

--- a/modules/core/src/lib/deck-picker.js
+++ b/modules/core/src/lib/deck-picker.js
@@ -44,11 +44,16 @@ export default class DeckPicker {
       layerId: null,
       info: null
     };
+    this._onError = null;
   }
 
   setProps(props) {
     if ('layerFilter' in props) {
       this.layerFilter = props.layerFilter;
+    }
+
+    if ('onError' in props) {
+      this._onError = props.onError;
     }
   }
 
@@ -316,6 +321,7 @@ export default class DeckPicker {
     this.pickLayersPass.render({
       layers,
       layerFilter: this.layerFilter,
+      onError: this._onError,
       viewports,
       onViewportActive,
       pickingFBO,

--- a/modules/core/src/lib/deck-renderer.js
+++ b/modules/core/src/lib/deck-renderer.js
@@ -16,6 +16,7 @@ export default class DeckRenderer {
     this._needsRedraw = 'Initial render';
     this.renderBuffers = [];
     this.lastPostProcessEffect = null;
+    this._onError = null;
   }
 
   setProps(props) {
@@ -27,6 +28,10 @@ export default class DeckRenderer {
     if ('drawPickingColors' in props && this.drawPickingColors !== props.drawPickingColors) {
       this.drawPickingColors = props.drawPickingColors;
       this._needsRedraw = 'drawPickingColors changed';
+    }
+
+    if ('onError' in props) {
+      this._onError = props.onError;
     }
   }
 
@@ -46,6 +51,7 @@ export default class DeckRenderer {
     const layerPass = this.drawPickingColors ? this.pickLayersPass : this.drawLayersPass;
 
     opts.layerFilter = this.layerFilter;
+    opts.onError = this._onError;
     opts.effects = opts.effects || [];
     opts.target = opts.target || Framebuffer.getDefaultFramebuffer(this.gl);
 

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -81,6 +81,7 @@ function getPropTypes(PropTypes) {
     onBeforeRender: PropTypes.func,
     onAfterRender: PropTypes.func,
     onLoad: PropTypes.func,
+    onError: PropTypes.func,
 
     // Debug settings
     debug: PropTypes.bool,
@@ -117,6 +118,7 @@ const defaultProps = {
   onBeforeRender: noop,
   onAfterRender: noop,
   onLoad: noop,
+  onError: null,
   _onMetrics: null,
 
   getCursor,

--- a/modules/core/src/lib/layer-manager.js
+++ b/modules/core/src/lib/layer-manager.js
@@ -229,7 +229,7 @@ export default class LayerManager {
     if (this._onError) {
       this._onError(error, layer);
     } else {
-      log.warn(`error during ${stage} of ${layerName(layer)}`, error)();
+      log.error(`error during ${stage} of ${layerName(layer)}`, error)();
     }
   }
 

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -616,7 +616,8 @@ export default class Layer extends Component {
 
     const currentProps = this.props;
     // Overwrite this.props during redraw to use in-transition prop values
-    this.props = this.internalState.propsInTransition;
+    // `internalState.propsInTransition` could be missing if `updateState` failed
+    this.props = this.internalState.propsInTransition || currentProps;
 
     const {opacity} = this.props;
     // apply gamma to opacity to make it visually "linear"

--- a/modules/core/src/passes/layers-pass.js
+++ b/modules/core/src/passes/layers-pass.js
@@ -103,7 +103,7 @@ export default class LayersPass extends Pass {
           if (onError) {
             onError(err, layer);
           } else {
-            log.warn(`error during drawing of ${layer}`, err)();
+            log.error(`error during drawing of ${layer}`, err)();
           }
         }
       }

--- a/modules/core/src/passes/layers-pass.js
+++ b/modules/core/src/passes/layers-pass.js
@@ -99,12 +99,11 @@ export default class LayersPass extends Pass {
             uniforms,
             parameters: layerParameters
           });
-        } catch (error) {
-          log.warn(`error during drawing of ${layer}`, error)();
+        } catch (err) {
           if (onError) {
-            onError(error, layer);
+            onError(err, layer);
           } else {
-            throw error;
+            log.warn(`error during drawing of ${layer}`, err)();
           }
         }
       }

--- a/test/modules/core/lib/layer-manager.spec.js
+++ b/test/modules/core/lib/layer-manager.spec.js
@@ -190,37 +190,22 @@ test('LayerManager#error handling', t => {
   }
 
   const layerManager = new LayerManager(gl);
-
-  // no onError handler
-  t.throws(
-    () => layerManager.setLayers([new BadLayer({id: 'crash-on-init', throw: true})]),
-    'Should throw if onError is missing'
-  );
-
   layerManager.setProps({onError});
 
-  t.doesNotThrow(
-    () =>
-      layerManager.setLayers([
-        new ScatterplotLayer({id: 'scatterplot'}),
-        new BadLayer({id: 'crash-on-init', throw: true}),
-        new BadLayer({id: 'crash-on-update', throw: false})
-      ]),
-    'Should not throw if onError is defined'
-  );
+  layerManager.setLayers([
+    new ScatterplotLayer({id: 'scatterplot'}),
+    new BadLayer({id: 'crash-on-init', throw: true}),
+    new BadLayer({id: 'crash-on-update', throw: false})
+  ]);
 
   t.is(errorArgs.length, 1, 'onError is called');
   t.is(errorArgs[0].layer.id, 'crash-on-init', 'onError is called with correct args');
 
-  t.doesNotThrow(
-    () =>
-      layerManager.setLayers([
-        new ScatterplotLayer({id: 'scatterplot'}),
-        new BadLayer({id: 'crash-on-init', throw: true}),
-        new BadLayer({id: 'crash-on-update', throw: true})
-      ]),
-    'Should not throw if onError is defined'
-  );
+  layerManager.setLayers([
+    new ScatterplotLayer({id: 'scatterplot'}),
+    new BadLayer({id: 'crash-on-init', throw: true}),
+    new BadLayer({id: 'crash-on-update', throw: true})
+  ]);
 
   t.is(errorArgs.length, 3, 'onError is called');
   t.is(errorArgs[1].layer.id, 'crash-on-init', 'onError is called with correct args');


### PR DESCRIPTION

For #4134

#### Change List
- Do not throw during layer lifecycles: initialize, update, finalize, draw
- Switch error logging from `log.warn` to `log.error`
- Add `onError` callback to `Deck` class (see updated documentation)
- Test
