### PR TITLE
Fix package.json for modules/arcgis

### DIFF
--- a/modules/arcgis/package.json
+++ b/modules/arcgis/package.json
@@ -1,10 +1,33 @@
 {
   "name": "@deck.gl/arcgis",
+  "description": "Use deck.gl as a custom ArcGIS API for JavaScript layer",
+  "license": "MIT",
   "version": "8.1.0-alpha.5",
-  "main": "index.js",
-  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "webgl",
+    "visualization",
+    "esri",
+    "arcgis"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/uber/deck.gl.git"
+  },
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
+  "esnext": "dist/es6/index.js",
+  "files": [
+    "dist",
+    "src",
+    "dist.min.js"
+  ],
+  "sideEffects": false,
   "scripts": {
-    "build-bundle": "../../node_modules/.bin/webpack --config ../../scripts/bundle.config.js"
+    "build-bundle": "webpack --config ../../scripts/bundle.config.js",
+    "prepublishOnly": "npm run build-bundle && npm run build-bundle -- --env.dev"
   },
   "peerDependencies": {
     "@deck.gl/core": "^8.0.0"


### PR DESCRIPTION
My previous PR #4252 was missing some build-related info in the `package.json` file for the `@deck.gl/arcgis` module. This is a first attempt at fixing it.