### PR TITLE
[test-utils] Fix testLayer

### DIFF
--- a/modules/core/src/lifecycle/component-state.js
+++ b/modules/core/src/lifecycle/component-state.js
@@ -19,7 +19,6 @@
 // THE SOFTWARE.
 
 import log from '../utils/log';
-import assert from '../utils/assert';
 import {isAsyncIterable} from '../utils/iterable-utils';
 import {PROP_SYMBOLS} from './constants';
 const {ASYNC_ORIGINAL, ASYNC_RESOLVED, ASYNC_DEFAULTS} = PROP_SYMBOLS;
@@ -172,9 +171,7 @@ export default class ComponentState {
     // Only update if loadCount is larger or equal to resolvedLoadCount
     // otherwise a more recent load has already completed
     const asyncProp = this.asyncProps[propName];
-    if (asyncProp && loadCount >= asyncProp.resolvedLoadCount) {
-      assert(value !== undefined);
-
+    if (asyncProp && loadCount >= asyncProp.resolvedLoadCount && value !== undefined) {
       // A chance to copy old props before updating
       this.freezeAsyncOldProps();
 

--- a/modules/geo-layers/src/mvt-tile-layer/mvt-tile-layer.js
+++ b/modules/geo-layers/src/mvt-tile-layer/mvt-tile-layer.js
@@ -8,25 +8,15 @@ import TileLayer from '../tile-layer/tile-layer';
 
 const defaultProps = Object.assign({}, TileLayer.defaultProps, {
   renderSubLayers: {type: 'function', value: renderSubLayers, compare: false},
-  urlTemplates: []
+  urlTemplates: {type: 'array', value: [], compare: true}
 });
 
 export default class MVTTileLayer extends TileLayer {
-  initializeState() {
-    super.initializeState();
-    const {urlTemplates} = this.props;
-
-    this.state = {
-      ...this.state,
-      urlTemplates
-    };
-  }
-
   async getTileData(tileProperties) {
-    const {urlTemplates} = this.state;
+    const {urlTemplates} = this.getCurrentLayer().props;
 
     if (!urlTemplates || !urlTemplates.length) {
-      return Promise.reject();
+      return Promise.reject('Invalid urlTemplates');
     }
 
     const templateReplacer = (_, property) => tileProperties[property];

--- a/modules/geo-layers/src/terrain-layer/terrain-layer.js
+++ b/modules/geo-layers/src/terrain-layer/terrain-layer.js
@@ -63,7 +63,10 @@ export default class TerrainLayer extends CompositeLayer {
   updateState({props, oldProps}) {
     const terrainImageChanged = props.terrainImage !== oldProps.terrainImage;
     if (terrainImageChanged) {
-      const isTiled = props.terrainImage.includes('{x}') && props.terrainImage.includes('{y}');
+      const isTiled =
+        props.terrainImage &&
+        props.terrainImage.includes('{x}') &&
+        props.terrainImage.includes('{y}');
       this.setState({isTiled});
     }
 
@@ -81,6 +84,9 @@ export default class TerrainLayer extends CompositeLayer {
   }
 
   loadTerrain({terrainImage, bounds, elevationDecoder, meshMaxError, workerUrl}) {
+    if (!terrainImage) {
+      return null;
+    }
     const options = {
       terrain: {
         bounds,
@@ -135,9 +141,9 @@ export default class TerrainLayer extends CompositeLayer {
     return new SimpleMeshLayer({
       id: props.id,
       wireframe: props.wireframe,
-      mesh: props.data.then(([mesh]) => mesh),
+      mesh: props.data.then(result => result && result[0]),
       data: [1],
-      texture: props.data.then(([, texture]) => texture),
+      texture: props.data.then(result => result && result[1]),
       getPolygonOffset: null,
       coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
       getPosition: d => [0, 0, 0],

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "gl": "^4.3.3",
     "glsl-transpiler": "^1.8.3",
     "jsdom": "^15.0.0",
-    "ocular-dev-tools": "0.1.5",
+    "ocular-dev-tools": "^0.1.8",
     "png.js": "^0.1.1",
     "pre-commit": "^1.2.2",
     "pre-push": "^0.1.1",

--- a/test/modules/geo-layers/terrain-layer.spec.js
+++ b/test/modules/geo-layers/terrain-layer.spec.js
@@ -20,14 +20,41 @@
 
 import test from 'tape-catch';
 import {generateLayerTests, testLayer} from '@deck.gl/test-utils';
-import {TerrainLayer} from '@deck.gl/geo-layers';
+import {TerrainLayer, TileLayer} from '@deck.gl/geo-layers';
+import {SimpleMeshLayer} from '@deck.gl/mesh-layers';
 
 test('TerrainLayer', t => {
   const testCases = generateLayerTests({
     Layer: TerrainLayer,
+    sampleProps: {
+      terrainImage: 'https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png',
+      surfaceImage: 'https://wms.chartbundle.com/tms/1.0.0/sec/{z}/{x}/{y}.png?origin=nw'
+    },
     assert: t.ok,
-    onBeforeUpdate: ({testCase}) => t.comment(testCase.title)
+    onBeforeUpdate: ({testCase}) => t.comment(testCase.title),
+    onAfterUpdate: ({layer, subLayers}) => {
+      if (layer.props.terrainImage) {
+        t.ok(subLayers[0] instanceof TileLayer, 'rendered TileLayer');
+      }
+    }
   });
   testLayer({Layer: TerrainLayer, testCases, onError: t.notOk});
+
+  const testCasesNonTiled = generateLayerTests({
+    Layer: TerrainLayer,
+    sampleProps: {
+      terrainImage: 'https://s3.amazonaws.com/elevation-tiles-prod/terrarium/1/0/0.png',
+      bounds: [-180, 85, 0, 0]
+    },
+    assert: t.ok,
+    onBeforeUpdate: ({testCase}) => t.comment(testCase.title),
+    onAfterUpdate: ({layer, subLayers}) => {
+      if (layer.props.terrainImage) {
+        t.ok(subLayers[0] instanceof SimpleMeshLayer, 'rendered SimpleMeshLayer');
+      }
+    }
+  });
+  testLayer({Layer: TerrainLayer, testCases: testCasesNonTiled, onError: t.notOk});
+
   t.end();
 });

--- a/test/modules/imports-spec.js
+++ b/test/modules/imports-spec.js
@@ -46,13 +46,13 @@ test('Top-level imports', t0 => {
     return false;
   };
 
-  test('import "deck.gl"', t => {
+  t0.test('import "deck.gl"', t => {
     t.notOk(hasEmptyExports(deck), 'No empty top-level export in deck.gl');
     t.notOk(hasEmptyExports(core), 'No empty top-level export in @deck.gl/core');
     t.end();
   });
 
-  test('import layers', t => {
+  t0.test('import layers', t => {
     t.notOk(hasEmptyExports(layers), 'No empty top-level export in @deck.gl/layers');
     t.notOk(
       hasEmptyExports(aggregationLayers),
@@ -63,7 +63,7 @@ test('Top-level imports', t0 => {
     t.end();
   });
 
-  test('import utilities', t => {
+  t0.test('import utilities', t => {
     t.notOk(hasEmptyExports(json), 'No empty top-level export in @deck.gl/json');
     t.notOk(hasEmptyExports(googleMaps), 'No empty top-level export in @deck.gl/google-maps');
     t.notOk(hasEmptyExports(mapbox), 'No empty top-level export in @deck.gl/mapbox');
@@ -72,7 +72,7 @@ test('Top-level imports', t0 => {
     t.end();
   });
 
-  test('selected imports', t => {
+  t0.test('selected imports', t => {
     t.ok(deck.Layer, 'Layer symbol imported');
     t.ok(deck.ScatterplotLayer, 'ScatterplotLayer symbol imported');
     t.ok(deck.ScreenGridLayer, 'ScreenGridLayer symbol imported');
@@ -88,7 +88,7 @@ test('Top-level imports', t0 => {
     t.end();
   });
 
-  test('deck.gl default import', t => {
+  t0.test('deck.gl default import', t => {
     t.ok(DeckGL, 'DeckGL symbol imported from /react');
     t.end();
   });

--- a/test/node.js
+++ b/test/node.js
@@ -1,5 +1,9 @@
 require('reify');
 
+// Polyfill for loaders
+// TODO - @loaders.gl/polyfills seems to freeze the tests
+global.fetch = () => Promise.reject('fetch not available in node');
+
 // Polyfill with JSDOM
 const {JSDOM} = require('jsdom');
 const dom = new JSDOM(`<!DOCTYPE html>`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7897,10 +7897,10 @@ octokit-pagination-methods@^1.1.0:
   resolved "https://registry.yarnpkg.com/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz#cf472edc9d551055f9ef73f6e42b4dbb4c80bea4"
   integrity sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==
 
-ocular-dev-tools@0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/ocular-dev-tools/-/ocular-dev-tools-0.1.5.tgz#17986a8440689c1375e404318123b6a2adfff261"
-  integrity sha512-lFR+0CtH/lEicsyRosNUuOh+1bZdW+uCshoxaUz5WHSsO2qHBi6qrboHYTOA2EFn+jUwcEcrtDGHJEGh7xl1hA==
+ocular-dev-tools@^0.1.8:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/ocular-dev-tools/-/ocular-dev-tools-0.1.8.tgz#da026de73fbe4e7aab1dc31339a5d83cf3c91839"
+  integrity sha512-ax/FXpqi9PtP1hzTdd+GlzTwscaChZdu7T/hqcHTvnCZf4PZluRuH/obIt+Ln31xl6eS2roCDt1pOsv5MSD70A==
   dependencies:
     "@babel/cli" "^7.0.0"
     "@babel/core" "^7.0.0"


### PR DESCRIPTION
#### Background

test-utils' `testLayer` was relying on errors thrown by `LayerManager` and `DeckRenderer`. As of #4135 we are no longer throwing errors, but calling the `onError` callback. This resulted in several new layer tests not failing despite of lifecycle errors.

#### Change List
- Fix `testLayer` error handling
- Fix `TerrainLayer` tests
- Fix `MVTTileLayer` tests
- Fix an unnecessary crash in `ComponentState` when async prop is rejected