### PR TITLE
Project module: support pre-projected positions

### DIFF
--- a/modules/core/src/shaderlib/project/project.glsl.js
+++ b/modules/core/src/shaderlib/project/project.glsl.js
@@ -121,7 +121,9 @@ vec4 project_position(vec4 position, vec3 position64Low) {
 
   vec4 position_world = project_uModelMatrix * position;
 
-  if (project_uCoordinateSystem == COORDINATE_SYSTEM_LNGLAT && project_uProjectionMode == PROJECTION_MODE_WEB_MERCATOR_AUTO_OFFSET) {
+  if (project_uProjectionMode == PROJECTION_MODE_WEB_MERCATOR_AUTO_OFFSET &&
+    (project_uCoordinateSystem == COORDINATE_SYSTEM_LNGLAT ||
+     project_uCoordinateSystem == COORDINATE_SYSTEM_CARTESIAN)) {
     // Subtract high part of 64 bit value. Convert remainder to float32, preserving precision.
     position_world.xyz -= project_uCoordinateOrigin;
     position_world.xyz += position64Low;

--- a/modules/core/src/shaderlib/project/project.glsl.js
+++ b/modules/core/src/shaderlib/project/project.glsl.js
@@ -111,16 +111,15 @@ vec2 project_mercator_(vec2 lnglat) {
 // Projects positions (defined by project_uCoordinateSystem) to common space (defined by project_uProjectionMode)
 //
 vec4 project_position(vec4 position, vec3 position64Low) {
-  if (project_uCoordinateSystem == COORDINATE_SYSTEM_LNGLAT && project_uProjectionMode == PROJECTION_MODE_WEB_MERCATOR) {
-    return project_uModelMatrix * vec4(
-      project_mercator_(position.xy) * WORLD_SCALE,
-      project_size(position.z),
-      position.w
-    );
-  }
-
   vec4 position_world = project_uModelMatrix * position;
 
+  if (project_uCoordinateSystem == COORDINATE_SYSTEM_LNGLAT && project_uProjectionMode == PROJECTION_MODE_WEB_MERCATOR) {
+    return vec4(
+      project_mercator_(position_world.xy) * WORLD_SCALE,
+      project_size(position_world.z),
+      position_world.w
+    );
+  }
   if (project_uProjectionMode == PROJECTION_MODE_WEB_MERCATOR_AUTO_OFFSET &&
     (project_uCoordinateSystem == COORDINATE_SYSTEM_LNGLAT ||
      project_uCoordinateSystem == COORDINATE_SYSTEM_CARTESIAN)) {

--- a/test/apps/mapbox-tile/app.js
+++ b/test/apps/mapbox-tile/app.js
@@ -4,6 +4,7 @@ import React, {PureComponent} from 'react';
 import {render} from 'react-dom';
 import DeckGL from '@deck.gl/react';
 import {TileLayer} from '@deck.gl/geo-layers';
+import {COORDINATE_SYSTEM} from '@deck.gl/core';
 
 import {decodeTile} from './utils/decode';
 
@@ -95,6 +96,7 @@ class Root extends PureComponent {
         layers={[
           new TileLayer({
             ...MAP_LAYER_STYLES,
+            coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
             getPolygonOffset: null,
             pickable: true,
             getTileData

--- a/test/modules/core/shaderlib/project/viewport-uniforms.spec.js
+++ b/test/modules/core/shaderlib/project/viewport-uniforms.spec.js
@@ -87,6 +87,8 @@ const UNIFORMS_64 = {
   project64_uScale: Number
 };
 
+const EPSILON = 1e-4;
+
 function getUniformsError(uniforms, formats) {
   for (const name in UNIFORMS) {
     const value = uniforms[name];
@@ -106,8 +108,21 @@ test('project#getUniforms', t => {
   t.notOk(getUniformsError(uniforms, UNIFORMS), 'Uniforms validated');
   t.deepEqual(uniforms.project_uCenter, [0, 0, 0, 0], 'Returned zero projection center');
 
+  uniforms = project.getUniforms({
+    viewport: TEST_VIEWPORTS.map,
+    coordinateSystem: COORDINATE_SYSTEM.CARTESIAN
+  });
+  t.notOk(getUniformsError(uniforms, UNIFORMS), 'Uniforms validated');
+  t.deepEqual(uniforms.project_uCenter, [0, 0, 0, 0], 'Returned zero projection center');
+
   uniforms = project.getUniforms({viewport: TEST_VIEWPORTS.mapHighZoom});
   t.notOk(getUniformsError(uniforms, UNIFORMS), 'Uniforms validated');
+  t.ok(uniforms.project_uCenter.some(x => x), 'Returned non-trivial projection center');
+  t.ok(
+    Math.abs(uniforms.project_uCenter[0]) < EPSILON &&
+      Math.abs(uniforms.project_uCenter[1]) < EPSILON,
+    'project center at center of clipspace'
+  );
   t.deepEqual(
     uniforms.project_uCoordinateOrigin,
     [-122.42694091796875, 37.75153732299805, 0],
@@ -122,6 +137,23 @@ test('project#getUniforms', t => {
   });
   t.notOk(getUniformsError(uniforms, UNIFORMS), 'Uniforms validated');
   t.ok(uniforms.project_uCenter.some(x => x), 'Returned non-trivial projection center');
+
+  uniforms = project.getUniforms({
+    viewport: TEST_VIEWPORTS.mapHighZoom,
+    coordinateSystem: COORDINATE_SYSTEM.CARTESIAN
+  });
+  t.notOk(getUniformsError(uniforms, UNIFORMS), 'Uniforms validated');
+  t.ok(uniforms.project_uCenter.some(x => x), 'Returned non-trivial projection center');
+  t.ok(
+    Math.abs(uniforms.project_uCenter[0]) < EPSILON &&
+      Math.abs(uniforms.project_uCenter[1]) < EPSILON,
+    'project center at center of clipspace'
+  );
+  t.ok(
+    uniforms.project_uCommonUnitsPerWorldUnit[0] === 1 &&
+      uniforms.project_uCommonUnitsPerWorldUnit[1] === 1,
+    'Returned correct distanceScales'
+  );
 
   uniforms = project.getUniforms({
     viewport: TEST_VIEWPORTS.infoVis,


### PR DESCRIPTION
For #4104

#### Background

This PR fixes the usage of `COORDINATE_SYSTEM.CARTESIAN` with `WebMercatorViewport`. In this case, positions are in common space instead of lng-lat. This is discussed in #3935, where the source data (mapbox vector tiles) is pre-projected to the Web Mercator plane.

More generically, this is needed to support alternative 2D projections such as Stereographic, Albers, etc. For these projections, it is not feasible to do the full projection on the GPU with acceptable performance and precision. We will need to project lng-lat positions to the common space on the CPU, and then use these positions with a geospatial viewport.

#### Change List
- Address more `coordinateSystem`/`projectionMode` combinations in uniform calculation
- Unit tests
