### PR TITLE
[Binary support, part 2] @deck.gl/jupyter-widget: Process binary data within DeckGLModel

### DIFF
--- a/modules/jupyter-widget/package.json
+++ b/modules/jupyter-widget/package.json
@@ -23,7 +23,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "watch": "(cd ../main && npm run build-bundle -- --env.dev) && ln -f ../main/dist/dist.dev.js ./dist/deckgl.dev.js && webpack-dev-server --env.dev --port 8080",
+    "watch": "webpack --watch",
     "build": "webpack",
     "build:labextension": "npm pack",
     "prepublishOnly": "webpack"

--- a/modules/jupyter-widget/src/binary-transport.js
+++ b/modules/jupyter-widget/src/binary-transport.js
@@ -65,7 +65,7 @@ function deserializeMatrix(arr, manager) {
     // Each entry here represents a single column in
     // a pandas.DataFrame arriving from the pydeck backend
     const layerId = datum.layer_id;
-    const accessorName = datum.accessor;
+    const accessorName = datum.accessor_name;
     if (!dataBuffer[layerId]) {
       dataBuffer[layerId] = {};
     }
@@ -75,10 +75,10 @@ function deserializeMatrix(arr, manager) {
       layerId,
       accessorName,
       columnName: datum.column_name,
-      matrix: {data: new ArrayType(datum.matrix.data), shape: datum.matrix.shape}
+      matrix: {data: new ArrayType(datum.matrix.data.buffer), shape: datum.matrix.shape}
     };
     if (dataBuffer[layerId][accessorName].matrix.data.length === 0) {
-      console.warn(`No records in accessor ${accessor} belonging to ${layerId}`); // eslint-disable-line
+      console.warn(`No records in accessor ${accessorName} belonging to ${layerId}`); // eslint-disable-line
     }
   }
   // Becomes the data stored within the widget model at `model.get('data_buffer')`

--- a/modules/jupyter-widget/src/binary-transport.js
+++ b/modules/jupyter-widget/src/binary-transport.js
@@ -5,30 +5,30 @@ import jsonConverter from './create-deck';
 // https://deck.gl/#/documentation/developer-guide/performance-optimization?section=supply-attributes-directly
 
 // eslint-disable-next-line complexity
-function dtypeToTypedArray(dtype, data) {
+function dtypeToTypedArray(dtype) {
   // Supports converting a numpy-typed array to a JavaScript-typed array
   // based on a string value dtype and a DataView `data`
   switch (dtype) {
     case 'int8':
-      return new Int8Array(data);
+      return Int8Array;
     case 'uint8':
-      return new Uint8Array(data);
+      return Uint8Array;
     case 'int16':
-      return new Int16Array(data);
+      return Int16Array;
     case 'uint16':
-      return new Uint16Array(data);
+      return Uint16Array;
     case 'float32':
-      return new Float32Array(data);
+      return Float32Array;
     case 'float64':
-      return new Float64Array(data);
+      return Float64Array;
     case 'int32':
-      return new Int32Array(data);
+      return Int32Array;
     case 'uint32':
-      return new Uint32Array(data);
+      return Uint32Array;
     case 'int64':
-      return new BigInt64Array(data); // eslint-disable-line no-undef
+      return BigInt64Array; // eslint-disable-line no-undef
     case 'uint64':
-      return new BigUint64Array(data); // eslint-disable-line no-undef
+      return BigUint64Array; // eslint-disable-line no-undef
     default:
       throw new Error(`Unrecognized dtype ${dtype}`);
   }
@@ -60,29 +60,29 @@ function deserializeMatrix(arr, manager) {
   if (!arr) {
     return null;
   }
-  const renderable = {};
+  const dataBuffer = {};
   for (const datum of arr.payload) {
     // Each entry here represents a single column in
     // a pandas.DataFrame arriving from the pydeck backend
     const layerId = datum.layer_id;
-    const accessor = datum.accessor;
-    if (renderable[layerId] === undefined) {
-      renderable[layerId] = {};
+    const accessorName = datum.accessor;
+    if (!dataBuffer[layerId]) {
+      dataBuffer[layerId] = {};
     }
     // Creates a typed array of the numpy data as a row-major ordered matrix, with shape specified elsewhere
-    const rowMajorOrderMatrix = dtypeToTypedArray(datum.matrix.dtype, datum.matrix.data.buffer);
-    renderable[layerId][accessor] = {
+    const ArrayType = dtypeToTypedArray(datum.matrix.dtype);
+    dataBuffer[layerId][accessorName] = {
       layerId,
-      accessor,
+      accessorName,
       columnName: datum.column_name,
-      matrix: {data: rowMajorOrderMatrix, shape: datum.matrix.shape}
+      matrix: {data: new ArrayType(datum.matrix.data), shape: datum.matrix.shape}
     };
-    if (renderable[layerId][accessor].matrix.data.length === 0) {
+    if (dataBuffer[layerId][accessorName].matrix.data.length === 0) {
       console.warn(`No records in accessor ${accessor} belonging to ${layerId}`); // eslint-disable-line
     }
   }
   // Becomes the data stored within the widget model at `model.get('data_buffer')`
-  return renderable;
+  return dataBuffer;
 }
 
 function constructDataProp(dataBuffer, layerId) {

--- a/modules/jupyter-widget/src/binary-transport.js
+++ b/modules/jupyter-widget/src/binary-transport.js
@@ -1,0 +1,157 @@
+// eslint-disable-next-line complexity
+function dtypeToTypedArray(dtype, data) {
+  switch (dtype) {
+    case 'int8':
+      return new Int8Array(data);
+    case 'uint8':
+      return new Uint8Array(data);
+    case 'int16':
+      return new Int16Array(data);
+    case 'uint16':
+      return new Uint16Array(data);
+    case 'float32':
+      return new Float32Array(data);
+    case 'float64':
+      return new Float64Array(data);
+    case 'int32':
+      return new Int32Array(data);
+    case 'uint32':
+      return new Uint32Array(data);
+    case 'int64':
+      return new BigInt64Array(data); // eslint-disable-line no-undef
+    case 'uint64':
+      return new BigUint64Array(data); // eslint-disable-line no-undef
+    default:
+      throw new Error(`Unrecognized dtype ${dtype}`);
+  }
+}
+
+function deserializeMatrix(arr, manager) {
+  /* 
+   * Data is sent from the pydeck backend
+   * in the following format:
+   *
+   * {'<layer ID>': 
+   *     {'<accessor function name e.g. getPosition>': {
+   *        {
+   *          layer_id: <duplicate ID of layer as above>
+   *          column_name: <string name of column>
+   *          matrix: {
+   *            data: <binary data, a row major order representation of a matrix>,
+   *            shape: [<height>, <width>],
+   *            dtype: <string representation of typed array data type>
+   *          }
+   *
+   * Multiple layers and multiple accessors are possible.
+   *
+   * Objects at the JSON path `<accessor name>.matrix.data`
+   * are vectors representing a 1 x n matrix,
+   * or they can represent a m x n matrix in row major order form;
+   * shape of the matrix is given at <accessor name>.matrix.data.shape
+   */
+  if (!arr) {
+    return null;
+  }
+  const renderable = {};
+  for (const datum of arr.payload) {
+    // Each entry here represents a single column in
+    // a pandas.DataFrame arriving from the pydeck backend
+    const layerId = datum.layer_id;
+    const accessor = datum.accessor;
+    if (renderable[layerId] === undefined) {
+      renderable[layerId] = {};
+    }
+    // Columns can be nested
+    const convertedBinary = dtypeToTypedArray(datum.matrix.dtype, datum.matrix.data.buffer);
+    renderable[layerId][accessor] = {
+      layerId,
+      accessor,
+      columnName: datum.column_name,
+      matrix: {data: convertedBinary, shape: datum.matrix.shape}
+    };
+    if (renderable[layerId][accessor].matrix.data.length === 0) {
+      console.warn(`No records in accessor ${accessor} belonging to ${layerId}`); // eslint-disable-line
+    }
+  }
+  return renderable;
+}
+
+function makeLayerAccessorPropFunction({width, accessor}) {
+  /* data.src is a layer-specific data dictionary keyed by accessor */
+  return (object, {index, data, target}) => {
+    for (let j = 0; j < width; j++) {
+      target[j] = data.src[accessor][index * width + j];
+    }
+    return target;
+  };
+}
+
+function getLayer(deckLayers, layerId) {
+  for (const layer of deckLayers) {
+    if (layer.id === layerId) {
+      return layer;
+    }
+  }
+  return null;
+}
+
+function getCurrentLayerProps(layer) {
+  const LayerConstructor = layer.__proto__.constructor; // eslint-disable-line
+  const layerProps = layer.props;
+  return {
+    LayerConstructor,
+    layerProps
+  };
+}
+
+function getAccessorNamesFrom(dataBuffer, layerId) {
+  return Object.keys(dataBuffer[layerId]);
+}
+
+function constructData(dataBuffer, layerId) {
+  const src = {};
+  let length = 0;
+  const accessors = getAccessorNamesFrom(dataBuffer, layerId);
+  // For each accessor, we have a row major ordered matrix of data,
+  // represented as a single vector under `src[accessor]`
+  for (const accessor of accessors) {
+    const currentData = dataBuffer[layerId][accessor];
+    length = Math.max(currentData.matrix.shape[0], length);
+    src[accessor] = currentData.matrix.data;
+  }
+  return {
+    src,
+    length
+  };
+}
+
+function makeBinaryAccessorProps(accessors, layerId, dataBuffer) {
+  const dataAccessorProps = {};
+  for (const accessor of accessors) {
+    // width of matrix
+    const width = dataBuffer[layerId][accessor].matrix.shape[1] || 1;
+    const newAccessorFunction = makeLayerAccessorPropFunction({width, accessor});
+    dataAccessorProps[accessor] = newAccessorFunction;
+  }
+  return dataAccessorProps;
+}
+
+function processDataBuffer({currentLayers, dataBuffer}) {
+  const updatedLayers = [];
+  const updateLayerIds = Object.keys(dataBuffer);
+  for (const layerId of updateLayerIds) {
+    const currentLayer = getLayer(currentLayers, layerId);
+    const newLayerData = constructData(dataBuffer, layerId);
+    const {LayerConstructor, layerProps} = getCurrentLayerProps(currentLayer);
+    const accessors = getAccessorNamesFrom(dataBuffer, layerId);
+    const accessorProps = makeBinaryAccessorProps(accessors, layerId, dataBuffer);
+    const combinedProps = {...layerProps, ...accessorProps};
+    combinedProps.data = newLayerData;
+    const layer = new LayerConstructor({...combinedProps});
+    updatedLayers.push(layer);
+  }
+
+  return updatedLayers;
+}
+
+export {deserializeMatrix, processDataBuffer};

--- a/modules/jupyter-widget/src/binary-transport.js
+++ b/modules/jupyter-widget/src/binary-transport.js
@@ -85,18 +85,11 @@ function deserializeMatrix(arr, manager) {
   return renderable;
 }
 
-function getAccessorNamesFrom(dataBuffer, layerId) {
-  // Given data transferred from pydeck's backend,
-  // get the names of the accessors using binary data on a particular layer
-  return Object.keys(dataBuffer[layerId]);
-}
-
 function constructDataProp(dataBuffer, layerId) {
   const src = {length: 0, attributes: {}};
-  const accessors = getAccessorNamesFrom(dataBuffer, layerId);
   // For each accessor, we have a row major ordered matrix of data,
-  // represented as a single vector under `src[accessor]`
-  for (const accessor of accessors) {
+  // represented as a single vector under `[accessor]matrix.data`
+  for (const accessor in dataBuffer[layerId]) {
     const currentData = dataBuffer[layerId][accessor];
     src.length = Math.max(currentData.matrix.shape[0], src.length);
     src.attributes[accessor] = {

--- a/modules/jupyter-widget/src/binary-transport.js
+++ b/modules/jupyter-widget/src/binary-transport.js
@@ -37,11 +37,11 @@ function deserializeMatrix(obj, manager) {
     return null;
   }
   for (const layerId in obj) {
-    for (const accessorName in obj[layerId].attributes) {
-      const {dtype, value} = obj[layerId].attributes[accessorName];
+    const attributes = obj[layerId].attributes;
+    for (const accessorName in attributes) {
+      const {dtype, value} = attributes[accessorName];
       const ArrayType = dtypeToTypedArray(dtype);
       obj[layerId].attributes[accessorName].value = new ArrayType(value.buffer);
-      delete obj[layerId].attributes[accessorName].dtype;
     }
   }
   // Becomes the data stored within the widget model at `model.get('data_buffer')`

--- a/modules/jupyter-widget/src/binary-transport.js
+++ b/modules/jupyter-widget/src/binary-transport.js
@@ -41,7 +41,7 @@ function deserializeMatrix(obj, manager) {
     for (const accessorName in attributes) {
       const {dtype, value} = attributes[accessorName];
       const ArrayType = dtypeToTypedArray(dtype);
-      obj[layerId].attributes[accessorName].value = new ArrayType(value.buffer);
+      attributes[accessorName].value = new ArrayType(value.buffer);
     }
   }
   // Becomes the data stored within the widget model at `model.get('data_buffer')`

--- a/modules/jupyter-widget/src/binary-transport.js
+++ b/modules/jupyter-widget/src/binary-transport.js
@@ -1,5 +1,3 @@
-import jsonConverter from './create-deck';
-
 // Functions to wrangle data from pydeck's row major order matrix dataframe to the deck.gl binary data format.
 // The format used is described here:
 // https://deck.gl/#/documentation/developer-guide/performance-optimization?section=supply-attributes-directly
@@ -100,10 +98,8 @@ function constructDataProp(dataBuffer, layerId) {
   return src;
 }
 
-function processDataBuffer({dataBuffer, jsonProps}) {
+function processDataBuffer({dataBuffer, convertedJsonProps}) {
   // Takes JSON props and combines them with the binary data buffer
-  jsonConverter.convert(jsonProps);
-  const convertedJsonProps = jsonConverter.convertedJson;
   for (let i = 0; i < convertedJsonProps.layers.length; i++) {
     const layer = convertedJsonProps.layers[i];
     // Replace data on every layer prop

--- a/modules/jupyter-widget/src/create-deck.js
+++ b/modules/jupyter-widget/src/create-deck.js
@@ -37,7 +37,7 @@ const jsonConverterConfiguration = {
 
 registerLoaders([CSVLoader, Tile3DLoader]);
 
-const jsonConverter = new deck.JSONConverter({
+export const jsonConverter = new deck.JSONConverter({
   configuration: jsonConverterConfiguration
 });
 

--- a/modules/jupyter-widget/src/create-deck.js
+++ b/modules/jupyter-widget/src/create-deck.js
@@ -37,7 +37,7 @@ const jsonConverterConfiguration = {
 
 registerLoaders([CSVLoader, Tile3DLoader]);
 
-export const jsonConverter = new deck.JSONConverter({
+const jsonConverter = new deck.JSONConverter({
   configuration: jsonConverterConfiguration
 });
 
@@ -90,3 +90,5 @@ function injectFunction(warnFunction, messageHandler) {
     return warnFunction(...args);
   };
 }
+
+export default jsonConverter;

--- a/modules/jupyter-widget/src/widget.js
+++ b/modules/jupyter-widget/src/widget.js
@@ -4,6 +4,7 @@ import {DOMWidgetModel, DOMWidgetView} from '@jupyter-widgets/base';
 import {MODULE_NAME, MODULE_VERSION} from './version';
 
 import {createDeck, updateDeck} from './create-deck';
+import {deserializeMatrix, processDataBuffer} from './binary-transport';
 
 const MAPBOX_CSS_URL = 'https://api.tiles.mapbox.com/mapbox-gl-js/v1.2.1/mapbox-gl.css';
 const ERROR_BOX_CLASSNAME = 'error-box';
@@ -25,7 +26,6 @@ function loadCss(url) {
   link.href = url;
   document.getElementsByTagName('head')[0].appendChild(link);
 }
-
 // Note: Variables shared explictly between Python and JavaScript use snake_case
 export class DeckGLModel extends DOMWidgetModel {
   defaults() {
@@ -40,6 +40,7 @@ export class DeckGLModel extends DOMWidgetModel {
       json_input: null,
       mapbox_key: null,
       selected_data: [],
+      data_buffer: null,
       tooltip: null,
       width: '100%',
       height: 500,
@@ -48,8 +49,11 @@ export class DeckGLModel extends DOMWidgetModel {
   }
 
   static get serializers() {
-    return {...DOMWidgetModel.serializers};
-    // Add any extra serializers here
+    return {
+      ...DOMWidgetModel.serializers,
+      // Add any extra serializers here
+      data_buffer: {deserialize: deserializeMatrix}
+    };
   }
 
   static get model_name() {
@@ -119,6 +123,19 @@ export class DeckGLView extends DOMWidgetView {
     super.render();
 
     this.model.on('change:json_input', this.valueChanged.bind(this), this);
+    this.model.on('change:data_buffer', this.dataBufferChanged.bind(this), this);
+    this.dataBufferChanged();
+  }
+
+  dataBufferChanged() {
+    if (this.model.get('data_buffer')) {
+      const currentLayers = this.deck.props.layers;
+      const newLayers = processDataBuffer({
+        currentLayers,
+        dataBuffer: this.model.get('data_buffer')
+      });
+      this.deck.setProps({layers: newLayers});
+    }
   }
 
   valueChanged() {

--- a/modules/jupyter-widget/src/widget.js
+++ b/modules/jupyter-widget/src/widget.js
@@ -128,13 +128,13 @@ export class DeckGLView extends DOMWidgetView {
   }
 
   dataBufferChanged() {
+    const jsonProps = this.model.get('json_input');
     if (this.model.get('data_buffer')) {
-      const currentLayers = this.deck.props.layers;
-      const newLayers = processDataBuffer({
-        currentLayers,
-        dataBuffer: this.model.get('data_buffer')
+      const convertedJsonProps = processDataBuffer({
+        dataBuffer: this.model.get('data_buffer'),
+        jsonProps
       });
-      this.deck.setProps({layers: newLayers});
+      this.deck.setProps(convertedJsonProps);
     }
   }
 

--- a/modules/jupyter-widget/src/widget.js
+++ b/modules/jupyter-widget/src/widget.js
@@ -129,15 +129,14 @@ export class DeckGLView extends DOMWidgetView {
   }
 
   dataBufferChanged() {
-    const jsonProps = this.model.get('json_input');
     if (this.model.get('data_buffer')) {
-      jsonConverter.convert(jsonProps);
-      const convertedJsonProps = jsonConverter.convertedJson;
       const propsWithBinary = processDataBuffer({
         dataBuffer: this.model.get('data_buffer'),
-        convertedJsonProps
+        jsonProps: this.model.get('json_input')
       });
-      this.deck.setProps(propsWithBinary);
+
+      jsonConverter.convert(propsWithBinary);
+      this.deck.setProps(jsonConverter.convertedJson);
     }
   }
 

--- a/modules/jupyter-widget/src/widget.js
+++ b/modules/jupyter-widget/src/widget.js
@@ -4,6 +4,7 @@ import {DOMWidgetModel, DOMWidgetView} from '@jupyter-widgets/base';
 import {MODULE_NAME, MODULE_VERSION} from './version';
 
 import {createDeck, updateDeck} from './create-deck';
+import jsonConverter from './create-deck';
 import {deserializeMatrix, processDataBuffer} from './binary-transport';
 
 const MAPBOX_CSS_URL = 'https://api.tiles.mapbox.com/mapbox-gl-js/v1.2.1/mapbox-gl.css';
@@ -130,11 +131,13 @@ export class DeckGLView extends DOMWidgetView {
   dataBufferChanged() {
     const jsonProps = this.model.get('json_input');
     if (this.model.get('data_buffer')) {
-      const convertedJsonProps = processDataBuffer({
+      jsonConverter.convert(jsonProps);
+      const convertedJsonProps = jsonConverter.convertedJson;
+      const propsWithBinary = processDataBuffer({
         dataBuffer: this.model.get('data_buffer'),
-        jsonProps
+        convertedJsonProps
       });
-      this.deck.setProps(convertedJsonProps);
+      this.deck.setProps(propsWithBinary);
     }
   }
 

--- a/modules/jupyter-widget/src/widget.js
+++ b/modules/jupyter-widget/src/widget.js
@@ -135,8 +135,8 @@ export class DeckGLView extends DOMWidgetView {
         jsonProps: this.model.get('json_input')
       });
 
-      jsonConverter.convert(propsWithBinary);
-      this.deck.setProps(jsonConverter.convertedJson);
+      const convertedJson = jsonConverter.convert(propsWithBinary);
+      this.deck.setProps(convertedJson);
     }
   }
 

--- a/test/modules/jupyter-widget/binary-transport.spec.js
+++ b/test/modules/jupyter-widget/binary-transport.spec.js
@@ -1,0 +1,80 @@
+import test from 'tape-catch';
+
+test('jupyter-widget: binary-transport', t0 => {
+  let binaryTransportModule;
+  try {
+    binaryTransportModule = require('@deck.gl/jupyter-widget/binary-transport');
+  } catch (error) {
+    t0.comment('dist mode, skipping tooltip tests');
+    t0.end();
+    return;
+  }
+  const EXPECTED_DATA_PROP = {length: 5, attributes: {value: new Int32Array(), size: 2}};
+
+  const EXAMPLE_TRANSFER = {
+    'xxxx-layer-id': {
+      getPosition: {
+        layer_id: 'xxxx-layer-id',
+        column_name: 'dataVectorName',
+        matrix: {
+          data: DataView(),
+          shape: [5, 2],
+          dtype: 'int32'
+        }
+      }
+    }
+  };
+
+  const EXPECTED_CONVERSION = {
+    'xxxx-layer-id': {
+      accessorFuncName: {
+        layer_id: 'xxxx-layer-id',
+        column_name: 'dataVectorName',
+        matrix: {
+          data: new Int32Array(),
+          shape: [5, 2]
+        }
+      }
+    }
+  };
+
+  t0.test('deserializeMatrix', t => {
+    const TEST_TABLE = [
+      {input: null, expected: null, msg: 'Null arr should produce null output'},
+      {
+        input: EXAMPLE_TRANSFER,
+        expected: EXPECTED_CONVERSION,
+        msg: 'Test conversion of DataView to TypedArray'
+      }
+    ];
+    for (const testCase of TEST_TABLE) {
+      t.deepEquals(
+        binaryTransportModule.deserializeMatrix(testCase.input),
+        testCase.expected,
+        `deserializeMatrix: ${testCase.msg}`
+      );
+    }
+    t.end();
+  });
+
+  t0.test('constructDataProp', t => {
+    const dataProp = binaryTransportModule.constructDataProp(EXPECTED_CONVERSION, 'xxxx-layer-id');
+    t.deepEquals(dataProp, EXPECTED_DATA_PROP, 'Should create properly shaped data prop');
+    t.end();
+  });
+
+  t0.test('processDataBuffer', t => {
+    const DEMO_PROPS = {radius: 100, '@@type': 'ScatterplotLayer'};
+    const convertedJsonProps = binaryTransportModule.processDataBuffer({
+      dataBuffer: EXPECTED_CONVERSION,
+      jsonProps: DEMO_PROPS
+    });
+    t.deepEquals(
+      convertedJsonProps.layers[0].data,
+      EXPECTED_DATA_PROP,
+      'should convert buffer input and props to new layers'
+    );
+    t.deepEquals(convertedJsonProps.layers[0].id, 'xxxx-layer-id', 'should use specified layer ID');
+    t.end();
+  });
+});

--- a/test/modules/jupyter-widget/binary-transport.spec.js
+++ b/test/modules/jupyter-widget/binary-transport.spec.js
@@ -2,18 +2,14 @@ import test from 'tape-catch';
 
 const DEMO_ARRAY = new Uint32Array([0, 10, 2, 20]);
 
-function getDataView() {
-  const t = DEMO_ARRAY;
-  const dv = new DataView(t.buffer, t.byteOffset, t.byteLength);
-  return dv;
-}
+const DEMO_VALUE = new DataView(DEMO_ARRAY.buffer, DEMO_ARRAY.byteOffset, DEMO_ARRAY.byteLength);
 
 const EXAMPLE_TRANSFER = {
   'layer-id': {
     length: 2,
     attributes: {
       getPosition: {
-        value: getDataView(),
+        value: DEMO_VALUE,
         size: 2,
         dtype: 'uint32'
       }

--- a/test/modules/jupyter-widget/binary-transport.spec.js
+++ b/test/modules/jupyter-widget/binary-transport.spec.js
@@ -23,7 +23,8 @@ const EXPECTED_CONVERSION = {
     attributes: {
       getPosition: {
         value: DEMO_ARRAY,
-        size: 2
+        size: 2,
+        dtype: 'uint32'
       }
     }
   }
@@ -42,7 +43,7 @@ const DEMO_JSON_PROPS = {
   ]
 };
 
-test.only('jupyter-widget: binary-transport', t0 => {
+test('jupyter-widget: binary-transport', t0 => {
   let binaryTransportModule;
   try {
     binaryTransportModule = require('@deck.gl/jupyter-widget/binary-transport');

--- a/test/modules/jupyter-widget/index.js
+++ b/test/modules/jupyter-widget/index.js
@@ -1,2 +1,3 @@
+import './binary-transport.spec';
 import './index.spec';
 import './widget-tooltip.spec';


### PR DESCRIPTION
Change `npm run watch` for faster development within JupyterLab, which can call `jlpm run watch` on the package.json here.

Incorporate binary data transfer within the DeckGLWidget widget.

<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #4103 
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
