### PR TITLE
Fix jumpy projection using WEB_MERCATOR_AUTO_OFFSET with CARTESIAN coordinates

### DIFF
--- a/modules/core/src/shaderlib/project/viewport-uniforms.js
+++ b/modules/core/src/shaderlib/project/viewport-uniforms.js
@@ -78,6 +78,8 @@ export function getOffsetOrigin(
           Math.fround(viewport.center[1]),
           0
         ];
+        // Geospatial origin (wgs84) must match shaderCoordinateOrigin (common)
+        geospatialOrigin = viewport.unprojectPosition(shaderCoordinateOrigin);
       }
       break;
 

--- a/test/modules/core/shaderlib/project/project-functions.spec.js
+++ b/test/modules/core/shaderlib/project/project-functions.spec.js
@@ -88,7 +88,7 @@ const TEST_CASES = [
       viewport: TEST_VIEWPORT,
       coordinateSystem: COORDINATE_SYSTEM.CARTESIAN
     },
-    result: [174.15111111111113, -58.11045723102637, 0]
+    result: [174.15110778808594, -58.11044311523443, 0]
   },
   {
     title: 'LNGLAT_OFFSETS',

--- a/test/modules/core/shaderlib/project/viewport-uniforms.spec.js
+++ b/test/modules/core/shaderlib/project/viewport-uniforms.spec.js
@@ -144,9 +144,10 @@ test('project#getUniforms', t => {
   });
   t.notOk(getUniformsError(uniforms, UNIFORMS), 'Uniforms validated');
   t.ok(uniforms.project_uCenter.some(x => x), 'Returned non-trivial projection center');
+  // CARTESIAN + WEB_MERCATOR_AUTO_OFFSET is rounded in the common space
   t.ok(
-    Math.abs(uniforms.project_uCenter[0]) < EPSILON &&
-      Math.abs(uniforms.project_uCenter[1]) < EPSILON,
+    Math.abs(uniforms.project_uCenter[0]) < EPSILON * 10 &&
+      Math.abs(uniforms.project_uCenter[1]) < EPSILON * 10,
     'project center at center of clipspace'
   );
   t.ok(


### PR DESCRIPTION
`geospatialOrigin` is frounded in lnglat space while `shaderCoordinateOrigin` is frounded in common space.

#### Change List
- Match `geospatialOrigin` and `shaderCoordinateOrigin`
- Tests
