### PR TITLE
Improve TerrainLayer loading experience

### DIFF
--- a/docs/layers/terrain-layer.md
+++ b/docs/layers/terrain-layer.md
@@ -158,7 +158,7 @@ Set `workerUrl` to empty string to disable worker (improves error messages).
 
 ##### `color` (Color, optional)
 
-Color to use before `surfaceImage` is loaded or if `surfaceImage` is unavailable. Equivalent to setting SimpleMeshLayer `getColor` prop to `d => prop.color`.
+Color to use if `surfaceImage` is unavailable. Equivalent to setting SimpleMeshLayer `getColor` prop to `d => prop.color`.
 
 - Default: `[255, 255, 255]`
 

--- a/website/src/components/demos/terrain-demo.js
+++ b/website/src/components/demos/terrain-demo.js
@@ -46,7 +46,8 @@ const LOCATIONS = {
 const SURFACE_IMAGES = {
   Sectional: 'https://wms.chartbundle.com/tms/1.0.0/sec/{z}/{x}/{y}.png?origin=nw',
   Satellite: `https://api.mapbox.com/v4/mapbox.satellite/{z}/{x}/{y}@2x.png?access_token=${MAPBOX_TOKEN}`,
-  Street: 'https://c.tile.openstreetmap.org/{z}/{x}/{y}.png'
+  Street: 'https://c.tile.openstreetmap.org/{z}/{x}/{y}.png',
+  None: null
 };
 
 export default class TerrainDemo extends Component {


### PR DESCRIPTION
For #4236 

#### Change List
- Only display a tile if both the mesh and the surface image are loaded
- Fix an update issue in non-tiled scenario when `terrainImage` is changed
- Restore no texture option in the demo