### PR TITLE
Fix PointCloud sizeUnits as "meters"

### DIFF
--- a/modules/layers/src/point-cloud-layer/point-cloud-layer.js
+++ b/modules/layers/src/point-cloud-layer/point-cloud-layer.js
@@ -114,7 +114,7 @@ export default class PointCloudLayer extends Layer {
     const {viewport} = this.context;
     const {pointSize, sizeUnits} = this.props;
 
-    const sizeMultiplier = sizeUnits === 'meters' ? viewport.distanceScales.pixelsPerMeter[2] : 1;
+    const sizeMultiplier = sizeUnits === 'meters' ? 1 / viewport.metersPerPixel : 1;
 
     this.state.model
       .setUniforms(

--- a/test/modules/layers/point-cloud-layer.spec.js
+++ b/test/modules/layers/point-cloud-layer.spec.js
@@ -1,5 +1,6 @@
 import test from 'tape-catch';
 import {testLayer} from '@deck.gl/test-utils';
+import {equals} from 'math.gl';
 
 import {PointCloudLayer} from '@deck.gl/layers';
 
@@ -31,6 +32,27 @@ test('PointCloudLayer#loaders.gl support', t => {
           layer.props.data.attributes.POSITION.value,
           'used external attribute'
         );
+      }
+    },
+    {
+      updateProps: {
+        sizeUnits: 'meters'
+      },
+      onAfterUpdate: ({layer}) => {
+        const uniforms = layer.state.model.getUniforms();
+        t.ok(
+          equals(uniforms.radiusPixels, 0.000255808143),
+          'radiusPixels correct for sizeUnits "meters"'
+        );
+      }
+    },
+    {
+      updateProps: {
+        sizeUnits: 'pixels'
+      },
+      onAfterUpdate: ({layer}) => {
+        const uniforms = layer.state.model.getUniforms();
+        t.is(uniforms.radiusPixels, 10, 'radiusPixels is correct for sizeUnits "pixels"');
       }
     }
   ];


### PR DESCRIPTION
When the prop **sizeUnits** was set to **meters** it would access a field that didn't exist.
This has been corrected and a test added.
