### PR TITLE
Fix .gl and .state access

### DIFF
--- a/modules/arcgis/src/arcgis-deck-external-renderer.js
+++ b/modules/arcgis/src/arcgis-deck-external-renderer.js
@@ -20,8 +20,8 @@ export default function loadArcGISDeckExternalRenderer(externalRenderers, Collec
     // eslint-disable-next-line
     const dpr = window.devicePixelRatio;
     this.deckFbo = new Framebuffer(gl, {
-      width: Math.round(this.view.state.size[0] * dpr),
-      height: Math.round(this.view.state.size[1] * dpr)
+      width: Math.round(this.view.size[0] * dpr),
+      height: Math.round(this.view.size[1] * dpr)
     });
     this.initializeDeckGL(gl);
     this.deckLayers.on('change', () => {
@@ -31,15 +31,15 @@ export default function loadArcGISDeckExternalRenderer(externalRenderers, Collec
 
   ArcGISDeckExternalRenderer.prototype.setup = setup;
 
-  function render(renderParameters) {
-    const gl = renderParameters.context;
+  function render(context) {
+    const gl = context.gl;
     const screenFbo = gl.getParameter(gl.FRAMEBUFFER_BINDING);
     // eslint-disable-next-line
     const dpr = window.devicePixelRatio;
     this.createOrResizeFramebuffer(
       gl,
-      Math.round(this.view.state.size[0] * dpr),
-      Math.round(this.view.state.size[1] * dpr)
+      Math.round(this.view.size[0] * dpr),
+      Math.round(this.view.size[1] * dpr)
     );
 
     this.deckgl.setProps({
@@ -66,8 +66,8 @@ export default function loadArcGISDeckExternalRenderer(externalRenderers, Collec
         viewport: [
           0,
           0,
-          Math.round(this.view.state.size[0] * dpr),
-          Math.round(this.view.state.size[1] * dpr)
+          Math.round(this.view.size[0] * dpr),
+          Math.round(this.view.size[1] * dpr)
         ]
       },
       () => {

--- a/modules/arcgis/src/arcgis-deck-external-renderer.js
+++ b/modules/arcgis/src/arcgis-deck-external-renderer.js
@@ -63,12 +63,7 @@ export default function loadArcGISDeckExternalRenderer(externalRenderers, Collec
         blend: true,
         blendFunc: [gl.ONE, gl.ONE_MINUS_SRC_ALPHA],
         framebuffer: screenFbo,
-        viewport: [
-          0,
-          0,
-          Math.round(this.view.size[0] * dpr),
-          Math.round(this.view.size[1] * dpr)
-        ]
+        viewport: [0, 0, Math.round(this.view.size[0] * dpr), Math.round(this.view.size[1] * dpr)]
       },
       () => {
         this.model.setUniforms({u_texture: this.deckFbo}).draw();

--- a/test/apps/arcgis/README.md
+++ b/test/apps/arcgis/README.md
@@ -1,0 +1,23 @@
+<div align="center">
+   <img width="150" heigth="150" src="https://webpack.js.org/assets/icon-square-big.svg" />
+</div>
+
+## Example: Use deck.gl with Esri ArcGIS API for JavaScript
+
+This sample shows how to use the `@deck.gl/arcgis` module to add a deck.gl layer to an [ArcGIS JavaScript](https://developers.arcgis.com/javascript/) app.
+Uses [Webpack](https://github.com/webpack/webpack) and the [ArcGIS Webpack plugin](https://github.com/Esri/arcgis-webpack-plugin)
+to bundle files and serves it with [webpack-dev-server](https://webpack.js.org/guides/development/#webpack-dev-server).
+
+## Usage
+
+To install dependencies:
+
+```bash
+npm install
+# or
+yarn
+```
+
+Commands:
+* `npm start` is the development target, to serves the app and hot reload.
+* `npm run build` is the production target, to create the final bundle and write to disk.

--- a/test/apps/arcgis/app.js
+++ b/test/apps/arcgis/app.js
@@ -1,0 +1,110 @@
+import {loadArcGISModules} from '@deck.gl/arcgis';
+import {GeoJsonLayer, ArcLayer} from '@deck.gl/layers';
+
+// source: Natural Earth http://www.naturalearthdata.com/ via geojson.xyz
+const AIR_PORTS =
+  'https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_10m_airports.geojson';
+
+loadArcGISModules(['esri/Map', 'esri/views/MapView', 'esri/views/SceneView', 'esri/views/3d/externalRenderers']).then(({ArcGISDeckLayer, ArcGISDeckExternalRenderer, modules}) => {
+  const [ArcGISMap, MapView, SceneView, externalRenderers] = modules;
+
+  const layer = new ArcGISDeckLayer({
+    deckLayers: [
+      new GeoJsonLayer({
+        id: 'airports',
+        data: AIR_PORTS,
+        // Styles
+        filled: true,
+        pointRadiusMinPixels: 2,
+        pointRadiusScale: 2000,
+        getRadius: f => 11 - f.properties.scalerank,
+        getFillColor: [200, 0, 80, 180],
+        // Interactive props
+        pickable: true,
+        autoHighlight: true,
+        onClick: info =>
+          // eslint-disable-next-line
+          info.object && alert(`${info.object.properties.name} (${info.object.properties.abbrev})`)
+      }),
+      new ArcLayer({
+        id: 'arcs',
+        data: AIR_PORTS,
+        dataTransform: d => d.features.filter(f => f.properties.scalerank < 4),
+        // Styles
+        getSourcePosition: f => [-0.4531566, 51.4709959], // London
+        getTargetPosition: f => f.geometry.coordinates,
+        getSourceColor: [0, 128, 200],
+        getTargetColor: [200, 0, 80],
+        getWidth: 1
+      })
+    ]
+  });
+
+  // In the ArcGIS API for JavaScript the MapView is responsible
+  // for displaying a Map, which usually contains at least a basemap.
+  // eslint-disable-next-line
+  const mapView = new MapView({
+    container: 'mapViewDiv',
+    map: new ArcGISMap({
+      basemap: 'dark-gray-vector',
+      layers: [layer]
+    }),
+    center: [0.119167, 52.205276],
+    zoom: 5
+  });
+
+  const sceneView = new SceneView({
+    container: "sceneViewDiv",
+    map: new ArcGISMap({
+      basemap: "dark-gray-vector"
+    }),
+    environment: {
+      atmosphereEnabled: false
+    },
+    center: [0.1278, 51.5074],
+    camera: {
+      position: {
+        x: 0.1278,
+        y: 30.5074,
+        z: 10000000
+      },
+
+      tilt: 0
+    },
+    viewingMode: "local"
+  });
+
+  const extren = new ArcGISDeckExternalRenderer(sceneView, {
+    deckLayers: [
+      new GeoJsonLayer({
+        id: 'airports',
+        data: AIR_PORTS,
+        // Styles
+        filled: true,
+        pointRadiusMinPixels: 2,
+        pointRadiusScale: 2000,
+        getRadius: f => 11 - f.properties.scalerank,
+        getFillColor: [200, 0, 80, 180],
+        // Interactive props
+        pickable: true,
+        autoHighlight: true,
+        onClick: info =>
+          // eslint-disable-next-line
+          info.object && alert(`${info.object.properties.name} (${info.object.properties.abbrev})`)
+      }),
+      new ArcLayer({
+        id: 'arcs',
+        data: AIR_PORTS,
+        dataTransform: d => d.features.filter(f => f.properties.scalerank < 4),
+        // Styles
+        getSourcePosition: f => [-0.4531566, 51.4709959], // London
+        getTargetPosition: f => f.geometry.coordinates,
+        getSourceColor: [0, 128, 200],
+        getTargetColor: [200, 0, 80],
+        getWidth: 1
+      })
+    ]
+  });
+  
+  externalRenderers.add(sceneView, extren);
+});

--- a/test/apps/arcgis/app.js
+++ b/test/apps/arcgis/app.js
@@ -5,7 +5,12 @@ import {GeoJsonLayer, ArcLayer} from '@deck.gl/layers';
 const AIR_PORTS =
   'https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_10m_airports.geojson';
 
-loadArcGISModules(['esri/Map', 'esri/views/MapView', 'esri/views/SceneView', 'esri/views/3d/externalRenderers']).then(({ArcGISDeckLayer, ArcGISDeckExternalRenderer, modules}) => {
+loadArcGISModules([
+  'esri/Map',
+  'esri/views/MapView',
+  'esri/views/SceneView',
+  'esri/views/3d/externalRenderers'
+]).then(({ArcGISDeckLayer, ArcGISDeckExternalRenderer, modules}) => {
   const [ArcGISMap, MapView, SceneView, externalRenderers] = modules;
 
   const layer = new ArcGISDeckLayer({
@@ -54,9 +59,9 @@ loadArcGISModules(['esri/Map', 'esri/views/MapView', 'esri/views/SceneView', 'es
   });
 
   const sceneView = new SceneView({
-    container: "sceneViewDiv",
+    container: 'sceneViewDiv',
     map: new ArcGISMap({
-      basemap: "dark-gray-vector"
+      basemap: 'dark-gray-vector'
     }),
     environment: {
       atmosphereEnabled: false
@@ -71,7 +76,7 @@ loadArcGISModules(['esri/Map', 'esri/views/MapView', 'esri/views/SceneView', 'es
 
       tilt: 0
     },
-    viewingMode: "local"
+    viewingMode: 'local'
   });
 
   const extren = new ArcGISDeckExternalRenderer(sceneView, {
@@ -105,6 +110,6 @@ loadArcGISModules(['esri/Map', 'esri/views/MapView', 'esri/views/SceneView', 'es
       })
     ]
   });
-  
+
   externalRenderers.add(sceneView, extren);
 });

--- a/test/apps/arcgis/index.html
+++ b/test/apps/arcgis/index.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset='UTF-8' />
+    <title>deck.gl w/ Esri ArcGIS API for JavaScript example</title>
+    <link rel="stylesheet" href="https://js.arcgis.com/4.14/esri/themes/light/main.css"/>
+    <style>
+      html,
+      body,
+      #mapViewDiv,
+      #sceneViewDiv {
+        padding: 0;
+        margin: 0;
+        width: 100%;
+      }
+      
+      #mapViewDiv,
+      #sceneViewDiv {
+        height: 50%;
+      }
+      
+      html,
+      body {
+        height: 100%;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="mapViewDiv"></div>
+    <div id="sceneViewDiv"></div>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/test/apps/arcgis/package.json
+++ b/test/apps/arcgis/package.json
@@ -1,0 +1,16 @@
+{
+  "scripts": {
+    "start": "webpack-dev-server --progress --hot --open",
+    "start-local": "webpack-dev-server --env.local --progress --hot --open",
+    "build": "webpack -p"
+  },
+  "dependencies": {
+    "@deck.gl/core": "^8.0.0",
+    "@deck.gl/layers": "^8.0.0"
+  },
+  "devDependencies": {
+    "webpack": "^4.20.2",
+    "webpack-cli": "^3.1.2",
+    "webpack-dev-server": "^3.1.1"
+  }
+}

--- a/test/apps/arcgis/webpack.config.js
+++ b/test/apps/arcgis/webpack.config.js
@@ -1,0 +1,13 @@
+// NOTE: To use this example standalone (e.g. outside of deck.gl repo)
+// delete the local development overrides at the bottom of this file
+
+const CONFIG = {
+  mode: 'development',
+
+  entry: {
+    app: './app.js'
+  }
+};
+
+// This line enables bundling against src in this repo rather than installed module
+module.exports = env => (env ? require('../webpack.config.local')(CONFIG)(env) : CONFIG);


### PR DESCRIPTION
It seems like a [recent change](https://github.com/uber/deck.gl/pull/4302/commits/02f3ecd8ea0e0075bd70d562641929964f5d5589) _"broke"_ `ArcGISDeckExternalRenderer`, the 3D integration between deck.gl and ArcGIS.

It's tricky to see the breakage because there is still no sample app, nor test, in the codebase. Plus, 3D integration was WIP, and things did not look correct, but at least it was possible to write apps that did not crash.

I am fine with merging this; to see the positive impact of this PR I am working on some pens that I will share once ready. Once things are looking good I will work on adding automated testing and a `pure-js` sample app in the codebase, specific for 3D.