### PR TITLE
pydeck: add offline capability for pydeck for #4290

### DIFF
--- a/bindings/pydeck/pydeck/bindings/deck.py
+++ b/bindings/pydeck/pydeck/bindings/deck.py
@@ -125,6 +125,7 @@ class Deck(JSONMixin):
         iframe_width=700,
         iframe_height=500,
         as_string=False,
+        offline=False,
         **kwargs
     ):
         """Write a file and loads it to an iframe, if in a Jupyter environment;

--- a/bindings/pydeck/pydeck/io/html.py
+++ b/bindings/pydeck/pydeck/io/html.py
@@ -23,9 +23,15 @@ TEMPLATES_PATH = os.path.join(os.path.dirname(__file__), "./templates/")
 j2_env = jinja2.Environment(
     loader=jinja2.FileSystemLoader(TEMPLATES_PATH), trim_blocks=True
 )
-CDN_URL = "https://cdn.jsdelivr.net/npm/@deck.gl/jupyter-widget@{}/dist/index.js".format(
-    DECKGL_SEMVER
-)
+
+def cdn_picker(offline=False):
+    if offline:
+        CDN_URL = os.path.abspath('../nbextension/static/index.js')
+    else:
+        CDN_URL = "https://cdn.jsdelivr.net/npm/@deck.gl/jupyter-widget@{}/dist/index.js".format(
+            DECKGL_SEMVER
+        )
+    return CDN_URL
 
 
 def render_json_to_html(
@@ -34,12 +40,13 @@ def render_json_to_html(
     tooltip=True,
     css_background_color=None,
     custom_libraries=None,
+    offline=False
 ):
     js = j2_env.get_template("index.j2")
     html_str = js.render(
         mapbox_key=mapbox_key,
         json_input=json_input,
-        deckgl_jupyter_widget_bundle=CDN_URL,
+        deckgl_jupyter_widget_bundle=cdn_picker(offline),
         tooltip=convert_js_bool(tooltip),
         css_background_color=css_background_color,
         custom_libraries=custom_libraries
@@ -93,7 +100,8 @@ def deck_to_html(
     iframe_width=500,
     tooltip=True,
     custom_libraries=None,
-    as_string=False
+    as_string=False,
+    offline=False
 ):
     """Converts deck.gl format JSON to an HTML page"""
     html = render_json_to_html(
@@ -102,6 +110,7 @@ def deck_to_html(
         tooltip=tooltip,
         css_background_color=css_background_color,
         custom_libraries=custom_libraries,
+        offline=False
     )
 
     if as_string:


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #4290 
<!-- For other PRs without open issue -->
#### Background
The pydeck install already has the necessary javascript come with it on install, so I set up an argument to allow for HTML documents to point to the absolute path of the javascript file. 
<!-- For all the PRs -->
#### Change List
- Add an argument in pydeck to allow the option to have offline HTML documents rendered.
- Add a function that processes that by getting the absolute path of the javascript needed. 

@ajduberstein - If this isn't what you're looking for, just let me know and I'd be happy to edit it! I think this might still need a test written for it, which I'm happy to provide if desired. 