### PR TITLE
TerrainLayer fixes

### DIFF
--- a/modules/geo-layers/src/terrain-layer/terrain-layer.js
+++ b/modules/geo-layers/src/terrain-layer/terrain-layer.js
@@ -30,7 +30,7 @@ const defaultProps = {
   // Image url that encodes height data
   terrainImage: {type: 'string', value: null},
   // Image url to use as texture
-  surfaceImage: {type: 'string', value: 0},
+  surfaceImage: {type: 'string', value: null, optional: true},
   // Martini error tolerance in meters, smaller number -> more detailed mesh
   meshMaxError: {type: 'number', value: 4.0},
   // Bounding box of the terrain image, [minX, minY, maxX, maxY] in world coordinates
@@ -124,7 +124,7 @@ export default class TerrainLayer extends CompositeLayer {
           .replace('{x}', x)
           .replace('{y}', y)
           .replace('{z}', z)
-      : 0;
+      : false;
 
     return new SimpleMeshLayer({
       id: props.id,
@@ -151,7 +151,7 @@ export default class TerrainLayer extends CompositeLayer {
 
     if (this.state.isTiled) {
       return new TileLayer(this.props, {
-        id: `${this.props.id}-terrain`,
+        id: `${this.props.id}-tiles`,
         getTileData: this.getTiledTerrainData.bind(this),
         renderSubLayers: this.renderSubLayers,
         updateTriggers: {
@@ -161,7 +161,7 @@ export default class TerrainLayer extends CompositeLayer {
     }
     return new SimpleMeshLayer(
       this.getSubLayerProps({
-        id: 'terrain'
+        id: 'mesh'
       }),
       {
         data: [1],

--- a/modules/geo-layers/src/tile-layer/tile-2d-header.js
+++ b/modules/geo-layers/src/tile-layer/tile-2d-header.js
@@ -1,7 +1,7 @@
 import {log} from '@deck.gl/core';
 
 export default class Tile2DHeader {
-  constructor({getTileData, x, y, z, onTileLoad, onTileError}) {
+  constructor({x, y, z, onTileLoad, onTileError}) {
     this.x = x;
     this.y = y;
     this.z = z;
@@ -11,7 +11,6 @@ export default class Tile2DHeader {
 
     this.content = null;
     this._isLoaded = false;
-    this._loader = this._loadData(getTileData);
 
     this.onTileLoad = onTileLoad;
     this.onTileError = onTileError;
@@ -33,13 +32,13 @@ export default class Tile2DHeader {
     return result;
   }
 
-  _loadData(getTileData) {
+  loadData(getTileData) {
     const {x, y, z, bbox} = this;
     if (!getTileData) {
-      return null;
+      return;
     }
 
-    return Promise.resolve(getTileData({x, y, z, bbox}))
+    this._loader = Promise.resolve(getTileData({x, y, z, bbox}))
       .then(buffers => {
         this.content = buffers;
         this._isLoaded = true;

--- a/modules/geo-layers/src/tile-layer/tileset-2d.js
+++ b/modules/geo-layers/src/tile-layer/tileset-2d.js
@@ -266,7 +266,6 @@ export default class Tileset2D {
 
     if (!tile && create) {
       tile = new Tile2DHeader({
-        getTileData: this._getTileData,
         x,
         y,
         z,
@@ -274,6 +273,7 @@ export default class Tileset2D {
         onTileError: this.onTileError
       });
       Object.assign(tile, this.getTileMetadata(tile));
+      tile.loadData(this._getTileData);
       this._cache.set(tileId, tile);
       this._dirty = true;
     }

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "jsdom": false
   },
   "devDependencies": {
-    "@loaders.gl/csv": "^2.0.2",
-    "@loaders.gl/polyfills": "^2.0.2",
+    "@loaders.gl/csv": "^2.1.0-alpha.4",
+    "@loaders.gl/polyfills": "^2.1.0-alpha.4",
     "@luma.gl/engine": "^8.1.0-alpha.4",
     "@luma.gl/test-utils": "^8.1.0-alpha.4",
     "@probe.gl/bench": "^3.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1572,14 +1572,6 @@
     math.gl "^3.1.2"
     probe.gl "^3.2.0"
 
-"@loaders.gl/core@2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/core/-/core-2.0.2.tgz#1ca39ce7168379bd24e39a2a443672b01bf764af"
-  integrity sha512-l2atBRmKln/0M6GEbtobS1fIIYzGfbN72Vloc3V4+p31gxDsWj35QLvHMAc4K8SOE0lk5gRDcZkJjYQo90JoUQ==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
-    "@loaders.gl/loader-utils" "2.0.2"
-
 "@loaders.gl/core@2.1.0-alpha.4", "@loaders.gl/core@^2.1.0-alpha.4":
   version "2.1.0-alpha.4"
   resolved "https://registry.yarnpkg.com/@loaders.gl/core/-/core-2.1.0-alpha.4.tgz#a6c518d97c7b7bbf491ac3a1a20749b832d58e6e"
@@ -1587,14 +1579,6 @@
   dependencies:
     "@babel/runtime" "^7.3.1"
     "@loaders.gl/loader-utils" "2.1.0-alpha.4"
-
-"@loaders.gl/csv@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/csv/-/csv-2.0.2.tgz#2dad2e41476dc643fbc30ea4542ce2084a5c2bda"
-  integrity sha512-Kp73jghUIFgEdFU2y4J4Ya8vlLw+if1rrhdRsXDluyOZ6yrw2phz62FSDjV2YUHyKMlXcA1Lb7wO35cGgTYvjA==
-  dependencies:
-    "@loaders.gl/core" "2.0.2"
-    "@loaders.gl/tables" "2.0.2"
 
 "@loaders.gl/csv@^2.1.0-alpha.4":
   version "2.1.0-alpha.4"
@@ -1625,13 +1609,6 @@
   resolved "https://registry.yarnpkg.com/@loaders.gl/images/-/images-2.0.2.tgz#546929146b38a428e55905e513b4b9ec7afc58e2"
   integrity sha512-H6xhSvM24CI++P46TZRLX+95mn5B4HaP0jWGSIn2Lo0aBpcI9/T8z2EZhJyihjoR450fph1ER0j+Mnz+ovHEGg==
 
-"@loaders.gl/loader-utils@2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/loader-utils/-/loader-utils-2.0.2.tgz#9ee11de0ae9f8d8d7c763fb5d17b3eeb0b5a888d"
-  integrity sha512-sowdxj1wE2lSXSBSJswNjWfJvfdi21ZG9nB7OmenvbPiqcd1NyjUVsr+TeiTBiRsPlyQhp5BjVEYnywDLHSNUg==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
-
 "@loaders.gl/loader-utils@2.1.0-alpha.4":
   version "2.1.0-alpha.4"
   resolved "https://registry.yarnpkg.com/@loaders.gl/loader-utils/-/loader-utils-2.1.0-alpha.4.tgz#92d623f2edf12084de48ae359958baac95ab8085"
@@ -1647,10 +1624,10 @@
     "@loaders.gl/images" "2.1.0-alpha.4"
     math.gl "^3.1.2"
 
-"@loaders.gl/polyfills@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/polyfills/-/polyfills-2.0.2.tgz#1fcf43ef9df5115f7045507eade7ae1d9e964b1a"
-  integrity sha512-o8qsMp3cpGbKBNDeBvgA9GKP1XU/4eVLCB4yDH9ApKicM+Akralrox7+kVPG1aL1LXsVlmAaAnY3Zda63fO+uw==
+"@loaders.gl/polyfills@^2.1.0-alpha.4":
+  version "2.1.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/polyfills/-/polyfills-2.1.0-alpha.4.tgz#4db9e7532785fb5f3317d016693ce15bd5b0b79c"
+  integrity sha512-wa3aJsFj5n1BDwfaca6EgpSgewml52/+YPSdQysrh8QiEkyR0ysNBtIf1Ol20jl3dFiIEJekOjeTDjaALv+2xg==
   dependencies:
     "@babel/runtime" "^7.3.1"
     get-pixels "^3.3.2"
@@ -1658,13 +1635,6 @@
     save-pixels "^2.3.2"
     stream-to-async-iterator "^0.2.0"
     through "^2.3.8"
-
-"@loaders.gl/tables@2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/tables/-/tables-2.0.2.tgz#ba090c9460ce6006d413cc4ad79d027c4cbc62f2"
-  integrity sha512-XNaDn7toDTc6DGVp+CPy09wMJoJAuulHxt4767n8jUFwwQijEdnNn+zwoZK4l7mjFVOqWs/SJ2Aje2OsYfErMA==
-  dependencies:
-    "@loaders.gl/core" "2.0.2"
 
 "@loaders.gl/tables@2.1.0-alpha.4":
   version "2.1.0-alpha.4"


### PR DESCRIPTION
The TileLayer refactor broke TerrainLayer (`bbox` must be available before calling `getTileData`)

#### Change List
- Call `getTileData` after tile metadata is populated
- Fix id collision in TerrainLayer
- Bump root loaders.gl dependencies
