### PR TITLE
Improve flatten perf

### DIFF
--- a/modules/core/src/lib/composite-layer.js
+++ b/modules/core/src/lib/composite-layer.js
@@ -218,7 +218,7 @@ export default class CompositeLayer extends Layer {
       // Flatten the returned array, removing any null, undefined or false
       // this allows layers to render sublayers conditionally
       // (see CompositeLayer.renderLayers docs)
-      subLayers = flatten(subLayers, {filter: Boolean});
+      subLayers = flatten(subLayers, Boolean);
       this.internalState.subLayers = subLayers;
     }
     debug(TRACE_RENDER_LAYERS, this, shouldUpdate, subLayers);

--- a/modules/core/src/lib/layer-manager.js
+++ b/modules/core/src/lib/layer-manager.js
@@ -172,7 +172,7 @@ export default class LayerManager {
     }
     this.lastRenderedLayers = newLayers;
 
-    newLayers = flatten(newLayers, {filter: Boolean});
+    newLayers = flatten(newLayers, Boolean);
 
     for (const layer of newLayers) {
       layer.context = this.context;

--- a/modules/core/src/lib/view-manager.js
+++ b/modules/core/src/lib/view-manager.js
@@ -209,7 +209,7 @@ export default class ViewManager {
   // Update the view descriptor list and set change flag if needed
   // Does not actually rebuild the `Viewport`s until `getViewports` is called
   _setViews(views) {
-    views = flatten(views, {filter: Boolean});
+    views = flatten(views, Boolean);
 
     const viewsChanged = this._diffViews(views, this.views);
     if (viewsChanged) {

--- a/modules/core/src/utils/flatten.js
+++ b/modules/core/src/utils/flatten.js
@@ -30,24 +30,24 @@
  * @param {Array} result=[] - Optional array to push value into
  * @return {Array} Returns the new flattened array (new array or `result` if provided)
  */
-export function flatten(array, {filter = () => true, map = x => x, result = []} = {}) {
+export function flatten(array, filter = () => true) {
   // Wrap single object in array
   if (!Array.isArray(array)) {
-    return filter(array) ? [map(array)] : [];
+    return filter(array) ? [array] : [];
   }
   // Deep flatten and filter the array
-  return flattenArray(array, filter, map, result);
+  return flattenArray(array, filter, []);
 }
 
 // Deep flattens an array. Helper to `flatten`, see its parameters
-function flattenArray(array, filter, map, result) {
+function flattenArray(array, filter, result) {
   let index = -1;
   while (++index < array.length) {
     const value = array[index];
     if (Array.isArray(value)) {
-      flattenArray(value, filter, map, result);
+      flattenArray(value, filter, result);
     } else if (filter(value)) {
-      result.push(map(value));
+      result.push(value);
     }
   }
   return result;

--- a/test/modules/core/utils/flatten.spec.js
+++ b/test/modules/core/utils/flatten.spec.js
@@ -49,9 +49,7 @@ const FLATTEN_TEST_CASES = [
   },
   {
     title: 'nested three levels with predicate',
-    opts: {
-      filter: Boolean
-    },
+    opts: Boolean,
     argument: [1, [[2], null], [[4, [null]], 6]],
     result: [1, 2, 4, 6]
   }


### PR DESCRIPTION
Before:

- Array of 10,000 items: 18.3K iterations/s ±4.33%
- Array of 1,000 nested items (max depth = 10): 25.2K iterations/s ±2.64%

After:

- Array of 10,000 items: 23.7K iterations/s ±8.20%
- Array of 1,000 nested items (max depth = 10): 34.9K iterations/s ±4.09%

`Array.flat(Infinity)`:

- Array of 10,000 items: 608 iterations/s ±3.79%
- Array of 1,000 nested items (max depth = 10): 1.22K iterations/s ±1.59%

#### Change List
- Private `flatten` utility API
