### PR TITLE
pydeck: Embed HTML in documentation directly

### DIFF
--- a/bindings/pydeck/docs/conf.py
+++ b/bindings/pydeck/docs/conf.py
@@ -30,3 +30,6 @@ texinfo_documents = [
 epub_title = project
 epub_exclude_files = ["search.html"]
 autoclass_content = "both"
+html_theme_options = {
+    "includehidden": False
+}

--- a/bindings/pydeck/docs/conf.py
+++ b/bindings/pydeck/docs/conf.py
@@ -6,7 +6,7 @@ import os
 sys.path.insert(0, os.path.abspath("../"))
 
 project = "pydeck"
-copyright = "2020, Uber Technologies, Inc."
+copyright = "2020, MIT License"
 author = "Andrew Duberstein"
 # The short X.Y version
 version = "0.3"
@@ -21,7 +21,7 @@ language = None
 exclude_patterns = ["_build"]
 pygments_style = None
 html_theme = "sphinx_rtd_theme"
-html_static_path = ["css/custom.css", "gallery/html"]
+html_static_path = ["gallery/html"]
 htmlhelp_basename = "pydeckdoc"
 man_pages = [(master_doc, "pydeck", "pydeck Documentation", [author], 1)]
 texinfo_documents = [

--- a/bindings/pydeck/docs/gallery/html/grid.html
+++ b/bindings/pydeck/docs/gallery/html/grid.html
@@ -1,3 +1,4 @@
+
 <style>
 .wrapper {
   display: grid;
@@ -8,6 +9,7 @@
   margin: 0;
   min-height: 60px;
   position: relative;
+
 }
 .thumb-text {
   z-index: 1;

--- a/bindings/pydeck/docs/gallery/html/grid.html
+++ b/bindings/pydeck/docs/gallery/html/grid.html
@@ -1,4 +1,3 @@
-
 <style>
 .wrapper {
   display: grid;
@@ -9,7 +8,6 @@
   margin: 0;
   min-height: 60px;
   position: relative;
-
 }
 .thumb-text {
   z-index: 1;

--- a/bindings/pydeck/docs/images.rst
+++ b/bindings/pydeck/docs/images.rst
@@ -76,7 +76,6 @@
    gallery/bitmap_layer
    gallery/column_layer
    gallery/contour_layer
-   gallery/custom_layer.png
    gallery/custom_layer
    gallery/geojson_layer
    gallery/great_circle_layer

--- a/bindings/pydeck/docs/images.rst
+++ b/bindings/pydeck/docs/images.rst
@@ -1,0 +1,69 @@
+..
+  These image tags are manually added to include these images in the _static directory
+  TODO this should be automated in the future.
+
+.. image:: gallery/images/arc_layer.png
+   :width: 0
+
+.. image:: gallery/images/bitmap_layer.png
+   :width: 0
+
+.. image:: gallery/images/column_layer.png
+   :width: 0
+
+.. image:: gallery/images/contour_layer.png
+   :width: 0
+
+.. image:: gallery/images/custom_layer.png
+   :width: 0
+
+.. image:: gallery/images/geojson_layer.png
+   :width: 0
+
+.. image:: gallery/images/great_circle_layer.png
+   :width: 0
+
+.. image:: gallery/images/grid_layer.png
+   :width: 0
+
+.. image:: gallery/images/h3_cluster_layer.png
+   :width: 0
+
+.. image:: gallery/images/h3_hexagon_layer.png
+   :width: 0
+
+.. image:: gallery/images/heatmap_layer.png
+   :width: 0
+
+.. image:: gallery/images/hexagon_layer.png
+   :width: 0
+
+.. image:: gallery/images/icon_layer.png
+   :width: 0
+
+.. image:: gallery/images/line_layer.png
+   :width: 0
+
+.. image:: gallery/images/path_layer.png
+   :width: 0
+
+.. image:: gallery/images/point_cloud_layer.png
+   :width: 0
+
+.. image:: gallery/images/polygon_layer.png
+   :width: 0
+
+.. image:: gallery/images/s2_layer.png
+   :width: 0
+
+.. image:: gallery/images/scatterplot_layer.png
+   :width: 0
+
+.. image:: gallery/images/screengrid_layer.png
+   :width: 0
+
+.. image:: gallery/images/text_layer.png
+   :width: 0
+
+.. image:: gallery/images/trips_layer.png
+   :width: 0

--- a/bindings/pydeck/docs/images.rst
+++ b/bindings/pydeck/docs/images.rst
@@ -67,3 +67,32 @@
 
 .. image:: gallery/images/trips_layer.png
    :width: 0
+
+.. toctree::
+   :hidden:
+   :maxdepth: 0
+
+   gallery/arc_layer
+   gallery/bitmap_layer
+   gallery/column_layer
+   gallery/contour_layer
+   gallery/custom_layer.png
+   gallery/custom_layer
+   gallery/geojson_layer
+   gallery/great_circle_layer
+   gallery/grid_layer
+   gallery/h3_cluster_layer
+   gallery/h3_hexagon_layer
+   gallery/heatmap_layer
+   gallery/hexagon_layer
+   gallery/icon_layer
+   gallery/line_layer
+   gallery/path_layer
+   gallery/point_cloud_layer
+   gallery/polygon_layer
+   gallery/s2_layer
+   gallery/scatterplot_layer
+   gallery/screengrid_layer
+   gallery/text_layer
+   gallery/tile_3d_layer
+   gallery/trips_layer

--- a/bindings/pydeck/docs/index.rst
+++ b/bindings/pydeck/docs/index.rst
@@ -7,80 +7,13 @@ Get started by `installing pydeck <installation.html>`__.
 
 Gallery
 ^^^^^^^
-..
-  These image tags are manually added to include these images in the _static directory
-  TODO this should be automated in the future.
 
 .. raw:: html
    :file: gallery/html/grid.html
 
-.. image:: gallery/images/arc_layer.png
-   :width: 0
+.. include:: images.rst
 
-.. image:: gallery/images/bitmap_layer.png
-   :width: 0
-
-.. image:: gallery/images/column_layer.png
-   :width: 0
-
-.. image:: gallery/images/contour_layer.png
-   :width: 0
-
-.. image:: gallery/images/custom_layer.png
-   :width: 0
-
-.. image:: gallery/images/geojson_layer.png
-   :width: 0
-
-.. image:: gallery/images/great_circle_layer.png
-   :width: 0
-
-.. image:: gallery/images/grid_layer.png
-   :width: 0
-
-.. image:: gallery/images/h3_cluster_layer.png
-   :width: 0
-
-.. image:: gallery/images/h3_hexagon_layer.png
-   :width: 0
-
-.. image:: gallery/images/heatmap_layer.png
-   :width: 0
-
-.. image:: gallery/images/hexagon_layer.png
-   :width: 0
-
-.. image:: gallery/images/icon_layer.png
-   :width: 0
-
-.. image:: gallery/images/line_layer.png
-   :width: 0
-
-.. image:: gallery/images/path_layer.png
-   :width: 0
-
-.. image:: gallery/images/point_cloud_layer.png
-   :width: 0
-
-.. image:: gallery/images/polygon_layer.png
-   :width: 0
-
-.. image:: gallery/images/s2_layer.png
-   :width: 0
-
-.. image:: gallery/images/scatterplot_layer.png
-   :width: 0
-
-.. image:: gallery/images/screengrid_layer.png
-   :width: 0
-
-.. image:: gallery/images/text_layer.png
-   :width: 0
-
-.. image:: gallery/images/trips_layer.png
-   :width: 0
-
-Documentation
+API reference
 ^^^^^^^^^^^^^
 
 `pydeck in Jupyter <jupyter.html>`__

--- a/bindings/pydeck/docs/index.rst
+++ b/bindings/pydeck/docs/index.rst
@@ -79,14 +79,12 @@ Configure the lighting within a visualization.
 .. toctree::
    :maxdepth: 1
    :caption: Getting started
-   :hidden:
 
    installation
 
 .. toctree::
    :maxdepth: 1
    :caption: Usage
-   :hidden:
 
    layer
    deck
@@ -98,7 +96,6 @@ Configure the lighting within a visualization.
 .. toctree::
    :maxdepth: 1
    :caption: Jupyter
-   :hidden:
 
    jupyter
    binary_transfer
@@ -106,7 +103,6 @@ Configure the lighting within a visualization.
 .. toctree::
    :maxdepth: 1
    :caption: Further customization
-   :hidden:
 
    tooltip
    custom_layers

--- a/bindings/pydeck/docs/scripts/README.md
+++ b/bindings/pydeck/docs/scripts/README.md
@@ -1,0 +1,8 @@
+Documentation example scripts
+=============================
+
+* `embed_examples.py` creates a series of .rst files with both embedded source code
+   and an embedded example in them.
+* `generate_grid_html.py` creates an HTML grid of links to those rst pages within thumbnails.
+   It is the landing page for pydeck's website.
+* `snap_thumbnails.py` creates the .png files used as those thumbnails from examples.

--- a/bindings/pydeck/docs/scripts/embed_examples.py
+++ b/bindings/pydeck/docs/scripts/embed_examples.py
@@ -17,7 +17,7 @@ DOC_TEMPLATE = jinja2.Template(
 
 .. raw:: html
 
-    <a style="float:right;" target="_blank" href="{{deckgl_doc_url}}">deck.gl docs</a>
+    <a id="deck-link" target="_blank" href="{{deckgl_doc_url}}">deck.gl docs</a>
     <br />
 
 .. raw:: html
@@ -29,6 +29,12 @@ DOC_TEMPLATE = jinja2.Template(
     #deck-container {
         height: 50vh;
         max-width: 650px;
+        width: 100%;
+    }
+    #deck-link {
+        float: right;
+        position: relative;
+        top: -20px;
     }
     </style>
 

--- a/bindings/pydeck/docs/scripts/embed_examples.py
+++ b/bindings/pydeck/docs/scripts/embed_examples.py
@@ -17,7 +17,20 @@ DOC_TEMPLATE = jinja2.Template(
 
 .. raw:: html
 
-    <iframe width="650" height="400" src="{{hosted_html_path}}"></iframe>
+    <a style="float:right;" target="_blank" href="{{deckgl_doc_url}}">deck.gl docs</a>
+    <br />
+
+.. raw:: html
+   :file: ./html/{{ snake_name }}.html
+
+.. raw:: html
+
+    <style>
+    #deck-container {
+        height: 50vh;
+        max-width: 650px;
+    }
+    </style>
 
 Source
 ------
@@ -25,12 +38,6 @@ Source
 .. code-block:: python
 
 {{ python_code|indent(4, True) }}
-
-.. raw:: html
-
-    <br />
-    <a style="float:left;" target="_blank" href="{{hosted_html_path}}">Full screen example</a>
-    <a style="float:right;" target="_blank" href="{{deckgl_doc_url}}">deck.gl docs</a>
 
 """
 )
@@ -58,6 +65,7 @@ def create_rst(fname):
     python_code = open(fname, "r").read()
     doc_source = DOC_TEMPLATE.render(
         layer_name=to_presentation_name(layer_name),
+        snake_name=layer_name,
         python_code=python_code,
         hosted_html_path=os.path.join(STATIC_PATH, html_fname),
         deckgl_doc_url=deckgl_doc_url,

--- a/bindings/pydeck/docs/scripts/embed_examples.py
+++ b/bindings/pydeck/docs/scripts/embed_examples.py
@@ -13,7 +13,7 @@ from utils import to_presentation_name, to_snake_case_layer_name
 DOC_TEMPLATE = jinja2.Template(
     """
 {{ layer_name }}
-================================
+^^^^^^^^^^^^^^^^
 
 .. raw:: html
 

--- a/bindings/pydeck/pyproject.toml
+++ b/bindings/pydeck/pyproject.toml
@@ -9,7 +9,7 @@ requires = [
 
 [tool.black]
 line-length = 120
-target-version = ['py37']
+target-version = ['py34']
 include = '\.pyi?$'
 exclude = '''
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #4103 

Read the Docs doesn't seem to support isolated html pages that aren't explicitly included somewhere in the toctree or via a link

<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
- More explicit MIT license
- Embed HTML directly rather than use iframes (fixes tooltip cropping issues–div would get cut-off in the iframe)
- Separate out file used to include assets in toctree (images.rst, formerly part of index.rst)