### PR TITLE
pydeck: Add support for background colors in standalone HTML renderer

### DIFF
--- a/bindings/pydeck/pydeck/bindings/deck.py
+++ b/bindings/pydeck/pydeck/bindings/deck.py
@@ -21,6 +21,7 @@ class Deck(JSONMixin):
         height=500,
         tooltip=True,
         description=None,
+        effects=None,
     ):
         """This is the renderer and configuration for a deck.gl visualization, similar to the
         `Deck <https://deck.gl/#/documentation/deckgl-api-reference/deck>`_ class from deck.gl.
@@ -77,6 +78,7 @@ class Deck(JSONMixin):
         self.deck_widget.width = width
         self.deck_widget.tooltip = tooltip
         self.description = description
+        self.effects = effects
         if self.mapbox_key is None:
             warnings.warn(
                 "Mapbox API key is not set. This may impact available features of pydeck.",
@@ -119,6 +121,7 @@ class Deck(JSONMixin):
         notebook_display=True,
         iframe_width=700,
         iframe_height=500,
+        **kwargs
     ):
         """Write a file and loads it to an iframe, if in a Jupyter environment;
         otherwise, write a file and optionally open it in a web browser
@@ -151,5 +154,6 @@ class Deck(JSONMixin):
             iframe_height=iframe_height,
             iframe_width=iframe_width,
             tooltip=self.deck_widget.tooltip,
+            **kwargs
         )
         return f

--- a/bindings/pydeck/pydeck/io/html.py
+++ b/bindings/pydeck/pydeck/io/html.py
@@ -7,27 +7,36 @@ import webbrowser
 import jinja2
 
 
-TEMPLATES_PATH = os.path.join(os.path.dirname(__file__), './templates/')
-j2_env = jinja2.Environment(loader=jinja2.FileSystemLoader(TEMPLATES_PATH),
-                            trim_blocks=True)
-CDN_URL = 'https://cdn.jsdelivr.net/npm/@deck.gl/jupyter-widget@^8.0.0/dist/index.js'
+TEMPLATES_PATH = os.path.join(os.path.dirname(__file__), "./templates/")
+j2_env = jinja2.Environment(
+    loader=jinja2.FileSystemLoader(TEMPLATES_PATH), trim_blocks=True
+)
+CDN_URL = "https://cdn.jsdelivr.net/npm/@deck.gl/jupyter-widget@^8.0.0/dist/index.js"
 
-def render_json_to_html(json_input, mapbox_key=None, tooltip=True):
-    js = j2_env.get_template('index.j2')
-    if type(tooltip) == bool:
-        tooltip = 'true' if tooltip else 'false'
+
+def convert_js_bool(py_bool):
+    if type(py_bool) != bool:
+        return py_bool
+    return 'true' if py_bool else 'false'
+
+
+def render_json_to_html(
+    json_input, mapbox_key=None, tooltip=True, css_background_color=None
+):
+    js = j2_env.get_template("index.j2")
     html_str = js.render(
         mapbox_key=mapbox_key,
         json_input=json_input,
         deckgl_jupyter_widget_bundle=CDN_URL,
-        tooltip=tooltip
+        tooltip=convert_js_bool(tooltip),
+        css_background_color=css_background_color
     )
     return html_str
 
 
 def display_html(filename=None, height=500, width=500):
     """Converts HTML into a temporary file and opens it in the system browser."""
-    url = 'file://{}'.format(filename)
+    url = "file://{}".format(filename)
     # Hack to prevent blank page
     time.sleep(0.5)
     webbrowser.open(url)
@@ -38,12 +47,13 @@ def check_directory_exists(path):
 
 
 def open_named_or_temporary_file(pathname=None):
-    if pathname and not pathname.endswith('/'):
+    if pathname and not pathname.endswith("/"):
         filename = add_html_extension(pathname)
-        return open(filename, 'w+')
+        return open(filename, "w+")
     directory = make_directory_if_not_exists(pathname) or os.path.curdir
     return tempfile.NamedTemporaryFile(
-        prefix='pydeck', mode='w+', suffix='.html', dir=directory, delete=False)
+        prefix="pydeck", mode="w+", suffix=".html", dir=directory, delete=False
+    )
 
 
 def make_directory_if_not_exists(path):
@@ -53,23 +63,30 @@ def make_directory_if_not_exists(path):
 
 
 def add_html_extension(fname):
-    SUFFIX = '.html'
+    SUFFIX = ".html"
     if fname.endswith(SUFFIX):
         return str(fname)
-    return str(fname + '.html')
+    return str(fname + ".html")
 
 
 def deck_to_html(
-        deck_json,
-        mapbox_key=None,
-        filename=None,
-        open_browser=False,
-        notebook_display=False,
-        iframe_height=500,
-        iframe_width=500,
-        tooltip=True):
+    deck_json,
+    mapbox_key=None,
+    filename=None,
+    open_browser=False,
+    notebook_display=False,
+    css_background_color=None,
+    iframe_height=500,
+    iframe_width=500,
+    tooltip=True,
+):
     """Converts deck.gl format JSON to an HTML page"""
-    html = render_json_to_html(deck_json, mapbox_key=mapbox_key, tooltip=tooltip)
+    html = render_json_to_html(
+        deck_json,
+        mapbox_key=mapbox_key,
+        tooltip=tooltip,
+        css_background_color=css_background_color,
+    )
     f = None
     try:
         f = open_named_or_temporary_file(filename)
@@ -82,6 +99,13 @@ def deck_to_html(
         display_html(realpath(f.name))
     if notebook_display:
         from IPython.display import IFrame  # noqa
+
         notebook_to_html_path = relpath(f.name)
-        display(IFrame(os.path.join('./', notebook_to_html_path), width=iframe_width, height=iframe_height))  # noqa
+        display(  # noqa
+            IFrame(
+                os.path.join("./", notebook_to_html_path),
+                width=iframe_width,
+                height=iframe_height,
+            )
+        )
     return realpath(f.name)

--- a/bindings/pydeck/pydeck/io/templates/index.j2
+++ b/bindings/pydeck/pydeck/io/templates/index.j2
@@ -28,6 +28,9 @@
     
     #deckgl-overlay {
       z-index: 2;
+{% if css_background_color %}
+      background: {{css_background_color}};
+{% endif %}
     }
     
     #deck-map-wrapper {


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #4103 
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
- Add background color
- Add effects to deck object
