### PR TITLE
fix docs

### DIFF
--- a/docs/api-reference/first-person-view.md
+++ b/docs/api-reference/first-person-view.md
@@ -24,8 +24,8 @@ To render, a `FirstPersonView` needs to be combined with a `viewState` object wi
 * `position` (`Number[3]`, optional) - meter offsets of the camera from the lng-lat anchor point. Default `[0, 0, 0]`.
 * `bearing` (`Number`, optional) - bearing angle in degrees. Default `0` (north).
 * `pitch` (`Number`, optional) - pitch angle in degrees. Default `0` (horizontal).
-- `maxPitch` (`Number`, optional) - max pitch angle. Default `90` (up).
-- `minPitch` (`Number`, optional) - min pitch angle. Default `-90` (down).
+- `maxPitch` (`Number`, optional) - max pitch angle. Default `90` (down).
+- `minPitch` (`Number`, optional) - min pitch angle. Default `-90` (up).
 
 
 ## FirstPersonController


### PR DESCRIPTION
Address an error in the docs for `FirstPersonView` where the pitch angle `90` was deemed _"up"_ and `-90` was deemed _"down"_, while it's actually the opposite, which for mapping makes sense.