### PR TITLE
TileLayer improvements

### DIFF
--- a/docs/layers/base-tile-layer.md
+++ b/docs/layers/base-tile-layer.md
@@ -31,7 +31,6 @@ To use pre-bundled scripts:
 <!-- or -->
 <script src="https://unpkg.com/@deck.gl/core@^8.0.0/dist.min.js"></script>
 <script src="https://unpkg.com/@deck.gl/layers@^8.0.0/dist.min.js"></script>
-<script src="https://unpkg.com/@deck.gl/geo-layers@^8.0.0/dist.min.js"></script>
 ```
 
 ```js
@@ -80,6 +79,15 @@ Hide tiles when under-zoomed.
 The maximum cache size for a tile layer. If not defined, it is calculated using the number of tiles in the current viewport times constant 5 (5 is picked because it's a common zoom range).
 
 - Default: `null`
+
+##### `strategy` (Enum, optional)
+
+How the tile layer determines the visibility of tiles. One of the following:
+
+* `'default'`: If some tiles in the current viewport are waiting for data to load, aggresively use cached content from other zoom levels to fill the empty space.
+* `'exclusive'`: Avoid showing overlapping tiles when backfilling with cached content.
+
+- Default: `BaseTileLayer.STRATEGY_DEFAULT`
 
 ### Render Options
 

--- a/docs/layers/base-tile-layer.md
+++ b/docs/layers/base-tile-layer.md
@@ -84,10 +84,10 @@ The maximum cache size for a tile layer. If not defined, it is calculated using 
 
 How the tile layer determines the visibility of tiles. One of the following:
 
-* `'default'`: If some tiles in the current viewport are waiting for data to load, aggresively use cached content from other zoom levels to fill the empty space.
-* `'exclusive'`: Avoid showing overlapping tiles when backfilling with cached content.
+* `'best-available'`: If a tile in the current viewport is waiting for its data to load, use cached content from the closest zoom level to fill the empty space. This approach minimizes the visual flashing due to missing content.
+* `'no-overlap'`: Avoid showing overlapping tiles when backfilling with cached content. This is usually favorable when tiles do not have opaque backgrounds.
 
-- Default: `BaseTileLayer.STRATEGY_DEFAULT`
+- Default: `'best-available'`
 
 ### Render Options
 

--- a/modules/geo-layers/src/tile-layer/utils/viewport-util.js
+++ b/modules/geo-layers/src/tile-layer/utils/viewport-util.js
@@ -55,7 +55,6 @@ export function getTileIndices(viewport, maxZoom, minZoom) {
     expected  2  3  0  1  2  3
    */
   let [minX, minY] = getTileIndex([bbox[0], bbox[3]], scale);
-  // eslint-disable-next-line prefer-const
   let [maxX, maxY] = getTileIndex([bbox[2], bbox[1]], scale);
   const indices = [];
 
@@ -65,7 +64,8 @@ export function getTileIndices(viewport, maxZoom, minZoom) {
    */
   minX = Math.floor(minX);
   maxX = Math.min(minX + scale, maxX); // Avoid creating duplicates
-  minY = Math.floor(minY);
+  minY = Math.max(0, Math.floor(minY));
+  maxY = Math.min(scale, maxY);
   for (let x = minX; x < maxX; x++) {
     for (let y = minY; y < maxY; y++) {
       // Cast to valid x between [0, scale]

--- a/modules/layers/src/base-tile-layer/utils/tile-2d-header.js
+++ b/modules/layers/src/base-tile-layer/utils/tile-2d-header.js
@@ -1,14 +1,14 @@
-export default class Tile {
+export default class Tile2DHeader {
   constructor({getTileData, x, y, z, onTileLoad, onTileError, tileToBoundingBox}) {
     this.x = x;
     this.y = y;
     this.z = z;
     this.bbox = tileToBoundingBox(this.x, this.y, this.z);
-    this.isVisible = true;
+    this.selected = true;
     this.parent = null;
     this.children = [];
 
-    this._data = null;
+    this.content = null;
     this._isLoaded = false;
     this._loader = this._loadData(getTileData);
 
@@ -17,7 +17,7 @@ export default class Tile {
   }
 
   get data() {
-    return this._data || this._loader;
+    return this.content || this._loader;
   }
 
   get isLoaded() {
@@ -32,7 +32,7 @@ export default class Tile {
 
     return Promise.resolve(getTileData({x, y, z, bbox}))
       .then(buffers => {
-        this._data = buffers;
+        this.content = buffers;
         this._isLoaded = true;
         this.onTileLoad(this);
         return buffers;

--- a/modules/layers/src/base-tile-layer/utils/tile.js
+++ b/modules/layers/src/base-tile-layer/utils/tile.js
@@ -5,10 +5,13 @@ export default class Tile {
     this.z = z;
     this.bbox = tileToBoundingBox(this.x, this.y, this.z);
     this.isVisible = true;
-    this.getTileData = getTileData;
+    this.parent = null;
+    this.children = [];
+
     this._data = null;
     this._isLoaded = false;
-    this._loader = this._loadData();
+    this._loader = this._loadData(getTileData);
+
     this.onTileLoad = onTileLoad;
     this.onTileError = onTileError;
   }
@@ -21,13 +24,13 @@ export default class Tile {
     return this._isLoaded;
   }
 
-  _loadData() {
+  _loadData(getTileData) {
     const {x, y, z, bbox} = this;
-    if (!this.getTileData) {
+    if (!getTileData) {
       return null;
     }
 
-    return Promise.resolve(this.getTileData({x, y, z, bbox}))
+    return Promise.resolve(getTileData({x, y, z, bbox}))
       .then(buffers => {
         this._data = buffers;
         this._isLoaded = true;
@@ -38,11 +41,5 @@ export default class Tile {
         this._isLoaded = true;
         this.onTileError(err);
       });
-  }
-
-  isOverlapped(tile) {
-    const {x, y, z} = this;
-    const m = Math.pow(2, tile.z - z);
-    return Math.floor(tile.x / m) === x && Math.floor(tile.y / m) === y;
   }
 }

--- a/modules/layers/src/base-tile-layer/utils/tileset-2d.js
+++ b/modules/layers/src/base-tile-layer/utils/tileset-2d.js
@@ -1,4 +1,4 @@
-import Tile from './tile';
+import Tile2DHeader from './tile-2d-header';
 
 const TILE_STATE_UNKNOWN = 0;
 const TILE_STATE_VISIBLE = 1;
@@ -25,15 +25,15 @@ const TILE_STATE_HIDDEN = 4;
 // tiles that should be displayed in the current viewport
 const TILE_STATE_SELECTED = 5;
 
-export const STRATEGY_EXCLUSIVE = 'exclusive';
-export const STRATEGY_DEFAULT = 'default';
+export const STRATEGY_REPLACE = 'no-overlap';
+export const STRATEGY_DEFAULT = 'best-available';
 
 /**
  * Manages loading and purging of tiles data. This class caches recently visited tiles
  * and only create new tiles if they are present.
  */
 
-export default class TileCache {
+export default class Tileset2D {
   /**
    * Takes in a function that returns tile data, a cache size, and a max and a min zoom level.
    * Cache size defaults to 5 * number of tiles in the current viewport
@@ -77,6 +77,10 @@ export default class TileCache {
 
   get tiles() {
     return this._tiles;
+  }
+
+  get selectedTiles() {
+    return this._selectedTiles;
   }
 
   get isLoaded() {
@@ -212,7 +216,7 @@ export default class TileCache {
     let tile = this._cache.get(tileId);
 
     if (!tile && create) {
-      tile = new Tile({
+      tile = new Tile2DHeader({
         getTileData: this._getTileData,
         tileToBoundingBox: this._tileToBoundingBox,
         x,

--- a/test/modules/geo-layers/tile-layer/tile-layer.spec.js
+++ b/test/modules/geo-layers/tile-layer/tile-layer.spec.js
@@ -42,12 +42,12 @@ test('TileLayer#updateTriggers', t => {
       },
       onAfterUpdate({layer}) {
         t.equal(
-          layer.state.tileCache._tileToBoundingBox,
+          layer.state.tileset._tileToBoundingBox,
           tileToBoundingBox,
           'Should create a tileCache with correct tileToBoundingBox'
         );
         t.equal(
-          layer.state.tileCache._getTileIndices,
+          layer.state.tileset._getTileIndices,
           getTileIndices,
           'Should create a tileCache with correct _getTileIndices'
         );

--- a/test/modules/layers/base-tile-layer/base-tile-layer.spec.js
+++ b/test/modules/layers/base-tile-layer/base-tile-layer.spec.js
@@ -39,7 +39,7 @@ test('BaseTileLayer#updateTriggers', t => {
         getTileData: 0
       },
       onAfterUpdate({layer}) {
-        t.equal(layer.state.tileCache._getTileData, 0, 'Should create a tileCache.');
+        t.equal(layer.state.tileset._getTileData, 0, 'Should create a tileset.');
       }
     },
     {
@@ -48,9 +48,9 @@ test('BaseTileLayer#updateTriggers', t => {
       },
       onAfterUpdate({layer}) {
         t.equal(
-          layer.state.tileCache._getTileData,
+          layer.state.tileset._getTileData,
           0,
-          'Should not create a tileCache when updateTriggers not changed.'
+          'Should not create a tileset when updateTriggers not changed.'
         );
       }
     },
@@ -63,9 +63,9 @@ test('BaseTileLayer#updateTriggers', t => {
       },
       onAfterUpdate({layer}) {
         t.equal(
-          layer.state.tileCache._getTileData,
+          layer.state.tileset._getTileData,
           2,
-          'Should create a new tileCache with updated getTileData.'
+          'Should create a new tileset with updated getTileData.'
         );
       }
     }

--- a/test/modules/layers/index.js
+++ b/test/modules/layers/index.js
@@ -28,7 +28,7 @@ import './geojson-layer.spec';
 import './point-cloud-layer.spec';
 import './path-layer/path-layer-vertex.spec';
 import './icon-manager.spec';
-import './base-tile-layer/tile-cache.spec';
+import './base-tile-layer/tileset-2d.spec';
 import './base-tile-layer/base-tile-layer.spec';
 import './text-layer/utils.spec';
 import './text-layer/lru-cache.spec';


### PR DESCRIPTION
Resolves https://github.com/uber/deck.gl/issues/3511

This PR refactors `BaseTileLayer`/`TileCache` classes to function more similar to `Tile3DLayer`/`Tileset3D`. Traversal now reruns every time any tile finishes loading, instead of waiting for the entire viewport to load. The logic that determines tile visibilities is entirely moved into `TileCache`. It also uses a more sophisticated strategy (configurable by the user) to pick placeholders when a tile is pending.

The new API needs audit.

#### Change List
- Add `strategy` prop to `BaseTileLayer` (see documentation)
- `TileCache` rewrite
- Unit tests
