### PR TITLE
Fix GeoJSON multi-geometry highlighting

### DIFF
--- a/modules/layers/src/geojson-layer/geojson-layer.js
+++ b/modules/layers/src/geojson-layer/geojson-layer.js
@@ -188,8 +188,7 @@ export default class GeoJsonLayer extends CompositeLayer {
         }),
         {
           data: polygonFeatures,
-          getPolygon: getCoordinates,
-          highlightedObjectIndex: this._getHighlightedIndex(polygonFeatures)
+          getPolygon: getCoordinates
         }
       );
 
@@ -230,8 +229,7 @@ export default class GeoJsonLayer extends CompositeLayer {
         }),
         {
           data: polygonOutlineFeatures,
-          getPath: getCoordinates,
-          highlightedObjectIndex: this._getHighlightedIndex(polygonOutlineFeatures)
+          getPath: getCoordinates
         }
       );
 
@@ -269,8 +267,7 @@ export default class GeoJsonLayer extends CompositeLayer {
         }),
         {
           data: lineFeatures,
-          getPath: getCoordinates,
-          highlightedObjectIndex: this._getHighlightedIndex(lineFeatures)
+          getPath: getCoordinates
         }
       );
 

--- a/modules/layers/src/path-layer/path-layer.js
+++ b/modules/layers/src/path-layer/path-layer.js
@@ -170,13 +170,13 @@ export default class PathLayer extends Layer {
     }
   }
 
-  getPickingInfo({info}) {
-    if (info.picked && this.parent) {
-      const {data} = this.props;
-      const isDataWrapped = data[0] && data[0].__source;
-      if (isDataWrapped) {
-        info.object = data.find(d => d.__source.index === info.index);
-      }
+  getPickingInfo(params) {
+    const info = super.getPickingInfo(params);
+    const {object, index} = info;
+
+    if (object && object.__source) {
+      // data is wrapped
+      info.object = this.props.data.find(d => d.__source.index === index);
     }
     return info;
   }

--- a/modules/layers/src/path-layer/path-layer.js
+++ b/modules/layers/src/path-layer/path-layer.js
@@ -109,7 +109,8 @@ export default class PathLayer extends Layer {
       instancePickingColors: {
         size: 3,
         type: GL.UNSIGNED_BYTE,
-        accessor: (object, {index, target: value}) => this.encodePickingColor(object.__source ? object.__source.index : index, value)
+        accessor: (object, {index, target: value}) =>
+          this.encodePickingColor(object && object.__source ? object.__source.index : index, value)
       }
     });
     /* eslint-enable max-len */
@@ -169,13 +170,12 @@ export default class PathLayer extends Layer {
     }
   }
 
-
-  getPickingInfo(info) {
+  getPickingInfo({info}) {
     if (info.picked && this.parent) {
       const {data} = this.props;
       const isDataWrapped = data[0] && data[0].__source;
       if (isDataWrapped) {
-        info.object = data.findIndex(d => d.__source.index === info.index);
+        info.object = data.find(d => d.__source.index === info.index);
       }
     }
     return info;

--- a/modules/layers/src/path-layer/path-layer.js
+++ b/modules/layers/src/path-layer/path-layer.js
@@ -109,7 +109,7 @@ export default class PathLayer extends Layer {
       instancePickingColors: {
         size: 3,
         type: GL.UNSIGNED_BYTE,
-        accessor: (object, {index, target: value}) => this.encodePickingColor(index, value)
+        accessor: (object, {index, target: value}) => this.encodePickingColor(object.__source ? object.__source.index : index, value)
       }
     });
     /* eslint-enable max-len */
@@ -167,6 +167,18 @@ export default class PathLayer extends Layer {
       this.setState({model: this._getModel(gl)});
       attributeManager.invalidateAll();
     }
+  }
+
+
+  getPickingInfo(info) {
+    if (info.picked && this.parent) {
+      const {data} = this.props;
+      const isDataWrapped = data[0] && data[0].__source;
+      if (isDataWrapped) {
+        info.object = data.findIndex(d => d.__source.index === info.index);
+      }
+    }
+    return info;
   }
 
   draw({uniforms}) {

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -174,7 +174,8 @@ export default class SolidPolygonLayer extends Layer {
       pickingColors: {
         size: 3,
         type: GL.UNSIGNED_BYTE,
-        accessor: (object, {index, target: value}) => this.encodePickingColor(object.__source ? object.__source.index : index, value),
+        accessor: (object, {index, target: value}) =>
+          this.encodePickingColor(object && object.__source ? object.__source.index : index, value),
         shaderAttributes: {
           pickingColors: {
             divisor: 0
@@ -188,12 +189,12 @@ export default class SolidPolygonLayer extends Layer {
     /* eslint-enable max-len */
   }
 
-  getPickingInfo(info) {
+  getPickingInfo({info}) {
     if (info.picked && this.parent) {
       const {data} = this.props;
       const isDataWrapped = data[0] && data[0].__source;
       if (isDataWrapped) {
-        info.object = data.findIndex(d => d.__source.index === info.index);
+        info.object = data.find(d => d.__source.index === info.index);
       }
     }
     return info;

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -189,13 +189,13 @@ export default class SolidPolygonLayer extends Layer {
     /* eslint-enable max-len */
   }
 
-  getPickingInfo({info}) {
-    if (info.picked && this.parent) {
-      const {data} = this.props;
-      const isDataWrapped = data[0] && data[0].__source;
-      if (isDataWrapped) {
-        info.object = data.find(d => d.__source.index === info.index);
-      }
+  getPickingInfo(params) {
+    const info = super.getPickingInfo(params);
+    const {object, index} = info;
+
+    if (object && object.__source) {
+      // data is wrapped
+      info.object = this.props.data.find(d => d.__source.index === index);
     }
     return info;
   }

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -174,7 +174,7 @@ export default class SolidPolygonLayer extends Layer {
       pickingColors: {
         size: 3,
         type: GL.UNSIGNED_BYTE,
-        accessor: (object, {index, target: value}) => this.encodePickingColor(index, value),
+        accessor: (object, {index, target: value}) => this.encodePickingColor(object.__source ? object.__source.index : index, value),
         shaderAttributes: {
           pickingColors: {
             divisor: 0
@@ -186,6 +186,17 @@ export default class SolidPolygonLayer extends Layer {
       }
     });
     /* eslint-enable max-len */
+  }
+
+  getPickingInfo(info) {
+    if (info.picked && this.parent) {
+      const {data} = this.props;
+      const isDataWrapped = data[0] && data[0].__source;
+      if (isDataWrapped) {
+        info.object = data.findIndex(d => d.__source.index === info.index);
+      }
+    }
+    return info;
   }
 
   draw({uniforms}) {


### PR DESCRIPTION
For https://github.com/uber/deck.gl/pull/4365

#### Background

The GeoJsonLayer splits paths and polygons in Polygon, MultiLineString and MultiPolygon features into multiple data objects before passing them to the sublayers.

To highlight all paths/polygons in the same source geometry, they must be rendered with the same picking color.

#### Change List
- PathLayer picking color when used as a sublayer
- PolygonLayer picking color when used as a sublayer
- GeoJsonLayer treatment of `highlightedObjectIndex`
