### PR TITLE
Some minor changes for 8.1 ArcGIS docs

### DIFF
--- a/docs/api-reference/arcgis/deck-renderer.md
+++ b/docs/api-reference/arcgis/deck-renderer.md
@@ -1,6 +1,7 @@
 # DeckRenderer
 
-This class inherits implements the ArcGIS [ExternalRenderer](https://developers.arcgis.com/javascript/latest/api-reference/esri-views-3d-externalRenderers.html#ExternalRenderer) interface and can be added to maps created with the ArcGIS API for JavaScript.
+This class is an experimental implementation of the ArcGIS [ExternalRenderer](https://developers.arcgis.com/javascript/latest/api-reference/esri-views-3d-externalRenderers.html#ExternalRenderer) interface and can be added to 3D views of maps created with the ArcGIS
+API for JavaScript.
 
 `DeckRenderer` is only available when `loadArcGISModules()` is resolved.
 

--- a/docs/api-reference/arcgis/overview.md
+++ b/docs/api-reference/arcgis/overview.md
@@ -6,9 +6,9 @@ The functionality exported by this module must be loaded asynchronously using th
 This function can be used to load any module that ships with the ArcGIS API for JavaScript, plus an additional `arcGIS` module
 that acts as an interface between deck.gl and ArcGIS.
 
-2D integration with `MapView` is supported by the [DeckLayer](/docs/api-reference/deck-layer.md) class.
+2D integration with `MapView` is supported by the [DeckLayer](/docs/api-reference/arcgis/deck-layer.md) class.
 
-3D integration with `SceneView` is supported by the [DeckRenderer](/docs/api-reference/deck-renderer.md) class.
+3D integration with `SceneView` is experimental: see the [DeckRenderer](/docs/api-reference/arcgis/deck-renderer.md) class.
 
 ## Installation
 


### PR DESCRIPTION
This PR does two things:

- _Important_. Fixes two links in `docs/api-reference/arcgis/overview.md`
- _Less important but worth considering_. Adds the word _"experimental"_ in a couple of places wrt the novel `DeckRenderer` class.
