### PR TITLE
@deck.gl/jupyter-widget and pydeck: Fix binary data bug

### DIFF
--- a/bindings/pydeck/pydeck/bindings/layer.py
+++ b/bindings/pydeck/pydeck/bindings/layer.py
@@ -148,20 +148,24 @@ class Layer(JSONMixin):
             )
 
         layer_accessors = self._kwargs
-        inv_map = {v: k for k, v in layer_accessors.items()}
+        inverted_accessor_map = {v: k for k, v in layer_accessors.items()}
 
-        blobs = []
+        binary_transmission = []
+        # Loop through data columns and convert them to numpy arrays
         for column in data_set.columns:
+            # np.stack will take data arrays and conveniently extract the shape
             np_data = np.stack(data_set[column].to_numpy())
-            blobs.append(
+            # Get rid of the accssor so it doesn't appear in the JSON output
+            del self.__dict__[inverted_accessor_map[column]]
+            binary_transmission.append(
                 {
                     "layer_id": self.id,
                     "column_name": column,
-                    "accessor": camel_and_lower(inv_map[column]),
+                    "accessor": camel_and_lower(inverted_accessor_map[column]),
                     "np_data": np_data,
                 }
             )
-        return blobs
+        return binary_transmission
 
     @property
     def type(self):

--- a/bindings/pydeck/pydeck/bindings/layer.py
+++ b/bindings/pydeck/pydeck/bindings/layer.py
@@ -148,7 +148,7 @@ class Layer(JSONMixin):
             )
 
         layer_accessors = self._kwargs
-        inverted_accessor_map = {v: k for k, v in layer_accessors.items()}
+        inverted_accessor_map = {v: k for k, v in layer_accessors.items() if type(v) not in [list, dict, set]}
 
         binary_transmission = []
         # Loop through data columns and convert them to numpy arrays

--- a/modules/jupyter-widget/src/binary-transport.js
+++ b/modules/jupyter-widget/src/binary-transport.js
@@ -48,14 +48,15 @@ function deserializeMatrix(obj, manager) {
   return obj;
 }
 
-function processDataBuffer({dataBuffer, jsonProps}) {
+function processDataBuffer({dataBuffer, convertedJson}) {
   // Takes JSON props and combines them with the binary data buffer
-  for (let i = 0; i < jsonProps.layers.length; i++) {
-    const layerId = jsonProps.layers[i].id;
-    jsonProps.layers[i].data = dataBuffer[layerId];
+  for (let i = 0; i < convertedJson.layers.length; i++) {
+    const layerId = convertedJson.layers[i].id;
+    const layer = convertedJson.layers[i];
     // Replace data on every layer prop
+    convertedJson.layers[i] = layer.clone({data: dataBuffer[layerId]});
   }
-  return jsonProps;
+  return convertedJson;
 }
 
 export {deserializeMatrix, processDataBuffer};

--- a/modules/jupyter-widget/src/widget.js
+++ b/modules/jupyter-widget/src/widget.js
@@ -133,14 +133,13 @@ export class DeckGLView extends DOMWidgetView {
   }
 
   dataBufferChanged() {
-    if (this.model.get('data_buffer')) {
+    if (this.model.get('data_buffer') && this.model.get('json_input')) {
+      const convertedJson = jsonConverter.convert(this.model.get('json_input'));
       const propsWithBinary = processDataBuffer({
         dataBuffer: this.model.get('data_buffer'),
-        jsonProps: this.model.get('json_input')
+        convertedJson
       });
-
-      const convertedJson = jsonConverter.convert(propsWithBinary);
-      this.deck.setProps(convertedJson);
+      this.deck.setProps(propsWithBinary);
     }
   }
 

--- a/test/modules/jupyter-widget/binary-transport.spec.js
+++ b/test/modules/jupyter-widget/binary-transport.spec.js
@@ -45,12 +45,10 @@ const DEMO_JSON_PROPS = {
 
 test('jupyter-widget: binary-transport', t0 => {
   let binaryTransportModule;
-  let jsonModule;
-  let deckJsonConverter;
+  let widgetCreateDeckModule;
   try {
     binaryTransportModule = require('@deck.gl/jupyter-widget/binary-transport');
-    jsonModule = require('@deck.gl/json');
-    deckJsonConverter = jsonModule.jsonConverter;
+    widgetCreateDeckModule = require('@deck.gl/jupyter-widget/create-deck');
   } catch (error) {
     t0.comment('dist mode, skipping binary-transport tests');
     t0.end();
@@ -80,7 +78,7 @@ test('jupyter-widget: binary-transport', t0 => {
   t0.test('processDataBuffer', t => {
     const newProps = binaryTransportModule.processDataBuffer({
       dataBuffer: EXPECTED_CONVERSION,
-      convertedJson: deckJsonConverter.convert(DEMO_JSON_PROPS)
+      convertedJson: widgetCreateDeckModule.jsonConverter.convert(DEMO_JSON_PROPS)
     });
 
     t.deepEquals(

--- a/test/modules/jupyter-widget/binary-transport.spec.js
+++ b/test/modules/jupyter-widget/binary-transport.spec.js
@@ -45,8 +45,12 @@ const DEMO_JSON_PROPS = {
 
 test('jupyter-widget: binary-transport', t0 => {
   let binaryTransportModule;
+  let jsonModule;
+  let deckJsonConverter;
   try {
     binaryTransportModule = require('@deck.gl/jupyter-widget/binary-transport');
+    jsonModule = require('@deck.gl/json');
+    deckJsonConverter = jsonModule.jsonConverter;
   } catch (error) {
     t0.comment('dist mode, skipping binary-transport tests');
     t0.end();
@@ -76,7 +80,7 @@ test('jupyter-widget: binary-transport', t0 => {
   t0.test('processDataBuffer', t => {
     const newProps = binaryTransportModule.processDataBuffer({
       dataBuffer: EXPECTED_CONVERSION,
-      jsonProps: DEMO_JSON_PROPS
+      convertedJson: deckJsonConverter(DEMO_JSON_PROPS)
     });
 
     t.deepEquals(

--- a/test/modules/jupyter-widget/binary-transport.spec.js
+++ b/test/modules/jupyter-widget/binary-transport.spec.js
@@ -80,7 +80,7 @@ test('jupyter-widget: binary-transport', t0 => {
   t0.test('processDataBuffer', t => {
     const newProps = binaryTransportModule.processDataBuffer({
       dataBuffer: EXPECTED_CONVERSION,
-      convertedJson: deckJsonConverter(DEMO_JSON_PROPS)
+      convertedJson: deckJsonConverter.convert(DEMO_JSON_PROPS)
     });
 
     t.deepEquals(

--- a/test/modules/jupyter-widget/binary-transport.spec.js
+++ b/test/modules/jupyter-widget/binary-transport.spec.js
@@ -30,19 +30,6 @@ const EXPECTED_CONVERSION = {
   }
 };
 
-// Test deck.gl JSON configuration
-const DEMO_JSON_PROPS = {
-  viewport: null,
-  description: 'test json config',
-  layers: [
-    {
-      radius: 100,
-      id: 'layer-id',
-      '@@type': 'ScatterplotLayer'
-    }
-  ]
-};
-
 test('jupyter-widget: binary-transport', t0 => {
   let binaryTransportModule;
   let widgetCreateDeckModule;
@@ -75,14 +62,27 @@ test('jupyter-widget: binary-transport', t0 => {
     t.end();
   });
 
+  // Test deck.gl JSON configuration
+  const DEMO_JSON_PROPS = {
+    viewport: null,
+    description: 'Test JSON config, converted into a deck.gl Layer before testing',
+    layers: [
+      {
+        radius: 100,
+        id: 'layer-id',
+        '@@type': 'ScatterplotLayer'
+      }
+    ]
+  };
+
   t0.test('processDataBuffer', t => {
-    const newProps = binaryTransportModule.processDataBuffer({
+    const newDeckProps = binaryTransportModule.processDataBuffer({
       dataBuffer: EXPECTED_CONVERSION,
       convertedJson: widgetCreateDeckModule.jsonConverter.convert(DEMO_JSON_PROPS)
     });
 
     t.deepEquals(
-      newProps.layers[0].state.data,
+      newDeckProps.layers[0].props.data,
       EXPECTED_CONVERSION['layer-id'],
       'should convert buffer input and props to new layers'
     );

--- a/test/modules/jupyter-widget/binary-transport.spec.js
+++ b/test/modules/jupyter-widget/binary-transport.spec.js
@@ -82,8 +82,8 @@ test('jupyter-widget: binary-transport', t0 => {
     });
 
     t.deepEquals(
+      newProps.layers[0].state.data,
       EXPECTED_CONVERSION['layer-id'],
-      newProps.layers[0].data,
       'should convert buffer input and props to new layers'
     );
     t.end();


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- For other PRs without open issue -->
#### Background

Previously a TypedArray for a binary DataView could be embedded in the JSON passed to @deck.gl/json. It's unclear what changed but in recent code this TypedArray is being converted to a dictionary, which breaks binary transfer.

This PR updates the Python interface for binary transfer (which made this issue easier to test) and assigns the value of data in a TypedArray to an already-instantiated layer, rather than the JSON specification for that layer.

<!-- For all the PRs -->
#### Change List
- Update Python interface
- Have `@deck.gl/jupyter-widget/binary-transport` add data to layers via layers.clone instead of setting a layer's data attribute directly.