### PR TITLE
pydeck: Include `pydeck:` in title for bug report link

### DIFF
--- a/bindings/pydeck/docs/index.rst
+++ b/bindings/pydeck/docs/index.rst
@@ -72,7 +72,7 @@ Configure the lighting within a visualization.
 
    Currently, pydeck will **not** raise an error on incorrect or omitted Layer arguments.
    If nothing renders in your viewport, check your browser's `developer console <https://javascript.info/devtools>`__
-   or review the layer catalog. You are encouraged to file an issue by clicking `here <https://github.com/uber/deck.gl/issues/new?assignees=&labels=bug&template=bug-report.md&title=>`__
+   or review the layer catalog. You are encouraged to file an issue by clicking `here <https://github.com/uber/deck.gl/issues/new?assignees=&labels=bug&template=bug-report.md&title=pydeck:>`__
    and mention ``pydeck`` in the title.
 
 


### PR DESCRIPTION
The docs homepage has a link to create a bug report issue. This simply prefills `pydeck:` in the title bar as a nudge for a user to include `pydeck` in the title.

Alternatively, you could have a separate `pydeck` badge, and a `Bug Report (pydeck)` issue template that asks for Pydeck-specific info, like Jupyter environment, pydeck version, etc. And then also applies the `pydeck` badge.