### PR TITLE
[Binary support, part 2] @deck.gl/jupyter-widget: Add functions to support binary data transfer

### DIFF
--- a/bindings/pydeck/pydeck/bindings/deck.py
+++ b/bindings/pydeck/pydeck/bindings/deck.py
@@ -103,6 +103,14 @@ class Deck(JSONMixin):
         Intended for use in a Jupyter environment.
         """
         self.deck_widget.json_input = self.to_json()
+        has_binary = False
+        binary_data_sets = []
+        for layer in self.layers:
+            if layer.binary_transport:
+                binary_data_sets.extend(layer.get_binary_data())
+                has_binary = True
+        if has_binary:
+            self.deck_widget.data_buffer = binary_data_sets
 
     def to_html(
         self,

--- a/bindings/pydeck/pydeck/bindings/json_tools.py
+++ b/bindings/pydeck/pydeck/bindings/json_tools.py
@@ -3,8 +3,14 @@ Support serializing objects into JSON
 """
 import json
 
-# Ignore deck_widget and mapbox_key attributes
-IGNORE_KEYS = ['mapbox_key', 'deck_widget']
+# Attributes to ignore during JSON serialization
+IGNORE_KEYS = [
+    "mapbox_key",
+    "deck_widget",
+    "binary_data_sets",
+    "_binary_data",
+    "_kwargs",
+]
 
 
 def to_camel_case(snake_case):
@@ -20,10 +26,10 @@ def to_camel_case(snake_case):
     str
         Camel-cased (e.g., "camelCased") version of input string
     """
-    output_str = ''
+    output_str = ""
     should_upper_case = False
     for c in snake_case:
-        if c == '_':
+        if c == "_":
             should_upper_case = True
             continue
         output_str = output_str + c.upper() if should_upper_case else output_str + c
@@ -32,7 +38,11 @@ def to_camel_case(snake_case):
 
 
 def lower_first_letter(s):
-    return s[:1].lower() + s[1:] if s else ''
+    return s[:1].lower() + s[1:] if s else ""
+
+
+def camel_and_lower(w):
+    return lower_first_letter(to_camel_case(w))
 
 
 def lower_camel_case_keys(attrs):
@@ -44,9 +54,9 @@ def lower_camel_case_keys(attrs):
         Dictionary for which all the keys should be converted to camel-case
     """
     for snake_key in list(attrs.keys()):
-        if '_' not in snake_key:
+        if "_" not in snake_key:
             continue
-        camel_key = lower_first_letter(to_camel_case(snake_key))
+        camel_key = camel_and_lower(snake_key)
         attrs[camel_key] = attrs.pop(snake_key)
 
 
@@ -68,7 +78,6 @@ def serialize(serializable):
 
 
 class JSONMixin(object):
-
     def __repr__(self):
         """
         Override of string representation method to return a JSON-ified version of the

--- a/bindings/pydeck/pydeck/bindings/layer.py
+++ b/bindings/pydeck/pydeck/bindings/layer.py
@@ -1,22 +1,22 @@
 import uuid
 
+import numpy as np
+
 from ..data_utils import is_pandas_df
-from .json_tools import JSONMixin
+from .json_tools import JSONMixin, camel_and_lower
 
 
-TYPE_IDENTIFIER = '@@type'
-FUNCTION_IDENTIFIER = '@@='
+TYPE_IDENTIFIER = "@@type"
+FUNCTION_IDENTIFIER = "@@="
 QUOTE_CHARS = {"'", '"', "`"}
 
 
+class BinaryTransportException(Exception):
+    pass
+
+
 class Layer(JSONMixin):
-    def __init__(
-        self,
-        type,
-        data,
-        id=None,
-        **kwargs
-    ):
+    def __init__(self, type, data, id=None, binary_transport=None, **kwargs):
         """Configures a deck.gl layer for rendering on a map. Parameters passed
         here will be specific to the particular deck.gl layer that you are choosing to use.
 
@@ -30,10 +30,12 @@ class Layer(JSONMixin):
 
         type : str
             Type of layer to render, e.g., `HexagonLayer`
-        id : str
+        id : str, default None
             Unique name for layer
         data : str or list of dict of {str: Any} or pandas.DataFrame
             Either a URL of data to load in or an array of data
+        binary_transport : bool, default None
+            Boolean indicating binary data
         **kwargs
             Any of the parameters passable to a deck.gl layer.
 
@@ -75,10 +77,9 @@ class Layer(JSONMixin):
         """
         self.type = type
         self.id = id or str(uuid.uuid4())
-        self._data = None
-        self.data = data.to_dict(orient='records') if is_pandas_df(data) else data
 
         # Add any other kwargs to the JSON output
+        self._kwargs = kwargs.copy()
         if kwargs:
             for k, v in kwargs.items():
                 # We assume strings and arrays of strings are identifiers
@@ -89,22 +90,30 @@ class Layer(JSONMixin):
 
                 if isinstance(v, str) and v[0] in QUOTE_CHARS and v[0] == v[-1]:
                     # Skip quoted strings
-                    kwargs[k] = v.replace(v[0], '')
+                    kwargs[k] = v.replace(v[0], "")
                 elif isinstance(v, str):
                     # Have @deck.gl/json treat strings values as functions
                     kwargs[k] = FUNCTION_IDENTIFIER + v
 
                 elif isinstance(v, list) and v != [] and isinstance(v[0], str):
                     # Allows the user to pass lists e.g. to specify coordinates
-                    array_as_str = ''
+                    array_as_str = ""
                     for i, identifier in enumerate(v):
                         if i == len(v) - 1:
-                            array_as_str += '{}'.format(identifier)
+                            array_as_str += "{}".format(identifier)
                         else:
-                            array_as_str += '{}, '.format(identifier)
-                    kwargs[k] = '{}[{}]'.format(FUNCTION_IDENTIFIER, array_as_str)
+                            array_as_str += "{}, ".format(identifier)
+                    kwargs[k] = "{}[{}]".format(FUNCTION_IDENTIFIER, array_as_str)
 
             self.__dict__.update(kwargs)
+
+        self._data = None
+        self.binary_transport = binary_transport
+        self._binary_data = None
+        if not self.binary_transport:
+            self.data = data.to_dict(orient="records") if is_pandas_df(data) else data
+        else:
+            self.data = data
 
     @property
     def data(self):
@@ -112,11 +121,47 @@ class Layer(JSONMixin):
 
     @data.setter
     def data(self, data_set):
-        """Make the data attribute a list no matter the input type"""
-        if is_pandas_df(data_set):
-            self._data = data_set.to_dict(orient='records')
+        """Make the data attribute a list no matter the input type, unless
+        binary_transport is specified, which case we circumvent
+        serializing the data to JSON
+        """
+        if self.binary_transport:
+            self._binary_data = self._prepare_binary_data(data_set)
+        elif is_pandas_df(data_set):
+            self._data = data_set.to_dict(orient="records")
         else:
             self._data = data_set
+
+    def get_binary_data(self):
+        if not self.binary_transport:
+            raise BinaryTransportException(
+                "Layer must be flagged with `binary_transport=True`"
+            )
+        return self._binary_data
+
+    def _prepare_binary_data(self, data_set):
+        # Binary format conversion gives a sizable speedup but requires
+        # slightly stricter standards for data input
+        if not is_pandas_df(data_set):
+            raise BinaryTransportException(
+                "Layer data must be a `pandas.DataFrame` type"
+            )
+
+        layer_accessors = self._kwargs
+        inv_map = {v: k for k, v in layer_accessors.items()}
+
+        blobs = []
+        for column in data_set.columns:
+            np_data = np.stack(data_set[column].to_numpy())
+            blobs.append(
+                {
+                    "layer_id": self.id,
+                    "column_name": column,
+                    "accessor": camel_and_lower(inv_map[column]),
+                    "np_data": np_data,
+                }
+            )
+        return blobs
 
     @property
     def type(self):

--- a/bindings/pydeck/pydeck/data_utils/binary_transfer.py
+++ b/bindings/pydeck/pydeck/data_utils/binary_transfer.py
@@ -1,0 +1,75 @@
+import numpy as np
+
+from .type_checking import is_pandas_df
+
+# Grafted from
+# https://github.com/maartenbreddels/ipyvolume/blob/d13828dfd8b57739004d5daf7a1d93ad0839ed0f/ipyvolume/serialize.py#L219
+def array_to_binary(ar, obj=None, force_contiguous=True):
+    if ar is None:
+        return None
+    if ar.dtype.kind not in ["u", "i", "f"]:  # ints and floats
+        raise ValueError("unsupported dtype: %s" % (ar.dtype))
+    # WebGL does not support float64, case it here
+    if ar.dtype == np.float64:
+        ar = ar.astype(np.float32)
+    # JS does not support int64
+    if ar.dtype == np.int64:
+        ar = ar.astype(np.int32)
+    # make sure it's contiguous
+    if force_contiguous and not ar.flags["C_CONTIGUOUS"]:
+        ar = np.ascontiguousarray(ar)
+    return {"data": memoryview(ar), "dtype": str(ar.dtype), "shape": ar.shape}
+
+
+def serialize_columns(data_set_cols, obj=None):
+    if data_set_cols is None:
+        return None
+    payload = {'payload': []}
+    for col in data_set_cols:
+        bin_data = array_to_binary(col["np_data"])
+        payload['payload'].append({
+            "layer_id": col["layer_id"],
+            "column_name": col["column_name"],
+            "accessor": col["accessor"],
+            "matrix": bin_data,
+        })
+    return payload
+
+
+def deserialize_columns(value, obj=None):
+    pass
+
+
+def binary_to_array(value, obj=None):
+    return np.frombuffer(value["data"], dtype=value["dtype"]).reshape(value["shape"])
+
+
+def convert_df_to_matrix(df, obj=None, force_contiguous=True):
+    """
+    Flattens a pandas.DataFrame into a row-major format array
+
+    In this implementation, `position` | `color`
+
+    lng | lat | r | g | b
+    ----+-----+---+---+---
+     0.0  0.0  140   5   5
+    -1.0  1.0  100  10  10
+
+    becomes
+
+    [[0.0, 0.0, 140, 5, 5], [-1.0, 1.0, 100, 10, 10]]
+
+    """
+    if df is None or not is_pandas_df(df):
+        return None
+    matrix = df.values
+    try:
+        return array_to_binary(matrix)
+    except ValueError as e:
+        raise Exception("Binary conversion failed with message:", e)
+
+
+array_seralization = dict(to_json=array_to_binary, from_json=None)
+data_buffer_serialization = dict(
+    to_json=serialize_columns, from_json=deserialize_columns
+)

--- a/bindings/pydeck/pydeck/data_utils/binary_transfer.py
+++ b/bindings/pydeck/pydeck/data_utils/binary_transfer.py
@@ -1,7 +1,5 @@
 import numpy as np
 
-from .type_checking import is_pandas_df
-
 # Grafted from
 # https://github.com/maartenbreddels/ipyvolume/blob/d13828dfd8b57739004d5daf7a1d93ad0839ed0f/ipyvolume/serialize.py#L219
 def array_to_binary(ar, obj=None, force_contiguous=True):
@@ -36,40 +34,6 @@ def serialize_columns(data_set_cols, obj=None):
     return payload
 
 
-def deserialize_columns(value, obj=None):
-    pass
-
-
-def binary_to_array(value, obj=None):
-    return np.frombuffer(value["data"], dtype=value["dtype"]).reshape(value["shape"])
-
-
-def convert_df_to_matrix(df, obj=None, force_contiguous=True):
-    """
-    Flattens a pandas.DataFrame into a row-major format array
-
-    In this implementation, `position` | `color`
-
-    lng | lat | r | g | b
-    ----+-----+---+---+---
-     0.0  0.0  140   5   5
-    -1.0  1.0  100  10  10
-
-    becomes
-
-    [[0.0, 0.0, 140, 5, 5], [-1.0, 1.0, 100, 10, 10]]
-
-    """
-    if df is None or not is_pandas_df(df):
-        return None
-    matrix = df.values
-    try:
-        return array_to_binary(matrix)
-    except ValueError as e:
-        raise Exception("Binary conversion failed with message:", e)
-
-
-array_seralization = dict(to_json=array_to_binary, from_json=None)
 data_buffer_serialization = dict(
-    to_json=serialize_columns, from_json=deserialize_columns
+    to_json=serialize_columns, from_json=None
 )

--- a/bindings/pydeck/pydeck/data_utils/type_checking.py
+++ b/bindings/pydeck/pydeck/data_utils/type_checking.py
@@ -12,14 +12,3 @@ def is_pandas_df(obj):
         Returns True if object is a Pandas DataFrame and False otherwise
     """
     return obj.__class__.__module__ == 'pandas.core.frame' and obj.to_records and obj.to_dict
-
-
-def is_numpy_array(obj):
-    """Check if an object is a numpy array
-
-    Returns
-    -------
-    bool
-        Returns True if object is a numpy array, False otherwise
-    """
-    return 'numpy.ndarray' in str(obj.__class__) and obj.to_list

--- a/bindings/pydeck/pydeck/data_utils/type_checking.py
+++ b/bindings/pydeck/pydeck/data_utils/type_checking.py
@@ -12,3 +12,14 @@ def is_pandas_df(obj):
         Returns True if object is a Pandas DataFrame and False otherwise
     """
     return obj.__class__.__module__ == 'pandas.core.frame' and obj.to_records and obj.to_dict
+
+
+def is_numpy_array(obj):
+    """Check if an object is a numpy array
+
+    Returns
+    -------
+    bool
+        Returns True if object is a numpy array, False otherwise
+    """
+    return 'numpy.ndarray' in str(obj.__class__) and obj.to_list

--- a/bindings/pydeck/pydeck/io/html.py
+++ b/bindings/pydeck/pydeck/io/html.py
@@ -5,7 +5,6 @@ import time
 import webbrowser
 
 import jinja2
-from IPython.display import IFrame
 
 
 TEMPLATES_PATH = os.path.join(os.path.dirname(__file__), './templates/')
@@ -82,6 +81,7 @@ def deck_to_html(
     if open_browser:
         display_html(realpath(f.name))
     if notebook_display:
+        from IPython.display import IFrame  # noqa
         notebook_to_html_path = relpath(f.name)
         display(IFrame(os.path.join('./', notebook_to_html_path), width=iframe_width, height=iframe_height))  # noqa
     return realpath(f.name)

--- a/bindings/pydeck/pydeck/widget/widget.py
+++ b/bindings/pydeck/pydeck/widget/widget.py
@@ -5,7 +5,9 @@ from __future__ import unicode_literals
 import ipywidgets as widgets
 from traitlets import Any, Bool, Int, Unicode
 
+from ..data_utils.binary_transfer import data_buffer_serialization
 from ._frontend import module_name, module_version
+
 
 @widgets.register
 class DeckGLWidget(widgets.DOMWidget):
@@ -34,16 +36,20 @@ class DeckGLWidget(widgets.DOMWidget):
         js_warning : bool, default False
             Whether the string message from deck.gl should be rendered, defaults to False
     """
-    _model_name = Unicode('DeckGLModel').tag(sync=True)
+
+    _model_name = Unicode("DeckGLModel").tag(sync=True)
     _model_module = Unicode(module_name).tag(sync=True)
     _model_module_version = Unicode(module_version).tag(sync=True)
-    _view_name = Unicode('DeckGLView').tag(sync=True)
+    _view_name = Unicode("DeckGLView").tag(sync=True)
     _view_module = Unicode(module_name).tag(sync=True)
     _view_module_version = Unicode(module_version).tag(sync=True)
-    mapbox_key = Unicode('', allow_none=True).tag(sync=True)
-    json_input = Unicode('').tag(sync=True)
+    mapbox_key = Unicode("", allow_none=True).tag(sync=True)
+    json_input = Unicode("").tag(sync=True)
+    data_buffer = Any(default_value=None, allow_none=True).tag(
+        sync=True, **data_buffer_serialization
+    )
     height = Int(500).tag(sync=True)
-    width = Any('100%').tag(sync=True)
-    selected_data = Unicode('[]').tag(sync=True)
+    width = Any("100%").tag(sync=True)
+    selected_data = Unicode("[]").tag(sync=True)
     tooltip = Any(True).tag(sync=True)
     js_warning = Bool(False).tag(sync=True)

--- a/bindings/pydeck/requirements-dev.txt
+++ b/bindings/pydeck/requirements-dev.txt
@@ -13,3 +13,4 @@ requests
 sphinx
 recommonmark
 jupyterlab
+ipython>=5.8.0;python_version<"3.4"

--- a/bindings/pydeck/requirements.txt
+++ b/bindings/pydeck/requirements.txt
@@ -1,5 +1,5 @@
 ipykernel>=5.1.2;python_version>="3.4"
-ipython>=5.8.0;python_version<"3.4"
 ipywidgets>=7.0.0
 traitlets>=4.3.2
 Jinja2>=2.10.1
+numpy>=1.16.4

--- a/bindings/pydeck/tests/bindings/test_layer.py
+++ b/bindings/pydeck/tests/bindings/test_layer.py
@@ -1,0 +1,35 @@
+import pandas as pd
+import numpy as np
+
+from pydeck import Layer, Deck
+
+df = pd.DataFrame({"position": [[0, 0], [0, 0]]})
+
+
+def test_constructor_binary_transport():
+    test_layer = Layer(
+        "ScatterplotLayer",
+        data=df,
+        id="test-layer",
+        binary_transport=True,
+        get_position="position",
+        radius=10,
+    )
+    EXPECTED_DATUM = {
+        "layer_id": "test-layer",
+        "column_name": "position",
+        "accessor": "getPosition",
+        "np_data": np.array([[0, 0], [0, 0]]),
+    }
+
+    actual_datum = test_layer.get_binary_data()[0]
+
+    assert test_layer.radius == 10
+    assert test_layer.binary_transport == True
+    assert test_layer.data is None
+    assert len(test_layer.get_binary_data()) == 1
+    assert EXPECTED_DATUM["layer_id"] == actual_datum["layer_id"]
+    assert EXPECTED_DATUM["column_name"] == actual_datum["column_name"]
+    assert EXPECTED_DATUM["accessor"] == actual_datum["accessor"]
+    assert np.array_equal(EXPECTED_DATUM["np_data"], actual_datum["np_data"])
+    assert '0, 0' not in Deck(test_layer).to_json(), 'Should not write data to JSON output'

--- a/modules/jupyter-widget/src/binary-transport.js
+++ b/modules/jupyter-widget/src/binary-transport.js
@@ -1,0 +1,157 @@
+// eslint-disable-next-line complexity
+function dtypeToTypedArray(dtype, data) {
+  switch (dtype) {
+    case 'int8':
+      return new Int8Array(data);
+    case 'uint8':
+      return new Uint8Array(data);
+    case 'int16':
+      return new Int16Array(data);
+    case 'uint16':
+      return new Uint16Array(data);
+    case 'float32':
+      return new Float32Array(data);
+    case 'float64':
+      return new Float64Array(data);
+    case 'int32':
+      return new Int32Array(data);
+    case 'uint32':
+      return new Uint32Array(data);
+    case 'int64':
+      return new BigInt64Array(data); // eslint-disable-line no-undef
+    case 'uint64':
+      return new BigUint64Array(data); // eslint-disable-line no-undef
+    default:
+      throw new Error(`Unrecognized dtype ${dtype}`);
+  }
+}
+
+function deserializeMatrix(arr, manager) {
+  /* 
+   * Data is sent from the pydeck backend
+   * in the following format:
+   *
+   * {'<layer ID>': 
+   *     {'<accessor function name e.g. getPosition>': {
+   *        {
+   *          layer_id: <duplicate ID of layer as above>
+   *          column_name: <string name of column>
+   *          matrix: {
+   *            data: <binary data, a row major order representation of a matrix>,
+   *            shape: [<height>, <width>],
+   *            dtype: <string representation of typed array data type>
+   *          }
+   *
+   * Multiple layers and multiple accessors are possible.
+   *
+   * Objects at the JSON path `<accessor name>.matrix.data`
+   * are vectors representing a 1 x n matrix,
+   * or they can represent a m x n matrix in row major order form;
+   * shape of the matrix is given at <accessor name>.matrix.data.shape
+   */
+  if (!arr) {
+    return null;
+  }
+  const renderable = {};
+  for (const datum of arr.payload) {
+    // Each entry here represents a single column in
+    // a pandas.DataFrame arriving from the pydeck backend
+    const layerId = datum.layer_id;
+    const accessor = datum.accessor;
+    if (renderable[layerId] === undefined) {
+      renderable[layerId] = {};
+    }
+    // Columns can be nested
+    const convertedBinary = dtypeToTypedArray(datum.matrix.dtype, datum.matrix.data.buffer);
+    renderable[layerId][accessor] = {
+      layerId,
+      accessor,
+      columnName: datum.column_name,
+      matrix: {data: convertedBinary, shape: datum.matrix.shape}
+    };
+    if (renderable[layerId][accessor].matrix.data.length === 0) {
+      console.warn(`No records in accessor ${accessor} belonging to ${layerId}`); // eslint-disable-line
+    }
+  }
+  return renderable;
+}
+
+function makeLayerAccessorPropFunction({width, accessor}) {
+  /* data.src is a layer-specific data dictionary keyed by accessor */
+  return (object, {index, data, target}) => {
+    for (let j = 0; j < width; j++) {
+      target[j] = data.src[accessor][index * width + j];
+    }
+    return target;
+  };
+}
+
+function getLayer(deckLayers, layerId) {
+  for (const layer of deckLayers) {
+    if (layer.id === layerId) {
+      return layer;
+    }
+  }
+  return null;
+}
+
+function getCurrentLayerProps(layer) {
+  const LayerConstructor = layer.__proto__.constructor; // eslint-disable-line
+  const layerProps = layer.props;
+  return {
+    LayerConstructor,
+    layerProps
+  };
+}
+
+function getAccessorNamesFrom(dataBuffer, layerId) {
+  return Object.keys(dataBuffer[layerId]);
+}
+
+function constructData(dataBuffer, layerId) {
+  const src = {};
+  let length = 0;
+  const accessors = getAccessorNamesFrom(dataBuffer, layerId);
+  // For each accessor, we have a row major ordered matrix of data,
+  // represented as a single vector under `src[accessor]`
+  for (const accessor of accessors) {
+    const currentData = dataBuffer[layerId][accessor];
+    length = Math.max(currentData.matrix.shape[0], length);
+    src[accessor] = currentData.matrix.data;
+  }
+  return {
+    src,
+    length
+  };
+}
+
+function makeBinaryAccessorProps(accessors, layerId, dataBuffer) {
+  const dataAccessorProps = {};
+  for (const accessor of accessors) {
+    // width of matrix
+    const width = dataBuffer[layerId][accessor].matrix.shape[1] || 1;
+    const newAccessorFunction = makeLayerAccessorPropFunction({width, accessor});
+    dataAccessorProps[accessor] = newAccessorFunction;
+  }
+  return dataAccessorProps;
+}
+
+function processDataBuffer({currentLayers, dataBuffer}) {
+  const updatedLayers = [];
+  const updateLayerIds = Object.keys(dataBuffer);
+  for (const layerId of updateLayerIds) {
+    const currentLayer = getLayer(currentLayers, layerId);
+    const newLayerData = constructData(dataBuffer, layerId);
+    const {LayerConstructor, layerProps} = getCurrentLayerProps(currentLayer);
+    const accessors = getAccessorNamesFrom(dataBuffer, layerId);
+    const accessorProps = makeBinaryAccessorProps(accessors, layerId, dataBuffer);
+    const combinedProps = {...layerProps, ...accessorProps};
+    combinedProps.data = newLayerData;
+    const layer = new LayerConstructor({...combinedProps});
+    updatedLayers.push(layer);
+  }
+
+  return updatedLayers;
+}
+
+export {deserializeMatrix, processDataBuffer};


### PR DESCRIPTION
Support binary data transfer within @deck.gl/jupyter-widget

Data is received from pydeck in the format described in the comment on line 31 (`   * Data is sent from the pydeck backend...`)

<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #4103
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
- Add function to convert a typed array received from the pydeck backend
- Add functions to properly process a matrix received from the pydeck backend
