### PR TITLE
Non-Geospatial Tiling Example

### DIFF
--- a/examples/website/image-tile/README.md
+++ b/examples/website/image-tile/README.md
@@ -16,4 +16,8 @@ npm start
 
 ### Data Source
 
-A DeepZoom pyramid was created from a source image:
+A DeepZoom pyramid was created from a [source image](http://lroc.sese.asu.edu/posts/293).
+If you have [libvips](https://github.com/libvips/libvips) installed,
+you can run something from the command line like:
+
+`vips dzsave wac_nearside.tif moon.image --tile-size 512 --overlap 0`

--- a/examples/website/image-tile/README.md
+++ b/examples/website/image-tile/README.md
@@ -1,0 +1,19 @@
+This is a standalone high resolution image example using TileLayer and BitmapLayer, with non-geospatial coordinates
+on the [deck.gl](http://deck.gl) website.
+
+### Usage
+
+Copy the content of this folder to your project.
+
+```bash
+# install dependencies
+npm install
+# or
+yarn
+# bundle and serve the app with webpack
+npm start
+```
+
+### Data Source
+
+A DeepZoom pyramid was created from a source image:

--- a/examples/website/image-tile/app.js
+++ b/examples/website/image-tile/app.js
@@ -11,7 +11,8 @@ const INITIAL_VIEW_STATE = {
   zoom: -5
 };
 
-const ROOT_URL = 'moon.image';
+const ROOT_URL =
+  'https://raw.githubusercontent.com/uber-common/deck.gl-data/master/website/image-tiles/moon.image';
 
 export default class App extends PureComponent {
   constructor(props) {

--- a/examples/website/image-tile/app.js
+++ b/examples/website/image-tile/app.js
@@ -69,7 +69,8 @@ export default class App extends PureComponent {
         .then(str => new window.DOMParser().parseFromString(str, 'text/xml'))
         .then(dziXML => {
           if (Number(dziXML.getElementsByTagName('Image')[0].attributes.Overlap.value) !== 0) {
-            throw new Error('Overlap paramter is nonzero and should be 0');
+            // eslint-disable-next-line no-undef, no-console
+            console.warn('Overlap paramter is nonzero and should be 0');
           }
           this.setState({
             height: Number(dziXML.getElementsByTagName('Size')[0].attributes.Height.value),

--- a/examples/website/image-tile/app.js
+++ b/examples/website/image-tile/app.js
@@ -1,0 +1,110 @@
+import React, {PureComponent} from 'react';
+import {render} from 'react-dom';
+
+import DeckGL, {OrthographicView, COORDINATE_SYSTEM} from 'deck.gl';
+import {TileLayer} from '@deck.gl/geo-layers';
+import {BitmapLayer} from '@deck.gl/layers';
+import {load} from '@loaders.gl/core';
+
+const INITIAL_VIEW_STATE = {
+  target: [10000, 10000, 0],
+  zoom: 0
+};
+
+function inTileBounds({x, y, z}) {
+  const xInBounds = x < Math.ceil(31728 / (256 * 2 ** z)) && x >= 0;
+  const yInBounds = y < Math.ceil(51669 / (256 * 2 ** z)) && y >= 0;
+  return xInBounds && yInBounds;
+}
+
+function inImageBounds({top, bottom, left, right}) {
+  const bottomInBounds = bottom <= 51669;
+  const leftInBounds = left >= 0;
+  const rightInBounds = right <= 31728;
+  const topInBounds = top >= 0;
+  return topInBounds && bottomInBounds && leftInBounds && rightInBounds;
+}
+
+function cutOffBounds({left, bottom, right, top}) {
+  return {left, bottom: Math.min(51669, bottom), right: Math.min(31728, right), top};
+}
+
+export default class App extends PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {};
+    this._onHover = this._onHover.bind(this);
+    this._renderTooltip = this._renderTooltip.bind(this);
+  }
+
+  _onHover({x, y, sourceLayer, tile}) {
+    this.setState({x, y, hoveredObject: {sourceLayer, tile}});
+  }
+
+  _renderTooltip() {
+    const {x, y, hoveredObject} = this.state;
+    const {sourceLayer, tile} = hoveredObject || {};
+    return (
+      sourceLayer &&
+      tile && (
+        <div className="tooltip" style={{left: x, top: y}}>
+          tile: x: {tile.x}, y: {tile.y}, z: {tile.z}
+        </div>
+      )
+    );
+  }
+
+  _renderLayers() {
+    const {autoHighlight = true, highlightColor = [60, 60, 60, 40]} = this.props;
+
+    return [
+      new TileLayer({
+        pickable: true,
+        onHover: this._onHover,
+        autoHighlight,
+        highlightColor,
+        minZoom: -16,
+        maxZoom: 0,
+        coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
+        getTileData: ({x, y, z}) => {
+          if (inTileBounds({x, y, z: -z})) {
+            return load(`sample_image/${16 + z}/${x}_${y}.jpeg`);
+          }
+          return null;
+        },
+
+        renderSubLayers: props => {
+          const {
+            bbox: {left, bottom, right, top}
+          } = props.tile;
+          const newBounds = cutOffBounds({left, bottom, right, top});
+          if (inImageBounds(newBounds)) {
+            return new BitmapLayer(props, {
+              data: null,
+              image: props.data,
+              bounds: [newBounds.left, newBounds.bottom, newBounds.right, newBounds.top]
+            });
+          }
+          return null;
+        }
+      })
+    ];
+  }
+
+  render() {
+    return (
+      <DeckGL
+        views={[new OrthographicView({id: 'ortho'})]}
+        layers={this._renderLayers()}
+        initialViewState={INITIAL_VIEW_STATE}
+        controller={true}
+      >
+        {this._renderTooltip}
+      </DeckGL>
+    );
+  }
+}
+
+export function renderToDOM(container) {
+  render(<App />, container);
+}

--- a/examples/website/image-tile/app.js
+++ b/examples/website/image-tile/app.js
@@ -47,8 +47,8 @@ export default class App extends PureComponent {
   }
 
   inTileBounds({x, y, z}) {
-    const xInBounds = x < Math.ceil(this.state.width / (512 * 2 ** z)) && x >= 0;
-    const yInBounds = y < Math.ceil(this.state.height / (512 * 2 ** z)) && y >= 0;
+    const xInBounds = x < Math.ceil(this.state.width / (this.state.tileSize * 2 ** z)) && x >= 0;
+    const yInBounds = y < Math.ceil(this.state.height / (this.state.tileSize * 2 ** z)) && y >= 0;
     return xInBounds && yInBounds;
   }
 
@@ -83,11 +83,12 @@ export default class App extends PureComponent {
 
   _renderLayers() {
     const {autoHighlight = true, highlightColor = [60, 60, 60, 40]} = this.props;
-
+    const {tileSize} = this.state;
     return [
       new TileLayer({
         pickable: true,
         onHover: this._onHover,
+        tileSize,
         autoHighlight,
         highlightColor,
         minZoom: -16,

--- a/examples/website/image-tile/index.html
+++ b/examples/website/image-tile/index.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>deck.gl Example</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body {
+      margin: 0;
+      font-family: sans-serif;
+      width: 100vw;
+      height: 100vh;
+      overflow: hidden;
+    }
+
+    .tooltip {
+      pointer-events: none;
+      position: absolute;
+      z-index: 9;
+      font-size: 12px;
+      padding: 8px;
+      background: #000;
+      color: #fff;
+      min-width: 160px;
+      max-height: 360px;
+      overflow-y: hidden;
+    }
+
+  </style>
+</head>
+<body>
+<div id="app"></div>
+</body>
+<script type="text/javascript" src="app.js"></script>
+<script type="text/javascript">
+  App.renderToDOM(document.getElementById('app'));
+</script>
+</html>

--- a/examples/website/image-tile/index.html
+++ b/examples/website/image-tile/index.html
@@ -11,6 +11,7 @@
       width: 100vw;
       height: 100vh;
       overflow: hidden;
+      background-color: black;
     }
 
     .tooltip {

--- a/examples/website/image-tile/package.json
+++ b/examples/website/image-tile/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "map-tile",
+  "version": "0.0.0",
+  "license": "MIT",
+  "scripts": {
+    "start-local": "webpack-dev-server --env.local --progress --hot --open",
+    "start": "webpack-dev-server --progress --hot --open"
+  },
+  "dependencies": {
+    "deck.gl": "^8.0.0",
+    "react": "^16.3.0",
+    "react-dom": "^16.3.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.4.0",
+    "@babel/preset-react": "^7.0.0",
+    "babel-loader": "^8.0.5",
+    "webpack": "^4.20.2",
+    "webpack-cli": "^3.1.2",
+    "webpack-dev-server": "^3.1.1"
+  }
+}

--- a/examples/website/image-tile/webpack.config.js
+++ b/examples/website/image-tile/webpack.config.js
@@ -1,0 +1,37 @@
+// NOTE: To use this example standalone (e.g. outside of deck.gl repo)
+// delete the local development overrides at the bottom of this file
+
+const webpack = require('webpack');
+
+const CONFIG = {
+  mode: 'development',
+
+  entry: {
+    app: './app.js'
+  },
+
+  output: {
+    library: 'App'
+  },
+
+  module: {
+    rules: [
+      {
+        // Transpile ES6 to ES5 with babel
+        // Remove if your app does not use JSX or you don't need to support old browsers
+        test: /\.js$/,
+        loader: 'babel-loader',
+        exclude: [/node_modules/],
+        options: {
+          presets: ['@babel/preset-react']
+        }
+      }
+    ]
+  },
+
+  // Optional: Enables reading mapbox token from environment variable
+  plugins: [new webpack.EnvironmentPlugin(['MapboxAccessToken'])]
+};
+
+// This line enables bundling against src in this repo rather than installed module
+module.exports = env => (env ? require('../../webpack.config.local')(CONFIG)(env) : CONFIG);

--- a/examples/website/image-tile/webpack.config.js
+++ b/examples/website/image-tile/webpack.config.js
@@ -1,8 +1,6 @@
 // NOTE: To use this example standalone (e.g. outside of deck.gl repo)
 // delete the local development overrides at the bottom of this file
 
-const webpack = require('webpack');
-
 const CONFIG = {
   mode: 'development',
 
@@ -27,10 +25,7 @@ const CONFIG = {
         }
       }
     ]
-  },
-
-  // Optional: Enables reading mapbox token from environment variable
-  plugins: [new webpack.EnvironmentPlugin(['MapboxAccessToken'])]
+  }
 };
 
 // This line enables bundling against src in this repo rather than installed module


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
Following up on https://github.com/uber/deck.gl/issues/4230#issuecomment-590906607, this is the tiling example.   This is in conjunction with the data being merged on to master here: https://github.com/uber-common/deck.gl-data/pull/15.  We should probably hold off on merging this PR until we can test the raw data on master there locally.
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
After @Pessimistress merged #4246 I am giving an example here of the non-geospatial use-case, displaying the capability and also matoivating future creation of a new controller that has smoother zoom/pan as per https://github.com/uber/deck.gl/issues/4230#issuecomment-590911073
#### Change List
- Add a non-geospatial tiling example
