### PR TITLE
@deck.gl/json: Fix bug dropping props with falsy values

### DIFF
--- a/modules/json/src/helpers/convert-functions.js
+++ b/modules/json/src/helpers/convert-functions.js
@@ -26,11 +26,7 @@ export default function convertFunctions(props, configuration) {
       propValue = trimFunctionIdentifier(propValue);
       propValue = parseExpressionString(propValue, configuration);
     }
-
-    // Invalid functions return null, show default value instead.
-    if (propValue !== null) {
-      replacedProps[propName] = propValue;
-    }
+    replacedProps[propName] = propValue;
   }
 
   return replacedProps;

--- a/modules/json/src/helpers/convert-functions.js
+++ b/modules/json/src/helpers/convert-functions.js
@@ -28,7 +28,7 @@ export default function convertFunctions(props, configuration) {
     }
 
     // Invalid functions return null, show default value instead.
-    if (propValue) {
+    if (propValue !== null) {
       replacedProps[propName] = propValue;
     }
   }

--- a/modules/json/src/helpers/instantiate-class.js
+++ b/modules/json/src/helpers/instantiate-class.js
@@ -1,6 +1,6 @@
 import convertFunctions from './convert-functions';
 
-// This attempts to instantate a class. Either as a class or as a react component
+// This attempts to instantiate a class, either as a class or as a React component
 export function instantiateClass(type, props, configuration) {
   // Find the class
   const Class = configuration.classes[type];

--- a/modules/json/src/helpers/instantiate-class.js
+++ b/modules/json/src/helpers/instantiate-class.js
@@ -1,6 +1,6 @@
 import convertFunctions from './convert-functions';
 
-// This attempts to instantate a class. Eiher as a class or as a react component
+// This attempts to instantate a class. Either as a class or as a react component
 export function instantiateClass(type, props, configuration) {
   // Find the class
   const Class = configuration.classes[type];

--- a/test/modules/json/helpers/convert-functions.spec.js
+++ b/test/modules/json/helpers/convert-functions.spec.js
@@ -104,7 +104,7 @@ test('convertFunctions#asFunctions', t => {
   t.end();
 });
 
-test.only('convertFunctions#assureAllKeysPresent', t => {
+test('convertFunctions#assureAllKeysPresent', t => {
   const EXAMPLE_PROPS = {
     data: 'shp.geojson',
     stroked: true,

--- a/test/modules/json/helpers/convert-functions.spec.js
+++ b/test/modules/json/helpers/convert-functions.spec.js
@@ -123,8 +123,10 @@ test('convertFunctions#assureAllKeysPresent', t => {
       );
     } else {
       t.ok(
-        convertedProps[key]({x: 10}) === 100,
-        `convertFunctions converted function ${EXAMPLE_PROPS[key]} to expected value`
+        convertedProps.getElevation({x: 10}) === 100,
+        `convertFunctions converted function ${key} to expected value, ${convertedProps.getElevation(
+          10
+        )}`
       );
     }
   }

--- a/test/modules/json/helpers/convert-functions.spec.js
+++ b/test/modules/json/helpers/convert-functions.spec.js
@@ -4,6 +4,7 @@ import convertFunctions from '@deck.gl/json/helpers/convert-functions';
 
 const TEST_CASES = [
   {expr: 'true', expected: true}, // boolean literal
+  {expr: 'false', expected: false},
 
   // array expression
   {expr: '([1,2,3])[0]', expected: 1},
@@ -99,6 +100,33 @@ test('convertFunctions#asFunctions', t => {
   const convertedProps = convertFunctions(props, {});
   for (const key in convertedProps) {
     t.ok(typeof convertedProps[key] === 'function', 'convertFunctions converted prop to function');
+  }
+  t.end();
+});
+
+test.only('convertFunctions#assureAllKeysPresent', t => {
+  const EXAMPLE_PROPS = {
+    data: 'shp.geojson',
+    stroked: true,
+    filled: false,
+    lineWidthMinPixels: 2,
+    getElevation: '@@=x * 10',
+    opacity: 0.9
+  };
+
+  const convertedProps = convertFunctions(EXAMPLE_PROPS, {});
+  for (const key in EXAMPLE_PROPS) {
+    if (key !== 'getElevation') {
+      t.ok(
+        EXAMPLE_PROPS[key] === convertedProps[key],
+        `convertFunctions converted prop ${key} input to expected value ${EXAMPLE_PROPS[key]}`
+      );
+    } else {
+      t.ok(
+        convertedProps[key]({x: 10}) === 100,
+        `convertFunctions converted function ${EXAMPLE_PROPS[key]} to expected value`
+      );
+    }
   }
   t.end();
 });


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For  #4177
<!-- For other PRs without open issue -->
#### Background

Boolean props on all layers created via @deck.gl/json appear to have been returning to their default value if specified as `false`.

The bug only affected situations where a prop's default value is `true`, and the user wished to deactivate it, e.g. `stroked` and `filled` exhibit this behavior in the GeoJsonLayer, while `extruded` does not, because of their [defaults](https://github.com/uber/deck.gl/blob/master/docs/layers/geojson-layer.md#filled-boolean-optional).

<!-- For all the PRs -->
#### Change List
- Fix bug
- Add test to prevent regression
