### PR TITLE
Fix using `getColor` with constant in SimpleMeshLayer

### DIFF
--- a/examples/website/mesh/app.js
+++ b/examples/website/mesh/app.js
@@ -1,4 +1,3 @@
-/* global window */
 import React, {PureComponent} from 'react';
 import {render} from 'react-dom';
 import DeckGL from '@deck.gl/react';
@@ -12,7 +11,6 @@ import {
 import {SolidPolygonLayer} from '@deck.gl/layers';
 import {SimpleMeshLayer} from '@deck.gl/mesh-layers';
 
-import {Matrix4} from 'math.gl';
 import {OBJLoader} from '@loaders.gl/obj';
 import {registerLoaders} from '@loaders.gl/core';
 
@@ -64,42 +62,12 @@ const background = [
 ];
 
 export default class App extends PureComponent {
-  constructor(props) {
-    super(props);
-    this.state = {
-      modelMatrix: new Matrix4()
-    };
-    this._frameId = null;
-    this._rotate = this._rotate.bind(this);
-  }
-
-  componentDidMount() {
-    this._frameId = window.requestAnimationFrame(this._rotate);
-  }
-
-  componentWillUnmount() {
-    if (this._frameId) {
-      window.cancelAnimationFrame(this._frameId);
-    }
-  }
-
-  _rotate() {
-    const matrix = new Matrix4(this.state.modelMatrix);
-    matrix.rotateX((0.005 / 180) * Math.PI);
-    this.setState({
-      modelMatrix: matrix
-    });
-    window.requestAnimationFrame(this._rotate);
-  }
-
   render() {
-    const {modelMatrix} = this.state;
     const layers = [
       new SimpleMeshLayer({
         id: 'mini-coopers',
         data: SAMPLE_DATA,
         mesh: MESH_URL,
-        modelMatrix,
         coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
         getPosition: d => d.position,
         getColor: d => d.color,
@@ -110,7 +78,6 @@ export default class App extends PureComponent {
         id: 'background',
         data: background,
         extruded: false,
-        modelMatrix,
         coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
         getPolygon: f => f,
         getFillColor: [0, 0, 0, 0]

--- a/modules/core/src/lib/attribute/attribute.js
+++ b/modules/core/src/lib/attribute/attribute.js
@@ -93,6 +93,7 @@ export default class Attribute extends DataColumn {
 
   setNeedsUpdate(reason = this.id, dataRange) {
     this.state.needsUpdate = this.state.needsUpdate || reason;
+    this.setNeedsRedraw(reason);
     if (dataRange) {
       const {startRow = 0, endRow = Infinity} = dataRange;
       this.state.updateRanges = range.add(this.state.updateRanges, [startRow, endRow]);


### PR DESCRIPTION
When the prop `mesh` is loaded asynchronously, we create a new model, and invalidates all attributes.

The bug is in the Attribute class. If `instanceColors` is a constant, without changing the constant value, the `attribute.neesRedraw` flag is not set during an update, so the attribute is never sent on the new model.

#### Change List

- Mark invalidated attributes as `needsRedraw`
