### PR TITLE
pydeck: Update RTD.io config to install pydeck and generate embedded examples

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,5 +11,10 @@ sphinx:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
+  version: 3.7
   install:
     - requirements: bindings/pydeck/requirements-dev.txt
+    - requirements: bindings/pydeck/requirements.txt
+    - method: pip
+      path: bindings/pydeck
+  system_packages: true

--- a/bindings/pydeck/docs/conf.py
+++ b/bindings/pydeck/docs/conf.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 # Point Sphinx autodoc at our source
 import os
+import subprocess
 import sys
-
-from docs.scripts import embed_examples
 
 sys.path.insert(0, os.path.abspath("../"))
 
@@ -37,4 +36,12 @@ add_module_names = False
 
 
 def setup(app):
-    embed_examples.main()
+    if os.environ.get("READTHEDOCS"):
+        print("RTD running in the following directory:", os.getcwd())
+        subprocess.call(
+            "{python} bindings/pydeck/docs/scripts/embed_examples.py".format(python=sys.executable), shell=True,
+        )
+    else:
+        from docs.scripts import embed_examples  # noqa
+
+        embed_examples.main()


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #4103

Support for ReadTheDocs.io to build documentation from scratch.

This might take a few PRs to get right.

Multi-language docs, stable and development docs, and hosted Elasticsearch are all good reasons to use ReadTheDocs.io. While we're not doing it in the short-term, I'd like to support the option to host docs here.

<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
- Install pydeck from scratch for RTD
- Support RTD running embed_examples.py
