### PR TITLE
[react] Fix support for mix-blend-mode style

### DIFF
--- a/modules/react/src/utils/extract-styles.js
+++ b/modules/react/src/utils/extract-styles.js
@@ -1,0 +1,35 @@
+const CANVAS_ONLY_STYLES = {
+  mixBlendMode: null
+};
+
+export default function extractStyles({width, height, style}) {
+  // This styling is enforced for correct positioning with children
+  const containerStyle = {
+    position: 'absolute',
+    zIndex: 0,
+    left: 0,
+    top: 0,
+    width,
+    height
+  };
+
+  // Fill the container
+  const canvasStyle = {
+    left: 0,
+    top: 0
+  };
+
+  if (style) {
+    for (const key in style) {
+      if (key in CANVAS_ONLY_STYLES) {
+        // apply style to the canvas, but not deck's children, e.g. mix-blend-mode
+        canvasStyle[key] = style[key];
+      } else {
+        // apply style to the container, e.g. position/flow settings
+        containerStyle[key] = style[key];
+      }
+    }
+  }
+
+  return {containerStyle, canvasStyle};
+}

--- a/test/modules/react/index.js
+++ b/test/modules/react/index.js
@@ -20,5 +20,6 @@
 
 import './utils/evaluate-children.spec';
 import './utils/extract-jsx-layers.spec';
+import './utils/extract-styles.spec';
 import './utils/position-children-under-views.spec';
 import './deckgl.spec';

--- a/test/modules/react/utils/extract-styles.spec.js
+++ b/test/modules/react/utils/extract-styles.spec.js
@@ -1,0 +1,23 @@
+import test from 'tape-catch';
+import extractStyles from '@deck.gl/react/utils/extract-styles';
+
+test('extractStyles', t => {
+  let result = extractStyles({width: '100%', height: '100%'});
+  t.is(result.containerStyle.width, '100%', 'containerStyle has width');
+  t.is(result.containerStyle.height, '100%', 'containerStyle has height');
+  t.ok(result.canvasStyle, 'returns canvasStyle');
+
+  result = extractStyles({
+    width: 600,
+    height: 400,
+    style: {float: 'left', mixBlendMode: 'color-burn'}
+  });
+  t.is(result.containerStyle.width, 600, 'containerStyle has width');
+  t.is(result.containerStyle.height, 400, 'containerStyle has height');
+  t.is(result.containerStyle.float, 'left', 'containerStyle contains custom style');
+  t.notOk(result.containerStyle.mixBlendMode, 'containerStyle does not contain canvas only style');
+  t.is(result.canvasStyle.mixBlendMode, 'color-burn', 'canvasStyle contains custom style');
+  t.notOk(result.canvasStyle.float, 'canvasStyle does not contain positioning style');
+
+  t.end();
+});


### PR DESCRIPTION
#### Background

In 7.x, apps can set the mix-blend-mode CSS property of the canvas by specifying the `style` prop of the `DeckGL` React component. This is important for compositing deck.gl's canvas with a base map. Due to a bug fix for positioning, the approach was broken in 8.0.

#### Change List
- Memoize element styles
- Whitelist `mixBlendMode` for the canvas
