### PR TITLE
pydeck: Allow an empty layer argument in Deck object

### DIFF
--- a/bindings/pydeck/pydeck/bindings/deck.py
+++ b/bindings/pydeck/pydeck/bindings/deck.py
@@ -67,7 +67,7 @@ class Deck(JSONMixin):
         if isinstance(layers, Layer):
             self.layers.append(layers)
         else:
-            self.layers = layers
+            self.layers = layers or []
         self.views = views
         self.map_style = map_style
         # Use passed view state

--- a/bindings/pydeck/tests/bindings/test_deck.py
+++ b/bindings/pydeck/tests/bindings/test_deck.py
@@ -29,10 +29,7 @@ def test_warning():
 
 def test_deck_layer_args():
     """Verify layer argument null cases"""
-    CASES = [
-        ({"layers": None}, []),
-        ({"layers": []}, [])
-    ]
+    CASES = [({"layers": None}, []), ({"layers": []}, [])]
     for [args, expected_output] in CASES:
         r = Deck(**args)
         assert r.layers == expected_output

--- a/bindings/pydeck/tests/bindings/test_deck.py
+++ b/bindings/pydeck/tests/bindings/test_deck.py
@@ -27,6 +27,17 @@ def test_warning():
         os.environ.update(_environ)
 
 
+def test_deck_layer_args():
+    """Verify layer argument null cases"""
+    CASES = [
+        ({"layers": None}, []),
+        ({"layers": []}, [])
+    ]
+    for [args, expected_output] in CASES:
+        r = Deck(**args)
+        assert r.layers == expected_output
+
+
 def test_json_output():
     """Verify that the JSON rendering produces an @deck.gl/json library-compliant JSON object
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
<!-- For other PRs without open issue -->
#### Background

Address #4493

<!-- For all the PRs -->
#### Change List
- Handle empty layers
- Add test case
