### PR TITLE
Fix bundle dependencies

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 // prettier-ignore
 module.exports = {
-  plugins: ['react'],
+  plugins: ['react', 'import'],
   extends: ['uber-jsx', 'uber-es2015', 'prettier', 'prettier/react', 'plugin:import/errors'],
   overrides: [{
     files: ['*.spec.js', 'webpack.config.js', '**/bundle/*.js'],
@@ -13,8 +13,11 @@ module.exports = {
       '@luma.gl/core',
       '@luma.gl/constants',
       'math.gl',
-      'viewport-mercator-project'
-    ]
+      '@math.gl/web-mercator'
+    ],
+    react: {
+      version: 'detect'
+    }
   },
   rules: {
     'guard-for-in': 0,

--- a/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-cell-layer.js
+++ b/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-cell-layer.js
@@ -20,7 +20,8 @@
 
 import {Layer, fp64LowPart, project32, gouraudLighting, picking} from '@deck.gl/core';
 import GL from '@luma.gl/constants';
-import {Model, CubeGeometry, fp64 as fp64ShaderModule} from '@luma.gl/core';
+import {Model, CubeGeometry} from '@luma.gl/core';
+import {fp64arithmetic} from '@luma.gl/shadertools';
 import {defaultColorRange, colorRangeToFlatArray} from '../utils/color-utils';
 
 import vs from './gpu-grid-cell-layer-vertex.glsl';
@@ -57,7 +58,7 @@ export default class GPUGridCellLayer extends Layer {
     return super.getShaders({
       vs,
       fs,
-      modules: [project32, gouraudLighting, picking, fp64ShaderModule]
+      modules: [project32, gouraudLighting, picking, fp64arithmetic]
     });
   }
 

--- a/modules/core/bundle/lumagl.js
+++ b/modules/core/bundle/lumagl.js
@@ -12,6 +12,13 @@ export {
   getParameters,
   setParameters,
   withParameters,
+  cssToDeviceRatio,
+  // Copy and blit
+  // These are needed by submodules and rely on using the same copy
+  // of Texture2D & Framebuffer
+  readPixelsToBuffer,
+  copyToTexture,
+  cloneTextureFrom,
   // WebGL1 classes
   Buffer,
   Program,

--- a/modules/core/src/effects/post-process-effect.js
+++ b/modules/core/src/effects/post-process-effect.js
@@ -1,7 +1,6 @@
 import Effect from '../lib/effect';
 import ScreenPass from '../passes/screen-pass';
-/* eslint-disable import/no-extraneous-dependencies */
-import {normalizeShaderModule} from '@luma.gl/shadertools';
+import {normalizeShaderModule} from '@luma.gl/core';
 
 export default class PostProcessEffect extends Effect {
   constructor(module, props = {}) {

--- a/modules/extensions/package.json
+++ b/modules/extensions/package.json
@@ -29,6 +29,9 @@
     "build-bundle": "webpack --config ../../scripts/bundle.config.js",
     "prepublishOnly": "npm run build-bundle && npm run build-bundle -- --env.dev"
   },
+  "dependencies": {
+    "@luma.gl/shadertools": "^8.1.0-alpha.2"
+  },
   "peerDependencies": {
     "@deck.gl/core": "^8.0.0"
   }

--- a/modules/extensions/src/fp64/project64.js
+++ b/modules/extensions/src/fp64/project64.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {fp64} from '@luma.gl/core';
+import {fp64} from '@luma.gl/shadertools';
 const {fp64ify, fp64ifyMatrix4} = fp64;
 import {project, _memoize as memoize} from '@deck.gl/core';
 

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -20,7 +20,7 @@
 
 import {Layer, project32, gouraudLighting, picking, COORDINATE_SYSTEM} from '@deck.gl/core';
 import GL from '@luma.gl/constants';
-import {Model, Geometry, hasFeature, FEATURES} from '@luma.gl/core';
+import {Model, Geometry, hasFeatures, FEATURES} from '@luma.gl/core';
 
 // Polygon geometry generation is managed by the polygon tesselator
 import PolygonTesselator from './polygon-tesselator';
@@ -82,7 +82,7 @@ export default class SolidPolygonLayer extends Layer {
       polygonTesselator: new PolygonTesselator({
         preproject: coordinateSystem === COORDINATE_SYSTEM.LNGLAT,
         fp64: this.use64bitPositions(),
-        IndexType: !gl || hasFeature(gl, FEATURES.ELEMENT_INDEX_UINT32) ? Uint32Array : Uint16Array
+        IndexType: !gl || hasFeatures(gl, FEATURES.ELEMENT_INDEX_UINT32) ? Uint32Array : Uint16Array
       })
     });
 

--- a/modules/mesh-layers/package.json
+++ b/modules/mesh-layers/package.json
@@ -33,6 +33,7 @@
     "@deck.gl/core": "^8.0.0"
   },
   "dependencies": {
-    "@luma.gl/experimental": "^8.1.0-alpha.2"
+    "@luma.gl/experimental": "^8.1.0-alpha.2",
+    "@luma.gl/shadertools": "^8.1.0-alpha.2"
   }
 }

--- a/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.js
+++ b/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.js
@@ -18,8 +18,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {Layer, project32, picking} from '@deck.gl/core';
-import {isWebGL2, pbr, log} from '@luma.gl/core';
+import {Layer, project32, picking, log} from '@deck.gl/core';
+import {isWebGL2} from '@luma.gl/core';
+import {pbr} from '@luma.gl/shadertools';
 import {ScenegraphNode, createGLTFObjects} from '@luma.gl/experimental';
 import GL from '@luma.gl/constants';
 import {waitForGLTFAssets} from './gltf-utils';
@@ -122,7 +123,7 @@ export default class ScenegraphLayer extends Layer {
       log.deprecated(
         'ScenegraphLayer.props.scenegraph',
         'Use GLTFLoader instead of GLTFScenegraphLoader'
-      );
+      )();
       scenegraphData = props.scenegraph;
     }
 

--- a/scripts/bundle.config.js
+++ b/scripts/bundle.config.js
@@ -31,15 +31,7 @@ function getExternals(packageInfo) {
 
   if (externals['@deck.gl/core']) {
     // Do not bundle luma.gl if `core` is peer dependency
-    externals = [
-      externals,
-      (context, request, callback) => {
-        if (/^@?luma\.gl/.test(request)) {
-          return callback(null, 'luma');
-        }
-        return callback();
-      }
-    ];
+    externals['@luma.gl/core'] = 'luma';
   }
 
   return externals;


### PR DESCRIPTION
For #4254

#### Change List
- Bundle config: do not make luma submodules other than `@luma.gl/core` externals
- Audit submodule usage of `@luma.gl/core`, make sure that they match the luma APIs exposed by standalone bundle
- Fix eslint settings
