### PR TITLE
TextLayer: support UTF-32 characters when using binary data

### DIFF
--- a/modules/layers/src/text-layer/utils.js
+++ b/modules/layers/src/text-layer/utils.js
@@ -303,7 +303,7 @@ export function getTextFromBuffer({value, length, stride, offset, startIndices})
   for (let index = 0; index < length; index++) {
     const startIndex = startIndices[index];
     const endIndex = startIndices[index + 1] || characterCount;
-    texts[index] = String.fromCharCode.apply(null, codes.subarray(startIndex, endIndex));
+    texts[index] = String.fromCodePoint.apply(null, codes.subarray(startIndex, endIndex));
   }
 
   return {texts, characterCount};


### PR DESCRIPTION
For #4434

See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCodePoint

#### Change List
- Replace `fromCharCode` with `fromCodePoint`
