### PR TITLE
Fix TerrainLayer support for single mesh

### DIFF
--- a/docs/layers/terrain-layer.md
+++ b/docs/layers/terrain-layer.md
@@ -18,17 +18,16 @@ import {TerrainLayer} from '@deck.gl/geo-layers';
 export const App = ({viewport}) => {
 
   const layer = new TerrainLayer({
-    minZoom: 0,
-    maxZoom: 23,
-    strategy: 'no-overlap',
     elevationDecoder: {
-      rScaler: 256,
-      gScaler: 1,
-      bScaler: 1/256,
-      offset: -32768
+      rScaler: 2,
+      gScaler: 0,
+      bScaler: 0,
+      offset: 0
     },
-    elevationData: 'https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png',
-    texture: 'https://wms.chartbundle.com/tms/1.0.0/sec/{z}/{x}/{y}.png?origin=nw'
+    // Digital elevation model from https://www.usgs.gov/
+    elevationData: 'https://raw.githubusercontent.com/uber-common/deck.gl-data/master/website/terrain.png',
+    texture: 'https://raw.githubusercontent.com/uber-common/deck.gl-data/master/website/terrain-mask.png',
+    bounds: [-122.5233, 37.6493, -122.3566, 37.8159],
   });
   return <DeckGL {...viewport} layers={[layer]} />;
 };

--- a/docs/layers/terrain-layer.md
+++ b/docs/layers/terrain-layer.md
@@ -156,15 +156,21 @@ Set `workerUrl` to an empty string to disable worker during debugging (improves 
 
 ##### `color` (Color, optional)
 
-Color to use if `texture` is unavailable. Equivalent to setting SimpleMeshLayer's `getColor` prop.
+Color to use if `texture` is unavailable. Forwarded to `SimpleMeshLayer`'s `getColor` prop.
 
 - Default: `[255, 255, 255]`
 
 ##### `wireframe` (Boolean, optional)
 
-Forwarded to SimpleMeshLayer `wireframe` prop.
+Forwarded to `SimpleMeshLayer`'s `wireframe` prop.
 
 - Default: `false`
+
+##### `material` (Object, optional)
+
+Forwarded to `SimpleMeshLayer`'s `material` prop.
+
+- Default: `true`
 
 
 ## Sub Layers

--- a/modules/geo-layers/src/terrain-layer/terrain-layer.js
+++ b/modules/geo-layers/src/terrain-layer/terrain-layer.js
@@ -53,7 +53,8 @@ const defaultProps = {
   // Supply url to local terrain worker bundle. Only required if running offline and cannot access CDN.
   workerUrl: {type: 'string', value: null},
   // Same as SimpleMeshLayer wireframe
-  wireframe: false
+  wireframe: false,
+  material: true
 };
 
 // Turns array of templates into a single string to work around shallow change
@@ -168,7 +169,15 @@ export default class TerrainLayer extends CompositeLayer {
   }
 
   renderLayers() {
-    const {color, elevationData, texture, wireframe, meshMaxError, elevationDecoder} = this.props;
+    const {
+      color,
+      material,
+      elevationData,
+      texture,
+      wireframe,
+      meshMaxError,
+      elevationDecoder
+    } = this.props;
 
     if (this.state.isTiled) {
       return new TileLayer(
@@ -178,6 +187,7 @@ export default class TerrainLayer extends CompositeLayer {
         {
           wireframe,
           color,
+          material,
           getTileData: this.getTiledTerrainData.bind(this),
           renderSubLayers: this.renderSubLayers.bind(this),
           updateTriggers: {
@@ -201,8 +211,10 @@ export default class TerrainLayer extends CompositeLayer {
         data: DUMMY_DATA,
         mesh: this.state.terrain,
         texture,
+        _instanced: false,
         getPosition: d => [0, 0, 0],
         getColor: color,
+        material,
         wireframe
       }
     );

--- a/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.js
+++ b/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.js
@@ -196,12 +196,14 @@ export default class SimpleMeshLayer extends Layer {
     }
 
     const {viewport} = this.context;
-    const {sizeScale, coordinateSystem} = this.props;
+    const {sizeScale, coordinateSystem, _instanced} = this.props;
 
     this.state.model.draw({
       uniforms: Object.assign({}, uniforms, {
         sizeScale,
-        composeModelMatrix: shouldComposeModelMatrix(viewport, coordinateSystem),
+        // _instanced is a hack to use world position instead of meter offsets in mesh
+        // TODO - formalize API
+        composeModelMatrix: !_instanced || shouldComposeModelMatrix(viewport, coordinateSystem),
         flatShading: !this.state.hasNormals
       })
     });

--- a/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.js
+++ b/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.js
@@ -83,6 +83,9 @@ const defaultProps = {
     depthFunc: GL.LEQUAL
   },
 
+  // _instanced is a hack to use world position instead of meter offsets in mesh
+  // TODO - formalize API
+  _instanced: true,
   // NOTE(Tarek): Quick and dirty wireframe. Just draws
   // the same mesh with LINE_STRIPS. Won't follow edges
   // of the original mesh.
@@ -201,8 +204,6 @@ export default class SimpleMeshLayer extends Layer {
     this.state.model.draw({
       uniforms: Object.assign({}, uniforms, {
         sizeScale,
-        // _instanced is a hack to use world position instead of meter offsets in mesh
-        // TODO - formalize API
         composeModelMatrix: !_instanced || shouldComposeModelMatrix(viewport, coordinateSystem),
         flatShading: !this.state.hasNormals
       })

--- a/website/src/components/demos/geo-layer-demos.js
+++ b/website/src/components/demos/geo-layer-demos.js
@@ -149,17 +149,18 @@ export const TerrainLayerDemo = createLayerDemoClass({
     }
   },
   props: {
-    minZoom: 0,
-    maxZoom: 23,
-    strategy: 'no-overlap',
     elevationDecoder: {
-      rScaler: 256,
-      gScaler: 1,
-      bScaler: 1 / 256,
-      offset: -32768
+      rScaler: 2,
+      gScaler: 0,
+      bScaler: 0,
+      offset: 0
     },
-    terrainImage: 'https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png',
-    surfaceImage: 'https://wms.chartbundle.com/tms/1.0.0/sec/{z}/{x}/{y}.png?origin=nw'
+    elevationData: `${DATA_URI}/terrain.png`,
+    texture: `${DATA_URI}/terrain-mask.png`,
+    bounds: [-122.5233, 37.6493, -122.3566, 37.8159],
+    material: {
+      diffuse: 1
+    }
   }
 })
 

--- a/website/src/utils/layer-params.js
+++ b/website/src/utils/layer-params.js
@@ -48,6 +48,8 @@ export function propToParam(key, propType, value) {
     }
     case 'color':
       return {...param, type: 'color'};
+    case 'url':
+      return {...param, type: 'link'};
     case 'object':
       if (/mapping|domain|range/i.test(key)) {
         return {...param, type: 'json'};


### PR DESCRIPTION
For #3591 

![image](https://user-images.githubusercontent.com/2059298/76375187-6a233c80-6302-11ea-83b5-cf41cf9d9723.png)


#### Change List
- Change the embedded example in TerrainLayer docs to use single mesh (easier for users to click on images and see what they are). We already have a tiled example in the Examples tab.
- Forward the `material` prop to `SimpleMeshLayer`
- `SimpleMeshLayer`: added a hack to allow `mesh` to use world coordinates instead of meter-offsets @xintongxia 
