### PR TITLE
Remove unnecessary code from project glsl

### DIFF
--- a/modules/core/src/shaderlib/project/project.glsl.js
+++ b/modules/core/src/shaderlib/project/project.glsl.js
@@ -156,11 +156,6 @@ vec2 project_position(vec2 position) {
 }
 
 vec4 project_common_position_to_clipspace(vec4 position, mat4 viewProjectionMatrix, vec4 center) {
-  if (project_uCoordinateSystem == COORDINATE_SYSTEM_METER_OFFSETS ||
-    project_uCoordinateSystem == COORDINATE_SYSTEM_LNGLAT_OFFSETS) {
-    // Needs to be divided with project_uCommonUnitsPerMeter
-    position.w *= project_uCommonUnitsPerMeter.z;
-  }
   return viewProjectionMatrix * position + center;
 }
 

--- a/test/modules/core/shaderlib/project/project-glsl.spec.js
+++ b/test/modules/core/shaderlib/project/project-glsl.spec.js
@@ -29,7 +29,7 @@ const {fp64LowPart} = fp64;
 
 import {compileVertexShader} from '../shaderlib-test-utils';
 import {getPixelOffset, clipspaceToScreen, runOnGPU, verifyResult} from './project-glsl-test-utils';
-const PIXEL_TOLERANCE = 0.01;
+const PIXEL_TOLERANCE = 1e-4;
 
 const TEST_VIEWPORT = new WebMercatorViewport({
   longitude: -122,


### PR DESCRIPTION
#### Background

In offset mode `project_common_position_to_clipspace`, the fourth component does not matter as it is dropped by `viewProjectionMatrix`:

https://github.com/uber/deck.gl/blob/848420ca1fc3214d8c81ecffb79354ce01bd064c/modules/core/src/shaderlib/project/viewport-uniforms.js#L129

#### Change List
- Remove unnecessary code from `project_common_position_to_clipspace`
- Tighten test cases
