### PR TITLE
Fix modelMatrix application in the project module

### DIFF
--- a/modules/core/src/shaderlib/project/project.glsl.js
+++ b/modules/core/src/shaderlib/project/project.glsl.js
@@ -111,18 +111,18 @@ vec2 project_mercator_(vec2 lnglat) {
 // Projects positions (defined by project_uCoordinateSystem) to common space (defined by project_uProjectionMode)
 //
 vec4 project_position(vec4 position, vec3 position64Low) {
+  vec4 position_world = project_uModelMatrix * position;
+
   // Work around for a Mac+NVIDIA bug https://github.com/uber/deck.gl/issues/4145
   if (project_uProjectionMode == PROJECTION_MODE_WEB_MERCATOR) {
     if (project_uCoordinateSystem == COORDINATE_SYSTEM_LNGLAT) {
-      return project_uModelMatrix * vec4(
-        project_mercator_(position.xy) * WORLD_SCALE,
-        project_size(position.z),
-        position.w
+      return vec4(
+        project_mercator_(position_world.xy) * WORLD_SCALE,
+        project_size(position_world.z),
+        position_world.w
       );
     }
   }
-
-  vec4 position_world = project_uModelMatrix * position;
 
   if (project_uCoordinateSystem == COORDINATE_SYSTEM_LNGLAT && project_uProjectionMode == PROJECTION_MODE_WEB_MERCATOR_AUTO_OFFSET) {
     // Subtract high part of 64 bit value. Convert remainder to float32, preserving precision.


### PR DESCRIPTION
This is already fixed in master, patch 8.0

#### Change List
- Apply modelMatrix before mercator projection
