### PR TITLE
[React] fix missing key error

### DIFF
--- a/modules/react/src/utils/position-children-under-views.js
+++ b/modules/react/src/utils/position-children-under-views.js
@@ -79,7 +79,7 @@ export default function positionChildrenUnderViews({children, viewports, deck, C
           deck._onViewStateChange(params);
         }
       };
-      return createElement(ContextProvider, {value: contextValue}, viewElement);
+      return createElement(ContextProvider, {key, value: contextValue}, viewElement);
     }
 
     return viewElement;


### PR DESCRIPTION
Pull request #4098 partially fixed issue with missing key error. Context
element is used in array children and also misses key. This PR fully fixes
issue #4116.
