### PR TITLE
data-filter: support double precision

### DIFF
--- a/docs/api-reference/extensions/data-filter-extension.md
+++ b/docs/api-reference/extensions/data-filter-extension.md
@@ -59,10 +59,11 @@ new deck.DataFilterExtension({});
 ## Constructor
 
 ```js
-new DataFilterExtension({filterSize});
+new DataFilterExtension({filterSize, fp64});
 ```
 
 * `filterSize` (Number) - the size of the filter (number of columns to filter by). The data filter can show/hide data based on 1-4 numeric properties of each object. Default `1`.
+* `fp64` (Boolean) - if `true`, use 64-bit precision instead of 32-bit. Default `false`. See the "remarks" section below for use cases and limitations.
 
 
 ## Layer Properties
@@ -163,6 +164,22 @@ When an object is "faded", manipulate its opacity so that it appears more transl
 * Default: `true`
 
 Enable/disable the data filter. If the data filter is disabled, all objects are rendered.
+
+
+## Remarks
+
+### Filter precision
+
+By default, both the filter values and the filter range are uploaded to the GPU as 32-bit floats. When using very large filter values, most commonly Epoch timestamps, 32-bit float representation could lead to an error margin of >1 minute. Enabling 64-bit precision by setting `fp64: true` would allow the filter range to be evaluated more accurately. However, 64-bit support requires one extra attribute slot, edging closer to the WebGL limit of 16 attributes. Depending on the layer that the `DataFilterExtension` is used with, it may interfere with the layer's ability to use other extensions.
+
+If this becomes an issue, an alternative technique is to transform each filter value by subtracting a fixed "origin" value, thus making the numbers smaller:
+
+```js
+getFilterValue: d => d.timestamp - ORIGIN_TS,
+filterRange: [rangeStart - ORIGIN_TS, rangeEnd - ORIGIN_TS]
+```
+
+32-bit float can accurately represent each second within ~190 days (`2^24`). Unless the filter values require both a large span and fine intervals, 32-bit would be sufficient.
 
 
 ## Limitations

--- a/docs/api-reference/extensions/data-filter-extension.md
+++ b/docs/api-reference/extensions/data-filter-extension.md
@@ -170,7 +170,7 @@ Enable/disable the data filter. If the data filter is disabled, all objects are 
 
 ### Filter precision
 
-By default, both the filter values and the filter range are uploaded to the GPU as 32-bit floats. When using very large filter values, most commonly Epoch timestamps, 32-bit float representation could lead to an error margin of >1 minute. Enabling 64-bit precision by setting `fp64: true` would allow the filter range to be evaluated more accurately. However, 64-bit support requires one extra attribute slot, edging closer to the WebGL limit of 16 attributes. Depending on the layer that the `DataFilterExtension` is used with, it may interfere with the layer's ability to use other extensions.
+By default, both the filter values and the filter range are uploaded to the GPU as 32-bit floats. When using very large filter values, most commonly Epoch timestamps, 32-bit float representation could lead to an error margin of >1 minute. Enabling 64-bit precision by setting `fp64: true` would allow the filter range to be evaluated more accurately. However, 64-bit support requires one extra attribute slot, which increases the risk of exceeding the hardware limit on vertex attributes. Depending on the layer that the `DataFilterExtension` is used with, it may interfere with the layer's ability to use other extensions.
 
 If this becomes an issue, an alternative technique is to transform each filter value by subtracting a fixed "origin" value, thus making the numbers smaller:
 
@@ -179,7 +179,7 @@ getFilterValue: d => d.timestamp - ORIGIN_TS,
 filterRange: [rangeStart - ORIGIN_TS, rangeEnd - ORIGIN_TS]
 ```
 
-32-bit float can accurately represent each second within ~190 days (`2^24`). Unless the filter values require both a large span and fine intervals, 32-bit would be sufficient.
+32-bit floats can accurately represent each second within ~190 days (`2^24`). Unless the filter values require both a large span and fine granularity, 32-bit floats should be sufficient.
 
 
 ## Limitations

--- a/examples/website/data-filter/app.js
+++ b/examples/website/data-filter/app.js
@@ -26,7 +26,9 @@ const MS_PER_DAY = 8.64e7;
 
 const dataFilter = new DataFilterExtension({
   filterSize: 1,
-  fp64: false // enable for higher precision
+  // Enable for higher precision, e.g. 1 second granularity
+  // See DataFilterExtension documentation for how to pick precision
+  fp64: false
 });
 
 export default class App extends Component {

--- a/examples/website/data-filter/app.js
+++ b/examples/website/data-filter/app.js
@@ -22,9 +22,12 @@ const INITIAL_VIEW_STATE = {
   bearing: 0
 };
 
-const MS_PER_DAY = 8.64e7; // milliseconds in a day
+const MS_PER_DAY = 8.64e7;
 
-const dataFilter = new DataFilterExtension({filterSize: 1});
+const dataFilter = new DataFilterExtension({
+  filterSize: 1,
+  fp64: false // enable for higher precision
+});
 
 export default class App extends Component {
   constructor(props) {
@@ -54,7 +57,7 @@ export default class App extends Component {
     }
     return data.reduce(
       (range, d) => {
-        const t = d.timestamp / MS_PER_DAY;
+        const t = d.timestamp;
         range[0] = Math.min(range[0], t);
         range[1] = Math.max(range[1], t);
         return range;
@@ -88,7 +91,7 @@ export default class App extends Component {
             return [255 - r * 15, r * 5, r * 10];
           },
 
-          getFilterValue: d => d.timestamp / MS_PER_DAY, // in days
+          getFilterValue: d => d.timestamp,
           filterRange: [filterValue[0], filterValue[1]],
           filterSoftRange: [
             filterValue[0] * 0.9 + filterValue[1] * 0.1,
@@ -125,7 +128,7 @@ export default class App extends Component {
   }
 
   _formatLabel(t) {
-    const date = new Date(t * MS_PER_DAY);
+    const date = new Date(t);
     return `${date.getUTCFullYear()}/${date.getUTCMonth() + 1}`;
   }
 
@@ -155,6 +158,7 @@ export default class App extends Component {
             min={timeRange[0]}
             max={timeRange[1]}
             value={filterValue}
+            animationSpeed={MS_PER_DAY * 30}
             formatLabel={this._formatLabel}
             onChange={({value}) => this.setState({filterValue: value})}
           />

--- a/examples/website/data-filter/range-input.js
+++ b/examples/website/data-filter/range-input.js
@@ -31,8 +31,6 @@ const TickBar = styled('div', {
   maxWidth: '80vw'
 });
 
-const ANIMATION_SPEED = 30;
-
 export default class RangeInput extends PureComponent {
   constructor(props) {
     super(props);
@@ -61,9 +59,9 @@ export default class RangeInput extends PureComponent {
   }
 
   _animate() {
-    const {min, max, value} = this.props;
+    const {min, max, value, animationSpeed} = this.props;
     const span = value[1] - value[0];
-    let newValueMin = value[0] + ANIMATION_SPEED;
+    let newValueMin = value[0] + animationSpeed;
     if (newValueMin + span >= max) {
       newValueMin = min;
     }

--- a/modules/extensions/src/data-filter/shader-module.js
+++ b/modules/extensions/src/data-filter/shader-module.js
@@ -11,9 +11,19 @@ uniform bool filter_enabled;
 uniform bool filter_transformSize;
 
 #ifdef NON_INSTANCED_MODEL
-attribute DATAFILTER_TYPE filterValues;
+  #define DATAFILTER_ATTRIB filterValues
+  #define DATAFILTER_ATTRIB_64LOW filterValues64Low
 #else
-attribute DATAFILTER_TYPE instanceFilterValues;
+  #define DATAFILTER_ATTRIB instanceFilterValues
+  #define DATAFILTER_ATTRIB_64LOW instanceFilterValues64Low
+#endif
+
+attribute DATAFILTER_TYPE DATAFILTER_ATTRIB;
+#ifdef DATAFILTER_DOUBLE
+  attribute DATAFILTER_TYPE DATAFILTER_ATTRIB_64LOW;
+
+  uniform DATAFILTER_TYPE filter_min64High;
+  uniform DATAFILTER_TYPE filter_max64High;
 #endif
 
 varying float dataFilter_value;
@@ -30,16 +40,16 @@ float dataFilter_reduceValue(vec3 value) {
 float dataFilter_reduceValue(vec4 value) {
   return min(min(value.x, value.y), min(value.z, value.w));
 }
-void dataFilter_setValue(DATAFILTER_TYPE value) {
+void dataFilter_setValue(DATAFILTER_TYPE valueFromMin, DATAFILTER_TYPE valueFromMax) {
   if (filter_enabled) {
     if (filter_useSoftMargin) {
       dataFilter_value = dataFilter_reduceValue(
-        smoothstep(filter_min, filter_softMin, value) *
-        (1.0 - smoothstep(filter_softMax, filter_max, value))
+        smoothstep(filter_min, filter_softMin, valueFromMin) *
+        (1.0 - smoothstep(filter_softMax, filter_max, valueFromMax))
       );
     } else {
       dataFilter_value = dataFilter_reduceValue(
-        step(filter_min, value) * step(value, filter_max)
+        step(filter_min, valueFromMin) * step(valueFromMax, filter_max)
       );
     }
   } else {
@@ -86,12 +96,44 @@ const getUniforms = opts => {
   return uniforms;
 };
 
+const getUniforms64 = opts => {
+  if (!opts || !opts.extensions) {
+    return {};
+  }
+  const uniforms = getUniforms(opts);
+  if (Number.isFinite(uniforms.filter_min)) {
+    const min64High = Math.fround(uniforms.filter_min);
+    uniforms.filter_min -= min64High;
+    uniforms.filter_softMin -= min64High;
+    uniforms.filter_min64High = min64High;
+
+    const max64High = Math.fround(uniforms.filter_max);
+    uniforms.filter_max -= max64High;
+    uniforms.filter_softMax -= max64High;
+    uniforms.filter_max64High = max64High;
+  } else {
+    const min64High = uniforms.filter_min.map(Math.fround);
+    uniforms.filter_min = uniforms.filter_min.map((x, i) => x - min64High[i]);
+    uniforms.filter_softMin = uniforms.filter_softMin.map((x, i) => x - min64High[i]);
+    uniforms.filter_min64High = min64High;
+
+    const max64High = uniforms.filter_max.map(Math.fround);
+    uniforms.filter_max = uniforms.filter_max.map((x, i) => x - max64High[i]);
+    uniforms.filter_softMax = uniforms.filter_softMax.map((x, i) => x - max64High[i]);
+    uniforms.filter_max64High = max64High;
+  }
+  return uniforms;
+};
+
 const inject = {
   'vs:#main-start': `
-    #ifdef NON_INSTANCED_MODEL
-    dataFilter_setValue(filterValues);
+    #ifdef DATAFILTER_DOUBLE
+      dataFilter_setValue(
+        DATAFILTER_ATTRIB - filter_min64High + DATAFILTER_ATTRIB_64LOW,
+        DATAFILTER_ATTRIB - filter_max64High + DATAFILTER_ATTRIB_64LOW
+      );
     #else
-    dataFilter_setValue(instanceFilterValues);
+      dataFilter_setValue(DATAFILTER_ATTRIB, DATAFILTER_ATTRIB);
     #endif
   `,
 
@@ -109,10 +151,18 @@ const inject = {
   `
 };
 
-export default {
+export const shaderModule = {
   name: 'data-filter',
   vs,
   fs,
   inject,
   getUniforms
+};
+
+export const shaderModule64 = {
+  name: 'data-filter-fp64',
+  vs,
+  fs,
+  inject,
+  getUniforms: getUniforms64
 };

--- a/test/modules/extensions/data-filter.spec.js
+++ b/test/modules/extensions/data-filter.spec.js
@@ -7,8 +7,9 @@ test('DataFilterExtension#constructor', t => {
   let extension = new DataFilterExtension();
   t.is(extension.opts.filterSize, 1, 'Extension has filterSize');
 
-  extension = new DataFilterExtension({filterSize: 3, softMargin: true});
+  extension = new DataFilterExtension({filterSize: 3, fp64: true});
   t.is(extension.opts.filterSize, 3, 'Extension has filterSize');
+  t.ok(extension.opts.fp64, 'fp64 is enabled');
 
   t.throws(
     () => new DataFilterExtension({filterSize: 5}),
@@ -55,6 +56,18 @@ test('DataFilterExtension', t => {
         t.deepEqual(uniforms.filter_softMax, [18000, 8000], 'has correct uniforms');
         t.is(uniforms.filter_useSoftMargin, true, 'has correct uniforms');
         t.is(uniforms.filter_transformSize, false, 'has correct uniforms');
+      }
+    },
+    {
+      updateProps: {
+        extensions: [new DataFilterExtension({filterSize: 2, fp64: true})]
+      },
+      onAfterUpdate: ({layer}) => {
+        const {uniforms} = layer.state.model.program;
+        t.deepEqual(uniforms.filter_min64High, [10000, 0], 'has double uniforms');
+        t.deepEqual(uniforms.filter_max64High, [20000, 100000], 'has double uniforms');
+        t.deepEqual(uniforms.filter_min, [0, 0], 'has correct uniforms');
+        t.deepEqual(uniforms.filter_softMax, [-2000, -92000], 'has correct uniforms');
       }
     }
   ];


### PR DESCRIPTION
#### Background

Provide a way to filter UNIX timestamps accurately.

#### Change List
- Add `fp64` option to `DataFilterExtension`
- Docs
- Unit tests