### PR TITLE
Clean up ArcGIS module API and docs

### DIFF
--- a/docs/api-reference/arcgis/arcgis-deck-layer.md
+++ b/docs/api-reference/arcgis/arcgis-deck-layer.md
@@ -2,21 +2,16 @@
 
 This class inherits from the ArcGIS [Layer](https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-Layer.html) class and can be added to maps created with the ArcGIS API for JavaScript. Its content is defined by the `deckLayers` property, which is a collection of deck.gl layers.
 
+`ArcGISDeckLayer` is only available when `loadArcGISModules()` is resolved.
+
 ## Usage
 
 ```js
 import {loadArcGISModules} from '@deck.gl/arcgis';
 import {GeoJsonLayer, ArcLayer} from '@deck.gl/layers';
 
-loadArcGISModules([
-  "esri/Map",
-  "esri/views/MapView"
-]).then(([
-  arcGIS,
-  ArcGISMap,
-  MapView
-]) => {
-  const layer = new arcGIS.ArcGISDeckLayer({
+loadArcGISModules().then(({ArcGISDeckLayer}) => {
+  const layer = new ArcGISDeckLayer({
     deckLayers: [
       new GeoJsonLayer({
         ...
@@ -26,16 +21,6 @@ loadArcGISModules([
       })
     ]
   });
-  
-  const mapView = new MapView({
-    container: "viewDiv",
-    map: new ArcGISMap({
-      basemap: "dark-gray-vector",
-      layers: [layer]
-    }),
-    center: [0.119167, 52.205276],
-    zoom: 5
-  });
 });
 ```
 
@@ -43,7 +28,7 @@ loadArcGISModules([
 ## Constructor
 
 ```js
-const layer = new arcGIS.ArcGISDeckLayer(props)
+const layer = new ArcGISDeckLayer(props)
 ```
 
 `props` are forwarded to a `Deck` instance. The following [Deck](/docs/api-reference/deck.md) props are supported:

--- a/docs/api-reference/arcgis/load-arcgis-modules.md
+++ b/docs/api-reference/arcgis/load-arcgis-modules.md
@@ -1,0 +1,25 @@
+# loadArcGISModules
+
+This utility function initializes the classes in this module by loading ArcGIS dependencies. Optionally, it can also load additional dependencies from the `esri` namespace.
+
+## Usage
+
+```js
+import {loadArcGISModules} from '@deck.gl/arcgis';
+
+loadArcGISModules(['esri/Map', 'esri/views/MapView'], {version: '4.14'})
+  .then(({ArcGISDeckLayer, modules}) => {
+    const [ArcGISMap, MapView] = modules;
+    ...
+  });
+```
+
+Arguments:
+
+- `modules` (Array, optional) - Array of esri modules to load, passed to [esri-loader](https://github.com/Esri/esri-loader)'s `loadModules`
+- `loadScriptOptions` (Object, optional) - [esri-loader options](https://github.com/Esri/esri-loader#configuring-esri-loader)
+
+Returns: a promise that resolves to an object with the following fields:
+
+- [ArcGISDeckLayer](/docs/api-reference/arcgis/arcgis-deck-layer.md)
+- modules (Array) - if the `modules` argument was specified, will represent the resolved result from `esri-loader`'s `loadModules`

--- a/docs/api-reference/arcgis/overview.md
+++ b/docs/api-reference/arcgis/overview.md
@@ -6,7 +6,7 @@ The functionality exported by this module must be loaded asynchronously using th
 This function can be used to load any module that ships with the ArcGIS API for JavaScript, plus an additional `arcGIS` module
 that acts as an interface between deck.gl and ArcGIS.
 
-At the moment only 2D integration with `MapView` is supported; it is provided by the `arcGIS.ArcGISDeckLayer` class.
+At the moment only 2D integration with `MapView` is supported; it is provided by the `ArcGISDeckLayer` class.
 
 ## Installation
 
@@ -19,16 +19,7 @@ At the moment only 2D integration with `MapView` is supported; it is provided by
 <script src="https://unpkg.com/@deck.gl/arcgis@^1.0.0/dist.min.js"></script>
 <!-- usage -->
 <script type="text/javascript">
-deck.loadArcGISModules([
-  "esri/Map",
-  "esri/views/MapView"
-]).then(([
-  arcGIS,
-  ArcGISMap,
-  MapView
-]) => {
-  const {ArcGISDeckLayer} = arcGIS;
-  ...
+  const {loadArcGISModules} = deck;
 </script>
 ```
 
@@ -44,16 +35,32 @@ npm install @deck.gl/core @deck.gl/arcgis
 import {loadArcGISModules} from '@deck.gl/arcgis';
 
 loadArcGISModules([
-  "esri/Map",
-  "esri/views/MapView"
-]).then(([
-  arcGIS,
-  ArcGISMap,
-  MapView
-]) => {
-  const {ArcGISDeckLayer} = arcGIS;
-  ...
-</script>
+  'esri/Map',
+  'esri/views/MapView'
+]).then(({ArcGISDeckLayer, modules}) => {
+  const [ArcGISMap, MapView] = modules;
+
+  const layer = new ArcGISDeckLayer({
+    deckLayers: [
+      new GeoJsonLayer({
+        ...
+      }),
+      new ArcLayer({
+        ...
+      })
+    ]
+  });
+
+  const mapView = new MapView({
+    container: "viewDiv",
+    map: new ArcGISMap({
+      basemap: "dark-gray-vector",
+      layers: [layer]
+    }),
+    center: [0.119167, 52.205276],
+    zoom: 5
+  });
+});
 ```
 
 ## Supported Features and Limitations
@@ -63,6 +70,8 @@ Supported deck.gl features:
 - Layers
 - Effects
 - Attribute transitions
+- Auto-highlighting
+- `onHover` and `onClick` callbacks
 
 Not supported features:
 
@@ -70,6 +79,3 @@ Not supported features:
 - Views
 - Controller
 - React integration
-- Gesture event callbacks (e.g. `onDrag*`)
-- Auto-highlighting
-- `onHover` and `onClick` callbacks

--- a/examples/get-started/pure-js/arcgis/app.js
+++ b/examples/get-started/pure-js/arcgis/app.js
@@ -5,8 +5,9 @@ import {GeoJsonLayer, ArcLayer} from '@deck.gl/layers';
 const AIR_PORTS =
   'https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_10m_airports.geojson';
 
-loadArcGISModules(['esri/Map', 'esri/views/MapView']).then(([arcGIS, ArcGISMap, MapView]) => {
-  const layer = new arcGIS.ArcGISDeckLayer({
+loadArcGISModules(['esri/Map', 'esri/views/MapView']).then(({ArcGISDeckLayer, modules}) => {
+  const [ArcGISMap, MapView] = modules;
+  const layer = new ArcGISDeckLayer({
     deckLayers: [
       new GeoJsonLayer({
         id: 'airports',

--- a/website/contents/pages.js
+++ b/website/contents/pages.js
@@ -676,6 +676,23 @@ export const docPages = generatePath([
     name: 'Submodule API Reference',
     children: [
       {
+        name: '@deck.gl/arcgis',
+        children: [
+          {
+            name: 'Overview',
+            content: getDocUrl('api-reference/arcgis/overview.md')
+          },
+          {
+            name: 'ArcGISDeckLayer',
+            content: getDocUrl('api-reference/arcgis/arcgis-deck-layer.md')
+          },
+          {
+            name: 'loadArcGISModules',
+            content: getDocUrl('api-reference/arcgis/load-arcgis-modules.md')
+          }
+        ]
+      },
+      {
         name: '@deck.gl/extensions',
         children: [
           {


### PR DESCRIPTION
#### Change List
- Change the resolved result of `loadArcGISModules` from array to object (see updated docs)
- Allow empty `modules` argument to `loadArcGISModules`
- Documentation pass

@damix911 