### PR TITLE
pydeck: Add containerized JupyterLab/Jupyter Notebook tools for local development

### DIFF
--- a/bindings/pydeck/tests/dev-containers/README.md
+++ b/bindings/pydeck/tests/dev-containers/README.md
@@ -1,0 +1,18 @@
+Dockerized development tools
+===============
+
+Files in this directory can be used to spin up JupyterLab and Jupyter Notebook environments for rapid testing.
+
+Ideally run this in an isolated Python 3.7 environment, with `pyppeteer` installed.
+Docker and docker-compose are also required for these tools to work.
+
+- `build-and-screenshot.sh` creates screenshots of the current state of the containers
+- `snap.py` creates screenshots of the current state of the test.ipynb file
+- `docker-compose up -d` will run two containerized Jupyter environments,
+   one with JupyterLab and another with Jupyter Notebook, and install a specified build of pydeck.
+   The `PYDECK_VERSION` and `PYPI_INSTALL_URL` can be used to specify the version of pydeck to download and test.
+- `docker-compose down` will stop the containers this directory starts
+
+An example use case would be testing a version of pydeck published to test.pypi.com.
+
+This tool is only for local development.

--- a/bindings/pydeck/tests/dev-containers/build-and-screenshot.sh
+++ b/bindings/pydeck/tests/dev-containers/build-and-screenshot.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+export PYDECK_VERSION=0.2.1
+export PYPI_INSTALL_URL=https://test.pypi.org/simple/
+docker-compose build --parallel && docker-compose up --no-build -d
+python snap.py
+docker-compose down

--- a/bindings/pydeck/tests/dev-containers/docker-compose.yml
+++ b/bindings/pydeck/tests/dev-containers/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3'
+
+services:
+  jupyterlab:
+    build:
+      context: .
+      dockerfile: ./jupyterlab/Dockerfile
+      args:
+        PYDECK_VERSION: ${PYDECK_VERSION}
+        PYPI_INSTALL_URL: ${PYPI_INSTALL_URL}
+        JUPYTER_TOKEN: 'token'
+    ports: 
+      - "8888:8888"
+  jupyternb:
+    build:
+      context: .
+      dockerfile: ./jupyternb/Dockerfile
+      args:
+        PYDECK_VERSION: ${PYDECK_VERSION}
+        PYPI_INSTALL_URL: ${PYPI_INSTALL_URL}
+        JUPYTER_TOKEN: 'token'
+    ports: 
+      - "8889:8888"

--- a/bindings/pydeck/tests/dev-containers/jupyterlab/Dockerfile
+++ b/bindings/pydeck/tests/dev-containers/jupyterlab/Dockerfile
@@ -1,0 +1,26 @@
+FROM jupyter/minimal-notebook:latest
+
+USER root
+
+ARG PYDECK_VERSION
+ARG PYPI_INSTALL_URL
+ARG JUPYTER_TOKEN
+
+RUN test -n "$PYDECK_VERSION"
+RUN test -n "$PYPI_INSTALL_URL"
+
+ENV JUPYTER_TOKEN=$JUPYTER_TOKEN
+
+RUN echo "Installing $PYDECK_VERSION of pydeck from $PYPI_INSTALL_URL"
+
+RUN pip install jupyterlab && \ 
+    pip install ipywidgets && \
+    jupyter serverextension enable --py jupyterlab --sys-prefix && \
+    pip install -i $PYPI_INSTALL_URL pydeck==$PYDECK_VERSION && \
+    jupyter labextension install @jupyter-widgets/jupyterlab-manager && \
+    jupyter labextension install @deck.gl/jupyter-widget
+
+ADD test.ipynb .
+
+EXPOSE 8888
+CMD ["jupyter", "lab", "--allow-root"]

--- a/bindings/pydeck/tests/dev-containers/jupyternb/Dockerfile
+++ b/bindings/pydeck/tests/dev-containers/jupyternb/Dockerfile
@@ -1,0 +1,25 @@
+FROM jupyter/minimal-notebook:latest
+
+USER root
+
+ARG PYDECK_VERSION
+ARG PYPI_INSTALL_URL
+ARG JUPYTER_TOKEN
+
+RUN test -n "$PYDECK_VERSION"
+RUN test -n "$PYPI_INSTALL_URL"
+
+RUN echo "Installing $PYDECK_VERSION of pydeck from $PYPI_INSTALL_URL"
+
+ENV JUPYTER_TOKEN=$JUPYTER_TOKEN
+
+RUN pip install jupyter && \ 
+    pip install ipywidgets && \
+    pip install -i $PYPI_INSTALL_URL pydeck==$PYDECK_VERSION && \
+    jupyter nbextension install --sys-prefix --symlink --overwrite --py pydeck && \
+    jupyter nbextension enable --sys-prefix --py pydeck
+
+ADD test.ipynb .
+
+EXPOSE 8888
+CMD ["jupyter", "notebook", "--allow-root"]

--- a/bindings/pydeck/tests/dev-containers/snap.py
+++ b/bindings/pydeck/tests/dev-containers/snap.py
@@ -1,0 +1,47 @@
+import os
+import logging
+
+import asyncio
+
+from pyppeteer import launch
+
+NOTEBOOK_URL = 'http://localhost:8889/notebooks/test.ipynb?token=token'
+LAB_URL = 'http://127.0.0.1:8888/lab/tree/test.ipynb?token=token'
+
+NB_PLAY_BUTTON_XPATH = '/html/body/div[3]/div[3]/div[2]/div/div/div[5]/button[1]/span'
+LAB_PLAY_BUTTON_XPATH = '/html/body/div[1]/div[3]/div[2]/div[3]/div[2]/div[1]/div[6]/button/span'
+
+
+async def go_to_page_and_screenshot(url, fname, click_path, output_dir='./screenshots'):
+    browser = None
+    try:
+        browser = await launch(headless=True, args=['--no-sandbox', '--disable-setuid-sandbox'])
+        page = await browser.newPage()
+        await page.goto(url, waitUntil='networkidle2')
+        elements = await page.xpath(click_path)
+        for element in elements:
+            await element.click()
+        await page.setViewport({'width': 768, 'height': 1300})
+        path = os.path.join(str(output_dir), fname)
+        logging.info("Writing screenshot to %s" % path)
+        # hack: sleep five seconds, wait for visualization to load
+        await asyncio.sleep(5)
+        await page._screenshotTask('png', {
+            'path': path,
+            'fullPage': True
+        })
+        await browser.close()
+    except Exception as e:
+        browser.process.kill()
+        raise e
+
+
+async def screenshot():
+    # Wait for docker containers to start
+    await asyncio.sleep(5)
+    await go_to_page_and_screenshot(NOTEBOOK_URL, 'notebook-screenshot.png', NB_PLAY_BUTTON_XPATH)
+    await go_to_page_and_screenshot(LAB_URL, 'lab-screenshot.png', LAB_PLAY_BUTTON_XPATH)
+
+
+if __name__ == '__main__':
+    asyncio.get_event_loop().run_until_complete(screenshot())

--- a/bindings/pydeck/tests/dev-containers/test.ipynb
+++ b/bindings/pydeck/tests/dev-containers/test.ipynb
@@ -1,0 +1,71 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pydeck as pdk\n",
+    "\n",
+    "# 2014 locations of car accidents in the UK\n",
+    "UK_ACCIDENTS_DATA = ('https://raw.githubusercontent.com/uber-common/'\n",
+    "                     'deck.gl-data/master/examples/3d-heatmap/heatmap-data.csv')\n",
+    "\n",
+    "# Define a layer to display on a map\n",
+    "layer = pdk.Layer(\n",
+    "    'HexagonLayer',\n",
+    "    UK_ACCIDENTS_DATA,\n",
+    "    get_position=['lng', 'lat'],\n",
+    "    auto_highlight=True,\n",
+    "    elevation_scale=50,\n",
+    "    pickable=True,\n",
+    "    elevation_range=[0, 3000],\n",
+    "    extruded=True,                 \n",
+    "    coverage=1)\n",
+    "\n",
+    "# Set the viewport location\n",
+    "view_state = pdk.ViewState(\n",
+    "    longitude=-1.415,\n",
+    "    latitude=52.2323,\n",
+    "    zoom=6,\n",
+    "    min_zoom=5,\n",
+    "    max_zoom=15,\n",
+    "    pitch=40.5,\n",
+    "    bearing=-27.36)\n",
+    "\n",
+    "# Render\n",
+    "r = pdk.Deck(layers=[layer], initial_view_state=view_state)\n",
+    "r.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #4103 
<!-- For other PRs without open issue -->
#### Background

A group of scripts that make local dev testing/release faster. A great deal of my time while publishing is around verifying that pydeck continues to work in its different environments.

<!-- For all the PRs -->
#### Change List
- Add docker-compose and Dockerfiles to create/run JupyterLab and Jupyter Notebook
- Add Python script `snap.py` for running test Jupyter notebook in both Jupyter environments
- Add test notebook `test.ipynb`
