### PR TITLE
pydeck/jupyter-widget: Call mergeConfiguration again after addCustomLibraries complete

### DIFF
--- a/modules/jupyter-widget/src/create-deck.js
+++ b/modules/jupyter-widget/src/create-deck.js
@@ -167,4 +167,4 @@ function injectFunction(warnFunction, messageHandler) {
   };
 }
 
-export {jsonConverter, createDeck, updateDeck};
+export {jsonConverter, createDeck, updateDeck, addCustomLibraries};

--- a/test/modules/jupyter-widget/create-deck.spec.js
+++ b/test/modules/jupyter-widget/create-deck.spec.js
@@ -37,11 +37,10 @@ test('jupyter-widget: dynamic-registration', t0 => {
       [
         {
           libraryName: TEST_LIBRARY_NAME,
-          resourceUri: '/index.js',
-          onComplete
+          resourceUri: '/index.js'
         }
       ],
-      () => Promise.resolve()
+      onComplete
     );
   });
 

--- a/test/modules/jupyter-widget/create-deck.spec.js
+++ b/test/modules/jupyter-widget/create-deck.spec.js
@@ -21,7 +21,7 @@ test('jupyter-widget: dynamic-registration', t0 => {
     return;
   }
 
-  t0.test('loadExternalLibrary', t => {
+  t0.test('addCustomLibraries', t => {
     const TEST_LIBRARY_NAME = 'DemoLibrary';
     window[TEST_LIBRARY_NAME] = {DemoCompositeLayer};
     const onComplete = () => {
@@ -33,12 +33,14 @@ test('jupyter-widget: dynamic-registration', t0 => {
       delete window[TEST_LIBRARY_NAME];
       t.end();
     };
-    module.loadExternalLibrary(
-      {
-        libraryName: TEST_LIBRARY_NAME,
-        resourceUri: '/index.js',
-        onComplete
-      },
+    module.addCustomLibraries(
+      [
+        {
+          libraryName: TEST_LIBRARY_NAME,
+          resourceUri: '/index.js',
+          onComplete
+        }
+      ],
       () => Promise.resolve()
     );
   });


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #4103 

<!-- For other PRs without open issue -->
#### Background
- As discussed in #4375 there is an issue when the jupyter widget initializes using a synchronous API but the custom library script loading happens asynchronously. 

#### Change List
- Wait for script loading to complete
