### PR TITLE
TileLayer and MVTLayer API audit

### DIFF
--- a/docs/layers/mvt-layer.md
+++ b/docs/layers/mvt-layer.md
@@ -9,7 +9,7 @@
 
 `MVTLayer` is a derived `TileLayer` that makes it possible to visualize very large datasets through MVTs ([Mapbox Vector Tiles](https://docs.mapbox.com/vector-tiles/specification/)). Behaving like `TileLayer`, it will only load, decode and render MVTs containing features that are visible within the current viewport.
 
-MVTs are loaded from a network server, so you need to specify your own tile server URLs in `urlTemplates` property. You can provide as many templates as you want for a unique set of tiles. All URL templates will be balanced by [this algorithm](https://github.com/uber/deck.gl/blob/58f8b848f3ccf1676e90c7810e1b6d115a9d53d0/modules/geo-layers/src/mvt-layer/mvt-layer.js#L51-L53), ensuring that tiles will be always requested to the same server depending on their index.
+Data is loaded from URL templates in the `data` property.
 
 This layer also handles feature clipping so that there are no features divided by tile divisions.
 
@@ -19,11 +19,24 @@ import {MVTLayer} from '@deck.gl/geo-layers';
 
 export const App = ({viewport}) => {
   const layer = new MVTLayer({
-    urlTemplates: [
-      `https://a.tiles.mapbox.com/v4/mapbox.boundaries-adm0-v3/{z}/{x}/{y}.vector.pbf?access_token=${MapboxAccessToken}`
-    ],
+    data: `https://a.tiles.mapbox.com/v4/mapbox.mapbox-streets-v7/{z}/{x}/{y}.vector.pbf?access_token=${MAPBOX_TOKEN}`,
 
-    getFillColor: [140, 170, 180]
+    minZoom: 0,
+    maxZoom: 23,
+    getLineColor: [192, 192, 192],
+    getFillColor: [140, 170, 180],
+
+    getLineWidth: f => {
+      switch (f.properties.class) {
+        case 'street':
+          return 6;
+        case 'motorway':
+          return 10;
+        default:
+          return 1;
+      }
+    },
+    lineWidthMinPixels: 1
   });
 
   return <DeckGL {...viewport} layers={[layer]} />;
@@ -63,21 +76,17 @@ new deck.MVTLayer({});
 
 ## Properties
 
-Inherits all properties from [`TileLayer`](/docs/layers/tile-layer.md) and [base `Layer`](/docs/api-reference/layer.md), and you can use [`GeoJSONLayer`](/docs/layers/geojson-layer.md) properties to style features.
+Inherits all properties from [`TileLayer`](/docs/layers/tile-layer.md) and [base `Layer`](/docs/api-reference/layer.md), with exceptions indicated below.
 
-It also adds a custom property:
+If using the default `renderSubLayers`, supports all [`GeoJSONLayer`](/docs/layers/geojson-layer.md) properties to style features.
 
-##### `urlTemplates` (Array)
 
-- Default `[]`
+##### `data` (String|Array)
 
-URL templates to load tiles from network. Templates don't require a specific format. The layer will replace `{x}`, `{y}`, `{z}` ocurrences to the proper tile index before requesting it to the server.
+Required. Either a URL template or an array of URL templates from which the MVT data should be loaded. See `TileLayer`'s `data` prop documentation for the templating syntax.
 
-When specifiying more than one URL template, all templates will be balanced by [this algorithm](https://github.com/uber/deck.gl/blob/58f8b848f3ccf1676e90c7810e1b6d115a9d53d0/modules/geo-layers/src/mvt-layer/mvt-layer.js#L51-L53), ensuring that tiles will be always requested to the same server depending on their index.
+The `getTileData` prop from the `TileLayer` class will not be called.
 
-### Callbacks
-
-Inherits all callbacks from [`TileLayer`](/docs/layers/tile-layer.md) and [base `Layer`](/docs/api-reference/layer.md).
 
 ## Source
 

--- a/examples/website/map-tile/app.js
+++ b/examples/website/map-tile/app.js
@@ -4,7 +4,6 @@ import {render} from 'react-dom';
 import DeckGL from '@deck.gl/react';
 import {TileLayer} from '@deck.gl/geo-layers';
 import {BitmapLayer} from '@deck.gl/layers';
-import {load} from '@loaders.gl/core';
 
 const INITIAL_VIEW_STATE = {
   latitude: 47.65,
@@ -13,9 +12,6 @@ const INITIAL_VIEW_STATE = {
   maxZoom: 20,
   bearing: 0
 };
-
-// https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames#Tile_servers
-const tileServer = 'https://c.tile.openstreetmap.org/';
 
 export default class App extends PureComponent {
   constructor(props) {
@@ -47,6 +43,9 @@ export default class App extends PureComponent {
 
     return [
       new TileLayer({
+        // https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames#Tile_servers
+        data: 'https://c.tile.openstreetmap.org/{z}/{x}/{y}.png',
+
         pickable: true,
         onHover: this._onHover,
         autoHighlight,
@@ -54,8 +53,6 @@ export default class App extends PureComponent {
         // https://wiki.openstreetmap.org/wiki/Zoom_levels
         minZoom: 0,
         maxZoom: 19,
-
-        getTileData: ({x, y, z}) => load(`${tileServer}/${z}/${x}/${y}.png`),
 
         renderSubLayers: props => {
           const {

--- a/modules/geo-layers/src/tile-layer/utils.js
+++ b/modules/geo-layers/src/tile-layer/utils.js
@@ -2,6 +2,43 @@ import {lngLatToWorld} from '@math.gl/web-mercator';
 
 const TILE_SIZE = 512;
 
+export const urlType = {
+  type: 'url',
+  value: '',
+  validate: value =>
+    typeof value === 'string' ||
+    (Array.isArray(value) && value.every(url => typeof url === 'string')),
+  equals: (value1, value2) => {
+    if (value1 === value2) {
+      return true;
+    }
+    if (!Array.isArray(value1) || !Array.isArray(value2)) {
+      return false;
+    }
+    const len = value1.length;
+    if (len !== value2.length) {
+      return false;
+    }
+    for (let i = 0; i < len; i++) {
+      if (value1[i] !== value2[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+};
+
+export function getURLFromTemplate(template, properties) {
+  if (!template || !template.length) {
+    return null;
+  }
+  if (Array.isArray(template)) {
+    const index = Math.abs(properties.x + properties.y) % template.length;
+    template = template[index];
+  }
+  return template.replace(/\{ *([\w_-]+) *\}/g, (_, property) => properties[property]);
+}
+
 /**
  * gets the bounding box of a viewport
  */

--- a/modules/test-utils/src/generate-layer-tests.js
+++ b/modules/test-utils/src/generate-layer-tests.js
@@ -98,7 +98,8 @@ export function generateLayerTests({
       // Default assert
       if (runDefaultAsserts) {
         if (params.layer.isComposite) {
-          if (count(params.layer.props.data)) {
+          const {data} = params.layer.props;
+          if (data && typeof data === 'object' && count(data)) {
             assert(params.subLayers.length, 'Layer should have sublayers');
           }
         } else {

--- a/test/modules/geo-layers/mvt-layer.spec.js
+++ b/test/modules/geo-layers/mvt-layer.spec.js
@@ -11,9 +11,7 @@ test('MVTLayer', t => {
     Layer: MVTLayer,
     assert: t.ok,
     sampleProps: {
-      urlTemplates: [
-        'https://a.basemaps.cartocdn.com/rastertiles/voyager_labels_under/{z}/{x}/{y}.png'
-      ]
+      data: 'https://a.basemaps.cartocdn.com/rastertiles/voyager_labels_under/{z}/{x}/{y}.png'
     },
     onBeforeUpdate: ({testCase}) => t.comment(testCase.title)
   });

--- a/test/modules/geo-layers/tile-layer/tile-layer.spec.js
+++ b/test/modules/geo-layers/tile-layer/tile-layer.spec.js
@@ -42,7 +42,7 @@ test('TileLayer', t => {
   };
 
   const renderSubLayers = props => {
-    return new ScatterplotLayer(props);
+    return new ScatterplotLayer(props, {id: `${props.id}-fill`});
   };
   const renderNestedSubLayers = props => {
     return [
@@ -69,8 +69,24 @@ test('TileLayer', t => {
   const testCases = [
     {
       props: {
+        data:
+          'https://raw.githubusercontent.com/uber-common/deck.gl-data/master/website/bart.geo.json'
+      },
+      onBeforeUpdate: () => {
+        t.comment('Default getTileData');
+      },
+      onAfterUpdate: ({layer, subLayers}) => {
+        t.is(subLayers.length, 2, 'Rendered sublayers');
+        t.notOk(layer.isLoaded, 'Layer is not loaded');
+      }
+    },
+    {
+      props: {
         getTileData,
         renderSubLayers
+      },
+      onBeforeUpdate: () => {
+        t.comment('Custom getTileData');
       },
       onAfterUpdate: ({layer, subLayers}) => {
         t.is(subLayers.length, 2, 'Rendered sublayers');

--- a/test/modules/geo-layers/tile-layer/utils.spec.js
+++ b/test/modules/geo-layers/tile-layer/utils.spec.js
@@ -1,5 +1,10 @@
 import test from 'tape-catch';
-import {getTileIndices, tileToBoundingBox} from '@deck.gl/geo-layers/tile-layer/utils';
+import {
+  getTileIndices,
+  tileToBoundingBox,
+  urlType,
+  getURLFromTemplate
+} from '@deck.gl/geo-layers/tile-layer/utils';
 import {WebMercatorViewport, OrthographicView} from '@deck.gl/core';
 
 const TEST_CASES = [
@@ -272,5 +277,75 @@ test('tileToBoundingBox#Infovis', t => {
     '4,-1,2 with custom tileSize Should match the results.'
   );
 
+  t.end();
+});
+
+test('urlType', t => {
+  t.ok(urlType.validate(urlType.value), 'default value is validated');
+  t.ok(urlType.validate('https://server.com/{z}/{x}/{y}.png'), 'string is validated');
+  t.ok(urlType.validate(['https://server.com/{z}/{x}/{y}.png']), 'array of string is validated');
+  t.notOk(urlType.validate(null), 'is not valid');
+  t.notOk(urlType.validate(['https://server.com/{z}/{x}/{y}.png', null]), 'is not valid');
+
+  t.ok(urlType.equals('', ''), 'should be equal');
+  t.ok(
+    urlType.equals('https://server.com/{z}/{x}/{y}.png', 'https://server.com/{z}/{x}/{y}.png'),
+    'should be equal'
+  );
+  t.ok(
+    urlType.equals(['https://server.com/{z}/{x}/{y}.png'], ['https://server.com/{z}/{x}/{y}.png']),
+    'should be equal'
+  );
+  t.notOk(
+    urlType.equals('https://server.com/{z}/{x}/{y}.png', [
+      'https://server.com/ep1/{z}/{x}/{y}.png',
+      'https://server.com/ep2/{z}/{x}/{y}.png'
+    ]),
+    'should not be equal'
+  );
+  t.notOk(
+    urlType.equals(
+      ['https://server.com/{z}/{x}/{y}.png'],
+      ['https://server.com/ep1/{z}/{x}/{y}.png', 'https://server.com/ep2/{z}/{x}/{y}.png']
+    ),
+    'should not be equal'
+  );
+  t.notOk(
+    urlType.equals(
+      [
+        'https://anotherserver.com/ep1/{z}/{x}/{y}.png',
+        'https://anotherserver.com/ep2/{z}/{x}/{y}.png'
+      ],
+      ['https://server.com/ep1/{z}/{x}/{y}.png', 'https://server.com/ep2/{z}/{x}/{y}.png']
+    ),
+    'should not be equal'
+  );
+
+  t.end();
+});
+
+test('getURLFromTemplate', t => {
+  const TEST_TEMPLATE = 'https://server.com/{z}/{x}/{y}.png';
+  const TEST_TEMPLATE_ARRAY = [
+    'https://server.com/ep1/{x}/{y}.png',
+    'https://server.com/ep2/{x}/{y}.png'
+  ];
+  t.is(
+    getURLFromTemplate(TEST_TEMPLATE, {x: 1, y: 2, z: 0}),
+    'https://server.com/0/1/2.png',
+    'single string template'
+  );
+  t.is(
+    getURLFromTemplate(TEST_TEMPLATE_ARRAY, {x: 1, y: 2, z: 0}),
+    'https://server.com/ep2/1/2.png',
+    'array of templates'
+  );
+  t.is(
+    getURLFromTemplate(TEST_TEMPLATE_ARRAY, {x: 2, y: 2, z: 0}),
+    'https://server.com/ep1/2/2.png',
+    'array of templates'
+  );
+  t.is(getURLFromTemplate(null, {x: 1, y: 2, z: 0}), null, 'invalid template');
+  t.is(getURLFromTemplate([], {x: 1, y: 2, z: 0}), null, 'empty array');
   t.end();
 });

--- a/test/render/test-cases/mvt-layer.js
+++ b/test/render/test-cases/mvt-layer.js
@@ -12,7 +12,8 @@ export default [
     },
     layers: [
       new MVTLayer({
-        urlTemplates: ['./test/data/mvt-tiles/{z}/{x}/{y}.mvt'],
+        id: 'mvt-layer',
+        data: ['./test/data/mvt-tiles/{z}/{x}/{y}.mvt'],
         getFillColor: [0, 0, 0, 128],
         getLineColor: [255, 0, 0, 128],
         lineWidthMinPixels: 1

--- a/test/render/test-cases/mvt-layer.js
+++ b/test/render/test-cases/mvt-layer.js
@@ -16,6 +16,13 @@ export default [
         data: ['./test/data/mvt-tiles/{z}/{x}/{y}.mvt'],
         getFillColor: [0, 0, 0, 128],
         getLineColor: [255, 0, 0, 128],
+        onTileError: error => {
+          if (error.message.includes('404')) {
+            // trying to load tiles in the previous viewport, ignore
+          } else {
+            throw error;
+          }
+        },
         lineWidthMinPixels: 1
       })
     ],

--- a/website/src/components/demo-launcher.js
+++ b/website/src/components/demo-launcher.js
@@ -27,9 +27,7 @@ class DemoLauncher extends Component {
     const DemoComponent = Demos[demo];
 
     if (DemoComponent) {
-      if (!DemoComponent.allowMissingData) {
-        this.props.loadData(demo, DemoComponent.data);
-      }
+      this.props.loadData(demo, DemoComponent.data);
       this.props.useParams(DemoComponent.parameters);
       this._mapStyle = DemoComponent.mapStyle;
 

--- a/website/src/components/demos/geo-layer-demos.js
+++ b/website/src/components/demos/geo-layer-demos.js
@@ -1,10 +1,21 @@
 /* global fetch */
-import {VectorTile} from '@mapbox/vector-tile';
-import Protobuf from 'pbf';
 import createLayerDemoClass from './layer-demo-base';
 import {DATA_URI} from '../../constants/defaults';
 
-import {GreatCircleLayer, S2Layer, TileLayer, H3HexagonLayer, H3ClusterLayer} from 'deck.gl';
+import {BitmapLayer} from '@deck.gl/layers';
+
+import {
+  GreatCircleLayer,
+  S2Layer,
+  TileLayer,
+  TripsLayer,
+  TerrainLayer,
+  MVTLayer,
+  H3HexagonLayer,
+  H3ClusterLayer
+} from '@deck.gl/geo-layers';
+
+const MAPBOX_TOKEN = process.env.MapboxAccessToken; // eslint-disable-line
 
 export const GreatCircleLayerDemo = createLayerDemoClass({
   Layer: GreatCircleLayer,
@@ -70,48 +81,111 @@ export const H3ClusterLayerDemo = createLayerDemoClass({
 
 export const TileLayerDemo = createLayerDemoClass({
   Layer: TileLayer,
-  formatTooltip: f => JSON.stringify(f.properties),
-  allowMissingData: true,
+  formatTooltip: ({tile}) => `x:${tile.x}, y:${tile.y}, z:${tile.z}`,
+  basemap: false,
   props: {
-    stroked: false,
+    data: 'https://c.tile.openstreetmap.org/{z}/{x}/{y}.png',
+    pickable: true,
+    minZoom: 0,
+    maxZoom: 19,
 
+    renderSubLayers: props => {
+      const {
+        bbox: {west, south, east, north}
+      } = props.tile;
+
+      return new BitmapLayer(props, {
+        data: null,
+        image: props.data,
+        bounds: [west, south, east, north]
+      });
+    }
+  }
+});
+
+export const TripsLayerDemo = createLayerDemoClass({
+  Layer: TripsLayer,
+  dataUrl: `${DATA_URI}/sf.trips.json`,
+  propParameters: {
+    currentTime: {
+      displayName: 'currentTime',
+      type: 'range',
+      value: 500,
+      step: 12,
+      min: 0,
+      max: 1200
+    },
+    trailLength: {
+      displayName: 'trailLength',
+      type: 'range',
+      value: 600,
+      step: 12,
+      min: 0,
+      max: 1200
+    }
+  },
+  props: {
+    getPath: d => d.waypoints.map(p => p.coordinates),
+    getTimestamps: d => d.waypoints.map(p => p.timestamp - 1554772579000),
+    getColor: [253, 128, 93],
+    opacity: 0.8,
+    widthMinPixels: 8,
+    rounded: true,
+    trailLength: 600,
+    currentTime: 500
+  }
+});
+
+export const TerrainLayerDemo = createLayerDemoClass({
+  Layer: TerrainLayer,
+  propParameters: {
+    meshMaxError: {
+      displayName: 'meshMaxError',
+      type: 'range',
+      value: 4.0,
+      step: 1,
+      min: 1,
+      max: 100
+    }
+  },
+  props: {
+    minZoom: 0,
+    maxZoom: 23,
+    strategy: 'no-overlap',
+    elevationDecoder: {
+      rScaler: 256,
+      gScaler: 1,
+      bScaler: 1 / 256,
+      offset: -32768
+    },
+    terrainImage: 'https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png',
+    surfaceImage: 'https://wms.chartbundle.com/tms/1.0.0/sec/{z}/{x}/{y}.png?origin=nw'
+  }
+})
+
+export const MVTLayerDemo = createLayerDemoClass({
+  Layer: MVTLayer,
+  basemap: false,
+  props: {
+    data: [
+      `https://a.tiles.mapbox.com/v4/mapbox.mapbox-streets-v7/{z}/{x}/{y}.vector.pbf?access_token=${MAPBOX_TOKEN}`
+    ],
+
+    minZoom: 0,
+    maxZoom: 23,
     getLineColor: [192, 192, 192],
     getFillColor: [140, 170, 180],
 
     getLineWidth: f => {
-      if (f.properties.layer === 'transportation') {
-        switch (f.properties.class) {
-          case 'primary':
-            return 12;
-          case 'motorway':
-            return 16;
-          default:
-            return 6;
-        }
+      switch (f.properties.class) {
+        case 'street':
+          return 6;
+        case 'motorway':
+          return 10;
+        default:
+          return 1;
       }
-      return 1;
     },
-    lineWidthMinPixels: 1,
-
-    getTileData: ({x, y, z}) => {
-      const mapSource = `https://a.tiles.mapbox.com/v4/mapbox.mapbox-streets-v7/${z}/${x}/${y}.vector.pbf?access_token=${
-        process.env.MapboxAccessToken // eslint-disable-line
-      }`;
-      return fetch(mapSource)
-        .then(response => response.arrayBuffer())
-        .then(buffer => {
-          const tile = new VectorTile(new Protobuf(buffer));
-          const features = [];
-          for (const layerName in tile.layers) {
-            const vectorTileLayer = tile.layers[layerName];
-            for (let i = 0; i < vectorTileLayer.length; i++) {
-              const vectorTileFeature = vectorTileLayer.feature(i);
-              const feature = vectorTileFeature.toGeoJSON(x, y, z);
-              features.push(feature);
-            }
-          }
-          return features;
-        });
-    }
+    lineWidthMinPixels: 1
   }
-});
+})

--- a/website/src/components/demos/layer-demo-base.js
+++ b/website/src/components/demos/layer-demo-base.js
@@ -25,11 +25,14 @@ const TOOLTIP_STYLE = {
 
 export default function createLayerDemoClass(settings) {
   const renderLayer = (data, params, extraProps = {}) => {
-    if (!data && !settings.allowMissingData) {
+    if (settings.dataUrl && !data) {
       return null;
     }
 
-    const props = {...settings.props, ...extraProps, data};
+    const props = {...settings.props, ...extraProps};
+    if (settings.dataUrl) {
+      props.data = data;
+    }
 
     if (params) {
       Object.keys(params).forEach(key => {
@@ -46,9 +49,9 @@ export default function createLayerDemoClass(settings) {
 
   class DemoClass extends Component {
     static get data() {
-      return {
+      return settings.dataUrl ? {
         url: settings.dataUrl
-      };
+      } : [];
     }
 
     static get parameters() {
@@ -81,12 +84,12 @@ export default function createLayerDemoClass(settings) {
     }
 
     _getTooltip(pickedInfo) {
-      if (!pickedInfo.object) {
+      if (!pickedInfo.picked) {
         return null;
       }
       const {formatTooltip} = settings;
       return {
-        text: formatTooltip ? formatTooltip(pickedInfo.object) : pickedInfo.index,
+        text: formatTooltip ? formatTooltip(pickedInfo.object || pickedInfo) : pickedInfo.index,
         style: TOOLTIP_STYLE
       };
     }
@@ -103,7 +106,7 @@ export default function createLayerDemoClass(settings) {
           controller={true}
           layers={layers}
         >
-          <StaticMap reuseMaps mapStyle={MAPBOX_STYLES.LIGHT} preventStyleDiffing={true} />
+          {settings.basemap !== false && <StaticMap reuseMaps mapStyle={MAPBOX_STYLES.LIGHT} preventStyleDiffing={true} />}
         </DeckGL>
       );
     }

--- a/website/src/components/demos/layer-demos.js
+++ b/website/src/components/demos/layer-demos.js
@@ -1,8 +1,8 @@
 import createLayerDemoClass from './layer-demo-base';
 import {DATA_URI} from '../../constants/defaults';
 
+import {COORDINATE_SYSTEM} from '@deck.gl/core';
 import {
-  COORDINATE_SYSTEM,
   ArcLayer,
   BitmapLayer,
   ColumnLayer,
@@ -14,15 +14,10 @@ import {
   PointCloudLayer,
   PolygonLayer,
   ScatterplotLayer,
-  TextLayer,
-  TripsLayer,
-  TerrainLayer,
-  MVTTileLayer
-} from 'deck.gl';
+  TextLayer
+} from '@deck.gl/layers';
 
 import {colorToRGBArray} from '../../utils/format-utils';
-
-const MAPBOX_TOKEN = process.env.MapboxAccessToken; // eslint-disable-line
 
 export const ArcLayerDemo = createLayerDemoClass({
   Layer: ArcLayer,
@@ -215,83 +210,8 @@ export const TextLayerDemo = createLayerDemoClass({
 
 export const BitmapLayerDemo = createLayerDemoClass({
   Layer: BitmapLayer,
-  allowMissingData: true,
   props: {
     bounds: [-122.519, 37.7045, -122.355, 37.829],
     image: `${DATA_URI}/sf-districts.png`
   }
 });
-
-export const TripsLayerDemo = createLayerDemoClass({
-  Layer: TripsLayer,
-  dataUrl: `${DATA_URI}/sf.trips.json`,
-  propParameters: {
-    currentTime: {
-      displayName: 'currentTime',
-      type: 'range',
-      value: 500,
-      step: 12,
-      min: 0,
-      max: 1200
-    },
-    trailLength: {
-      displayName: 'trailLength',
-      type: 'range',
-      value: 600,
-      step: 12,
-      min: 0,
-      max: 1200
-    }
-  },
-  props: {
-    getPath: d => d.waypoints.map(p => p.coordinates),
-    getTimestamps: d => d.waypoints.map(p => p.timestamp - 1554772579000),
-    getColor: [253, 128, 93],
-    opacity: 0.8,
-    widthMinPixels: 8,
-    rounded: true,
-    trailLength: 600,
-    currentTime: 500
-  }
-});
-
-export const TerrainLayerDemo = createLayerDemoClass({
-  Layer: TerrainLayer,
-  allowMissingData: true,
-  propParameters: {
-    meshMaxError: {
-      displayName: 'meshMaxError',
-      type: 'range',
-      value: 4.0,
-      step: 1,
-      min: 1,
-      max: 100
-    }
-  },
-  props: {
-    minZoom: 0,
-    maxZoom: 23,
-    strategy: 'no-overlap',
-    elevationDecoder: {
-      rScaler: 256,
-      gScaler: 1,
-      bScaler: 1 / 256,
-      offset: -32768
-    },
-    terrainImage: 'https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png',
-    surfaceImage: 'https://wms.chartbundle.com/tms/1.0.0/sec/{z}/{x}/{y}.png?origin=nw'
-  }
-})
-
-export const MVTTileLayerDemo = createLayerDemoClass({
-  Layer: MVTTileLayer,
-  allowMissingData: true,
-  props: {
-    minZoom: 0,
-    maxZoom: 23,
-    getFillColor: [140, 170, 180],
-    urlTemplates: [
-      `https://a.tiles.mapbox.com/v4/mapbox.boundaries-adm0-v3/{z}/{x}/{y}.vector.pbf?access_token=${MAPBOX_TOKEN}`
-    ]
-  }
-})


### PR DESCRIPTION
For #4317 

#### Change List
- Add `data` prop to `TileLayer`, make `getTileData` optional
- Remove `MVTLayer`'s `urlTemplates` prop, use `data` instead
- Validate and deep-compare URL templates
- Docs
- Tests
- Update website demos

