### PR TITLE
Remove HtmlWebpackPlugin from examples/playground

### DIFF
--- a/examples/playground/webpack.config.js
+++ b/examples/playground/webpack.config.js
@@ -4,7 +4,6 @@
 
 const {resolve} = require('path');
 const webpack = require('webpack');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 const CONFIG = {
   mode: 'development',


### PR DESCRIPTION
`HtmlWebpackPlugin` is unused, and not installed by `packages.json` for this example.

Note that tests were skipped locally when making this PR, because they were failing for me on `master`. (also `yarn bootstrap` was failing)