### PR TITLE
Fix transition for 64bit attributes

### DIFF
--- a/modules/core/src/lib/attribute/attribute-transition-utils.js
+++ b/modules/core/src/lib/attribute/attribute-transition-utils.js
@@ -110,7 +110,7 @@ export function padBuffer({
   const toData = isConstant
     ? attribute.value
     : attribute.getBuffer().getData({srcByteOffset: byteOffset});
-  if (attribute.settings.normalized) {
+  if (attribute.settings.normalized && !isConstant) {
     const getter = getData;
     getData = (value, chunk) => attribute._normalizeConstant(getter(value, chunk));
   }

--- a/modules/core/src/lib/attribute/data-column.js
+++ b/modules/core/src/lib/attribute/data-column.js
@@ -214,10 +214,11 @@ export default class DataColumn {
       state.externalBuffer = buffer;
       state.constant = false;
       this.value = opts.value;
+      const isBuffer64Bit = opts.value instanceof Float64Array;
 
       // Copy the type of the buffer into the accessor
       accessor.type = opts.type || buffer.accessor.type;
-      accessor.bytesPerElement = buffer.accessor.BYTES_PER_ELEMENT;
+      accessor.bytesPerElement = buffer.accessor.BYTES_PER_ELEMENT * (isBuffer64Bit ? 2 : 1);
       accessor.stride = getStride(accessor);
     } else if (opts.value) {
       this._checkExternalBuffer(opts);

--- a/modules/core/src/transitions/gpu-spring-transition.js
+++ b/modules/core/src/transitions/gpu-spring-transition.js
@@ -124,7 +124,12 @@ export default class GPUSpringTransition {
     });
 
     cycleBuffers(buffers);
-    this.attributeInTransition.update({buffer: buffers[1]});
+    this.attributeInTransition.update({
+      buffer: buffers[1],
+      // Hack: Float64Array is required for double-precision attributes
+      // to generate correct shader attributes
+      value: this.attribute.value
+    });
 
     const isTransitioning = readPixelsToArray(framebuffer)[0] > 0;
 


### PR DESCRIPTION

For https://github.com/uber/deck.gl/issues/4223

Stride is calculated incorrectly when setting external interleaved buffers.

This fix needs to be cherry-picked to the 8.0 release branch. I will add a render test in a follow up PR (render test setup has diverged on master).