### PR TITLE
pydeck: Support rendering in Google Collab

### DIFF
--- a/bindings/pydeck/pydeck/bindings/deck.py
+++ b/bindings/pydeck/pydeck/bindings/deck.py
@@ -124,6 +124,7 @@ class Deck(JSONMixin):
         notebook_display=True,
         iframe_width=700,
         iframe_height=500,
+        as_string=False,
         **kwargs
     ):
         """Write a file and loads it to an iframe, if in a Jupyter environment;
@@ -141,6 +142,8 @@ class Deck(JSONMixin):
             Height of Jupyter notebook iframe in pixels, if rendered in a Jupyter environment.
         iframe_height : int, default 500
             Width of Jupyter notebook iframe in pixels, if rendered in a Jupyter environment.
+        as_string : bool, default False
+            Whether the HTML should be written as a string rather than to a file. Defaults to writing to a file.
 
         Returns
         -------

--- a/bindings/pydeck/pydeck/bindings/deck.py
+++ b/bindings/pydeck/pydeck/bindings/deck.py
@@ -161,6 +161,7 @@ class Deck(JSONMixin):
             iframe_width=iframe_width,
             tooltip=self.deck_widget.tooltip,
             custom_libraries=pydeck_settings.custom_libraries,
+            as_string=as_string,
             **kwargs
         )
         return f

--- a/bindings/pydeck/pydeck/io/html.py
+++ b/bindings/pydeck/pydeck/io/html.py
@@ -118,9 +118,10 @@ def deck_to_html(
     if open_browser:
         display_html(realpath(f.name))
     if notebook_display:
+        from IPython.display import display  # noqa
 
         if in_google_collab:
-            from IPython.display import HTML, display, Javascript # noqa
+            from IPython.display import HTML, Javascript # noqa
             js_height_snippet = 'google.colab.output.setIframeHeight(0, true, {maxHeight: %s})' % iframe_height
             display(Javascript(js_height_snippet))
             display(HTML(html))


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #4103 
<!-- For other PRs without open issue -->
#### Background
Supports rendering of HTML pages in Collab

The 2-way interactive widget won't work in Collab yet. We seem to be awaiting this issue: https://github.com/googlecolab/colabtools/issues/60

<!-- For all the PRs -->
#### Change List
- Add built-in support for rendering .to_html in Google Collab