### PR TITLE
Workaround for invalid attribute index access

### DIFF
--- a/modules/layers/src/path-layer/path-tesselator.js
+++ b/modules/layers/src/path-layer/path-tesselator.js
@@ -30,7 +30,9 @@ export default class PathTesselator extends Tesselator {
     super({
       ...opts,
       attributes: {
-        positions: {size: 3, type: opts.fp64 ? Float64Array : Float32Array},
+        // Padding covers shaderAttributes for last segment in largest case fp64
+        // additional vertex + hi & low parts, 3 * 6
+        positions: {size: 3, padding: 18, type: opts.fp64 ? Float64Array : Float32Array},
         segmentTypes: {size: 1, type: Uint8ClampedArray}
       }
     });


### PR DESCRIPTION
In an application with heavy path layer usage the typed array manager
can get to a point where the number of points exactly fits in the
allocated buffer.  This problem is this does not appear to be accounting
for the shaderAttributes and results the runtime error:

  'glDrawElementsInstancedANGLE: attempt to access out of range vertices in attribute'

This extra padding 3 * 3 is based on how the type array manager needs to allocate.