### PR TITLE
pydeck: Update installation instructions for JupyterLab

### DIFF
--- a/bindings/pydeck/README.md
+++ b/bindings/pydeck/README.md
@@ -39,7 +39,8 @@ To install pydeck for JupyterLab, run the following:
 
 ```bash
 jupyter labextension install @jupyter-widgets/jupyterlab-manager
-jupyter labextension install @deck.gl/jupyter-widget
+DECKGL_SEMVER=`python -c "import pydeck; print(pydeck.frontend_semver.DECKGL_SEMVER)"`
+jupyter labextension install @deck.gl/jupyter-widget@$DECKGL_SEMVER
 ```
 
 ### Mapbox API token

--- a/bindings/pydeck/docs/installation.rst
+++ b/bindings/pydeck/docs/installation.rst
@@ -57,7 +57,9 @@ To enable pydeck for Jupyter Lab:
 .. code-block:: bash
 
         jupyter labextension install @jupyter-widgets/jupyterlab-manager
-        jupyter labextension install @deck.gl/jupyter-widget
+        DECKGL_SEMVER=`python -c "import pydeck; print(pydeck.frontend_semver.DECKGL_SEMVER)"`
+        jupyter labextension install @deck.gl/jupyter-widget@$DECKGL_SEMVER
+
 
 Currently while you can install pydeck in Google Collab via pip, it is not enabled for server use there.
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #4103 
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
- Update docs to align JupyterLab's @deck.gl/jupyter-widget installation to pydeck's

Trying to avoid this @deck.gl/jupyter-widget error: `Error: Module @deck.gl/jupyter-widget, semver range 8.1.0-beta.3 is not registered as a widget module`. A combination of synchronizing the dependencies via these instructions as well as `jupyter lab clean` got around this.