### PR TITLE
pydeck: Add 10 additional examples 

### DIFF
--- a/bindings/pydeck/examples/gpu_grid_layer.py
+++ b/bindings/pydeck/examples/gpu_grid_layer.py
@@ -1,0 +1,37 @@
+import pydeck as pdk
+import pandas as pd
+
+GPU_GRID_LAYER_DATA = (
+    "https://raw.githubusercontent.com/uber-common/"
+    "deck.gl-data/master/website/sf-bike-parking.json"
+)
+df = pd.read_json(GPU_GRID_LAYER_DATA)
+
+# Define a layer to display on a map
+layer = pdk.Layer(
+    "GPUGridLayer",
+    df,
+    pickable=True,
+    extruded=True,
+    cellSize=200,
+    elevation_scale=4,
+    get_position="COORDINATES",
+)
+
+# Set the viewport location
+view_state = pdk.ViewState(
+    latitude=37.7749295,
+    longitude=-122.4194155,
+    zoom=11,
+    bearing=0,
+    pitch=45
+)
+
+
+# Render
+r = pdk.Deck(
+    layers=[layer],
+    initial_view_state=view_state,
+    tooltip={"text": "{position}\nCount: {count}"},
+)
+r.to_html("gpu_grid_layer.html")

--- a/bindings/pydeck/examples/gpu_grid_layer.py
+++ b/bindings/pydeck/examples/gpu_grid_layer.py
@@ -20,11 +20,7 @@ layer = pdk.Layer(
 
 # Set the viewport location
 view_state = pdk.ViewState(
-    latitude=37.7749295,
-    longitude=-122.4194155,
-    zoom=11,
-    bearing=0,
-    pitch=45
+    latitude=37.7749295, longitude=-122.4194155, zoom=11, bearing=0, pitch=45
 )
 
 

--- a/bindings/pydeck/examples/great_circle_layer.py
+++ b/bindings/pydeck/examples/great_circle_layer.py
@@ -1,0 +1,41 @@
+import pydeck as pdk
+import pandas as pd
+
+GREAT_CIRCLE_LAYER_DATA = (
+    "https://raw.githubusercontent.com/uber-common/"
+    "deck.gl-data/master/website/flights.json"
+)
+df = pd.read_json(GREAT_CIRCLE_LAYER_DATA)
+
+# Use pandas to prepare data for tooltip
+df["from_name"] = df["from"].apply(lambda f: f["name"])
+df["to_name"] = df["to"].apply(lambda t: t["name"])
+
+# Define a layer to display on a map
+layer = pdk.Layer(
+    "GreatCircleLayer",
+    df,
+    pickable=True,
+    get_stroke_width=12,
+    get_source_position="from.coordinates",
+    get_target_position="to.coordinates",
+    get_source_color=[64, 255, 0],
+    get_target_color=[0, 128, 200],
+)
+
+# Set the viewport location
+view_state = pdk.ViewState(
+    latitude=50,
+    longitude=-40,
+    zoom=3,
+    bearing=0,
+    pitch=0
+)
+
+# Render
+r = pdk.Deck(
+    layers=[layer],
+    initial_view_state=view_state,
+    tooltip={"text": "{from_name} to {to_name}"},
+)
+r.to_html("great_circle_layer.html")

--- a/bindings/pydeck/examples/great_circle_layer.py
+++ b/bindings/pydeck/examples/great_circle_layer.py
@@ -24,13 +24,7 @@ layer = pdk.Layer(
 )
 
 # Set the viewport location
-view_state = pdk.ViewState(
-    latitude=50,
-    longitude=-40,
-    zoom=3,
-    bearing=0,
-    pitch=0
-)
+view_state = pdk.ViewState(latitude=50, longitude=-40, zoom=3, bearing=0, pitch=0)
 
 # Render
 r = pdk.Deck(

--- a/bindings/pydeck/examples/grid_layer.py
+++ b/bindings/pydeck/examples/grid_layer.py
@@ -20,11 +20,7 @@ layer = pdk.Layer(
 )
 
 view_state = pdk.ViewState(
-    latitude=37.7749295,
-    longitude=-122.4194155,
-    zoom=11,
-    bearing=0,
-    pitch=45
+    latitude=37.7749295, longitude=-122.4194155, zoom=11, bearing=0, pitch=45
 )
 
 # Render

--- a/bindings/pydeck/examples/grid_layer.py
+++ b/bindings/pydeck/examples/grid_layer.py
@@ -1,0 +1,36 @@
+import pydeck as pdk
+import pandas as pd
+
+CPU_GRID_LAYER_DATA = (
+    "https://raw.githubusercontent.com/uber-common/"
+    "deck.gl-data/master/website/sf-bike-parking.json"
+)
+df = pd.read_json(CPU_GRID_LAYER_DATA)
+
+# Define a layer to display on a map
+
+layer = pdk.Layer(
+    "GridLayer",
+    df,
+    pickable=True,
+    extruded=True,
+    cell_size=200,
+    elevation_scale=4,
+    get_position="COORDINATES",
+)
+
+view_state = pdk.ViewState(
+    latitude=37.7749295,
+    longitude=-122.4194155,
+    zoom=11,
+    bearing=0,
+    pitch=45
+)
+
+# Render
+r = pdk.Deck(
+    layers=[layer],
+    initial_view_state=view_state,
+    tooltip={"text": "{position}\nCount: {count}"},
+)
+r.to_html("grid_layer.html")

--- a/bindings/pydeck/examples/h3_cluster_layer.py
+++ b/bindings/pydeck/examples/h3_cluster_layer.py
@@ -23,11 +23,7 @@ layer = pdk.Layer(
 
 # Set the viewport location
 view_state = pdk.ViewState(
-    latitude=37.7749295,
-    longitude=-122.4194155,
-    zoom=11,
-    bearing=0,
-    pitch=30
+    latitude=37.7749295, longitude=-122.4194155, zoom=11, bearing=0, pitch=30
 )
 
 

--- a/bindings/pydeck/examples/h3_cluster_layer.py
+++ b/bindings/pydeck/examples/h3_cluster_layer.py
@@ -1,0 +1,38 @@
+import pydeck as pdk
+import pandas as pd
+
+H3_CLUSTER_LAYER_DATA = (
+    "https://raw.githubusercontent.com/uber-common/"
+    "deck.gl-data/master/website/sf.h3clusters.json"
+)
+df = pd.read_json(H3_CLUSTER_LAYER_DATA)
+
+# Define a layer to display on a map
+layer = pdk.Layer(
+    "H3ClusterLayer",
+    df,
+    pickable=True,
+    stroked=True,
+    filled=True,
+    extruded=False,
+    get_hexagons="hexIds",
+    get_fill_color="[255, (1 - mean / 500) * 255, 0]",
+    get_line_color=[255, 255, 255],
+    line_width_min_pixels=2,
+)
+
+# Set the viewport location
+view_state = pdk.ViewState(
+    latitude=37.7749295,
+    longitude=-122.4194155,
+    zoom=11,
+    bearing=0,
+    pitch=30
+)
+
+
+# Render
+r = pdk.Deck(
+    layers=[layer], initial_view_state=view_state, tooltip={"text": "Density: {mean}"}
+)
+r.to_html("h3_cluster_layer.html")

--- a/bindings/pydeck/examples/hexagon_layer.py
+++ b/bindings/pydeck/examples/hexagon_layer.py
@@ -1,0 +1,34 @@
+import pydeck as pdk
+
+HEXAGON_LAYER_DATA = (
+    "https://raw.githubusercontent.com/uber-common/"
+    "deck.gl-data/master/examples/3d-heatmap/heatmap-data.csv"
+)
+
+# Define a layer to display on a map
+layer = pdk.Layer(
+    "HexagonLayer",
+    HEXAGON_LAYER_DATA,
+    get_position=["lng", "lat"],
+    auto_highlight=True,
+    elevation_scale=50,
+    pickable=True,
+    elevation_range=[0, 3000],
+    extruded=True,
+    coverage=1,
+)
+
+# Set the viewport location
+view_state = pdk.ViewState(
+    longitude=-1.415,
+    latitude=52.2323,
+    zoom=6,
+    min_zoom=5,
+    max_zoom=15,
+    pitch=40.5,
+    bearing=-27.36,
+)
+
+# Render
+r = pdk.Deck(layers=[layer], initial_view_state=view_state)
+r.to_html("hexagon_layer.html")

--- a/bindings/pydeck/examples/s2_layer.py
+++ b/bindings/pydeck/examples/s2_layer.py
@@ -23,11 +23,7 @@ layer = pdk.Layer(
 
 # Set the viewport location
 view_state = pdk.ViewState(
-    latitude=37.7749295,
-    longitude=-122.4194155,
-    zoom=11,
-    bearing=0,
-    pitch=45
+    latitude=37.7749295, longitude=-122.4194155, zoom=11, bearing=0, pitch=45
 )
 
 # Render

--- a/bindings/pydeck/examples/s2_layer.py
+++ b/bindings/pydeck/examples/s2_layer.py
@@ -1,0 +1,39 @@
+import pydeck as pdk
+import pandas as pd
+
+S2_LAYER_DATA = (
+    "https://raw.githubusercontent.com/uber-common/"
+    "deck.gl-data/master/website/sf.s2cells.json"
+)
+df = pd.read_json(S2_LAYER_DATA)
+
+# Define a layer to display on a map
+layer = pdk.Layer(
+    "S2Layer",
+    df,
+    pickable=True,
+    wireframe=False,
+    filled=True,
+    extruded=True,
+    elevation_scale=1000,
+    getS2Token="token",
+    get_fill_color="[value * 255, (1 - value) * 255, (1 - value) * 128]",
+    get_elevation="value",
+)
+
+# Set the viewport location
+view_state = pdk.ViewState(
+    latitude=37.7749295,
+    longitude=-122.4194155,
+    zoom=11,
+    bearing=0,
+    pitch=45
+)
+
+# Render
+r = pdk.Deck(
+    layers=[layer],
+    initial_view_state=view_state,
+    tooltip={"text": "{token} value: {value}"},
+)
+r.to_html("s2_layer.html")

--- a/bindings/pydeck/examples/scatterplot_layer.py
+++ b/bindings/pydeck/examples/scatterplot_layer.py
@@ -31,11 +31,7 @@ layer = pdk.Layer(
 
 # Set the viewport location
 view_state = pdk.ViewState(
-    latitude=37.7749295,
-    longitude=-122.4194155,
-    zoom=10,
-    bearing=0,
-    pitch=45
+    latitude=37.7749295, longitude=-122.4194155, zoom=10, bearing=0, pitch=45
 )
 
 # Render

--- a/bindings/pydeck/examples/scatterplot_layer.py
+++ b/bindings/pydeck/examples/scatterplot_layer.py
@@ -1,0 +1,45 @@
+import pydeck as pdk
+import pandas as pd
+import math
+
+SCATTERPLOT_LAYER_DATA = (
+    "https://raw.githubusercontent.com/uber-common/"
+    "deck.gl-data/master/website/bart-stations.json"
+)
+df = pd.read_json(SCATTERPLOT_LAYER_DATA)
+
+# Use pandas to calculate additional data
+df["exits_radius"] = df["exits"].apply(lambda exits_count: math.sqrt(exits_count))
+
+# Define a layer to display on a map
+layer = pdk.Layer(
+    "ScatterplotLayer",
+    df,
+    pickable=True,
+    opacity=0.8,
+    stroked=True,
+    filled=True,
+    radius_scale=6,
+    radius_min_pixels=1,
+    radius_max_pixels=100,
+    line_width_min_pixels=1,
+    get_position="coordinates",
+    get_radius="exits_radius",
+    get_fill_color=[255, 140, 0],
+    get_line_color=[0, 0, 0],
+)
+
+# Set the viewport location
+view_state = pdk.ViewState(
+    latitude=37.7749295,
+    longitude=-122.4194155,
+    zoom=10,
+    bearing=0,
+    pitch=45
+)
+
+# Render
+r = pdk.Deck(
+    layers=[layer], initial_view_state=view_state, tooltip={"text": "{name}\n{address}"}
+)
+r.to_html("scatterplot_layer.html")

--- a/bindings/pydeck/examples/screengrid_layer.py
+++ b/bindings/pydeck/examples/screengrid_layer.py
@@ -28,11 +28,7 @@ layer = pdk.Layer(
 
 # Set the viewport location
 view_state = pdk.ViewState(
-    latitude=37.7749295,
-    longitude=-122.4194155,
-    zoom=11,
-    bearing=0,
-    pitch=0
+    latitude=37.7749295, longitude=-122.4194155, zoom=11, bearing=0, pitch=0
 )
 
 # Render

--- a/bindings/pydeck/examples/screengrid_layer.py
+++ b/bindings/pydeck/examples/screengrid_layer.py
@@ -1,0 +1,40 @@
+import pydeck as pdk
+import pandas as pd
+
+SCREEN_GRID_LAYER_DATA = (
+    "https://raw.githubusercontent.com/uber-common/"
+    "deck.gl-data/master/website/sf-bike-parking.json"
+)
+df = pd.read_json(SCREEN_GRID_LAYER_DATA)
+
+# Define a layer to display on a map
+layer = pdk.Layer(
+    "ScreenGridLayer",
+    df,
+    pickable=False,
+    opacity=0.8,
+    cell_size_pixels=50,
+    color_range=[
+        [0, 25, 0, 25],
+        [0, 85, 0, 85],
+        [0, 127, 0, 127],
+        [0, 170, 0, 170],
+        [0, 190, 0, 190],
+        [0, 255, 0, 255],
+    ],
+    get_position="COORDINATES",
+    get_weight="SPACES",
+)
+
+# Set the viewport location
+view_state = pdk.ViewState(
+    latitude=37.7749295,
+    longitude=-122.4194155,
+    zoom=11,
+    bearing=0,
+    pitch=0
+)
+
+# Render
+r = pdk.Deck(layers=[layer], initial_view_state=view_state)
+r.to_html("screengrid_layer.html")

--- a/bindings/pydeck/examples/text_layer.py
+++ b/bindings/pydeck/examples/text_layer.py
@@ -1,0 +1,37 @@
+import pydeck as pdk
+import pandas as pd
+
+TEXT_LAYER_DATA = (
+    "https://raw.githubusercontent.com/uber-common/"
+    "deck.gl-data/master/website/bart-stations.json"
+)
+df = pd.read_json(TEXT_LAYER_DATA)
+
+# Define a layer to display on a map
+layer = pdk.Layer(
+    "TextLayer",
+    df,
+    pickable=True,
+    get_position="coordinates",
+    get_text="name",
+    get_size=16,
+    get_color = [255, 255, 255],
+    get_angle=0,
+    get_text_anchor="'middle'",
+    get_alignment_baseline="'center'",
+)
+
+# Set the viewport location
+view_state = pdk.ViewState(
+    latitude=37.7749295,
+    longitude=-122.4194155,
+    zoom=10,
+    bearing=0,
+    pitch=45
+)
+
+# Render
+r = pdk.Deck(
+    layers=[layer], initial_view_state=view_state, tooltip={"text": "{name}\n{address}"}
+)
+r.to_html("text_layer.html")

--- a/bindings/pydeck/examples/text_layer.py
+++ b/bindings/pydeck/examples/text_layer.py
@@ -15,7 +15,7 @@ layer = pdk.Layer(
     get_position="coordinates",
     get_text="name",
     get_size=16,
-    get_color = [255, 255, 255],
+    get_color=[255, 255, 255],
     get_angle=0,
     get_text_anchor="'middle'",
     get_alignment_baseline="'center'",
@@ -23,11 +23,7 @@ layer = pdk.Layer(
 
 # Set the viewport location
 view_state = pdk.ViewState(
-    latitude=37.7749295,
-    longitude=-122.4194155,
-    zoom=10,
-    bearing=0,
-    pitch=45
+    latitude=37.7749295, longitude=-122.4194155, zoom=10, bearing=0, pitch=45
 )
 
 # Render

--- a/bindings/pydeck/examples/trips_layer.py
+++ b/bindings/pydeck/examples/trips_layer.py
@@ -1,0 +1,41 @@
+import pydeck as pdk
+import pandas as pd
+
+TRIPS_LAYER_DATA = (
+    "https://raw.githubusercontent.com/uber-common"
+    "/deck.gl-data/master/website/sf.trips.json"
+)
+
+df = pd.read_json(TRIPS_LAYER_DATA)
+
+df["coordinates"] = df["waypoints"].apply(lambda f: [item["coordinates"] for item in f])
+df["timestamps"] = df["waypoints"].apply(
+    lambda f: [item["timestamp"] - 1554772579000 for item in f]
+)
+
+df.drop(["waypoints"], axis=1, inplace=True)
+
+layer = pdk.Layer(
+    "TripsLayer",
+    df,
+    get_path="coordinates",
+    get_timestamps="timestamps",
+    get_color=[253, 128, 93],
+    opacity=0.8,
+    width_min_pixels=5,
+    rounded=True,
+    trail_length=600,
+    current_time=500,
+)
+
+view_state = pdk.ViewState(
+    latitude=37.7749295,
+    longitude=-122.4194155,
+    zoom=11,
+    bearing=0,
+    pitch=45
+)
+
+# Render
+r = pdk.Deck(layers=[layer], initial_view_state=view_state)
+r.to_html("trips_layer.html")

--- a/bindings/pydeck/examples/trips_layer.py
+++ b/bindings/pydeck/examples/trips_layer.py
@@ -29,11 +29,7 @@ layer = pdk.Layer(
 )
 
 view_state = pdk.ViewState(
-    latitude=37.7749295,
-    longitude=-122.4194155,
-    zoom=11,
-    bearing=0,
-    pitch=45
+    latitude=37.7749295, longitude=-122.4194155, zoom=11, bearing=0, pitch=45
 )
 
 # Render


### PR DESCRIPTION
Added following examples:

ScatterplotLayer
TextLayer
GPUGridLayer
GreatCircleLayer
HexagonLayer
H3ClusterLayer
GridLayer
S2Layer
ScreenGridLayer
TripsLayer
For #4281

Background
Added new examples into pydeck basing on javascript examples as requested.
There is one additional example (TripsLayer) comparing to pull request #4282 which was canceled. All of the comments provided in PR4282 are fixed in this pull request. Formatting is done with the help of python black library

Change List
Added: screengrid_layer.py, s2_layer.py, grid_layer.py, h3_cluster_layer.py, hexagon_layer.py, great_circle_layer.py, gpu_grid_layer.py, scatterplot_layer.py, text_layer.py, trips_layer.py into \bindings\pydeck\examples\