### PR TITLE
pydeck: fix custom layer module initialization

### DIFF
--- a/modules/jupyter-widget/src/create-deck.js
+++ b/modules/jupyter-widget/src/create-deck.js
@@ -88,6 +88,7 @@ function createDeck({
   try {
     addCustomLibraries(customLibraries);
   } catch (error) {
+    // eslint-disable-next-line
     console.error('pydeck: load of custom library failed', error, customLibraries);
   }
 

--- a/modules/jupyter-widget/src/create-deck.js
+++ b/modules/jupyter-widget/src/create-deck.js
@@ -83,10 +83,17 @@ function createDeck({
   customLibraries
 }) {
   let deckgl;
+
+  // First add custom libraries (ensure we have any new class defs before converting props!)
+  try {
+    addCustomLibraries(customLibraries);
+  } catch (error) {
+    console.error('pydeck: load of custom library failed', error, customLibraries);
+  }
+
   try {
     const props = jsonConverter.convert(jsonInput);
 
-    addCustomLibraries(customLibraries);
     const getTooltip = makeTooltip(tooltip);
 
     deckgl = new deck.DeckGL({


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
The layer module needs to be initialized before props are converted, otherwise the injected classes are not available during the first conversion.

<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
-
